### PR TITLE
support the different lengths & units that twicpics do

### DIFF
--- a/lib/plug_image.ex
+++ b/lib/plug_image.ex
@@ -1,6 +1,14 @@
 defmodule ImagePlug do
   @behaviour Plug
 
+  @type imgp_int() :: {:int, integer()}
+  @type imgp_float() :: {:float, float()}
+  @type imgp_expr() :: {:expr, float()}
+  @type imgp_number() :: imgp_int() | imgp_float() | imgp_expr()
+  @type imgp_pct() :: {:float, imgp_number()}
+  @type imgp_scale() :: {:float, imgp_number(), imgp_number()}
+  @type imgp_length() :: imgp_number() | imgp_pct() | imgp_scale()
+
   import Plug.Conn
 
   require Logger

--- a/lib/plug_image.ex
+++ b/lib/plug_image.ex
@@ -30,6 +30,9 @@ defmodule ImagePlug do
          {:ok, final_state} <- TransformChain.execute(%TransformState{image: image}, chain) do
       send_image(conn, final_state)
     else
+      {:error, {:invalid_params, {module, input}}} ->
+        Logger.info("parameter parse error for #{inspect(module)}: #{inspect(input)}")
+        send_resp(conn, 400, "invalid parameters")
       {:error, {:transform_error, %TransformState{errors: errors} = final_state}} ->
         # TODO: handle transform error - debug mode + graceful mode switch?
         Logger.info("transform_error(s): #{inspect(errors)}")

