### PR TITLE
Add NimbleOptions validation for cache config

### DIFF
--- a/lib/image_plug/cache.ex
+++ b/lib/image_plug/cache.ex
@@ -56,6 +56,9 @@ defmodule ImagePlug.Cache do
     end
   end
 
+  @doc false
+  def shared_option_keys, do: @shared_cache_option_keys
+
   @spec lookup(Plug.Conn.t(), ProcessingRequest.t(), String.t(), keyword()) :: lookup_result()
   def lookup(conn, %ProcessingRequest{} = request, origin_identity, opts) when is_list(opts) do
     case cache_config(opts) do
@@ -106,8 +109,8 @@ defmodule ImagePlug.Cache do
       {adapter, cache_opts} when is_list(cache_opts) ->
         if Keyword.keyword?(cache_opts) do
           with :ok <- validate_adapter(adapter),
-               :ok <- validate_shared_options(cache_opts),
-               :ok <- validate_adapter_options(adapter, cache_opts) do
+               {:ok, cache_opts} <- normalize_shared_options(cache_opts),
+               :ok <- validate_adapter_options(adapter, adapter_options(cache_opts)) do
             {:ok, adapter, cache_opts}
           end
         else
@@ -130,14 +133,24 @@ defmodule ImagePlug.Cache do
 
   defp validate_adapter(adapter), do: {:error, {:invalid_cache_config, {:adapter, adapter}}}
 
-  defp validate_shared_options(cache_opts) do
+  defp normalize_shared_options(cache_opts) do
     shared_opts = Keyword.take(cache_opts, @shared_cache_option_keys)
 
     case NimbleOptions.validate(shared_opts, @shared_cache_options_schema) do
-      {:ok, _cache_opts} -> :ok
-      {:error, error} -> {:error, {:invalid_cache_config, error}}
+      {:ok, validated_shared_opts} ->
+        {:ok, Keyword.merge(cache_opts, validated_shared_opts)}
+
+      {:error, error} ->
+        {:error, {:invalid_cache_config, shared_validation_error(error)}}
     end
   end
+
+  defp shared_validation_error(%NimbleOptions.ValidationError{key: key, value: value})
+       when key in @shared_cache_option_keys do
+    {key, value}
+  end
+
+  defp adapter_options(cache_opts), do: Keyword.drop(cache_opts, @shared_cache_option_keys)
 
   defp validate_adapter_options(adapter, cache_opts) do
     if function_exported?(adapter, :validate_options, 1) do

--- a/lib/image_plug/cache.ex
+++ b/lib/image_plug/cache.ex
@@ -9,6 +9,22 @@ defmodule ImagePlug.Cache do
   alias ImagePlug.Cache.Key
   alias ImagePlug.ProcessingRequest
 
+  @shared_cache_option_keys [:key_headers, :key_cookies, :max_body_bytes, :fail_on_cache_error]
+  @shared_cache_options_schema NimbleOptions.new!(
+                                 key_headers: [
+                                   type: {:list, :string}
+                                 ],
+                                 key_cookies: [
+                                   type: {:list, :string}
+                                 ],
+                                 max_body_bytes: [
+                                   type: {:or, [nil, :non_neg_integer]}
+                                 ],
+                                 fail_on_cache_error: [
+                                   type: :boolean
+                                 ]
+                               )
+
   @callback get(Key.t(), keyword()) :: {:hit, Entry.t()} | :miss | {:error, term()}
   @callback put(Key.t(), Entry.t(), keyword()) :: :ok | {:error, term()}
   @callback validate_options(keyword()) :: :ok | {:error, term()}
@@ -90,10 +106,7 @@ defmodule ImagePlug.Cache do
       {adapter, cache_opts} when is_list(cache_opts) ->
         if Keyword.keyword?(cache_opts) do
           with :ok <- validate_adapter(adapter),
-               :ok <- validate_binary_name_list(cache_opts, :key_headers),
-               :ok <- validate_max_body_bytes(cache_opts),
-               :ok <- validate_boolean(cache_opts, :fail_on_cache_error),
-               :ok <- validate_binary_name_list(cache_opts, :key_cookies),
+               :ok <- validate_shared_options(cache_opts),
                :ok <- validate_adapter_options(adapter, cache_opts) do
             {:ok, adapter, cache_opts}
           end
