### PR TITLE
Fix body limit decode race

### DIFF
--- a/lib/image_pipe/request/processor.ex
+++ b/lib/image_pipe/request/processor.ex
@@ -16,7 +16,8 @@ defmodule ImagePipe.Request.Processor do
   @type decoded() :: %{
           required(:decode_options) => keyword(),
           required(:image) => Vix.Vips.Image.t(),
-          required(:source_format) => source_format()
+          required(:source_format) => source_format(),
+          optional(:source_response) => Source.Response.t()
         }
 
   @spec process_source(Plan.t(), Source.Resolved.t(), keyword()) ::
@@ -55,6 +56,7 @@ defmodule ImagePipe.Request.Processor do
 
     with {:ok, image} <-
            decode_source_response(source_response, decode_options, opts)
+           |> prefer_source_body_limit(source_response)
            |> wrap_decode_error(),
          {:ok, source_format} <- SourceFormat.from_image(image),
          :ok <- validate_input_image(image, opts) |> wrap_input_limit_error() do
@@ -62,7 +64,8 @@ defmodule ImagePipe.Request.Processor do
        %{
          decode_options: decode_options,
          image: image,
-         source_format: source_format
+         source_format: source_format,
+         source_response: source_response
        }}
     end
   end
@@ -70,15 +73,17 @@ defmodule ImagePipe.Request.Processor do
   @spec process_decoded_source(decoded(), Plan.t(), keyword()) ::
           {:ok, State.t()} | {:error, term()}
   def process_decoded_source(
-        %{decode_options: decode_options, image: image},
+        %{decode_options: decode_options, image: image} = decoded,
         %Plan{} = plan,
         opts
       ) do
+    source_response = Map.get(decoded, :source_response)
+
     Telemetry.span(Telemetry.telemetry_opts(opts), [:transform, :execute], %{}, fn ->
       result =
         with {:ok, final_state} <-
-               execute_plan_pipelines(%State{image: image}, plan, opts) do
-          materialize_before_delivery(final_state, decode_options, opts)
+               execute_plan_pipelines(%State{image: image}, plan, opts, source_response) do
+          materialize_before_delivery(final_state, decode_options, opts, source_response)
         end
 
       {result, transform_stop_metadata(result)}
@@ -88,7 +93,8 @@ defmodule ImagePipe.Request.Processor do
   defp execute_plan_pipelines(
          %State{} = state,
          %Plan{pipelines: pipelines} = plan,
-         opts
+         opts,
+         source_response
        ) do
     last_index = length(pipelines) - 1
 
@@ -96,7 +102,7 @@ defmodule ImagePipe.Request.Processor do
     |> Enum.with_index()
     |> Enum.reduce_while(
       {:ok, state},
-      &execute_plan_pipeline_step(&1, &2, last_index, plan, opts)
+      &execute_plan_pipeline_step(&1, &2, last_index, plan, opts, source_response)
     )
   end
 
@@ -105,7 +111,8 @@ defmodule ImagePipe.Request.Processor do
          {:ok, %State{} = state},
          last_index,
          %Plan{} = plan,
-         opts
+         opts,
+         source_response
        ) do
     with {:ok, %State{} = state} <-
            Transform.execute_plan(
@@ -114,7 +121,7 @@ defmodule ImagePipe.Request.Processor do
              opts
            ),
          {:ok, %State{} = state} <-
-           maybe_materialize_between_pipelines(state, index, last_index, opts) do
+           maybe_materialize_between_pipelines(state, index, last_index, opts, source_response) do
       {:cont, {:ok, state}}
     else
       {:error, _reason} = error -> {:halt, error}
@@ -126,13 +133,25 @@ defmodule ImagePipe.Request.Processor do
        }),
        do: operations
 
-  defp maybe_materialize_between_pipelines(%State{} = state, index, last_index, opts)
+  defp maybe_materialize_between_pipelines(
+         %State{} = state,
+         index,
+         last_index,
+         opts,
+         source_response
+       )
        when index < last_index do
-    materialize_between_pipelines(state, opts)
+    materialize_between_pipelines(state, opts, source_response)
   end
 
-  defp maybe_materialize_between_pipelines(%State{} = state, _index, _last_index, _opts),
-    do: {:ok, state}
+  defp maybe_materialize_between_pipelines(
+         %State{} = state,
+         _index,
+         _last_index,
+         _opts,
+         _source_response
+       ),
+       do: {:ok, state}
 
   defp decode_source_response(%Source.Response{} = source_response, decode_options, opts) do
     image_open_module = Keyword.get(opts, :image_open_module, Image)