--- a/lib/plug_image/arithmetic_parser.ex
+++ b/lib/plug_image/arithmetic_parser.ex
@@ -1,0 +1,145 @@
+defmodule ImagePlug.ArithmeticParser do
+  @type token :: {:int, integer} | {:float, float} | {:op, binary} | :left_paren | :right_paren
+  @type expr :: {:int, integer} | {:float, float} | {:op, binary, expr(), expr()}
+
+  @spec parse(String.t()) :: {:ok, expr} | {:error, atom()}
+  def parse(input) do
+    case tokenize(input) do
+      {:ok, tokens} ->
+        case parse_expression(tokens, 0) do
+          {:ok, expr, []} -> {:ok, expr}
+          {:ok, _, _} -> {:error, :unexpected_token_after_expr}
+          {:error, _} = error -> error
+        end
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @spec evaluate(String.t()) :: {:ok, number} | {:error, atom()}
+  def parse_and_evaluate(input) do
+    case parse(input) do
+      {:ok, expr} -> evaluate(expr)
+      {:error, _} = error -> error
+    end
+  end
+
+  defp tokenize(input) do
+    input
+    |> String.replace(~r/\s+/, "")
+    |> String.graphemes()
+    |> do_tokenize([])
+  end
+
+  defp do_tokenize([], acc), do: {:ok, Enum.reverse(acc)}
+
+  defp do_tokenize([h | t], acc) when h in ~w(+ - * /) do
+    do_tokenize(t, [{:op, h} | acc])
+  end
+
+  defp do_tokenize(["(" | t], acc), do: do_tokenize(t, [:left_paren | acc])
+  defp do_tokenize([")" | t], acc), do: do_tokenize(t, [:right_paren | acc])
+
+  defp do_tokenize([h | t], acc) when h in ~w(0 1 2 3 4 5 6 7 8 9 .) do
+    {number, rest} = consume_number([h | t])
+
+    token =
+      if String.contains?(number, "."),
+        do: {:float, String.to_float(number)},
+        else: {:int, String.to_integer(number)}
+
+    do_tokenize(rest, [token | acc])
+  end
+
+  defp do_tokenize(_, _), do: {:error, :invalid_character}
+
+  defp consume_number(chars) do
+    {number, rest} = Enum.split_while(chars, &(&1 in ~w(0 1 2 3 4 5 6 7 8 9 .)))
+    {Enum.join(number), rest}
+  end
+
+  defp parse_expression(tokens, min_prec) do
+    case parse_primary(tokens) do
+      {:ok, lhs, rest} -> parse_binary_op(lhs, rest, min_prec)
+      {:error, _} = error -> error
+    end
+  end
+
+  defp parse_primary([{:int, n} | rest]), do: {:ok, {:int, n}, rest}
+  defp parse_primary([{:float, n} | rest]), do: {:ok, {:float, n}, rest}
+
+  defp parse_primary([:left_paren | rest]) do
+    case parse_expression(rest, 0) do
+      {:ok, expr, [:right_paren | rest2]} -> {:ok, expr, rest2}
+      {:ok, _, _} -> {:error, :mismatched_paren}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp parse_primary(_), do: {:error, :expected_primary_expression}
+
+  defp parse_binary_op(lhs, tokens, min_prec) do
+    case tokens do
+      [{:op, op} | rest] ->
+        prec = precedence(op)
+
+        if prec < min_prec do
+          {:ok, lhs, tokens}
+        else
+          case parse_expression(rest, prec + 1) do
+            {:ok, rhs, rest2} ->
+              new_lhs = {:op, op, lhs, rhs}
+              parse_binary_op(new_lhs, rest2, min_prec)
+
+            {:error, _} = error ->
+              error
+          end
+        end
+
+      _ ->
+        {:ok, lhs, tokens}
+    end
+  end
+
+  defp precedence("+"), do: 1
+  defp precedence("-"), do: 1
+  defp precedence("*"), do: 2
+  defp precedence("/"), do: 2
+
+  @spec evaluate(expr()) :: {:ok, number} | {:error, String.t()}
+  defp evaluate({:int, n}), do: {:ok, n}
+  defp evaluate({:float, n}), do: {:ok, n}
+
+  defp evaluate({:op, "+", lhs, rhs}) do
+    with {:ok, lval} <- evaluate(lhs),
+         {:ok, rval} <- evaluate(rhs) do
+      {:ok, lval + rval}
+    end
+  end
+
+  defp evaluate({:op, "-", lhs, rhs}) do
+    with {:ok, lval} <- evaluate(lhs),
+         {:ok, rval} <- evaluate(rhs) do
+      {:ok, lval - rval}
+    end
+  end
+
+  defp evaluate({:op, "*", lhs, rhs}) do
+    with {:ok, lval} <- evaluate(lhs),
+         {:ok, rval} <- evaluate(rhs) do
+      {:ok, lval * rval}
+    end
+  end
+
+  defp evaluate({:op, "/", lhs, rhs}) do
+    with {:ok, lval} <- evaluate(lhs),
+         {:ok, rval} <- evaluate(rhs) do
+      if rval == 0 do
+        {:error, :division_by_zero}
+      else
+        {:ok, lval / rval}
+      end
+    end
+  end
+end

--- a/lib/plug_image/param_parser.ex
+++ b/lib/plug_image/param_parser.ex
@@ -1,7 +1,11 @@
 defmodule ImagePlug.ParamParser do
   alias ImagePlug.Transform
 
-  @type transform_module() :: Transform.Crop | Transform.Focus | Transform.Scale
+  @type transform_module() ::
+          Transform.Crop
+          | Transform.Focus
+          | Transform.Scale
+          | Transform.Output
 
   @typedoc """
   A tuple of a module implementing `ImagePlug.Transform`
@@ -11,6 +15,7 @@ defmodule ImagePlug.ParamParser do
           {Transform.Crop, Transform.Crop.Parameters.t()}
           | {Transform.Focus, Transform.Focus.Parameters.t()}
           | {Transform.Scale, Transform.Scale.Parameters.t()}
+          | {Transform.Output, Transform.Output.Parameters.t()}
 
   @type transform_chain() :: list(transform_chain_item())
 
@@ -20,14 +25,6 @@ defmodule ImagePlug.ParamParser do
 
   @doc """
   Parse transform chain (a list of `ImagePlug.Transform` with parameters) from a `Plug.Conn`.