@@ -103,16 +116,6 @@ defmodule ImagePlug.Cache do
 
       invalid ->
         {:error, {:invalid_cache_config, invalid}}
-    end
-  end
-
-  defp validate_binary_name_list(opts, key) do
-    value = Keyword.get(opts, key, [])
-
-    if is_list(value) and Enum.all?(value, &is_binary/1) do
-      :ok
-    else
-      {:error, {:invalid_cache_config, {key, value}}}
     end
   end
 
@@ -127,6 +130,15 @@ defmodule ImagePlug.Cache do
 
   defp validate_adapter(adapter), do: {:error, {:invalid_cache_config, {:adapter, adapter}}}
 
+  defp validate_shared_options(cache_opts) do
+    shared_opts = Keyword.take(cache_opts, @shared_cache_option_keys)
+
+    case NimbleOptions.validate(shared_opts, @shared_cache_options_schema) do
+      {:ok, _cache_opts} -> :ok
+      {:error, error} -> {:error, {:invalid_cache_config, error}}
+    end
+  end
+
   defp validate_adapter_options(adapter, cache_opts) do
     if function_exported?(adapter, :validate_options, 1) do
       case adapter.validate_options(cache_opts) do
@@ -136,23 +148,6 @@ defmodule ImagePlug.Cache do
       end
     else
       :ok
-    end
-  end
-
-  defp validate_max_body_bytes(opts) do
-    value = Keyword.get(opts, :max_body_bytes)
-
-    if is_nil(value) or (is_integer(value) and value >= 0) do
-      :ok
-    else
-      {:error, {:invalid_cache_config, {:max_body_bytes, value}}}
-    end
-  end
-
-  defp validate_boolean(opts, key) do
-    case Keyword.get(opts, key, false) do
-      value when is_boolean(value) -> :ok
-      value -> {:error, {:invalid_cache_config, {key, value}}}
     end
   end
 

--- a/lib/image_plug/cache/file_system.ex
+++ b/lib/image_plug/cache/file_system.ex
@@ -11,6 +11,16 @@ defmodule ImagePlug.Cache.FileSystem do
   @metadata_version 1
   @hash_pattern ~r/\A[0-9A-Fa-f]{64}\z/
   @body_filename_pattern ~r/\A[0-9A-Fa-f]{64}\.[0-9a-f]{64}\.body\z/
+  @option_keys [:root, :path_prefix]
+  @options_schema NimbleOptions.new!(
+                    root: [
+                      required: true,
+                      type: {:custom, __MODULE__, :validate_root, []}
+                    ],
+                    path_prefix: [
+                      type: {:custom, __MODULE__, :validate_path_prefix, []}
+                    ]
+                  )
 
   @impl true
   def get(%Key{} = key, opts) when is_list(opts) do
@@ -37,8 +47,10 @@ defmodule ImagePlug.Cache.FileSystem do
 
   @impl true
   def validate_options(opts) when is_list(opts) do
-    with {:ok, root} <- root(opts),
-         {:ok, path_prefix} <- path_prefix(opts),
+    with {:ok, validated_opts} <-
+           NimbleOptions.validate(Keyword.take(opts, @option_keys), @options_schema),
+         root = Keyword.fetch!(validated_opts, :root),
+         path_prefix = Keyword.get(validated_opts, :path_prefix, ""),
          {:ok, {first_partition, second_partition}} <- partitions(String.duplicate("0", 64)) do
       dir = Path.join([root, path_prefix, first_partition, second_partition])
       meta_path = Path.join(dir, String.duplicate("0", 64) <> ".meta")
@@ -49,6 +61,37 @@ defmodule ImagePlug.Cache.FileSystem do
       end
     end
   end
+
+  @doc false
+  def validate_root(root) when is_binary(root) do
+    if Path.type(root) == :absolute do
+      {:ok, Path.expand(root)}
+    else
+      {:error, "expected absolute path, got: #{inspect(root)}"}
+    end
+  end
+
+  def validate_root(root), do: {:error, "expected absolute path string, got: #{inspect(root)}"}
+
+  @doc false
+  def validate_path_prefix(prefix) when is_binary(prefix) do
+    cond do
+      prefix == "" ->
+        {:ok, ""}
+
+      Path.type(prefix) == :absolute ->
+        {:error, "expected relative path without traversal, got: #{inspect(prefix)}"}
+
+      String.contains?(prefix, "\\") or invalid_path_prefix?(prefix) ->
+        {:error, "expected relative path without traversal, got: #{inspect(prefix)}"}
+
+      true ->
+        {:ok, prefix}
+    end
+  end
+
+  def validate_path_prefix(prefix),
+    do: {:error, "expected relative path string, got: #{inspect(prefix)}"}
 
   defp read_entry(paths, opts) do
     with {:ok, meta_binary} <- read_cache_file(paths.meta_path, :metadata, opts),

