### PR TITLE
Add demo setup alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,10 @@ spell out cache-off mode.
 The development server also serves a local demo fiddle at `/demo`. The fiddle is
 a small Svelte/Vite UI for changing common path options and previewing the
 generated SimpleServer request. Install the demo dependencies once before using
-the default server command:
+the server or `demo.verify` aliases:
 
 ```sh
-mise exec -- pnpm install
+mise exec -- mix demo.setup
 ```
 
 Starting `mix image_plug.server` also starts the Vite development server on

--- a/docs/transform_operations.md
+++ b/docs/transform_operations.md
@@ -193,19 +193,19 @@ Final output cache key data captures canonical semantic intent, not resolved
 execution details. It should be stable for matching plans and independent of
 parser-specific spelling, aliases, and compatibility quirks.
 
-Parser-specific quirks must not leak into transform key data. Keep behavior that
-product-neutral semantic Plan operations can't represent cleanly in
-parser/adapter code. Don't encode dialect syntax into operation cache key data.
+Parser-specific quirks must not leak into transform key data. Keep behavior in
+parser/adapter code when product-neutral Plan operations can't represent it.
+Don't encode dialect syntax into operation cache key data.
 
-Source-aware execution choices such as resize `mode: :auto` selecting
-fit/cover, ratio crop resolution, and DPR conversion affect executable work
-after a cache miss, but they don't enter the normal final output cache key.
+Some source-aware choices affect executable work after a cache miss. Examples
+include resize `mode: :auto` selecting fit/cover, ratio crop resolution, and DPR
+conversion. They don't enter the normal final output cache key.
 
 ## Mapping examples
 
 These examples show current Imgproxy URL concepts translated into semantic Plan
 operations. They describe Imgproxy planner behavior only. Future dialect docs
-should describe their own URL syntax separately.
+should describe their own URL syntax.
 
 | Imgproxy URL concept | Semantic Plan operations |
 | --- | --- |

--- a/mix.exs
+++ b/mix.exs
@@ -125,6 +125,7 @@ defmodule ImagePlug.MixProject do
       "demo.format": ["cmd pnpm run demo:format"],
       "demo.format.check": ["cmd pnpm run demo:format:check"],
       "demo.lint": ["cmd pnpm run demo:lint"],
+      "demo.setup": ["cmd pnpm install --frozen-lockfile"],
       "demo.test": ["cmd pnpm run demo:test"],
       "demo.verify": ["demo.test", "demo.check", "demo.format.check", "demo.lint", "demo.build"],
       setup: ["deps.get"],


### PR DESCRIPTION
## What changed

- Added a Mix alias for installing demo dependencies with the checked-in pnpm lockfile.
- Pointed the README at the alias before running the demo server or demo verification flow.
- Cleaned existing Vale nits in the transform operations docs.

## Why

`mix demo.verify` fails when demo dependencies are not installed. The new alias gives the setup step a project-owned command and keeps the README aligned with the Mix workflow.

## Validation

- `vale README.md docs/*.md`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix run -e 'Mix.Project.config()[:aliases] |> Keyword.fetch!(:"demo.setup") |> IO.inspect()'`
