### PR TITLE
Implement guarded streaming origin decode

### DIFF
--- a/lib/image_plug.ex
+++ b/lib/image_plug.ex
@@ -122,11 +122,26 @@ defmodule ImagePlug do
     with {:ok, origin_response} <-
            fetch_origin(request, origin_identity, opts) |> wrap_origin_error(),
          {:ok, image} <-
-           Image.from_binary(origin_response.body, access: :random, fail_on: :error)
-           |> wrap_decode_error(),
+           decode_origin_response(origin_response) |> wrap_origin_decode_error(),
          :ok <- validate_input_image(image, opts) |> wrap_input_limit_error(),
          {:ok, final_state} <- TransformChain.execute(%TransformState{image: image}, chain) do
       {:ok, final_state}
+    end
+  end
+
+  defp decode_origin_response(%Origin.Response{} = origin_response) do
+    case Image.open(origin_response.stream, access: :random, fail_on: :error) do
+      {:ok, image} ->
+        case Origin.stream_error(origin_response) do
+          nil -> {:ok, image}
+          reason -> {:error, {:origin, reason}}
+        end
+
+      {:error, decode_error} ->
+        case Origin.stream_error(origin_response) do
+          nil -> {:error, decode_error}
+          reason -> {:error, {:origin, reason}}
+        end
     end
   end
 
@@ -158,6 +173,9 @@ defmodule ImagePlug do
 
   defp wrap_decode_error({:error, _} = error), do: {:error, {:decode, error}}
   defp wrap_decode_error(result), do: result
+
+  defp wrap_origin_decode_error({:error, {:origin, error}}), do: {:error, {:origin, error}}
+  defp wrap_origin_decode_error(result), do: wrap_decode_error(result)
 
   defp validate_input_image(image, opts) do
     max_input_pixels = Keyword.get(opts, :max_input_pixels, 40_000_000)

--- a/lib/image_plug/origin.ex
+++ b/lib/image_plug/origin.ex
@@ -72,10 +72,12 @@ defmodule ImagePlug.Origin do
   end
 
   @doc """
-  Returns the terminal stream error after `response.stream` has been consumed.
+  Consumes and returns the terminal stream error after `response.stream` has
+  been consumed.
 
   Calling this before the stream reaches `:done` or an error may return `nil`
-  even if a later stream-time origin error occurs.
+  even if a later stream-time origin error occurs. The terminal stream status is
+  delivered as a process message, so this should only be called once.
   """
   def stream_error(%Response{ref: ref}) do
     receive do
@@ -223,6 +225,8 @@ defmodule ImagePlug.Origin do
   defp allow_req_test_owner(request_options, caller) do
     case Keyword.get(request_options, :plug) do
       {Req.Test, name} ->
+        # Req.Test stubs are process-owned; allow this spawned stream worker to
+        # use the caller's stub when tests pass `plug: {Req.Test, name}`.
         Req.Test.allow(name, caller, self())
 
       _plug ->

--- a/lib/image_plug/origin.ex
+++ b/lib/image_plug/origin.ex
@@ -1,7 +1,20 @@
 defmodule ImagePlug.Origin do
+  @moduledoc """
+  Origin URL construction and guarded HTTP streaming.
+
+  Origin responses are fetched with a repo-owned `Req.get(..., into: :self)` request
+  instead of `Image.from_req_stream/2`. That keeps ImagePlug in control of status and
+  content-type validation, byte limits, redirect and timeout configuration, and the
+  distinction between origin failures and image decode failures.
+
+  Successful fetches return a guarded enumerable in `Response.stream`. Consumers should
+  either consume that stream or call `close/1`. Stream-time origin failures are sent back
+  to the caller out-of-band because Vix consumes enumerables from a separate process.
+  """
+
   defmodule Response do
-    @enforce_keys [:body, :content_type, :headers, :url]
-    defstruct [:body, :content_type, :headers, :url]
+    @enforce_keys [:content_type, :headers, :ref, :stream, :url, :worker]
+    defstruct [:content_type, :headers, :ref, :stream, :url, :worker]
   end
 
   @default_max_body_bytes 10_000_000
@@ -55,13 +68,21 @@ defmodule ImagePlug.Origin do
         receive_timeout: receive_timeout
       )
 
-    case Req.get(request_options) do
-      {:ok, response} ->
-        handle_response(response, url, max_body_bytes, receive_timeout)
+    start_stream(url, request_options, max_body_bytes, receive_timeout)
+  end
 
-      {:error, exception} ->
-        {:error, {:transport, exception}}
+  def stream_error(%Response{ref: ref}) do
+    receive do
+      {^ref, {:stream_error, reason}} -> reason
+      {^ref, :stream_done} -> nil
+    after
+      0 -> nil
     end
