### PR TITLE
Split runtime responsibilities into Request, Origin, and Response namespaces

### DIFF
--- a/lib/image_plug.ex
+++ b/lib/image_plug.ex
@@ -5,9 +5,11 @@ defmodule ImagePlug do
 
   use Boundary,
     deps: [
+      ImagePlug.Origin,
       ImagePlug.Parser,
       ImagePlug.Plan,
-      ImagePlug.Runtime,
+      ImagePlug.Request,
+      ImagePlug.Response,
       ImagePlug.Transform
     ],
     exports: []
@@ -15,10 +17,10 @@ defmodule ImagePlug do
   @behaviour Plug
 
   alias ImagePlug.Plan
-  alias ImagePlug.Runtime.Options
-  alias ImagePlug.Runtime.RequestRunner
-  alias ImagePlug.Runtime.ResponseSender
-  alias ImagePlug.Runtime.SourceIdentity
+  alias ImagePlug.Request.Options
+  alias ImagePlug.Request.Runner
+  alias ImagePlug.Response.Sender
+  alias ImagePlug.Origin.Identity
   alias ImagePlug.Transform
 
   @impl Plug
@@ -30,18 +32,18 @@ defmodule ImagePlug do
 
     with {:ok, %Plan{} = plan} <- parser.parse(conn, opts) |> wrap_parser_error(),
          {:ok, %Plan{} = plan} <- validate_client_plan(plan),
-         {:ok, origin_identity} <- SourceIdentity.resolve(plan, opts) |> wrap_origin_error() do
-      result = RequestRunner.run(conn, plan, origin_identity, opts)
-      ResponseSender.send_result(conn, result, opts)
+         {:ok, origin_identity} <- Identity.resolve(plan, opts) |> wrap_origin_error() do
+      result = Runner.run(conn, plan, origin_identity, opts)
+      Sender.send_result(conn, result, opts)
     else
       {:error, {:parser, error}} ->
         parser.handle_error(conn, error)
 
       {:error, {:plan_validation, error}} ->
-        ResponseSender.send_result(conn, {:error, {:processing, error, []}}, opts)
+        Sender.send_result(conn, {:error, {:processing, error, []}}, opts)
 
       {:error, {:origin, error}} ->
-        ResponseSender.send_origin_error(conn, error)
+        Sender.send_origin_error(conn, error)
     end
   end
 

--- a/lib/image_plug/origin.ex
+++ b/lib/image_plug/origin.ex
@@ -1,4 +1,4 @@
-defmodule ImagePlug.Runtime.Origin do
+defmodule ImagePlug.Origin do
   @moduledoc """
   Origin URL construction and minimal Req-backed HTTP streaming.
 
@@ -7,6 +7,15 @@ defmodule ImagePlug.Runtime.Origin do
   enumerates the body, which is required because libvips consumes source
   enumerables outside the request process.
   """
+
+  use Boundary,
+    top_level?: true,
+    deps: [ImagePlug.Plan],
+    exports: [
+      Decoded,
+      Identity,
+      Response
+    ]
 
   defmodule Response do
     @moduledoc false

--- a/lib/image_plug/origin/decoded.ex
+++ b/lib/image_plug/origin/decoded.ex
@@ -1,4 +1,4 @@
-defmodule ImagePlug.Runtime.DecodedOrigin do
+defmodule ImagePlug.Origin.Decoded do
   @moduledoc false
 
   @enforce_keys [:decode_options, :image, :source_format]

--- a/lib/image_plug/origin/identity.ex
+++ b/lib/image_plug/origin/identity.ex
@@ -1,8 +1,8 @@
-defmodule ImagePlug.Runtime.SourceIdentity do
+defmodule ImagePlug.Origin.Identity do
   @moduledoc false
 
   alias ImagePlug.Plan
