### PR TITLE
Use Path.safe_relative for cache path containment

### DIFF
--- a/lib/image_plug/cache/file_system.ex
+++ b/lib/image_plug/cache/file_system.ex
@@ -413,16 +413,13 @@ defmodule ImagePlug.Cache.FileSystem do
   defp validate_under_root(root, path) do
     root = Path.expand(root)
     path = Path.expand(path)
+    relative = Path.relative_to(path, root, force: true)
 
-    if root?(root, path) do
-      :ok
-    else
-      {:error, {:path_outside_root, path}}
+    case Path.safe_relative(relative, root) do
+      {:ok, _relative} -> :ok
+      :error -> {:error, {:path_outside_root, path}}
     end
   end
-
-  defp root?("/", path), do: String.starts_with?(path, "/")
-  defp root?(root, path), do: path == root or String.starts_with?(path, root <> "/")
 
   defp body_filename(hash, body_sha256), do: "#{hash}.#{body_sha256}.body"
 

--- a/test/image_plug/cache/file_system_test.exs
+++ b/test/image_plug/cache/file_system_test.exs
@@ -102,6 +102,18 @@ defmodule ImagePlug.Cache.FileSystemTest do
     assert FileSystem.get(key(), root: "/") == :miss
   end
 
+  test "rejects cache paths that resolve outside the root through symlinks", %{root: root} do
+    outside_root = root <> "_outside"
+    File.rm_rf!(outside_root)
+    File.mkdir_p!(outside_root)
+    on_exit(fn -> File.rm_rf!(outside_root) end)
+
+    File.ln_s!(outside_root, Path.join(root, "aa"))
+
+    assert FileSystem.get(key("aabb" <> String.duplicate("1", 60)), root: root) ==
+             {:error, {:path_outside_root, Path.join([root, "aa", "bb"])}}
+  end
+
   test "rejects invalid hashes before path construction", %{root: root} do
     too_short_hash = String.duplicate("a", 63)
     non_hex_hash = String.duplicate("g", 64)


### PR DESCRIPTION
## Summary
- Replace the hand-rolled root-prefix check in the filesystem cache with `Path.relative_to/3` plus `Path.safe_relative/2`
- Preserve the existing `path_outside_root` error shape while using the standard path API
- Add a regression test that covers a symlink under the cache root pointing outside it

## Testing
- Added unit coverage for the symlink escape case
- Full test suite passed locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cache path validation to prevent path traversal security vulnerabilities from symlinks.

* **Tests**
  * Added test coverage verifying cache entries with paths outside the configured root are properly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->