+  end
+
+  def close(%Response{ref: ref, worker: worker}) do
+    send(worker, {:cancel, ref})
+    :ok
   end
 
   defp valid_root_url?(%URI{scheme: scheme, host: host})
@@ -74,28 +95,44 @@ defmodule ImagePlug.Origin do
   defp split_path(""), do: []
   defp split_path(path), do: path |> String.trim("/") |> String.split("/", trim: true)
 
-  defp handle_response(%Req.Response{} = response, url, max_body_bytes, receive_timeout) do
-    with :ok <- validate_status(response),
-         {:ok, content_type} <- validate_content_type(response),
-         {:ok, body} <- collect_body(response, max_body_bytes, receive_timeout) do
-      {:ok,
-       %Response{
-         body: body,
-         content_type: content_type,
-         headers: response_headers(response),
-         url: url
-       }}
-    else
-      {:error, reason} = error ->
-        cancel_response(response)
+  defp start_stream(url, request_options, max_body_bytes, receive_timeout) do
+    caller = self()
+    ref = make_ref()
 
-        case reason do
-          {:bad_status, _status} -> error
-          {:bad_content_type, _content_type} -> error
-          {:body_too_large, _limit} -> error
-          {:timeout, _receive_timeout} -> error
-          {:transport, _exception} -> error
-        end
+    {worker, monitor_ref} =
+      spawn_monitor(fn ->
+        stream_worker(
+          caller,
+          ref,
+          url,
+          request_options,
+          max_body_bytes,
+          receive_timeout
+        )
+      end)
+
+    receive do
+      {^ref, {:ok, %Response{} = response}} ->
+        Process.demonitor(monitor_ref, [:flush])
+
+        {:ok,
+         %Response{
+           response
+           | ref: ref,
+             worker: worker,
+             stream: response_stream(worker, ref)
+         }}
+
+      {^ref, {:error, reason}} ->
+        Process.demonitor(monitor_ref, [:flush])
+        {:error, reason}
+
+      {:DOWN, ^monitor_ref, :process, ^worker, reason} ->
+        {:error, {:transport, reason}}
+    after
+      receive_timeout ->
+        Process.exit(worker, :kill)
+        {:error, {:timeout, receive_timeout}}
     end
   end
 
@@ -127,53 +164,182 @@ defmodule ImagePlug.Origin do
     Enum.flat_map(headers, fn {key, values} -> Enum.map(values, &{key, &1}) end)
   end
 
-  defp collect_body(response, max_body_bytes, receive_timeout) do
-    do_collect_body(response, max_body_bytes, receive_timeout, [], 0)
+  defp stream_worker(
+         caller,
+         ref,
+         url,
+         request_options,
+         max_body_bytes,
+         receive_timeout
+       ) do
+    caller_monitor_ref = Process.monitor(caller)
+    allow_req_test_owner(request_options, caller)
+
+    case Req.get(request_options) do
+      {:ok, %Req.Response{} = response} ->
+        with :ok <- validate_status(response),
+             {:ok, content_type} <- validate_content_type(response) do
+          send(caller, {
+            ref,
+            {:ok,
+             %Response{
+               content_type: content_type,
+               headers: response_headers(response),
+               ref: nil,
+               stream: nil,
+               url: url,
+               worker: nil
+             }}
+          })
+
+          stream_loop(%{
+            caller: caller,
+            caller_monitor_ref: caller_monitor_ref,
+            max_body_bytes: max_body_bytes,
+            pending: [],
+            receive_timeout: receive_timeout,
+            ref: ref,
+            response: response,
+            size: 0
+          })
+        else
+          {:error, reason} ->
+            cancel_response(response)
+            send(caller, {ref, {:error, reason}})
+        end
+
+      {:error, exception} ->
+        send(caller, {ref, {:error, {:transport, exception}}})
+    end
   end
 
-  defp do_collect_body(response, max_body_bytes, receive_timeout, chunks, size) do
+  defp allow_req_test_owner(request_options, caller) do
+    case Keyword.get(request_options, :plug) do
+      {Req.Test, name} ->
+        Req.Test.allow(name, caller, self())
+
+      _plug ->
+        :ok
+    end
+  end
+
+  defp stream_loop(%{caller_monitor_ref: caller_monitor_ref, caller: caller, ref: ref} = state) do
     receive do
+      {:next, from, ^ref} ->
+        serve_next(from, state)
+
+      {:cancel, ^ref} ->
+        cancel_response(state.response)
+
+      {:DOWN, ^caller_monitor_ref, :process, ^caller, _reason} ->
+        cancel_response(state.response)
+    after
+      state.receive_timeout ->
+        fail_idle_stream(state, {:timeout, state.receive_timeout})
+    end
+  end
+
+  defp serve_next(from, %{pending: [pending | rest]} = state) do
+    deliver_pending(pending, from, %{state | pending: rest})
+  end
+
+  defp serve_next(from, %{receive_timeout: receive_timeout} = state) do
+    receive do
+      {:cancel, ref} when ref == state.ref ->
+        cancel_response(state.response)
+
+      {:DOWN, monitor_ref, :process, caller, _reason}
+      when monitor_ref == state.caller_monitor_ref and caller == state.caller ->
+        cancel_response(state.response)
+
       message ->