--- a/lib/image_plug/cache/file_system.ex
+++ b/lib/image_plug/cache/file_system.ex
@@ -47,8 +47,8 @@ defmodule ImagePlug.Cache.FileSystem do
 
   @impl true
   def validate_options(opts) when is_list(opts) do
-    with {:ok, validated_opts} <-
-           NimbleOptions.validate(Keyword.take(opts, @option_keys), @options_schema),
+    with :ok <- validate_unknown_options(opts),
+         {:ok, validated_opts} <- validate_known_options(opts),
          root = Keyword.fetch!(validated_opts, :root),
          path_prefix = Keyword.get(validated_opts, :path_prefix, ""),
          {:ok, {first_partition, second_partition}} <- partitions(String.duplicate("0", 64)) do
@@ -59,6 +59,22 @@ defmodule ImagePlug.Cache.FileSystem do
            :ok <- validate_under_root(root, meta_path) do
         :ok
       end
+    end
+  end
+
+  defp validate_known_options(opts) do
+    case NimbleOptions.validate(Keyword.take(opts, @option_keys), @options_schema) do
+      {:ok, validated_opts} -> {:ok, validated_opts}
+      {:error, error} -> {:error, options_validation_error(error)}
+    end
+  end
+
+  defp validate_unknown_options(opts) do
+    known_option_keys = @option_keys ++ ImagePlug.Cache.shared_option_keys()
+
+    case Keyword.keys(opts) -- known_option_keys do
+      [] -> :ok
+      unknown_keys -> {:error, {:unknown_options, Enum.uniq(unknown_keys)}}
     end
   end
 
@@ -92,6 +108,15 @@ defmodule ImagePlug.Cache.FileSystem do
 
   def validate_path_prefix(prefix),
     do: {:error, "expected relative path string, got: #{inspect(prefix)}"}
+
+  defp options_validation_error(%NimbleOptions.ValidationError{key: :root, value: nil}),
+    do: {:missing_required_option, :root}
+
+  defp options_validation_error(%NimbleOptions.ValidationError{key: :root, value: root}),
+    do: {:invalid_root, root}
+
+  defp options_validation_error(%NimbleOptions.ValidationError{key: :path_prefix, value: prefix}),
+    do: {:invalid_path_prefix, prefix}
 
   defp read_entry(paths, opts) do
     with {:ok, meta_binary} <- read_cache_file(paths.meta_path, :metadata, opts),