@@ -144,16 +163,19 @@ defmodule ImagePipe.Request.Processor do
     :exit, %Source.StreamError{reason: reason} -> {:error, {:source, reason}}
   end
 
-  defp materialize_before_delivery(%State{} = state, decode_options, opts) do
+  defp materialize_before_delivery(%State{} = state, decode_options, opts, source_response) do
     case Keyword.fetch!(decode_options, :access) do
-      :sequential -> materialize_state(state, opts) |> handle_materialization_result()
-      :random -> {:ok, state}
+      :sequential ->
+        materialize_state(state, opts) |> handle_materialization_result(source_response)
+
+      :random ->
+        {:ok, state}
     end
   end
 
-  defp materialize_between_pipelines(%State{} = state, opts) do
+  defp materialize_between_pipelines(%State{} = state, opts, source_response) do
     materialize_state(state, opts)
-    |> handle_materialization_result()
+    |> handle_materialization_result(source_response)
   end
 
   defp materialize_state(%State{} = state, opts) do
@@ -162,16 +184,33 @@ defmodule ImagePipe.Request.Processor do
     materializer.materialize(state, opts)
   end
 
-  defp handle_materialization_result({:error, {:config, _reason} = error}), do: {:error, error}
+  defp handle_materialization_result(result, source_response) do
+    result
+    |> prefer_source_body_limit(source_response)
+    |> do_handle_materialization_result()
+  end
 
-  defp handle_materialization_result({:error, materialize_error}),
+  defp do_handle_materialization_result({:error, {:source, _reason} = error}), do: {:error, error}
+
+  defp do_handle_materialization_result({:error, {:config, _reason} = error}), do: {:error, error}
+
+  defp do_handle_materialization_result({:error, materialize_error}),
     do: {:error, {:decode, materialize_error}}
 
-  defp handle_materialization_result({:ok, %State{} = state}), do: {:ok, state}
+  defp do_handle_materialization_result({:ok, %State{} = state}), do: {:ok, state}
 
   defp wrap_decode_error({:error, {:source, _reason}} = error), do: error
   defp wrap_decode_error({:error, error}), do: {:error, {:decode, error}}
   defp wrap_decode_error(result), do: result
+
+  defp prefer_source_body_limit(result, %Source.Response{} = source_response) do
+    case Source.body_limit_exceeded?(source_response) do
+      true -> {:error, {:source, :body_too_large}}
+      false -> result
+    end
+  end
+
+  defp prefer_source_body_limit(result, _source_response), do: result
 
   defp validate_input_image(image, opts) do
     max_input_pixels = Keyword.get(opts, :max_input_pixels, 40_000_000)

--- a/lib/image_pipe/source.ex
+++ b/lib/image_pipe/source.ex
@@ -93,10 +93,17 @@ defmodule ImagePipe.Source do
   @spec wrap_response(Response.t(), keyword()) :: {:ok, Response.t()} | {:error, error()}
   def wrap_response(%Response{stream: stream}, runtime_opts) do
     max_body_bytes = Keyword.get(runtime_opts, :max_body_bytes, :infinity)
-    {:ok, %Response{stream: %WrappedStream{stream: stream, max_body_bytes: max_body_bytes}}}
+    {:ok, %Response{stream: WrappedStream.new(stream, max_body_bytes)}}
   end
 
   def wrap_response(_response, _runtime_opts), do: {:error, {:source, :invalid_adapter_result}}
+
+  @spec body_limit_exceeded?(Response.t()) :: boolean()
+  def body_limit_exceeded?(%Response{stream: %WrappedStream{} = stream}) do
+    WrappedStream.body_limit_exceeded?(stream)
+  end
+
+  def body_limit_exceeded?(%Response{}), do: false
 
   defp validate_sources(sources) when is_list(sources) do
     with {:ok, source_configs} <- source_configs(sources) do

--- a/lib/image_pipe/source/wrapped_stream.ex
+++ b/lib/image_pipe/source/wrapped_stream.ex
@@ -1,34 +1,61 @@
 defmodule ImagePipe.Source.WrappedStream do
   @moduledoc false
 
-  @enforce_keys [:stream, :max_body_bytes]
+  @enforce_keys [:stream, :max_body_bytes, :body_limit_ref]
   defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          stream: Enumerable.t(),