-        case Req.parse_message(response, message) do
+        case Req.parse_message(state.response, message) do
           {:ok, parsed_chunks} ->
-            collect_chunks(response, parsed_chunks, max_body_bytes, receive_timeout, chunks, size)
+            pending = Enum.flat_map(parsed_chunks, &pending_chunk/1)
+            serve_next(from, %{state | pending: pending})
 
           {:error, exception} ->
-            {:error, {:transport, exception}}
+            fail_stream(from, state, {:transport, exception})
 
           :unknown ->
-            do_collect_body(response, max_body_bytes, receive_timeout, chunks, size)
+            serve_next(from, state)
         end
     after
       receive_timeout ->
-        {:error, {:timeout, receive_timeout}}
+        fail_stream(from, state, {:timeout, receive_timeout})
     end
   end
 
-  defp collect_chunks(response, parsed_chunks, max_body_bytes, receive_timeout, chunks, size) do
-    Enum.reduce_while(parsed_chunks, {:cont, chunks, size}, fn
-      {:data, data}, {:cont, chunks, size} ->
-        size = size + byte_size(data)
+  defp pending_chunk({:data, data}), do: [{:data, data}]
+  defp pending_chunk(:done), do: [:done]
+  defp pending_chunk({:trailers, _trailers}), do: []
 
-        if size > max_body_bytes do
-          {:halt, {:error, {:body_too_large, max_body_bytes}}}
-        else
-          {:cont, {:cont, [data | chunks], size}}
-        end
+  defp deliver_pending({:data, data}, from, state) do
+    size = state.size + byte_size(data)
 
-      :done, {:cont, chunks, _size} ->
-        {:halt, {:ok, chunks |> Enum.reverse() |> IO.iodata_to_binary()}}
-
-      {:trailers, _trailers}, acc ->
-        {:cont, acc}
-    end)
-    |> case do
-      {:cont, chunks, size} ->
-        do_collect_body(response, max_body_bytes, receive_timeout, chunks, size)
-
-      result ->
-        result
+    if is_integer(state.max_body_bytes) and size > state.max_body_bytes do
+      fail_stream(from, state, {:body_too_large, state.max_body_bytes})
+    else
+      send(from, {state.ref, {:data, data}})
+      stream_loop(%{state | size: size})
     end
+  end
+
+  defp deliver_pending(:done, from, state) do
+    send(state.caller, {state.ref, :stream_done})
+    send(from, {state.ref, :done})
+  end
+
+  defp fail_stream(from, state, reason) do
+    reason = normalize_stream_error(reason, state.receive_timeout)
+
+    send(state.caller, {state.ref, {:stream_error, reason}})
+    cancel_response(state.response)
+    send(from, {state.ref, {:error, reason}})
+  end
+
+  defp fail_idle_stream(state, reason) do
+    reason = normalize_stream_error(reason, state.receive_timeout)
+
+    send(state.caller, {state.ref, {:stream_error, reason}})
+    cancel_response(state.response)
+  end
+
+  defp normalize_stream_error(
+         {:transport, %Mint.TransportError{reason: :timeout}},
+         receive_timeout
+       ) do
+    {:timeout, receive_timeout}
+  end
+
+  defp normalize_stream_error(reason, _receive_timeout), do: reason
+
+  defp response_stream(worker, ref) do
+    Stream.resource(
+      fn -> %{monitor_ref: Process.monitor(worker), ref: ref, worker: worker} end,
+      fn state ->
+        send(state.worker, {:next, self(), state.ref})
+
+        receive do
+          {ref, {:data, data}} when ref == state.ref ->
+            {[data], state}
+
+          {ref, :done} when ref == state.ref ->
+            {:halt, state}
+
+          {ref, {:error, _reason}} when ref == state.ref ->
+            {:halt, state}
+
+          {:DOWN, monitor_ref, :process, worker, _reason}
+          when monitor_ref == state.monitor_ref and worker == state.worker ->
+            {:halt, state}
+        end
+      end,
+      fn state ->
+        send(state.worker, {:cancel, state.ref})
+        Process.demonitor(state.monitor_ref, [:flush])
+      end
+    )
   end
 
   defp cancel_response(%Req.Response{} = response) do

--- a/lib/image_plug/origin.ex
+++ b/lib/image_plug/origin.ex
@@ -182,7 +182,6 @@ defmodule ImagePlug.Origin do
          receive_timeout
        ) do
     caller_monitor_ref = Process.monitor(caller)