--- a/mix.exs
+++ b/mix.exs
@@ -38,6 +38,7 @@ defmodule ImagePlug.MixProject do
   defp deps do
     [
       {:plug, "~> 1.18"},
+      {:nimble_options, "~> 1.1"},
       {:image, "~> 0.37"},
       {:req, "~> 0.5"},
       {:bandit, "~> 1.0", only: [:test, :dev]},

--- a/test/image_plug/cache/file_system_test.exs
+++ b/test/image_plug/cache/file_system_test.exs
@@ -56,11 +56,22 @@ defmodule ImagePlug.Cache.FileSystemTest do
     {:ok, root: root}
   end
 
+  defp assert_validation_error(result, expected_message) do
+    assert {:error, %NimbleOptions.ValidationError{} = error} = result
+    assert Exception.message(error) =~ expected_message
+  end
+
   test "requires an absolute root" do
     assert FileSystem.get(key(), []) == {:error, {:missing_required_option, :root}}
 
     assert FileSystem.get(key(), root: "relative/cache") ==
              {:error, {:invalid_root, "relative/cache"}}
+
+    FileSystem.validate_options([])
+    |> assert_validation_error("required :root")
+
+    FileSystem.validate_options(root: "relative/cache")
+    |> assert_validation_error(":root")
   end
 
   test "rejects traversal-shaped path prefixes", %{root: root} do
@@ -81,6 +92,9 @@ defmodule ImagePlug.Cache.FileSystemTest do
 
     assert FileSystem.get(key(), root: root, path_prefix: "processed\\..\\outside") ==
              {:error, {:invalid_path_prefix, "processed\\..\\outside"}}
+
+    FileSystem.validate_options(root: root, path_prefix: "../outside")
+    |> assert_validation_error(":path_prefix")
   end
 
   test "accepts filesystem root as cache root" do

--- a/test/image_plug/cache/file_system_test.exs
+++ b/test/image_plug/cache/file_system_test.exs
@@ -56,22 +56,16 @@ defmodule ImagePlug.Cache.FileSystemTest do
     {:ok, root: root}
   end
 
-  defp assert_validation_error(result, expected_message) do
-    assert {:error, %NimbleOptions.ValidationError{} = error} = result
-    assert Exception.message(error) =~ expected_message
-  end
-
   test "requires an absolute root" do
     assert FileSystem.get(key(), []) == {:error, {:missing_required_option, :root}}
 
     assert FileSystem.get(key(), root: "relative/cache") ==
              {:error, {:invalid_root, "relative/cache"}}
 
-    FileSystem.validate_options([])
-    |> assert_validation_error("required :root")
+    assert FileSystem.validate_options([]) == {:error, {:missing_required_option, :root}}
 
-    FileSystem.validate_options(root: "relative/cache")
-    |> assert_validation_error(":root")
+    assert FileSystem.validate_options(root: "relative/cache") ==
+             {:error, {:invalid_root, "relative/cache"}}
   end
 
   test "rejects traversal-shaped path prefixes", %{root: root} do
@@ -93,8 +87,15 @@ defmodule ImagePlug.Cache.FileSystemTest do
     assert FileSystem.get(key(), root: root, path_prefix: "processed\\..\\outside") ==
              {:error, {:invalid_path_prefix, "processed\\..\\outside"}}
 
-    FileSystem.validate_options(root: root, path_prefix: "../outside")
-    |> assert_validation_error(":path_prefix")
+    assert FileSystem.validate_options(root: root, path_prefix: "../outside") ==
+             {:error, {:invalid_path_prefix, "../outside"}}
+  end
+
+  test "rejects unknown filesystem adapter options", %{root: root} do
+    assert FileSystem.validate_options(root: root, path_prefx: "processed") ==
+             {:error, {:unknown_options, [:path_prefx]}}
+
+    assert FileSystem.validate_options(root: root, fail_on_cache_error: true) == :ok
   end
 
   test "accepts filesystem root as cache root" do

--- a/test/image_plug/cache_test.exs
+++ b/test/image_plug/cache_test.exs
@@ -66,14 +66,6 @@ defmodule ImagePlug.CacheTest do
     }
   end
 