-  alias ImagePlug.Runtime.Origin
+  alias ImagePlug.Origin
 
   @spec resolve(Plan.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
   def resolve(%Plan{source: {:plain, source_path}}, opts) do

--- a/lib/image_plug/request.ex
+++ b/lib/image_plug/request.ex
@@ -1,0 +1,18 @@
+defmodule ImagePlug.Request do
+  @moduledoc false
+
+  use Boundary,
+    top_level?: true,
+    deps: [
+      ImagePlug.Plan,
+      ImagePlug.Cache,
+      ImagePlug.Origin,
+      ImagePlug.Output,
+      ImagePlug.Response,
+      ImagePlug.Transform
+    ],
+    exports: [
+      Options,
+      Runner
+    ]
+end

--- a/lib/image_plug/request/options.ex
+++ b/lib/image_plug/request/options.ex
@@ -1,4 +1,4 @@
-defmodule ImagePlug.Runtime.Options do
+defmodule ImagePlug.Request.Options do
   @moduledoc false
 
   alias ImagePlug.Cache

--- a/lib/image_plug/request/processor.ex
+++ b/lib/image_plug/request/processor.ex
@@ -1,9 +1,9 @@
-defmodule ImagePlug.Runtime.Processor do
+defmodule ImagePlug.Request.Processor do
   @moduledoc false
 
   alias ImagePlug.Plan
-  alias ImagePlug.Runtime.DecodedOrigin
-  alias ImagePlug.Runtime.Origin
+  alias ImagePlug.Origin.Decoded
+  alias ImagePlug.Origin
   alias ImagePlug.Transform
   alias ImagePlug.Transform.DecodePlanner
   alias ImagePlug.Transform.Materializer
@@ -15,14 +15,14 @@ defmodule ImagePlug.Runtime.Processor do
   @spec process_origin(Plan.t(), String.t(), keyword()) ::
           {:ok, State.t()} | {:error, term()}
   def process_origin(%Plan{} = plan, origin_identity, opts) do
-    with {:ok, %DecodedOrigin{} = decoded} <-
+    with {:ok, %Decoded{} = decoded} <-
            fetch_decode_validate_origin_with_source_format(plan, origin_identity, opts) do
       process_decoded_origin(decoded, plan, opts)
     end
   end
 
   @spec fetch_decode_validate_origin_with_source_format(Plan.t(), String.t(), keyword()) ::
-          {:ok, DecodedOrigin.t()} | {:error, term()}
+          {:ok, Decoded.t()} | {:error, term()}
   def fetch_decode_validate_origin_with_source_format(%Plan{} = plan, origin_identity, opts) do
     with {:ok, origin_response} <- fetch_origin(plan, origin_identity, opts) do
       decode_validate_origin_response(origin_response, plan, opts)
@@ -30,7 +30,7 @@ defmodule ImagePlug.Runtime.Processor do
   end
 
   @spec decode_validate_origin_response(Origin.Response.t(), Plan.t(), keyword()) ::
-          {:ok, DecodedOrigin.t()} | {:error, term()}
+          {:ok, Decoded.t()} | {:error, term()}
   def decode_validate_origin_response(%Origin.Response{} = origin_response, %Plan{} = plan, opts) do
     decode_options = DecodePlanner.open_options(first_pipeline_operations(plan))
 
@@ -41,7 +41,7 @@ defmodule ImagePlug.Runtime.Processor do
       source_format = source_format(image)
 
       {:ok,
-       %DecodedOrigin{
+       %Decoded{
          decode_options: decode_options,
          image: image,
          source_format: source_format
@@ -49,9 +49,9 @@ defmodule ImagePlug.Runtime.Processor do
     end
   end
 
-  @spec process_decoded_origin(DecodedOrigin.t(), Plan.t(), keyword()) ::
+  @spec process_decoded_origin(Decoded.t(), Plan.t(), keyword()) ::
           {:ok, State.t()} | {:error, term()}
-  def process_decoded_origin(%DecodedOrigin{} = decoded, %Plan{} = plan, opts) do
+  def process_decoded_origin(%Decoded{} = decoded, %Plan{} = plan, opts) do
     with {:ok, final_state} <-
            execute_plan_pipelines(%State{image: decoded.image}, plan, opts) do
       materialize_before_delivery(final_state, decoded.decode_options, opts)

--- a/lib/image_plug/request/runner.ex
+++ b/lib/image_plug/request/runner.ex
@@ -1,4 +1,4 @@
-defmodule ImagePlug.Runtime.RequestRunner do
+defmodule ImagePlug.Request.Runner do
   @moduledoc false
 
   alias ImagePlug.Cache
@@ -10,8 +10,8 @@ defmodule ImagePlug.Runtime.RequestRunner do
   alias ImagePlug.Plan
   alias ImagePlug.Plan.Output
   alias ImagePlug.Plan.Response
-  alias ImagePlug.Runtime.DecodedOrigin
-  alias ImagePlug.Runtime.Processor
+  alias ImagePlug.Origin.Decoded
+  alias ImagePlug.Request.Processor
   alias ImagePlug.Transform
   alias ImagePlug.Transform.State
 
@@ -216,7 +216,7 @@ defmodule ImagePlug.Runtime.RequestRunner do
 
   defp process_source_format_automatic(plan, origin_identity, opts, policy) do
     case Processor.fetch_decode_validate_origin_with_source_format(plan, origin_identity, opts) do
-      {:ok, %DecodedOrigin{} = decoded} ->
+      {:ok, %Decoded{} = decoded} ->
         resolve_source_format_automatic(decoded, plan, opts, policy)
 
       {:error, error} ->
@@ -224,7 +224,7 @@ defmodule ImagePlug.Runtime.RequestRunner do
     end
   end
 
-  defp resolve_source_format_automatic(%DecodedOrigin{} = decoded, plan, opts, policy) do
+  defp resolve_source_format_automatic(%Decoded{} = decoded, plan, opts, policy) do
     case Policy.resolve(policy, decoded.source_format) do
       {:ok, %Resolved{} = resolved_output} ->
         process_decoded_origin_with_output(decoded, plan, opts, resolved_output)

--- a/lib/image_plug/response.ex
+++ b/lib/image_plug/response.ex
@@ -1,19 +1,15 @@
-defmodule ImagePlug.Runtime do
+defmodule ImagePlug.Response do
   @moduledoc false
 
   use Boundary,
     top_level?: true,
     deps: [
-      ImagePlug.Plan,
       ImagePlug.Cache,
       ImagePlug.Output,
+      ImagePlug.Plan,
       ImagePlug.Transform
     ],
     exports: [
-      RequestRunner,
-      Origin,
-      ResponseSender,
-      SourceIdentity,
-      Options
+      Sender
     ]
 end

--- a/lib/image_plug/response/sender.ex
+++ b/lib/image_plug/response/sender.ex
@@ -1,4 +1,4 @@
-defmodule ImagePlug.Runtime.ResponseSender do
+defmodule ImagePlug.Response.Sender do
   @moduledoc false
 
   import Plug.Conn,
@@ -17,8 +17,15 @@ defmodule ImagePlug.Runtime.ResponseSender do
   alias ImagePlug.Output.Format
   alias ImagePlug.Output.Resolved
   alias ImagePlug.Plan.Response
-  alias ImagePlug.Runtime.RequestRunner
   alias ImagePlug.Transform.State
+
+  @type delivery() ::
+          {:cache_entry, Entry.t(), Response.t()}
+          | {:image, State.t(), Resolved.t(), Response.t()}
+
+  @type error() ::
+          {:cache, term()}
+          | {:processing, term(), [{String.t(), String.t()}]}
 
   @plan_validation_error_tags [
     :unsupported_source,
@@ -33,8 +40,8 @@ defmodule ImagePlug.Runtime.ResponseSender do
 
   @spec send_result(
           Plug.Conn.t(),
-          {:ok, RequestRunner.delivery()}
-          | {:error, RequestRunner.error()},
+          {:ok, delivery()}
+          | {:error, error()},
           keyword()
         ) :: Plug.Conn.t()
   def send_result(

--- a/test/image_plug/architecture_boundary_test.exs
+++ b/test/image_plug/architecture_boundary_test.exs
@@ -1,7 +1,14 @@
 defmodule ImagePlug.ArchitectureBoundaryTest do
   use ExUnit.Case, async: true
 
-  @runtime_globs ["lib/image_plug/runtime.ex", "lib/image_plug/runtime/**/*.ex"]
+  @request_origin_response_globs [
+    "lib/image_plug/request.ex",
+    "lib/image_plug/request/**/*.ex",
+    "lib/image_plug/origin.ex",
+    "lib/image_plug/origin/**/*.ex",
+    "lib/image_plug/response.ex",
+    "lib/image_plug/response/**/*.ex"
+  ]
   @imgproxy_parser_globs [
     "lib/image_plug/parser/imgproxy.ex",
     "lib/image_plug/parser/imgproxy/**/*.ex"
@@ -9,9 +16,11 @@ defmodule ImagePlug.ArchitectureBoundaryTest do
   @cache_key_files ["lib/image_plug/cache/key.ex"]
   @boundary_files %{
     ImagePlug.Cache => "lib/image_plug/cache.ex",
+    ImagePlug.Origin => "lib/image_plug/origin.ex",
     ImagePlug.Parser => "lib/image_plug/parser.ex",
     ImagePlug.Parser.Imgproxy => "lib/image_plug/parser/imgproxy.ex",
-    ImagePlug.Runtime => "lib/image_plug/runtime.ex",
+    ImagePlug.Request => "lib/image_plug/request.ex",
+    ImagePlug.Response => "lib/image_plug/response.ex",
     ImagePlug.Transform => "lib/image_plug/transform.ex"
   }
   @concrete_plan_names [
@@ -63,25 +72,109 @@ defmodule ImagePlug.ArchitectureBoundaryTest do
     assert_allowed_deps(imgproxy, [ImagePlug.Parser, ImagePlug.Plan, ImagePlug.Transform])
   end
 
-  test "runtime boundary declaration depends on generic facades only" do
-    runtime = boundary_declaration(ImagePlug.Runtime)
+  test "request boundary declaration depends on generic facades only" do
+    request = boundary_declaration(ImagePlug.Request)
 
-    assert_boundary_deps(runtime, [
+    assert_boundary_deps(request, [
       ImagePlug.Plan,
       ImagePlug.Cache,
+      ImagePlug.Origin,
       ImagePlug.Output,
+      ImagePlug.Response,
       ImagePlug.Transform
     ])
 
-    refute_boundary_deps(runtime, [ImagePlug.Parser | concrete_transform_modules()])
+    refute_boundary_deps(request, [ImagePlug.Parser | concrete_transform_modules()])
 
-    assert_boundary_exports(runtime, [
-      ImagePlug.Runtime.RequestRunner,
-      ImagePlug.Runtime.Origin,
-      ImagePlug.Runtime.ResponseSender,
-      ImagePlug.Runtime.SourceIdentity,
-      ImagePlug.Runtime.Options
+    assert_boundary_exports(request, [
+      ImagePlug.Request.Options,
+      ImagePlug.Request.Runner
     ])
+  end
+
+  test "origin boundary owns origin identity and fetch context" do
+    origin = boundary_declaration(ImagePlug.Origin)
+
+    assert_boundary_deps(origin, [ImagePlug.Plan])
+    refute_boundary_deps(origin, [ImagePlug.Request, ImagePlug.Response, ImagePlug.Cache])
+
+    assert_boundary_exports(origin, [
+      ImagePlug.Origin.Decoded,
+      ImagePlug.Origin.Identity,
+      ImagePlug.Origin.Response
+    ])
+  end
+
+  test "response boundary owns plug response delivery" do
+    response = boundary_declaration(ImagePlug.Response)
+
+    assert_boundary_deps(response, [
+      ImagePlug.Cache,
+      ImagePlug.Output,
+      ImagePlug.Plan,
+      ImagePlug.Transform
+    ])
+
+    refute_boundary_deps(response, [ImagePlug.Request, ImagePlug.Origin])
+
+    assert_boundary_exports(response, [
+      ImagePlug.Response.Sender
+    ])
+  end
+
+  test "old Runtime namespace files are gone" do
+    refute File.exists?("lib/image_plug/runtime.ex")
+    assert Path.wildcard("lib/image_plug/runtime/**/*.ex") == []
+  end
+
+  test "request, origin, and response code does not depend on concrete transform modules" do
+    violations =
+      for file <- request_origin_response_files(),
+          violation <- concrete_transform_references(file) do
+        "#{file}:#{violation.line} must not name #{violation.module}; use ImagePlug.Transform dispatch instead"
+      end
+
+    assert violations == []
+  end
+
+  test "request, origin, and response code does not depend on concrete plan operation modules" do
+    violations =
+      for file <- request_origin_response_files(),
+          violation <- concrete_plan_references(file) do
+        "#{file}:#{violation.line} must not name #{violation.module}; use generic Plan/Transform facades instead"
+      end
+
+    assert violations == []
+  end
+
+  test "request, origin, and response code does not inspect plan operation semantic staging" do
+    violations =
+      for file <- request_origin_response_files(),
+          violation <- plan_operation_semantic_references(file) do
+        "#{file}:#{violation.line} must not call #{violation.module}.semantic?/1; use ImagePlug.Transform executable planning instead"
+      end
+
+    assert violations == []
+  end
+
+  test "request, origin, and response code does not call removed or internal transform execution APIs" do
+    violations =
+      for file <- request_origin_response_files(),
+          violation <- runtime_forbidden_transform_execution_references(file) do
+        "#{file}:#{violation.line} must not use #{violation.module}; execute canonical plans through ImagePlug.Transform.execute_plan/3"
+      end
+
+    assert violations == []
+  end
+
+  test "request, origin, and response code does not depend on imgproxy parser structs" do
+    violations =
+      for file <- request_origin_response_files(),
+          violation <- imgproxy_parser_references(file) do
+        "#{file}:#{violation.line} must not name #{violation.module}; keep Imgproxy parser dependencies out of request, origin, and response code"
+      end
+
+    assert violations == []
   end
 
   test "cache boundary declaration avoids post-fetch transform state dependencies" do
@@ -109,7 +202,10 @@ defmodule ImagePlug.ArchitectureBoundaryTest do
 
     refute_boundary_deps(transform, [
       ImagePlug.Parser,
-      ImagePlug.Runtime,
+      ImagePlug.Request.Runner,
+      ImagePlug.Request,
+      ImagePlug.Origin,
+      ImagePlug.Response,
       ImagePlug.Cache,
       ImagePlug.Output
     ])
@@ -127,56 +223,6 @@ defmodule ImagePlug.ArchitectureBoundaryTest do
       ImagePlug.Transform.Operation.Flip,
       ImagePlug.Transform.Operation.Crop
     ])
-  end
-
-  test "runtime does not depend on concrete transform modules" do
-    violations =
-      for file <- runtime_files(),
-          violation <- concrete_transform_references(file) do
-        "#{file}:#{violation.line} must not name #{violation.module}; use ImagePlug.Transform dispatch instead"
-      end
-
-    assert violations == []
-  end
-
-  test "runtime does not depend on concrete plan operation modules" do
-    violations =
-      for file <- runtime_files(),
-          violation <- concrete_plan_references(file) do
-        "#{file}:#{violation.line} must not name #{violation.module}; use generic Plan/Transform facades instead"
-      end
-
-    assert violations == []
-  end
-
-  test "runtime does not inspect plan operation semantic staging" do
-    violations =
-      for file <- runtime_files(),
-          violation <- plan_operation_semantic_references(file) do
-        "#{file}:#{violation.line} must not call #{violation.module}.semantic?/1; use ImagePlug.Transform executable planning instead"
-      end
-
-    assert violations == []
-  end
-
-  test "runtime does not call removed or internal transform execution APIs" do
-    violations =
-      for file <- runtime_files(),
-          violation <- runtime_forbidden_transform_execution_references(file) do
-        "#{file}:#{violation.line} must not use #{violation.module}; execute canonical plans through ImagePlug.Transform.execute_plan/3"
-      end
-
-    assert violations == []
-  end
-
-  test "runtime does not depend on imgproxy parser structs" do
-    violations =
-      for file <- runtime_files(),
-          violation <- imgproxy_parser_references(file) do
-        "#{file}:#{violation.line} must not name #{violation.module}; keep Imgproxy parser dependencies out of runtime"
-      end
-
-    assert violations == []
   end
 
   test "cache key construction does not depend on post-fetch transform execution state" do
@@ -200,8 +246,8 @@ defmodule ImagePlug.ArchitectureBoundaryTest do
     assert violations == []
   end
 
-  defp runtime_files do
-    @runtime_globs
+  defp request_origin_response_files do
+    @request_origin_response_globs
     |> Enum.flat_map(&Path.wildcard/1)
     |> Enum.sort()
   end

--- a/test/image_plug/origin_test.exs
+++ b/test/image_plug/origin_test.exs
@@ -1,7 +1,7 @@
-defmodule ImagePlug.Runtime.OriginTest do
+defmodule ImagePlug.OriginTest do
   use ExUnit.Case, async: false
 
-  alias ImagePlug.Runtime.Origin
+  alias ImagePlug.Origin
 
   test "build_url encodes and joins path segments" do
     assert Origin.build_url("https://img.example/base", ["images", "cat 1.jpg"]) ==

--- a/test/image_plug/processor_test.exs
+++ b/test/image_plug/processor_test.exs
@@ -1,17 +1,17 @@
-defmodule ImagePlug.Runtime.ProcessorTest do
+defmodule ImagePlug.Request.ProcessorTest do
   use ExUnit.Case, async: true
 
   alias ImagePlug.Plan
   alias ImagePlug.Plan.Operation
   alias ImagePlug.Plan.Output
   alias ImagePlug.Plan.Pipeline
-  alias ImagePlug.Runtime.DecodedOrigin
-  alias ImagePlug.Runtime.Origin
-  alias ImagePlug.Runtime.Processor
-  alias ImagePlug.Runtime.ProcessorTest.DecodeErrorImageOpen
-  alias ImagePlug.Runtime.ProcessorTest.DecodeValidImageOpen
-  alias ImagePlug.Runtime.ProcessorTest.Materializer
-  alias ImagePlug.Runtime.ProcessorTest.OriginImage
+  alias ImagePlug.Origin.Decoded
+  alias ImagePlug.Origin
+  alias ImagePlug.Request.Processor
+  alias ImagePlug.Request.ProcessorTest.DecodeErrorImageOpen
+  alias ImagePlug.Request.ProcessorTest.DecodeValidImageOpen
+  alias ImagePlug.Request.ProcessorTest.Materializer
+  alias ImagePlug.Request.ProcessorTest.OriginImage
   alias ImagePlug.Transform.State
 
   defp opts do
@@ -59,7 +59,7 @@ defmodule ImagePlug.Runtime.ProcessorTest do
   end
 
   test "fetch_decode_validate_origin_with_source_format accepts plain plan sources" do
-    assert {:ok, %DecodedOrigin{} = decoded} =
+    assert {:ok, %Decoded{} = decoded} =
              fetch_decode_validate_origin_with_source_format(
                plan(),
                "http://origin.test/images/cat-300.jpg",
@@ -111,7 +111,7 @@ defmodule ImagePlug.Runtime.ProcessorTest do
       output: %Output{mode: {:explicit, :jpeg}}
     }
 
-    assert {:ok, %DecodedOrigin{} = decoded} =
+    assert {:ok, %Decoded{} = decoded} =
              fetch_decode_validate_origin_with_source_format(
                plan,
                "http://origin.test/images/cat-300.jpg",

--- a/test/image_plug/request_options_test.exs
+++ b/test/image_plug/request_options_test.exs
@@ -1,7 +1,7 @@
-defmodule ImagePlug.RuntimeOptionsTest do
+defmodule ImagePlug.RequestOptionsTest do
   use ExUnit.Case, async: true
 
-  alias ImagePlug.Runtime.Options
+  alias ImagePlug.Request.Options
 
   @base_opts [
     parser: ImagePlug.Parser.Imgproxy,

--- a/test/image_plug/request_runner_test.exs
+++ b/test/image_plug/request_runner_test.exs
@@ -1,4 +1,4 @@
-defmodule ImagePlug.Runtime.RequestRunnerTest do
+defmodule ImagePlug.Request.RunnerTest do
   use ExUnit.Case, async: true
 
   import Plug.Test
@@ -11,7 +11,7 @@ defmodule ImagePlug.Runtime.RequestRunnerTest do
   alias ImagePlug.Plan.Output
   alias ImagePlug.Plan.Pipeline
   alias ImagePlug.Plan.Response
-  alias ImagePlug.Runtime.RequestRunner
+  alias ImagePlug.Request.Runner
   alias ImagePlug.Transform.State
 
   defmodule CacheHit do
@@ -150,7 +150,7 @@ defmodule ImagePlug.Runtime.RequestRunnerTest do
     }
 
     assert {:ok, {:cache_entry, ^entry, %Response{}}} =
-             RequestRunner.run(
+             Runner.run(
                conn(:get, "/_/f:jpeg/plain/images/cat-300.jpg"),
                plan(),
                "http://origin.test/images/cat-300.jpg",
@@ -172,7 +172,7 @@ defmodule ImagePlug.Runtime.RequestRunnerTest do
       |> Plug.Conn.put_req_header("accept", "image/jpeg")
 
     assert {:ok, {:cache_entry, ^entry, %ImagePlug.Plan.Response{}}} =
-             RequestRunner.run(
+             Runner.run(
                conn,
                plan(output: %Output{mode: :automatic}),
                "http://origin.test/images/cat-300.jpg",
@@ -195,7 +195,7 @@ defmodule ImagePlug.Runtime.RequestRunnerTest do
              )
 
     assert {:ok, {:cache_entry, ^entry, %ImagePlug.Plan.Response{}}} =
-             RequestRunner.run(
+             Runner.run(
                conn(:get, "/_/rt:auto/w:100/h:100/f:jpeg/plain/images/cat-300.jpg"),
                plan(pipelines: [%Pipeline{operations: [operation]}]),
                "origin-version-1",
@@ -224,7 +224,7 @@ defmodule ImagePlug.Runtime.RequestRunnerTest do
              )
 
     assert {:ok, {:cache_entry, %Entry{content_type: "image/jpeg"}, %ImagePlug.Plan.Response{}}} =
-             RequestRunner.run(
+             Runner.run(
                conn(:get, "/_/rt:auto/w:100/h:100/f:jpeg/plain/images/cat-300.jpg"),
                plan(pipelines: [%Pipeline{operations: [operation]}]),
                "http://origin.test/images/cat-300.jpg",
@@ -253,7 +253,7 @@ defmodule ImagePlug.Runtime.RequestRunnerTest do
     }
 
     assert {:error, {:processing, :empty_pipeline_plan, []}} =
-             RequestRunner.run(
+             Runner.run(
                conn(:get, "/_/f:jpeg/plain/images/cat-300.jpg"),
                plan(pipelines: []),
                "http://origin.test/images/cat-300.jpg",
@@ -272,7 +272,7 @@ defmodule ImagePlug.Runtime.RequestRunnerTest do
     }
 
     assert {:error, {:processing, {:invalid_pipeline_plan, [:not_a_pipeline]}, []}} =
-             RequestRunner.run(
+             Runner.run(
                conn(:get, "/_/f:jpeg/plain/images/cat-300.jpg"),
                plan(pipelines: [:not_a_pipeline]),
                "http://origin.test/images/cat-300.jpg",
@@ -291,7 +291,7 @@ defmodule ImagePlug.Runtime.RequestRunnerTest do
     }
 
     assert {:error, {:processing, {:invalid_pipeline_operation, :not_operation}, []}} =
-             RequestRunner.run(
+             Runner.run(
                conn(:get, "/_/f:jpeg/plain/images/cat-300.jpg"),
                plan(pipelines: [%Pipeline{operations: [:not_operation]}]),
                "http://origin.test/images/cat-300.jpg",
@@ -303,7 +303,7 @@ defmodule ImagePlug.Runtime.RequestRunnerTest do
 
   test "invalid cache config returns cache errors before cache lookup" do
     assert {:error, {:cache, {:invalid_cache_config, {:fail_on_cache_error, "false"}}}} =
-             RequestRunner.run(
+             Runner.run(
                conn(:get, "/_/f:jpeg/plain/images/cat-300.jpg"),
                plan(),
                "http://origin.test/images/cat-300.jpg",
@@ -336,7 +336,7 @@ defmodule ImagePlug.Runtime.RequestRunnerTest do
             {:image, %State{} = state,
              %Resolved{format: :jpeg, quality: :default, representation_headers: []},
              %ImagePlug.Plan.Response{}}} =
-             RequestRunner.run(
+             Runner.run(
                conn(:get, "/_/f:jpeg/plain/images/cat-300.jpg"),
                plan,
                "http://origin.test/images/cat-300.jpg",
@@ -362,7 +362,7 @@ defmodule ImagePlug.Runtime.RequestRunnerTest do
             {:image, %State{},
              %Resolved{format: :webp, quality: {:quality, 70}, representation_headers: []},
              %ImagePlug.Plan.Response{}}} =
-             RequestRunner.run(
+             Runner.run(
                conn(:get, "/_/f:webp/fq:webp:70/plain/images/cat-300.jpg"),
                plan,
                "http://origin.test/images/cat-300.jpg",
@@ -383,7 +383,7 @@ defmodule ImagePlug.Runtime.RequestRunnerTest do
     plan = plan(pipelines: [%Pipeline{operations: operations}])
 
     assert {:ok, {:cache_entry, ^entry, %ImagePlug.Plan.Response{}}} =
-             RequestRunner.run(
+             Runner.run(
                conn(:get, "/_/f:jpeg/plain/images/cat-300.jpg"),
                plan,
                "http://origin.test/images/cat-300.jpg",
@@ -420,7 +420,7 @@ defmodule ImagePlug.Runtime.RequestRunnerTest do
     }
 
     assert {:ok, {:image, %State{}, %ImagePlug.Output.Resolved{}, ^response}} =
-             RequestRunner.run(
+             Runner.run(
                conn(:get, "/_/f:jpeg/plain/images/cat-300.jpg"),
                plan(response: response),
                "http://origin.test/images/cat-300.jpg",
@@ -435,7 +435,7 @@ defmodule ImagePlug.Runtime.RequestRunnerTest do
     }
 
     assert {:ok, {:cache_entry, ^entry, ^response}} =
-             RequestRunner.run(
+             Runner.run(
                conn(:get, "/_/f:jpeg/plain/images/cat-300.jpg"),
                plan(response: response),
                "http://origin.test/images/cat-300.jpg",
@@ -457,7 +457,7 @@ defmodule ImagePlug.Runtime.RequestRunnerTest do
     }
 
     assert {:ok, {:cache_entry, %Entry{content_type: "image/jpeg"}, ^response}} =
-             RequestRunner.run(
+             Runner.run(
                conn(:get, "/_/f:jpeg/plain/images/cat-300.jpg"),
                plan(response: response),
                "http://origin.test/images/cat-300.jpg",
@@ -470,7 +470,7 @@ defmodule ImagePlug.Runtime.RequestRunnerTest do
     refute_received {:cache_lookup, _another_key}
 
     assert {:error, {:cache, {:unsupported_delivery_content_type, "image/gif"}}} =
-             RequestRunner.run(
+             Runner.run(
                conn(:get, "/_/f:jpeg/plain/images/cat-300.jpg"),
                plan(response: response),
                "http://origin.test/images/cat-300.jpg",
@@ -481,7 +481,7 @@ defmodule ImagePlug.Runtime.RequestRunnerTest do
   test "output policy uses output plans without a processing request bridge" do
     request_runner_source =
       __DIR__
-      |> Path.join("../../lib/image_plug/runtime/request_runner.ex")
+      |> Path.join("../../lib/image_plug/request/runner.ex")
       |> Path.expand()
       |> File.read!()
 

--- a/test/image_plug/request_safety_test.exs
+++ b/test/image_plug/request_safety_test.exs
@@ -23,7 +23,7 @@ defmodule ImagePlug.RequestSafetyTest do
         parser: InvalidPlanParser,
         root_url: "not-a-valid-origin-url",
         cache: {CacheProbe, []},
-        origin_req_options: [plug: ImagePlug.Runtime.ProcessorTest.OriginShouldNotFetch]
+        origin_req_options: [plug: ImagePlug.Request.ProcessorTest.OriginShouldNotFetch]
       )
 
     assert conn.status == 422
@@ -38,7 +38,7 @@ defmodule ImagePlug.RequestSafetyTest do
         parser: InvalidPipelinePlanParser,
         root_url: "not-a-valid-origin-url",
         cache: {CacheProbe, []},
-        origin_req_options: [plug: ImagePlug.Runtime.ProcessorTest.OriginShouldNotFetch]
+        origin_req_options: [plug: ImagePlug.Request.ProcessorTest.OriginShouldNotFetch]
       )
 
     assert conn.status == 422
@@ -52,7 +52,7 @@ defmodule ImagePlug.RequestSafetyTest do
       ImagePlug.call(conn(:get, "/_/raw/plain/images/cat.jpg"),
         parser: ImagePlug.Parser.Imgproxy,
         root_url: "http://origin.test",
-        origin_req_options: [plug: ImagePlug.Runtime.ProcessorTest.OriginShouldNotFetch]
+        origin_req_options: [plug: ImagePlug.Request.ProcessorTest.OriginShouldNotFetch]
       )
 
     assert conn.status == 400
@@ -65,7 +65,7 @@ defmodule ImagePlug.RequestSafetyTest do
         root_url: "not-a-valid-origin-url",
         clock: fn -> DateTime.from_unix!(101) end,
         cache: {CacheProbe, []},
-        origin_req_options: [plug: ImagePlug.Runtime.ProcessorTest.OriginShouldNotFetch]
+        origin_req_options: [plug: ImagePlug.Request.ProcessorTest.OriginShouldNotFetch]
       )
 
     assert conn.status == 400

--- a/test/image_plug/response_sender_test.exs
+++ b/test/image_plug/response_sender_test.exs
@@ -1,11 +1,11 @@
-defmodule ImagePlug.Runtime.ResponseSenderTest do
+defmodule ImagePlug.Response.SenderTest do
   use ExUnit.Case, async: true
 
   import Plug.Test
 
   alias ImagePlug.Cache.Entry
   alias ImagePlug.Plan.Response
-  alias ImagePlug.Runtime.ResponseSender
+  alias ImagePlug.Response.Sender
 
   test "cache hits apply content disposition from plan response" do
     entry = %Entry{
@@ -18,7 +18,7 @@ defmodule ImagePlug.Runtime.ResponseSenderTest do
     response = %Response{disposition: :attachment, filename: "report"}
 
     conn =
-      ResponseSender.send_result(conn(:get, "/image"), {:ok, {:cache_entry, entry, response}}, [])
+      Sender.send_result(conn(:get, "/image"), {:ok, {:cache_entry, entry, response}}, [])
 
     assert conn.status == 200
 
@@ -39,7 +39,7 @@ defmodule ImagePlug.Runtime.ResponseSenderTest do
     response = %Response{disposition: :inline, filename: "miss"}
 
     conn =
-      ResponseSender.send_result(
+      Sender.send_result(
         conn(:get, "/image"),
         {:ok, {:image, state, resolved, response}},
         image_module: Image

--- a/test/image_plug/sequential_compatibility_test.exs
+++ b/test/image_plug/sequential_compatibility_test.exs
@@ -1,7 +1,7 @@
 defmodule ImagePlug.SequentialCompatibilityTest do
   use ExUnit.Case, async: true
 
-  alias ImagePlug.Runtime.Origin
+  alias ImagePlug.Origin
   alias ImagePlug.Transform.Chain
   alias ImagePlug.Transform.Materializer
   alias ImagePlug.Transform.Operation.AutoOrient

--- a/test/image_plug/transform_ir_characterization_test.exs
+++ b/test/image_plug/transform_ir_characterization_test.exs
@@ -9,7 +9,7 @@ defmodule ImagePlug.TransformIRCharacterizationTest do
   alias ImagePlug.Plan.Operation
   alias ImagePlug.Plan.Output
   alias ImagePlug.Plan.Pipeline
-  alias ImagePlug.Runtime.RequestRunner
+  alias ImagePlug.Request.Runner
   alias ImagePlug.Transform
   alias ImagePlug.Transform.Chain
   alias ImagePlug.Transform.Operation.Crop
@@ -62,7 +62,7 @@ defmodule ImagePlug.TransformIRCharacterizationTest do
     origin_identity = origin_identity(source)
 
     assert {:ok, {:image, %State{image: image}, _resolved_output, _response}} =
-             RequestRunner.run(
+             Runner.run(
                conn,
                plan,
                origin_identity,
@@ -199,7 +199,7 @@ defmodule ImagePlug.TransformIRCharacterizationTest do
     origin_identity = origin_identity(source)
 
     assert {:ok, {:cache_entry, ^entry, %ImagePlug.Plan.Response{}}} =
-             RequestRunner.run(
+             Runner.run(
                conn,
                plan,
                origin_identity,

--- a/test/image_plug_test.exs
+++ b/test/image_plug_test.exs
@@ -467,7 +467,7 @@ defmodule ImagePlug.ImagePlugTest do
     assert Keyword.fetch!(opts, :parser) == ImagePlug.ImagePlugTest.MissingParser
   end
 
-  test "plug facade delegates response delivery to runtime response sender" do
+  test "plug facade delegates response delivery to response sender" do
     image_plug_ast =
       __DIR__
       |> Path.join("../lib/image_plug.ex")
@@ -475,8 +475,8 @@ defmodule ImagePlug.ImagePlugTest do
       |> File.read!()
       |> Code.string_to_quoted!()
 
-    assert remote_call?(image_plug_ast, [:ResponseSender], :send_result, 3)
-    assert remote_call?(image_plug_ast, [:ResponseSender], :send_origin_error, 2)
+    assert remote_call?(image_plug_ast, [:Sender], :send_result, 3)
+    assert remote_call?(image_plug_ast, [:Sender], :send_origin_error, 2)
 
     refute remote_call?(image_plug_ast, [:Plug, :Conn], :send_resp)
     refute remote_call?(image_plug_ast, [:Plug, :Conn], :send_chunked)
@@ -488,9 +488,11 @@ defmodule ImagePlug.ImagePlugTest do
     assert boundary_option(image_plug_ast, :exports) == []
 
     assert boundary_option(image_plug_ast, :deps) |> boundary_aliases() == [
+             [:ImagePlug, :Origin],
              [:ImagePlug, :Parser],
              [:ImagePlug, :Plan],
-             [:ImagePlug, :Runtime],
+             [:ImagePlug, :Request],
+             [:ImagePlug, :Response],
              [:ImagePlug, :Transform]
            ]
   end

--- a/test/support/image_plug/request_processor_test/decode_error_image_open.ex
+++ b/test/support/image_plug/request_processor_test/decode_error_image_open.ex
@@ -1,4 +1,4 @@
-defmodule ImagePlug.Runtime.ProcessorTest.DecodeErrorImageOpen do
+defmodule ImagePlug.Request.ProcessorTest.DecodeErrorImageOpen do
   @moduledoc false
 
   def open(_stream, _opts), do: {:error, :forced_decode_error}

--- a/test/support/image_plug/request_processor_test/decode_valid_image_open.ex
+++ b/test/support/image_plug/request_processor_test/decode_valid_image_open.ex
@@ -1,4 +1,4 @@
-defmodule ImagePlug.Runtime.ProcessorTest.DecodeValidImageOpen do
+defmodule ImagePlug.Request.ProcessorTest.DecodeValidImageOpen do
   @moduledoc false
 
   def open(_stream, _decode_options) do

--- a/test/support/image_plug/request_processor_test/materializer.ex
+++ b/test/support/image_plug/request_processor_test/materializer.ex
@@ -1,4 +1,4 @@
-defmodule ImagePlug.Runtime.ProcessorTest.Materializer do
+defmodule ImagePlug.Request.ProcessorTest.Materializer do
   @moduledoc false
 
   use Boundary,

--- a/test/support/image_plug/request_processor_test/origin_image.ex
+++ b/test/support/image_plug/request_processor_test/origin_image.ex
@@ -1,4 +1,4 @@
-defmodule ImagePlug.Runtime.ProcessorTest.OriginImage do
+defmodule ImagePlug.Request.ProcessorTest.OriginImage do
   @moduledoc false
 
   def call(%Plug.Conn{request_path: "/images/cat-300.jpg"} = conn, _opts) do

--- a/test/support/image_plug/request_processor_test/origin_should_not_fetch.ex
+++ b/test/support/image_plug/request_processor_test/origin_should_not_fetch.ex
@@ -1,4 +1,4 @@
-defmodule ImagePlug.Runtime.ProcessorTest.OriginShouldNotFetch do
+defmodule ImagePlug.Request.ProcessorTest.OriginShouldNotFetch do
   @moduledoc false
 
   @spec call(Plug.Conn.t(), keyword()) :: no_return()


### PR DESCRIPTION
## Summary
- Replaced the vague `ImagePlug.Runtime` namespace with clearer ownership areas: `ImagePlug.Request`, `ImagePlug.Origin`, and `ImagePlug.Response`.
- Moved request orchestration, origin fetching/identity, and Plug response delivery into their new modules and boundaries.
- Updated architecture checks, tests, and support modules to use the new namespace layout.

## Testing
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix test`
- `git diff --check`
- Focused request/origin/response boundary tests passed locally