-    allow_req_test_owner(request_options, caller)
 
     case Req.get(request_options) do
       {:ok, %Req.Response{} = response} ->
@@ -219,18 +218,6 @@ defmodule ImagePlug.Origin do
 
       {:error, exception} ->
         send(caller, {ref, {:error, {:transport, exception}}})
-    end
-  end
-
-  defp allow_req_test_owner(request_options, caller) do
-    case Keyword.get(request_options, :plug) do
-      {Req.Test, name} ->
-        # Req.Test stubs are process-owned; allow this spawned stream worker to
-        # use the caller's stub when tests pass `plug: {Req.Test, name}`.
-        Req.Test.allow(name, caller, self())
-
-      _plug ->
-        :ok
     end
   end
 

--- a/lib/image_plug/origin.ex
+++ b/lib/image_plug/origin.ex
@@ -71,6 +71,12 @@ defmodule ImagePlug.Origin do
     start_stream(url, request_options, max_body_bytes, receive_timeout)
   end
 
+  @doc """
+  Returns the terminal stream error after `response.stream` has been consumed.
+
+  Calling this before the stream reaches `:done` or an error may return `nil`
+  even if a later stream-time origin error occurs.
+  """
   def stream_error(%Response{ref: ref}) do
     receive do
       {^ref, {:stream_error, reason}} -> reason
@@ -132,6 +138,7 @@ defmodule ImagePlug.Origin do
     after
       receive_timeout ->
         Process.exit(worker, :kill)
+        Process.demonitor(monitor_ref, [:flush])
         {:error, {:timeout, receive_timeout}}
     end
   end

--- a/test/image_plug/origin_test.exs
+++ b/test/image_plug/origin_test.exs
@@ -20,7 +20,7 @@ defmodule ImagePlug.OriginTest do
              {:error, {:invalid_path_segment, ["images", ".", "cat.jpg"]}}
   end
 
-  test "fetch validates status and image content type" do
+  test "fetch validates status and image content type and exposes a guarded stream" do
     Req.Test.stub(Origin, fn conn ->
       conn
       |> Plug.Conn.put_resp_header("content-type", "image/jpeg")
@@ -30,7 +30,8 @@ defmodule ImagePlug.OriginTest do
     assert {:ok, %Origin.Response{} = response} =
              Origin.fetch("https://img.example/cat.jpg", plug: {Req.Test, Origin})
 
-    assert response.body == "image bytes"
+    assert Enum.join(response.stream) == "image bytes"
+    assert Origin.stream_error(response) == nil
     assert response.content_type == "image/jpeg"
     assert response.url == "https://img.example/cat.jpg"
     assert {"content-type", "image/jpeg"} in response.headers
@@ -61,11 +62,11 @@ defmodule ImagePlug.OriginTest do
                plug: {Req.Test, Origin},
                url: "https://evil.example/dog.jpg",
                into: [],
-               receive_timeout: 1,
+               receive_timeout: 5_000,
                max_redirects: 0
              )
 
-    assert response.body == "img.example/cat.jpg"
+    assert Enum.join(response.stream) == "img.example/cat.jpg"
     assert response.url == "https://img.example/cat.jpg"
   end
 
@@ -109,17 +110,21 @@ defmodule ImagePlug.OriginTest do
              {:error, {:bad_content_type, "text/plain; charset=utf-8"}}
   end
 
-  test "stops reading when body exceeds limit" do
+  test "stream stops reading and records an origin error when body exceeds limit" do
     Req.Test.stub(Origin, fn conn ->
       conn
       |> Plug.Conn.put_resp_header("content-type", "image/png")
       |> Plug.Conn.send_resp(200, "123456")
     end)
 
-    assert Origin.fetch("https://img.example/cat.png",
-             plug: {Req.Test, Origin},
-             max_body_bytes: 5
-           ) == {:error, {:body_too_large, 5}}
+    assert {:ok, %Origin.Response{} = response} =
+             Origin.fetch("https://img.example/cat.png",
+               plug: {Req.Test, Origin},
+               max_body_bytes: 5
+             )
+
+    assert Enum.to_list(response.stream) == []
+    assert Origin.stream_error(response) == {:body_too_large, 5}
   end
 
   test "converts transport errors" do
@@ -129,5 +134,61 @@ defmodule ImagePlug.OriginTest do
 
     assert {:error, {:transport, %Req.TransportError{reason: :timeout}}} =
              Origin.fetch("https://img.example/cat.jpg", plug: {Req.Test, Origin})