-  defp assert_cache_validation_error(result, operation, expected_message) do
-    assert {:error,
-            {^operation, {:invalid_cache_config, %NimbleOptions.ValidationError{} = error}}} =
-             result
-
-    assert Exception.message(error) =~ expected_message
-  end
-
   test "returns disabled when no cache is configured" do
     assert Cache.lookup(
              conn(:get, "/_/plain/images/cat.jpg"),
@@ -264,21 +256,21 @@ defmodule ImagePlug.CacheTest do
   end
 
   test "invalid key header and cookie config returns a cache read error before key building" do
-    Cache.lookup(
-      conn(:get, "/_/format:webp/plain/images/cat.jpg"),
-      request(),
-      "https://origin.test/cat.jpg",
-      cache: {ShouldNotBeCalledAdapter, key_headers: [:accept_language]}
-    )
-    |> assert_cache_validation_error(:cache_read, ":key_headers")
+    assert {:error, {:cache_read, {:invalid_cache_config, {:key_headers, [:accept_language]}}}} =
+             Cache.lookup(
+               conn(:get, "/_/format:webp/plain/images/cat.jpg"),
+               request(),
+               "https://origin.test/cat.jpg",
+               cache: {ShouldNotBeCalledAdapter, key_headers: [:accept_language]}
+             )
 
-    Cache.lookup(
-      conn(:get, "/_/format:webp/plain/images/cat.jpg"),
-      request(),
-      "https://origin.test/cat.jpg",
-      cache: {ShouldNotBeCalledAdapter, key_cookies: [:tenant]}
-    )
-    |> assert_cache_validation_error(:cache_read, ":key_cookies")
+    assert {:error, {:cache_read, {:invalid_cache_config, {:key_cookies, [:tenant]}}}} =
+             Cache.lookup(
+               conn(:get, "/_/format:webp/plain/images/cat.jpg"),
+               request(),
+               "https://origin.test/cat.jpg",
+               cache: {ShouldNotBeCalledAdapter, key_cookies: [:tenant]}
+             )
   end
 
   test "invalid cache option lists return cache errors before adapter calls" do
@@ -295,29 +287,33 @@ defmodule ImagePlug.CacheTest do
   end
 
   test "invalid fail_on_cache_error config returns cache errors before adapter calls" do
-    Cache.lookup(
-      conn(:get, "/_/format:webp/plain/images/cat.jpg"),
-      request(),
-      "https://origin.test/cat.jpg",
-      cache: {ShouldNotBeCalledAdapter, fail_on_cache_error: "false"}
-    )
-    |> assert_cache_validation_error(:cache_read, ":fail_on_cache_error")
+    assert {:error, {:cache_read, {:invalid_cache_config, {:fail_on_cache_error, "false"}}}} =
+             Cache.lookup(
+               conn(:get, "/_/format:webp/plain/images/cat.jpg"),
+               request(),
+               "https://origin.test/cat.jpg",
+               cache: {ShouldNotBeCalledAdapter, fail_on_cache_error: "false"}
+             )
 
-    Cache.put(cache_key(), entry(), cache: {ShouldNotBeCalledAdapter, fail_on_cache_error: 1})
-    |> assert_cache_validation_error(:cache_write, ":fail_on_cache_error")
+    assert {:error, {:cache_write, {:invalid_cache_config, {:fail_on_cache_error, 1}}}} =
+             Cache.put(cache_key(), entry(),
+               cache: {ShouldNotBeCalledAdapter, fail_on_cache_error: 1}
+             )
   end
 
   test "invalid max_body_bytes config returns cache errors instead of changing cache policy" do
-    Cache.lookup(
-      conn(:get, "/_/format:webp/plain/images/cat.jpg"),
-      request(),
-      "https://origin.test/cat.jpg",
-      cache: {ShouldNotBeCalledAdapter, max_body_bytes: "10MB"}
-    )
-    |> assert_cache_validation_error(:cache_read, ":max_body_bytes")
+    assert {:error, {:cache_read, {:invalid_cache_config, {:max_body_bytes, "10MB"}}}} =
+             Cache.lookup(
+               conn(:get, "/_/format:webp/plain/images/cat.jpg"),
+               request(),
+               "https://origin.test/cat.jpg",
+               cache: {ShouldNotBeCalledAdapter, max_body_bytes: "10MB"}
+             )
 
-    Cache.put(cache_key(), entry(), cache: {ShouldNotBeCalledAdapter, max_body_bytes: -1})
-    |> assert_cache_validation_error(:cache_write, ":max_body_bytes")
+    assert {:error, {:cache_write, {:invalid_cache_config, {:max_body_bytes, -1}}}} =
+             Cache.put(cache_key(), entry(),
+               cache: {ShouldNotBeCalledAdapter, max_body_bytes: -1}
+             )
   end
 
   test "invalid adapter config returns cache errors instead of crashing" do

--- a/test/image_plug/cache_test.exs
+++ b/test/image_plug/cache_test.exs
@@ -66,6 +66,14 @@ defmodule ImagePlug.CacheTest do
     }
   end
 