-
-  ## Examples
-
-      iex> ImagePlug.ParamParser.parse("focus=20x30;scale=50p")
-      {:ok, [
-        {ImagePlug.Transform.Focus, %ImagePlug.Transform.Focus.FocusParams{left: 20, top: 30},
-        {ImagePlug.Transform.Scale, %ImagePlug.Transform.Scale.ScaleParams{width: {:pct, 50}, height: :auto}}
-      ]}
   """
   @callback parse(Plug.Conn.t()) :: {:ok, transform_chain()} | {:error, list(parse_error())}
 end

--- a/lib/plug_image/param_parser/twicpics.ex
+++ b/lib/plug_image/param_parser/twicpics.ex
@@ -40,22 +40,24 @@ defmodule ImagePlug.ParamParser.Twicpics do
 
   def parse_chain(chain_str) do
       Regex.scan(@params_regex, chain_str, capture: :all_but_first)
-      |> Enum.reduce_while([], fn
-        [transform_name, params_str], acc when is_map_key(@transforms, transform_name) ->
-          {:cont, [{:ok, {Map.get(@transforms, transform_name), params_str}} | acc]}
+      |> Enum.reduce_while({:ok, []}, fn
+        [transform_name, params_str], {:ok, transforms_acc} when is_map_key(@transforms, transform_name) ->
+          module = Map.get(@transforms, transform_name)
+
+          case @parsers[module].parse(params_str) do
+            {:ok, parsed_params} ->
+              {:cont, {:ok, [{module, parsed_params} | transforms_acc]}}
+
+            {:error, {:parameter_parse_error, input}} ->
+              {:halt, {:error, {:invalid_params, {module, "invalid input: #{input}"}}}}
+          end
 
         [transform_name, _params_str], acc ->
           {:cont, [{:error, {:invalid_transform, transform_name}} | acc]}
       end)
-      |> Enum.reverse()
-      |> Enum.reduce_while({:ok, []}, fn {:ok, {module, params_str}}, {:ok, transforms_acc} ->
-      case @parsers[module].parse(params_str) do
-        {:ok, parsed_params} ->
-          {:cont, {:ok, transforms_acc ++ {module, parsed_params}}}
-
-        {:error, {:parameter_parse_error, input}} ->
-          {:halt, {:error, {:invalid_params, {module, "invalid input: #{input}"}}}}
+      |> case do
+        {:ok, transforms} -> {:ok, Enum.reverse(transforms)}
+        other -> other
       end
-      end)
   end
 end

--- a/lib/plug_image/param_parser/twicpics.ex
+++ b/lib/plug_image/param_parser/twicpics.ex
@@ -27,11 +27,13 @@ defmodule ImagePlug.ParamParser.Twicpics do
     end
   end
 
+  # a `key=value` string followed by either a slash and a
+  # new key=value string or the end of the string using lookahead
+  @params_regex ~r/\/?([a-z]+)=(.+?(?=\/[a-z]+=|$))/
+
   def parse_chain(chain_str) do
     parsed_chain =
-      chain_str
-      |> String.split("/")
-      |> Enum.map(&String.split(&1, "="))
+      Regex.scan(@params_regex, chain_str, capture: :all_but_first)
       |> Enum.reduce_while([], fn
         [transform_name, params_str], acc when is_map_key(@transforms, transform_name) ->
           {:cont, [{:ok, {Map.get(@transforms, transform_name), params_str}} | acc]}

--- a/lib/plug_image/param_parser/twicpics.ex
+++ b/lib/plug_image/param_parser/twicpics.ex
@@ -22,7 +22,14 @@ defmodule ImagePlug.ParamParser.Twicpics do
     conn = Plug.Conn.fetch_query_params(conn)
 
     case conn.params do
-      %{"twic" => "v1/" <> chain} -> parse_chain(chain)
+      %{"twic" => input} -> parse_string(input)
+      _ -> {:ok, []}
+    end
+  end
+
+  def parse_string(input) do
+    case input do
+      "v1/" <> chain -> parse_chain(chain)
       _ -> {:ok, []}
     end
   end

--- a/lib/plug_image/param_parser/twicpics/common.ex
+++ b/lib/plug_image/param_parser/twicpics/common.ex
@@ -1,4 +1,4 @@
-defmodule ImagePlug.ParamParser.Twicpics.Shared do
+defmodule ImagePlug.ParamParser.Twicpics.Common do
   def with_parsed_units(units, fun) do
     case parse_all_units(units) do
       {:error, _} = error -> error

--- a/lib/plug_image/param_parser/twicpics/crop_parser.ex
+++ b/lib/plug_image/param_parser/twicpics/crop_parser.ex
@@ -1,5 +1,5 @@
 defmodule ImagePlug.ParamParser.Twicpics.CropParser do
-  import ImagePlug.ParamParser.Twicpics.Shared
+  import ImagePlug.ParamParser.Twicpics.Common
 
   alias ImagePlug.Transform.Crop.CropParams
 

--- a/lib/plug_image/param_parser/twicpics/crop_parser.ex
+++ b/lib/plug_image/param_parser/twicpics/crop_parser.ex
@@ -1,19 +1,7 @@
 defmodule ImagePlug.ParamParser.Twicpics.CropParser do
-  import NimbleParsec
-
   import ImagePlug.ParamParser.Twicpics.Shared
 
   alias ImagePlug.Transform.Crop.CropParams
-
-  defparsecp(
-    :internal_parse,
-    tag(parsec(:dimension), :crop_size)
-    |> optional(
-      ignore(ascii_char([?@]))
-      |> tag(parsec(:dimension), :coordinates)
-    )
-    |> eos()
-  )
 
   @doc """
   Parses a string into a `ImagePlug.Transform.Crop.CropParams` struct.
@@ -36,21 +24,37 @@ defmodule ImagePlug.ParamParser.Twicpics.CropParser do
   ## Examples
 
       iex> ImagePlug.ParamParser.Twicpics.CropParser.parse("250x25p")
-      {:ok, %ImagePlug.Transform.Crop.CropParams{width: {:int, 250}, height: {:pct, 25.0}, crop_from: :focus}}
+      {:ok, %ImagePlug.Transform.Crop.CropParams{width: {:int, 250}, height: {:pct, {:int, 25}}, crop_from: :focus}}
 
       iex> ImagePlug.ParamParser.Twicpics.CropParser.parse("20px25@10x50.1p")
-      {:ok, %ImagePlug.Transform.Crop.CropParams{width: {:pct, 20.0}, height: {:int, 25}, crop_from: %{left: {:int, 10}, top: {:pct, 50.1}}}}
+      {:ok, %ImagePlug.Transform.Crop.CropParams{width: {:pct, {:int, 20}}, height: {:int, 25}, crop_from: %{left: {:int, 10}, top: {:pct, {:float, 50.1}}}}}
   """
-  def parse(parameters) do
-    case internal_parse(parameters) do
-      {:ok, [crop_size: [x: width, y: height], coordinates: [x: left, y: top]], _, _, _, _} ->
-        {:ok, %CropParams{width: width, height: height, crop_from: %{left: left, top: top}}}
+  def parse(input) do
+    cond do
+      Regex.match?(~r/^(.+)x(.+)@(.+)x(.+)$/, input) ->
+        Regex.run(~r/^(.+)x(.+)@(.+)x(.+)$/, input, capture: :all_but_first)
+        |> with_parsed_units(fn [width, height, left, top] ->
+          {:ok,
+           %CropParams{
+             width: width,
+             height: height,
+             crop_from: %{left: left, top: top}
+           }}
+        end)
 
-      {:ok, [crop_size: [x: width, y: height]], _, _, _, _} ->
-        {:ok, %CropParams{width: width, height: height, crop_from: :focus}}
+      Regex.match?(~r/^(.+)x(.+)$/, input) ->
+        Regex.run(~r/^(.+)x(.+)$/, input, capture: :all_but_first)
+        |> with_parsed_units(fn [width, height] ->
+          {:ok,
+           %CropParams{
+             width: width,
+             height: height,
+             crop_from: :focus
+           }}
+        end)
 
-      {:error, msg, _, _, _, _} ->
-        {:error, {:parameter_parse_error, msg, parameters}}
+      true ->
+        {:error, {:parameter_parse_error, input}}
     end
   end
 end

--- a/lib/plug_image/param_parser/twicpics/focus_parser.ex
+++ b/lib/plug_image/param_parser/twicpics/focus_parser.ex
@@ -1,5 +1,5 @@
 defmodule ImagePlug.ParamParser.Twicpics.FocusParser do
-  import ImagePlug.ParamParser.Twicpics.Shared
+  import ImagePlug.ParamParser.Twicpics.Common
 
   alias ImagePlug.Transform.Focus.FocusParams
 

--- a/lib/plug_image/param_parser/twicpics/focus_parser.ex
+++ b/lib/plug_image/param_parser/twicpics/focus_parser.ex
@@ -1,22 +1,7 @@
 defmodule ImagePlug.ParamParser.Twicpics.FocusParser do
-  import NimbleParsec
-
   import ImagePlug.ParamParser.Twicpics.Shared
 
   alias ImagePlug.Transform.Focus.FocusParams
-
-  defcombinator(
-    :dimensions,
-    unwrap_and_tag(parsec(:int_size), :x)
-    |> ignore(ascii_char([?x]))
-    |> unwrap_and_tag(parsec(:int_size), :y)
-  )
-
-  defparsec(
-    :internal_parse,
-    tag(parsec(:dimensions), :crop_size)
-    |> eos()
-  )
 
   @doc """
   Parses a string into a `ImagePlug.Transform.Focus.FocusParams` struct.
@@ -37,16 +22,19 @@ defmodule ImagePlug.ParamParser.Twicpics.FocusParser do
 
   ## Examples
 
-      iex> ImagePlug.ParamParser.Twicpics.FocusParser.parse("250x25")
-      {:ok, %ImagePlug.Transform.Focus.FocusParams{left: 250, top: 25}}
+      iex> ImagePlug.ParamParser.Twicpics.FocusParser.parse("250x25.5")
+      {:ok, %ImagePlug.Transform.Focus.FocusParams{left: {:int, 250}, top: {:float, 25.5}}}
   """
-  def parse(parameters) do
-    case internal_parse(parameters) do
-      {:ok, [crop_size: [x: {:int, left}, y: {:int, top}]], _, _, _, _} ->
-        {:ok, %FocusParams{left: left, top: top}}
+  def parse(input) do
+    cond do
+      Regex.match?(~r/^(.+)x(.+)$/, input) ->
+        Regex.run(~r/^(.+)x(.+)$/, input, capture: :all_but_first)
+        |> with_parsed_units(fn [left, top] ->
+          {:ok, %FocusParams{left: left, top: top}}
+        end)
 
-      {:error, _, _, _, _, _} ->
-        {:error, :parameter_parse_error}
+      true ->
+        {:error, {:parameter_parse_error, input}}
     end
   end
 end

--- a/lib/plug_image/param_parser/twicpics/output_parser.ex
+++ b/lib/plug_image/param_parser/twicpics/output_parser.ex
@@ -11,15 +11,15 @@ defmodule ImagePlug.ParamParser.Twicpics.OutputParser do
       iex> ImagePlug.ParamParser.Twicpics.OutputParser.parse("avif")
       {:ok, %ImagePlug.Transform.Output.OutputParams{format: :avif}}
   """
-  def parse(parameters) do
-    case parameters do
+  def parse(input) do
+    case input do
       "auto" -> {:ok, %OutputParams{format: :auto}}
       "avif" -> {:ok, %OutputParams{format: :avif}}
       "webp" -> {:ok, %OutputParams{format: :webp}}
       "jpeg" -> {:ok, %OutputParams{format: :jpeg}}
       "png" -> {:ok, %OutputParams{format: :png}}
       "blurhash" -> {:ok, %OutputParams{format: :blurhash}}
-      _ -> {:error, :parameter_parse_error}
+      _ -> {:error, {:parameter_parse_error, input}}
     end
   end
 end

--- a/lib/plug_image/param_parser/twicpics/scale_parser.ex
+++ b/lib/plug_image/param_parser/twicpics/scale_parser.ex
@@ -1,5 +1,5 @@
 defmodule ImagePlug.ParamParser.Twicpics.ScaleParser do
-  import ImagePlug.ParamParser.Twicpics.Shared
+  import ImagePlug.ParamParser.Twicpics.Common
 
   alias ImagePlug.Transform.Scale.ScaleParams
 

--- a/lib/plug_image/transform.ex
+++ b/lib/plug_image/transform.ex
@@ -1,5 +1,36 @@
 defmodule ImagePlug.Transform do
   alias ImagePlug.TransformState
+  alias ImagePlug.ArithmeticParser
 
   @callback execute(TransformState.t(), String.t()) :: TransformState.t()
+
+  def eval_number({:int, int}), do: {:ok, int}
+  def eval_number({:float, float}), do: {:ok, float}
+  def eval_number({:expr, expr}), do: ArithmeticParser.parse_and_evaluate(expr)
+
+  def image_dim(%TransformState{image: image}, :width), do: Image.width(image)
+  def image_dim(%TransformState{image: image}, :height), do: Image.height(image)
+
+  @spec to_coord(TransformState.t(), :width | :height, ImagePlug.imgp_length()) ::
+          {:ok, integer()} | {:error, atom()}
+  def to_coord(state, dimension, length)
+  def to_coord(_state, _dimension, {:int, int}), do: {:ok, int}
+  def to_coord(_state, _dimension, {:float, float}), do: {:ok, round(float)}
+  def to_coord(_state, _dimension, {:expr, _} = expr), do: eval_number(expr)
+
+  def to_coord(state, dimension, {:scale, numerator_num, denominator_num}) do
+    with {:ok, numerator} <- eval_number(numerator_num),
+         {:ok, denominator} <- eval_number(denominator_num) do
+      {:ok, round(image_dim(state, dimension) * numerator / denominator)}
+    else
+      {:error, _} = error -> error
+    end
+  end
+
+  def to_coord(state, dimension, {:pct, num}) do
+    case eval_number(num) do
+      {:ok, result} -> {:ok, round(result / 100 * image_dim(state, dimension))}
+      {:error, _} = error -> error
+    end
+  end
 end

--- a/lib/plug_image/transform/scale.ex
+++ b/lib/plug_image/transform/scale.ex
@@ -1,6 +1,7 @@
 defmodule ImagePlug.Transform.Scale do
   @behaviour ImagePlug.Transform
 
+  alias ImagePlug.Transform
   alias ImagePlug.TransformState
 
   defmodule ScaleParams do
@@ -9,16 +10,16 @@ defmodule ImagePlug.Transform.Scale do
     """
     defstruct [:width, :height]
 
-    @type int_or_pct() :: {:int, integer()} | {:pct, integer()}
     @type t ::
-            %__MODULE__{width: int_or_pct() | :auto, height: int_or_pct()}
-            | %__MODULE__{width: int_or_pct(), height: int_or_pct() | :auto}
+            %__MODULE__{width: ImagePlug.imgp_length() | :auto, height: ImagePlug.imgp_length()}
+            | %__MODULE__{width: ImagePlug.imgp_length(), height: ImagePlug.imgp_length() | :auto}
   end
 
   @impl ImagePlug.Transform
   def execute(%TransformState{} = state, %ScaleParams{} = parameters) do
-    with coord_mapped_params <- map_params_to_coords(state.image, parameters),
-         {:ok, scaled_image} <- do_scale(state.image, coord_mapped_params) do
+    with {:ok, width} <- to_coord(state, :width, parameters.width),
+         {:ok, height} <- to_coord(state, :height, parameters.height),
+         {:ok, scaled_image} <- do_scale(state.image, %{width: width, height: height}) do
       # reset focus to :center on scale
       %TransformState{state | image: scaled_image, focus: :center}
     end
@@ -44,14 +45,6 @@ defmodule ImagePlug.Transform.Scale do
     {:error, {:unhandled_scale_parameters, parameters}}
   end
 
-  def to_coord(size, {:pct, pct}), do: round(size * pct / 100)
-  def to_coord(_size, {:int, int}), do: int
-  def to_coord(_size, :auto), do: :auto
-
-  def map_params_to_coords(image, %ScaleParams{width: width, height: height}) do
-    %{
-      width: to_coord(Image.width(image), width),
-      height: to_coord(Image.height(image), height)
-    }
-  end
+  def to_coord(_state, _dimension, :auto), do: {:ok, :auto}
+  def to_coord(state, dimension, length), do: Transform.to_coord(state, dimension, length)
 end

--- a/lib/plug_image/transform_chain.ex
+++ b/lib/plug_image/transform_chain.ex
@@ -10,7 +10,7 @@ defmodule ImagePlug.TransformChain do
   ## Examples
 
       iex> chain = [
-      ...>   {ImagePlug.Transform.Focus, %ImagePlug.Transform.Focus.FocusParams{left: 20, top: 30}},
+      ...>   {ImagePlug.Transform.Focus, %ImagePlug.Transform.Focus.FocusParams{left: {:int, 20}, top: {:int, 30}}},
       ...>   {ImagePlug.Transform.Crop, %ImagePlug.Transform.Crop.CropParams{width: {:int, 100}, height: {:int, 150}, crop_from: :focus}}
       ...> ]
       ...> {:ok, empty_image} = Image.new(500, 500)

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,6 @@ defmodule ImagePlug.MixProject do
       {:plug, "~> 1.16"},
       {:image, "~> 0.37"},
       {:req, "~> 0.5"},
-      {:nimble_parsec, "~> 1.4.0"},
       {:bandit, "~> 1.0", only: [:test, :dev]},
       {:stream_data, "~> 1.0", only: [:test, :dev]},
       {:excoveralls, ">= 0.0.0", only: [:test], runtime: false},

--- a/test/param_parser/twicpics_parser_test.exs
+++ b/test/param_parser/twicpics_parser_test.exs
@@ -1,4 +1,4 @@
-defmodule ParamParser.TwicpicsTest do
+defmodule ParamParser.TwicpicsParserTest do
   use ExUnit.Case, async: true
   use ExUnitProperties
 

--- a/test/twicpics_test.exs
+++ b/test/twicpics_test.exs
@@ -1,0 +1,35 @@
+defmodule TwicpicsTest do
+  use ExUnit.Case, async: true
+
+  alias ImagePlug.Transform
+  alias ImagePlug.ParamParser.Twicpics
+
+  test "parse from string" do
+    result = Twicpics.parse_string("v1/focus=(1/2)sx(2/3)s/crop=100x100/resize=200/output=avif")
+
+    assert result ==
+             {:ok,
+              [
+                {Transform.Focus,
+                 %Transform.Focus.FocusParams{
+                   left: {:scale, {:int, 1}, {:int, 2}},
+                   top: {:scale, {:int, 2}, {:int, 3}}
+                 }},
+                {Transform.Crop,
+                 %Transform.Crop.CropParams{
+                   width: {:int, 100},
+                   height: {:int, 100},
+                   crop_from: :focus
+                 }},
+                {Transform.Scale,
+                 %Transform.Scale.ScaleParams{
+                   width: {:int, 200},
+                   height: :auto
+                 }},
+                {Transform.Output,
+                 %Transform.Output.OutputParams{
+                   format: :avif
+                 }}
+              ]}
+  end
+end


### PR DESCRIPTION
## todo

- [x] fix error handling on parse errors

## length units

* pixels: `<number>` (e.g. for 50 pixels: `50`)
* scale: `(<number>/<number>)s` (e.g. for one third: `(1/3)s`)
* percentages: `<number>p` (e.g. 50%: `50p`)

## number

* literals: `50`, `50.45`
* expressions: `(1/3)`, `(4*(3+2)/4)`

numbers can be used in combination with the length units. e.g.:
`(4*6)` → `24`
`(1/(2*3))s` → `(1/6)s`
`(90/2)p` → `45p`