+  end
+
+  test "stream receive timeout is recorded as an origin error" do
+    port = start_slow_chunked_origin()
+
+    assert {:ok, %Origin.Response{} = response} =
+             Origin.fetch("http://127.0.0.1:#{port}/cat.png", receive_timeout: 200)
+
+    assert Enum.to_list(response.stream) == ["first chunk"]
+    assert Origin.stream_error(response) == {:timeout, 200}
+  end
+
+  test "unconsumed streams are canceled after receive timeout" do
+    Req.Test.stub(Origin, fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("content-type", "image/jpeg")
+      |> Plug.Conn.send_resp(200, "image bytes")
+    end)
+
+    assert {:ok, %Origin.Response{} = response} =
+             Origin.fetch("https://img.example/cat.jpg",
+               plug: {Req.Test, Origin},
+               receive_timeout: 100
+             )
+
+    Process.sleep(150)
+
+    assert Origin.stream_error(response) == {:timeout, 100}
+  end
+
+  defp start_slow_chunked_origin do
+    {:ok, listen_socket} =
+      :gen_tcp.listen(0, [:binary, packet: :raw, active: false, reuseaddr: true])
+
+    {:ok, {_address, port}} = :inet.sockname(listen_socket)
+
+    spawn_link(fn ->
+      {:ok, socket} = :gen_tcp.accept(listen_socket)
+      {:ok, _request} = :gen_tcp.recv(socket, 0)
+
+      :ok =
+        :gen_tcp.send(socket, [
+          "HTTP/1.1 200 OK\r\n",
+          "content-type: image/png\r\n",
+          "transfer-encoding: chunked\r\n",
+          "\r\n",
+          "b\r\nfirst chunk\r\n"
+        ])
+
+      Process.sleep(500)
+      :gen_tcp.send(socket, "c\r\nsecond chunk\r\n0\r\n\r\n")
+      :gen_tcp.close(socket)
+      :gen_tcp.close(listen_socket)
+    end)
+
+    port
   end
 end

--- a/test/image_plug/origin_test.exs
+++ b/test/image_plug/origin_test.exs
@@ -3,10 +3,6 @@ defmodule ImagePlug.OriginTest do
 
   alias ImagePlug.Origin
 
-  setup do
-    Req.Test.verify_on_exit!()
-  end
-
   test "build_url encodes and joins path segments" do
     assert Origin.build_url("https://img.example/base", ["images", "cat 1.jpg"]) ==
              {:ok, "https://img.example/base/images/cat%201.jpg"}
@@ -21,14 +17,14 @@ defmodule ImagePlug.OriginTest do
   end
 
   test "fetch validates status and image content type and exposes a guarded stream" do
-    Req.Test.stub(Origin, fn conn ->
+    plug = fn conn ->
       conn
       |> Plug.Conn.put_resp_header("content-type", "image/jpeg")
       |> Plug.Conn.send_resp(200, "image bytes")
-    end)
+    end
 
     assert {:ok, %Origin.Response{} = response} =
-             Origin.fetch("https://img.example/cat.jpg", plug: {Req.Test, Origin})
+             Origin.fetch("https://img.example/cat.jpg", plug: plug)
 
     assert Enum.join(response.stream) == "image bytes"
     assert Origin.stream_error(response) == nil
@@ -38,28 +34,28 @@ defmodule ImagePlug.OriginTest do
   end
 
   test "fetch accepts mixed-case image content type with parameters" do
-    Req.Test.stub(Origin, fn conn ->
+    plug = fn conn ->
       conn
       |> Plug.Conn.put_resp_header("content-type", "Image/JPEG; charset=binary")
       |> Plug.Conn.send_resp(200, "image bytes")
-    end)
+    end
 
     assert {:ok, %Origin.Response{} = response} =
-             Origin.fetch("https://img.example/cat.jpg", plug: {Req.Test, Origin})
+             Origin.fetch("https://img.example/cat.jpg", plug: plug)
 
     assert response.content_type == "Image/JPEG; charset=binary"
   end
 
   test "fetch does not allow request options to override safe options" do