+          max_body_bytes: non_neg_integer() | :infinity,
+          body_limit_ref: :atomics.atomics_ref()
+        }
+
+  @spec new(Enumerable.t(), non_neg_integer() | :infinity) :: t()
+  def new(stream, max_body_bytes) do
+    %__MODULE__{
+      stream: stream,
+      max_body_bytes: max_body_bytes,
+      body_limit_ref: :atomics.new(1, [])
+    }
+  end
+
+  @spec body_limit_exceeded?(t()) :: boolean()
+  def body_limit_exceeded?(%__MODULE__{body_limit_ref: body_limit_ref}) do
+    :atomics.get(body_limit_ref, 1) == 1
+  end
+
+  @spec mark_body_limit_exceeded(t()) :: :ok
+  def mark_body_limit_exceeded(%__MODULE__{body_limit_ref: body_limit_ref}) do
+    :atomics.put(body_limit_ref, 1, 1)
+    :ok
+  end
 end
 
 defimpl Enumerable, for: ImagePipe.Source.WrappedStream do
   alias ImagePipe.Source.StreamError
+  alias ImagePipe.Source.WrappedStream
 
-  def reduce(%{stream: stream, max_body_bytes: max_body_bytes}, acc, fun) do
-    reduce_stream(stream, max_body_bytes, acc, fun)
+  def reduce(%WrappedStream{} = wrapped, acc, fun) do
+    reduce_stream(wrapped, acc, fun)
   end
 
   def count(_wrapped), do: {:error, __MODULE__}
   def member?(_wrapped, _value), do: {:error, __MODULE__}
   def slice(_wrapped), do: {:error, __MODULE__}
 
-  defp reduce_stream(stream, max_body_bytes, {:cont, acc}, fun) do
+  defp reduce_stream(%WrappedStream{stream: stream} = wrapped, {:cont, acc}, fun) do
     consumer_failure_ref = make_ref()
 
     try do
       stream
-      |> Enumerable.reduce({:cont, {0, acc}}, reducer(max_body_bytes, fun, consumer_failure_ref))
+      |> Enumerable.reduce({:cont, {0, acc}}, reducer(wrapped, fun, consumer_failure_ref))
       |> unwrap_result(fun, consumer_failure_ref)
     rescue
       error in StreamError ->
         reraise error, __STACKTRACE__
 
       _error ->
-        raise StreamError, reason: :stream_exception
+        reraise StreamError.exception(reason: :stream_exception), __STACKTRACE__
     catch
       {^consumer_failure_ref, kind, reason, stacktrace} ->
         :erlang.raise(kind, reason, stacktrace)
@@ -38,13 +65,17 @@ defimpl Enumerable, for: ImagePipe.Source.WrappedStream do
     end
   end
 
-  defp reduce_stream(_stream, _max_body_bytes, {:halt, acc}, _fun),
+  defp reduce_stream(%WrappedStream{}, {:halt, acc}, _fun),
     do: {:halted, acc}
 
-  defp reduce_stream(stream, max_body_bytes, {:suspend, acc}, fun),
-    do: {:suspended, acc, &reduce_stream(stream, max_body_bytes, &1, fun)}
+  defp reduce_stream(%WrappedStream{} = wrapped, {:suspend, acc}, fun),
+    do: {:suspended, acc, &reduce_stream(wrapped, &1, fun)}
 
-  defp reducer(max_body_bytes, fun, consumer_failure_ref) do
+  defp reducer(
+         %WrappedStream{max_body_bytes: max_body_bytes} = wrapped,
+         fun,
+         consumer_failure_ref
+       ) do
     fn chunk, {size, acc} ->
       with {:ok, binary} <- validate_chunk(chunk),
            {:ok, new_size} <- add_size(size, binary, max_body_bytes) do
@@ -54,7 +85,12 @@ defimpl Enumerable, for: ImagePipe.Source.WrappedStream do
           {:suspend, acc} -> {:suspend, {new_size, acc}}
         end
       else
-        {:error, reason} -> raise StreamError, reason: reason
+        {:error, :body_too_large} ->
+          WrappedStream.mark_body_limit_exceeded(wrapped)
+          raise StreamError, reason: :body_too_large
+
+        {:error, reason} ->
+          raise StreamError, reason: reason
       end
     end
   end