+  defp assert_cache_validation_error(result, operation, expected_message) do
+    assert {:error,
+            {^operation, {:invalid_cache_config, %NimbleOptions.ValidationError{} = error}}} =
+             result
+
+    assert Exception.message(error) =~ expected_message
+  end
+
   test "returns disabled when no cache is configured" do
     assert Cache.lookup(
              conn(:get, "/_/plain/images/cat.jpg"),
@@ -256,21 +264,21 @@ defmodule ImagePlug.CacheTest do
   end
 
   test "invalid key header and cookie config returns a cache read error before key building" do
-    assert {:error, {:cache_read, {:invalid_cache_config, {:key_headers, [:accept_language]}}}} =
-             Cache.lookup(
-               conn(:get, "/_/format:webp/plain/images/cat.jpg"),
-               request(),
-               "https://origin.test/cat.jpg",
-               cache: {ShouldNotBeCalledAdapter, key_headers: [:accept_language]}
-             )
+    Cache.lookup(
+      conn(:get, "/_/format:webp/plain/images/cat.jpg"),
+      request(),
+      "https://origin.test/cat.jpg",
+      cache: {ShouldNotBeCalledAdapter, key_headers: [:accept_language]}
+    )
+    |> assert_cache_validation_error(:cache_read, ":key_headers")
 
-    assert {:error, {:cache_read, {:invalid_cache_config, {:key_cookies, [:tenant]}}}} =
-             Cache.lookup(
-               conn(:get, "/_/format:webp/plain/images/cat.jpg"),
-               request(),
-               "https://origin.test/cat.jpg",
-               cache: {ShouldNotBeCalledAdapter, key_cookies: [:tenant]}
-             )
+    Cache.lookup(
+      conn(:get, "/_/format:webp/plain/images/cat.jpg"),
+      request(),
+      "https://origin.test/cat.jpg",
+      cache: {ShouldNotBeCalledAdapter, key_cookies: [:tenant]}
+    )
+    |> assert_cache_validation_error(:cache_read, ":key_cookies")
   end
 
   test "invalid cache option lists return cache errors before adapter calls" do
@@ -287,33 +295,29 @@ defmodule ImagePlug.CacheTest do
   end
 
   test "invalid fail_on_cache_error config returns cache errors before adapter calls" do
-    assert {:error, {:cache_read, {:invalid_cache_config, {:fail_on_cache_error, "false"}}}} =
-             Cache.lookup(
-               conn(:get, "/_/format:webp/plain/images/cat.jpg"),
-               request(),
-               "https://origin.test/cat.jpg",
-               cache: {ShouldNotBeCalledAdapter, fail_on_cache_error: "false"}
-             )
+    Cache.lookup(
+      conn(:get, "/_/format:webp/plain/images/cat.jpg"),
+      request(),
+      "https://origin.test/cat.jpg",
+      cache: {ShouldNotBeCalledAdapter, fail_on_cache_error: "false"}
+    )
+    |> assert_cache_validation_error(:cache_read, ":fail_on_cache_error")
 
-    assert {:error, {:cache_write, {:invalid_cache_config, {:fail_on_cache_error, 1}}}} =
-             Cache.put(cache_key(), entry(),
-               cache: {ShouldNotBeCalledAdapter, fail_on_cache_error: 1}
-             )
+    Cache.put(cache_key(), entry(), cache: {ShouldNotBeCalledAdapter, fail_on_cache_error: 1})
+    |> assert_cache_validation_error(:cache_write, ":fail_on_cache_error")
   end
 
   test "invalid max_body_bytes config returns cache errors instead of changing cache policy" do
-    assert {:error, {:cache_read, {:invalid_cache_config, {:max_body_bytes, "10MB"}}}} =
-             Cache.lookup(
-               conn(:get, "/_/format:webp/plain/images/cat.jpg"),
-               request(),
-               "https://origin.test/cat.jpg",
-               cache: {ShouldNotBeCalledAdapter, max_body_bytes: "10MB"}
-             )
+    Cache.lookup(
+      conn(:get, "/_/format:webp/plain/images/cat.jpg"),
+      request(),
+      "https://origin.test/cat.jpg",
+      cache: {ShouldNotBeCalledAdapter, max_body_bytes: "10MB"}
+    )
+    |> assert_cache_validation_error(:cache_read, ":max_body_bytes")
 
-    assert {:error, {:cache_write, {:invalid_cache_config, {:max_body_bytes, -1}}}} =
-             Cache.put(cache_key(), entry(),
-               cache: {ShouldNotBeCalledAdapter, max_body_bytes: -1}
-             )
+    Cache.put(cache_key(), entry(), cache: {ShouldNotBeCalledAdapter, max_body_bytes: -1})
+    |> assert_cache_validation_error(:cache_write, ":max_body_bytes")
   end
 
   test "invalid adapter config returns cache errors instead of crashing" do


### PR DESCRIPTION
## Summary
- Replace bespoke cache option checks with NimbleOptions schemas for shared cache settings
- Add NimbleOptions-based validation for filesystem cache `:root` and `:path_prefix`
- Update tests to assert the new validation error shape and keep adapter-specific config passthrough intact

## Testing
- `mise exec -- mix test`
- `mise exec -- mix deps.get`
- `git diff --check`