-    Req.Test.stub(Origin, fn conn ->
+    plug = fn conn ->
       conn
       |> Plug.Conn.put_resp_header("content-type", "image/jpeg")
       |> Plug.Conn.send_resp(200, "#{conn.host}#{conn.request_path}")
-    end)
+    end
 
     assert {:ok, %Origin.Response{} = response} =
              Origin.fetch("https://img.example/cat.jpg",
-               plug: {Req.Test, Origin},
+               plug: plug,
                url: "https://evil.example/dog.jpg",
                into: [],
                receive_timeout: 5_000,
@@ -71,7 +67,7 @@ defmodule ImagePlug.OriginTest do
   end
 
   test "fetch allows redirect limits to be configured" do
-    Req.Test.stub(Origin, fn
+    plug = fn
       %{request_path: "/redirect"} = conn ->
         conn
         |> Plug.Conn.put_resp_header("location", "/final")
@@ -81,45 +77,45 @@ defmodule ImagePlug.OriginTest do
         conn
         |> Plug.Conn.put_resp_header("content-type", "image/jpeg")
         |> Plug.Conn.send_resp(200, "image bytes")
-    end)
+    end
 
     assert {:error, {:transport, %Req.TooManyRedirectsError{max_redirects: 0}}} =
              Origin.fetch("https://img.example/redirect",
-               plug: {Req.Test, Origin},
+               plug: plug,
                max_redirects: 0
              )
   end
 
   test "rejects non-success status" do
-    Req.Test.stub(Origin, fn conn ->
+    plug = fn conn ->
       Plug.Conn.send_resp(conn, 404, "not found")
-    end)
+    end
 
-    assert Origin.fetch("https://img.example/missing.jpg", plug: {Req.Test, Origin}) ==
+    assert Origin.fetch("https://img.example/missing.jpg", plug: plug) ==
              {:error, {:bad_status, 404}}
   end
 
   test "rejects non-image content type" do
-    Req.Test.stub(Origin, fn conn ->
+    plug = fn conn ->
       conn
       |> Plug.Conn.put_resp_header("content-type", "text/plain; charset=utf-8")
       |> Plug.Conn.send_resp(200, "not image bytes")
-    end)
+    end
 
-    assert Origin.fetch("https://img.example/cat.txt", plug: {Req.Test, Origin}) ==
+    assert Origin.fetch("https://img.example/cat.txt", plug: plug) ==
              {:error, {:bad_content_type, "text/plain; charset=utf-8"}}
   end
 
   test "stream stops reading and records an origin error when body exceeds limit" do
-    Req.Test.stub(Origin, fn conn ->
+    plug = fn conn ->
       conn
       |> Plug.Conn.put_resp_header("content-type", "image/png")
       |> Plug.Conn.send_resp(200, "123456")
-    end)
+    end
 
     assert {:ok, %Origin.Response{} = response} =
              Origin.fetch("https://img.example/cat.png",
-               plug: {Req.Test, Origin},
+               plug: plug,
                max_body_bytes: 5
              )
 
@@ -128,12 +124,12 @@ defmodule ImagePlug.OriginTest do
   end
 
   test "converts transport errors" do
-    Req.Test.stub(Origin, fn conn ->
+    plug = fn conn ->
       Req.Test.transport_error(conn, :timeout)
-    end)
+    end
 
     assert {:error, {:transport, %Req.TransportError{reason: :timeout}}} =
-             Origin.fetch("https://img.example/cat.jpg", plug: {Req.Test, Origin})
+             Origin.fetch("https://img.example/cat.jpg", plug: plug)
   end
 
   test "stream receive timeout is recorded as an origin error" do
@@ -147,15 +143,15 @@ defmodule ImagePlug.OriginTest do
   end
 
   test "unconsumed streams are canceled after receive timeout" do
-    Req.Test.stub(Origin, fn conn ->
+    plug = fn conn ->
       conn
       |> Plug.Conn.put_resp_header("content-type", "image/jpeg")
       |> Plug.Conn.send_resp(200, "image bytes")
-    end)
+    end
 
     assert {:ok, %Origin.Response{} = response} =
              Origin.fetch("https://img.example/cat.jpg",
-               plug: {Req.Test, Origin},
+               plug: plug,
                receive_timeout: 50
              )
 
@@ -163,14 +159,14 @@ defmodule ImagePlug.OriginTest do
   end
 
   test "close cancels an unconsumed stream" do
-    Req.Test.stub(Origin, fn conn ->
+    plug = fn conn ->
       conn
       |> Plug.Conn.put_resp_header("content-type", "image/jpeg")
       |> Plug.Conn.send_resp(200, "image bytes")
-    end)
+    end
 
     assert {:ok, %Origin.Response{} = response} =
-             Origin.fetch("https://img.example/cat.jpg", plug: {Req.Test, Origin})
+             Origin.fetch("https://img.example/cat.jpg", plug: plug)
 
     worker = response.worker
     monitor_ref = Process.monitor(worker)

--- a/test/image_plug/origin_test.exs
+++ b/test/image_plug/origin_test.exs
@@ -163,6 +163,23 @@ defmodule ImagePlug.OriginTest do
     assert_receive {^ref, {:stream_error, {:timeout, 50}}}, 100
   end
 
+  test "close cancels an unconsumed stream" do
+    Req.Test.stub(Origin, fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("content-type", "image/jpeg")
+      |> Plug.Conn.send_resp(200, "image bytes")
+    end)
+
+    assert {:ok, %Origin.Response{} = response} =
+             Origin.fetch("https://img.example/cat.jpg", plug: {Req.Test, Origin})
+
+    worker = response.worker
+    monitor_ref = Process.monitor(worker)
+
+    assert Origin.close(response) == :ok
+    assert_receive {:DOWN, ^monitor_ref, :process, ^worker, _reason}
+  end
+
   defp start_slow_chunked_origin do
     {:ok, listen_socket} =
       :gen_tcp.listen(0, [:binary, packet: :raw, active: false, reuseaddr: true])

--- a/test/image_plug/origin_test.exs
+++ b/test/image_plug/origin_test.exs
@@ -140,10 +140,10 @@ defmodule ImagePlug.OriginTest do
     port = start_slow_chunked_origin()
 
     assert {:ok, %Origin.Response{} = response} =
-             Origin.fetch("http://127.0.0.1:#{port}/cat.png", receive_timeout: 200)
+             Origin.fetch("http://127.0.0.1:#{port}/cat.png", receive_timeout: 100)
 
     assert Enum.to_list(response.stream) == ["first chunk"]
-    assert Origin.stream_error(response) == {:timeout, 200}
+    assert Origin.stream_error(response) == {:timeout, 100}
   end
 
   test "unconsumed streams are canceled after receive timeout" do
@@ -156,11 +156,11 @@ defmodule ImagePlug.OriginTest do
     assert {:ok, %Origin.Response{} = response} =
              Origin.fetch("https://img.example/cat.jpg",
                plug: {Req.Test, Origin},
-               receive_timeout: 100
+               receive_timeout: 50
              )
 
     ref = response.ref
-    assert_receive {^ref, {:stream_error, {:timeout, 100}}}, 200
+    assert_receive {^ref, {:stream_error, {:timeout, 50}}}, 100
   end
 
   defp start_slow_chunked_origin do
@@ -182,7 +182,7 @@ defmodule ImagePlug.OriginTest do
           "b\r\nfirst chunk\r\n"
         ])
 