@@ -110,21 +146,19 @@ defimpl Enumerable, for: ImagePipe.Source.WrappedStream do
   end
 
   defp continue_safely(continuation, command, fun, consumer_failure_ref) do
-    try do
-      continuation.(command)
-      |> unwrap_result(fun, consumer_failure_ref)
-    rescue
-      error in StreamError ->
-        reraise error, __STACKTRACE__
+    continuation.(command)
+    |> unwrap_result(fun, consumer_failure_ref)
+  rescue
+    error in StreamError ->
+      reraise error, __STACKTRACE__
 
-      _error ->
-        raise StreamError, reason: :stream_exception
-    catch
-      {^consumer_failure_ref, kind, reason, stacktrace} ->
-        :erlang.raise(kind, reason, stacktrace)
+    _error ->
+      reraise StreamError.exception(reason: :stream_exception), __STACKTRACE__
+  catch
+    {^consumer_failure_ref, kind, reason, stacktrace} ->
+      :erlang.raise(kind, reason, stacktrace)
 
-      _kind, _reason ->
-        raise StreamError, reason: :stream_exception
-    end
+    _kind, _reason ->
+      raise StreamError, reason: :stream_exception
   end
 end

--- a/test/image_pipe/processor_test.exs
+++ b/test/image_pipe/processor_test.exs
@@ -18,8 +18,33 @@ defmodule ImagePipe.Request.ProcessorTest do
 
   defmodule DecodeRaisesSourceStreamError do
     def open(stream, _decode_options) do
-      Enum.to_list(stream)
+      _ = Enum.to_list(stream)
       {:error, :should_not_reach_decode}
+    end
+  end
+
+  defmodule DecodeConsumesBodyLimitThenReturnsDecodeError do
+    def open(stream, _decode_options) do
+      parent = self()
+      ref = make_ref()
+
+      spawn(fn ->
+        result =
+          try do
+            _ = Enum.to_list(stream)
+            :completed
+          rescue
+            exception in [Source.StreamError] -> {:source_error, exception.reason}
+          end
+
+        send(parent, {ref, result})
+      end)
+
+      receive do
+        {^ref, {:source_error, :body_too_large}} -> {:error, :forced_decode_error}
+      after
+        1_000 -> {:error, :stream_did_not_hit_body_limit}
+      end
     end
   end
 
@@ -213,6 +238,22 @@ defmodule ImagePipe.Request.ProcessorTest do
                response,
                plan(),
                Keyword.put(opts(), :image_open_module, DecodeRaisesSourceStreamError)
+             )
+  end
+
+  test "body limit errors beat later decode errors from another stream consumer process" do
+    body = File.read!("priv/static/images/beach.jpg")
+
+    assert {:error, {:source, :body_too_large}} =
+             Processor.fetch_decode_validate_source_with_source_format(
+               plan(),
+               resolved_source(),
+               opts()
+               |> Keyword.put(:max_body_bytes, byte_size(body) - 1)
+               |> Keyword.put(
+                 :image_open_module,
+                 DecodeConsumesBodyLimitThenReturnsDecodeError
+               )
              )
   end
 end


### PR DESCRIPTION
## Summary

- Record when source stream body-limit enforcement fires before raising `Source.StreamError`.
- Prefer that recorded source failure over later libvips decode or materialization errors.
- Add a regression test for the path where another stream consumer sees the body limit but returns a decode error to the processor.

## Root cause

`Image.open/2` reads source streams through a vix worker process. When `max_body_bytes` trips after enough valid image bytes have been read, two error channels can race: the stream worker exits with `Source.StreamError`, while libvips can return a decode error from the truncated input. If the decode error reaches the producer first, the request is classified as unsupported format instead of an invalid source.

## Validation

- `mise exec -- mix test test/image_pipe/processor_test.exs test/image_pipe/source_test.exs test/image_pipe/plug_test.exs:1980 test/image_pipe/plug_test.exs:2020`
- `mise exec -- mix test test/image_pipe/plug_test.exs:1980 --seed 78929 --max-cases 8`
- `mise exec -- mix test test/image_pipe/request/source_session/producer_test.exs test/image_pipe/request/source_session_test.exs test/image_pipe/request_runner_test.exs`
- `mise exec -- mix test`
- `mise exec -- mix compile --warnings-as-errors`

`mise exec -- mix credo --strict` still exits nonzero on existing strict-mode design/readability/refactor findings.