-      Process.sleep(300)
+      Process.sleep(150)
       :gen_tcp.send(socket, "c\r\nsecond chunk\r\n0\r\n\r\n")
       :gen_tcp.close(socket)
       :gen_tcp.close(listen_socket)

--- a/test/image_plug/origin_test.exs
+++ b/test/image_plug/origin_test.exs
@@ -159,8 +159,7 @@ defmodule ImagePlug.OriginTest do
                receive_timeout: 50
              )
 
-    ref = response.ref
-    assert_receive {^ref, {:stream_error, {:timeout, 50}}}, 100
+    assert_eventually_stream_error(response, {:timeout, 50}, 100)
   end
 
   test "close cancels an unconsumed stream" do
@@ -206,5 +205,25 @@ defmodule ImagePlug.OriginTest do
     end)
 
     port
+  end
+
+  defp assert_eventually_stream_error(response, expected, timeout) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_assert_eventually_stream_error(response, expected, deadline)
+  end
+
+  defp do_assert_eventually_stream_error(response, expected, deadline) do
+    case Origin.stream_error(response) do
+      ^expected ->
+        :ok
+
+      nil ->
+        if System.monotonic_time(:millisecond) < deadline do
+          Process.sleep(5)
+          do_assert_eventually_stream_error(response, expected, deadline)
+        else
+          flunk("expected stream error #{inspect(expected)}")
+        end
+    end
   end
 end

--- a/test/image_plug/origin_test.exs
+++ b/test/image_plug/origin_test.exs
@@ -159,9 +159,8 @@ defmodule ImagePlug.OriginTest do
                receive_timeout: 100
              )
 
-    Process.sleep(150)
-
-    assert Origin.stream_error(response) == {:timeout, 100}
+    ref = response.ref
+    assert_receive {^ref, {:stream_error, {:timeout, 100}}}, 200
   end
 
   defp start_slow_chunked_origin do
@@ -183,7 +182,7 @@ defmodule ImagePlug.OriginTest do
           "b\r\nfirst chunk\r\n"
         ])
 
-      Process.sleep(500)
+      Process.sleep(300)
       :gen_tcp.send(socket, "c\r\nsecond chunk\r\n0\r\n\r\n")
       :gen_tcp.close(socket)
       :gen_tcp.close(listen_socket)

--- a/test/image_plug_test.exs
+++ b/test/image_plug_test.exs
@@ -82,6 +82,32 @@ defmodule ImagePlug.ImagePlugTest do
     end
   end
 
+  defmodule InvalidOriginImage do
+    def call(conn, _) do
+      conn
+      |> Plug.Conn.put_resp_content_type("image/png")
+      |> Plug.Conn.send_resp(200, "not actually a png")
+    end
+  end
+
+  defmodule SlowPartialOriginImage do
+    def init(opts), do: opts
+
+    def call(conn, _opts) do
+      body = File.read!("priv/static/images/cat-300.jpg")
+
+      conn =
+        conn
+        |> Plug.Conn.put_resp_content_type("image/jpeg")
+        |> Plug.Conn.send_chunked(200)
+
+      {:ok, conn} = Plug.Conn.chunk(conn, binary_part(body, 0, 128))
+      Process.sleep(250)
+      {:ok, conn} = Plug.Conn.chunk(conn, binary_part(body, 128, byte_size(body) - 128))
+      conn
+    end
+  end
+
   def sample_processing_request do
     %ProcessingRequest{
       signature: "_",
@@ -527,6 +553,49 @@ defmodule ImagePlug.ImagePlugTest do
 
     assert conn.status == 502
     assert conn.resp_body == "error fetching origin image"
+  end
+
+  test "honors max_body_bytes for valid image bytes while streaming into decode" do
+    body = File.read!("priv/static/images/cat-300.jpg")
+
+    conn =
+      conn(:get, "/_/plain/images/large-body.jpg")
+      |> ImagePlug.call(
+        root_url: "http://origin.test",
+        param_parser: ImagePlug.ParamParser.Native,
+        max_body_bytes: byte_size(body) - 1,
+        origin_req_options: [plug: OriginImage]
+      )
+
+    assert conn.status == 502
+    assert conn.resp_body == "error fetching origin image"
+  end
+
+  test "origin timeout while decoding a partial valid image remains an origin error" do
+    conn =
+      conn(:get, "/_/plain/images/slow.jpg")
+      |> ImagePlug.call(
+        root_url: "http://origin.test",
+        param_parser: ImagePlug.ParamParser.Native,
+        origin_receive_timeout: 100,
+        origin_req_options: [plug: SlowPartialOriginImage]
+      )
+
+    assert conn.status == 502
+    assert conn.resp_body == "error fetching origin image"
+  end
+
+  test "invalid streamed image bytes are decode errors" do
+    conn =
+      conn(:get, "/_/plain/images/broken.png")
+      |> ImagePlug.call(
+        root_url: "http://origin.test",
+        param_parser: ImagePlug.ParamParser.Native,
+        origin_req_options: [plug: InvalidOriginImage]
+      )
+
+    assert conn.status == 415
+    assert conn.resp_body == "origin response is not a supported image"
   end
 
   test "cache read errors fail open by default and continue to origin" do

--- a/test/image_plug_test.exs
+++ b/test/image_plug_test.exs
@@ -102,7 +102,7 @@ defmodule ImagePlug.ImagePlugTest do
         |> Plug.Conn.send_chunked(200)
 
       {:ok, conn} = Plug.Conn.chunk(conn, binary_part(body, 0, 128))
-      Process.sleep(250)
+      Process.sleep(100)
       {:ok, conn} = Plug.Conn.chunk(conn, binary_part(body, 128, byte_size(body) - 128))
       conn
     end
@@ -577,7 +577,7 @@ defmodule ImagePlug.ImagePlugTest do
       |> ImagePlug.call(
         root_url: "http://origin.test",
         param_parser: ImagePlug.ParamParser.Native,
-        origin_receive_timeout: 100,
+        origin_receive_timeout: 50,
         origin_req_options: [plug: SlowPartialOriginImage]
       )
 

--- a/test/image_plug_test.exs
+++ b/test/image_plug_test.exs
@@ -522,11 +522,11 @@ defmodule ImagePlug.ImagePlugTest do
     {:ok, image} = Image.new(20, 20, color: :white)
     body = Image.write!(image, :memory, suffix: ".png")
 
-    Req.Test.stub(__MODULE__, fn conn ->
+    plug = fn conn ->
       conn
       |> Plug.Conn.put_resp_content_type("image/png")
       |> Plug.Conn.send_resp(200, body)
-    end)
+    end
 
     conn =
       conn(:get, "/_/w:10/plain/images/large.png")
@@ -534,7 +534,7 @@ defmodule ImagePlug.ImagePlugTest do
         root_url: "http://origin.test",
         param_parser: ImagePlug.ParamParser.Native,
         max_input_pixels: 399,
-        origin_req_options: [plug: {Req.Test, __MODULE__}]
+        origin_req_options: [plug: plug]
       )
 
     assert conn.status == 413


### PR DESCRIPTION
## Summary
- Replace full-body origin buffering with a repo-owned guarded Req stream that preserves status, content-type, timeout, redirect, and byte-limit behavior.
- Decode the origin response through `Image.open/2` while keeping origin failures distinct from decode failures.
- Add regression coverage for streamed byte limits, partial/slow origin responses, unconsumed stream cancellation, and lifecycle cleanup.

## Testing
- `mise exec -- mix test` passed.
- Added focused unit/integration coverage for origin streaming, timeout handling, close/cancel behavior, and decode/error mapping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented streaming image fetch pipeline enabling incremental data consumption and cancellation support.
  * Added APIs to check stream errors and explicitly close origin image streams.

* **Bug Fixes**
  * Enhanced error handling during streaming to properly detect and report size limit violations, timeouts, and invalid content-type mismatches.

* **Tests**
  * Added comprehensive streaming validation tests covering timeout scenarios, size limit enforcement, and error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->