### PR TITLE
Implement CDN HTTP cache support

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ ImagePipe's fixed plan order.
   partial, rejected, missing, and out-of-scope Imgproxy features.
 - [Cache](docs/cache.md) documents filesystem response caching, cache keys,
   stored headers, failure modes, and cache safety boundaries.
+- [CDN HTTP caching](docs/cdn-http-cache.md) documents generated
+  `Cache-Control`, ETags, `Vary: Accept`, source stability, and CDN behavior.
 - [Operational notes](docs/operational_notes.md) documents request safety,
   source fetching, decode planning, multi-pipeline behavior, and automatic
   output negotiation.

--- a/docs/cdn-http-cache.md
+++ b/docs/cdn-http-cache.md
@@ -1,0 +1,248 @@
+# CDN HTTP Caching
+
+ImagePipe can emit shared HTTP cache headers for public image routes when a
+resolved source identity names stable bytes. The feature is opt-in at the Plug
+level, and a source adapter can override it.
+
+```elixir
+forward "/images",
+  to: ImagePipe.Plug,
+  init_opts: [
+    parser: ImagePipe.Parser.Imgproxy,
+    sources: [
+      path:
+        {ImagePipe.Source.File,
+         root: "/srv/images",
+         root_id: "primary",
+         stable: :trusted,
+         http_cache: :enabled}
+    ],
+    http_cache: [mode: :enabled]
+  ]
+```
+
+`http_cache: [mode: :enabled]` on the Plug turns on generated shared-cache
+headers. `http_cache: :enabled` on a source forces that source to use the HTTP
+cache path even when the Plug option uses `mode: :disabled`. `http_cache:
+:disabled` on a source suppresses generated cache headers even when the Plug
+option uses `mode: :enabled`.
+
+Source-level `http_cache: :enabled` doesn't force an ETag. The resolved source
+still needs strong byte identity.
+
+## Stable Source Bytes
+
+`stable: :trusted` tells a source adapter that the resolved source identity names
+the same bytes for every request. Use it only for write-once storage,
+content-addressed paths, or storage where your application policy prevents
+in-place replacement under the same identity.
+
+For `ImagePipe.Source.File`, `stable: :auto` isn't enough to generate byte
+identity. Files can be overwritten under the same path, so file sources need
+`stable: :trusted` before ImagePipe derives a strong byte identity from
+`root_id` and path segments.
+
+For `ImagePipe.Source.HTTP`, `stable: :trusted` derives byte identity from the
+URL components. ImagePipe doesn't put raw query strings into the identity. It
+stores a query SHA-256 so signed query URLs and rotating query credentials don't appear in
+ETags or telemetry.
+
+For `ImagePipe.Source.S3`, objects with a revision are stable under
+`stable: :auto` because the fetch includes the object version. S3 objects
+without a revision need `stable: :trusted` if the bucket or key policy is
+write-once.
+
+`stable` and `internal_cache` are separate settings. `stable` is about whether
+ImagePipe can create a public HTTP validator. `internal_cache` is about whether
+ImagePipe may reuse an encoded body from its configured cache. A route can use
+internal caching without generated HTTP cache headers.
+
+## Generated Headers
+
+For successful `GET` responses with generated HTTP caching enabled and strong
+byte identity, ImagePipe emits:
+
+```http
+Cache-Control: public, max-age=31536000, immutable
+ETag: "ip1-..."
+```
+
+When automatic output format selection depends on the request `Accept` header,
+ImagePipe also emits:
+
+```http
+Vary: Accept
+```
+
+Configure the CDN cache key to include `Accept` for routes that use automatic
+output. Explicit output formats don't emit `Vary: Accept`.
+
+ImagePipe merges an existing `Vary` header with `Accept`. If an earlier Plug set
+`Vary: Accept-Encoding`, the final header for automatic output is:
+
+```http
+Vary: Accept-Encoding, Accept
+```
+
+If an earlier Plug set `Vary: *`, ImagePipe preserves `Vary: *` and suppresses
+generated public cache headers.
+
+## Conditional Requests
+
+ImagePipe handles `If-None-Match` only for generated ETags. A matching `GET`
+returns `304 Not Modified` after source resolution and before cache lookup,
+source fetch, decode, transform, or encode.
+
+`If-None-Match` uses weak comparison for `GET`, so both of these match the
+generated ETag `"ip1-token"`:
+
+```http
+If-None-Match: "ip1-token"
+If-None-Match: W/"ip1-token"
+```
+
+v1 ignores `If-None-Match: *`, including on internal cache hits.
+Non-`GET` methods skip generated conditional handling.
+
+ImagePipe doesn't interpret host-supplied ETags. If an earlier Plug sets
+`ETag`, ImagePipe preserves it, suppresses its generated ETag, and doesn't use
+that host ETag to return `304`.
+
+## Host Headers
+
+Existing host policy wins over generated policy.
+
+If an earlier Plug sets `Cache-Control`, ImagePipe doesn't overwrite it. If the
+source has strong byte identity and no host ETag, ImagePipe may still add a
+generated ETag.
+
+If the selected `Cache-Control` contains `no-store`, ImagePipe doesn't generate
+an ETag.
+
+If the response has `Set-Cookie`, ImagePipe suppresses generated public cache
+headers.
+
+Required representation headers are separate from generated cache policy.
+Suppressing generated `Cache-Control` or `ETag` leaves `Vary: Accept` in place
+when automatic output uses `Accept`.
+
+## Missing Byte Identity
+
+If HTTP caching uses `mode: :enabled` but the resolved source doesn't provide
+strong byte identity, ImagePipe emits:
+
+```http
+Cache-Control: no-store
+```
+
+It doesn't emit a generated ETag. This is a safety fallback for a route that
+asked for shared-cache behavior but couldn't prove validator material.
+
+ImagePipe emits this required telemetry event:
+
+```text
+[:image_pipe, :http_cache, :fallback, :no_store]
+```
+
+Metadata is low-cardinality:
+
+```elixir
+%{
+  adapter: :path,
+  source_kind: :path,
+  reason: :missing_byte_identity
+}
+```
+
+The same event uses `reason: :missing_representation_material` if a future
+output mode can't fit in pre-fetch ETag material. No current output
+mode uses that branch.
+
+If a host already set `Cache-Control`, ImagePipe preserves the host policy
+instead of replacing it with `no-store`.
+
+## Telemetry
+
+HTTP cache preparation emits:
+
+```text
+[:image_pipe, :http_cache, :prepare]
+```
+
+Metadata includes `:effective_mode`, `:byte_identity`, and `:etag`. It doesn't
+include paths, source identities, or ETag values.
+
+A conditional `304` emits:
+
+```text
+[:image_pipe, :http_cache, :conditional, :match]
+```
+
+Metadata includes the method as `method: :get`. It doesn't include paths or
+ETag values.
+
+Internal cache hits that receive freshly prepared HTTP cache headers emit:
+
+```text
+[:image_pipe, :http_cache, :cache_hit, :headers]
+```
+
+Metadata reports whether a generated ETag, generated cache headers, and
+representation headers were present. It doesn't include cache keys, paths,
+source identities, or ETag values.
+
+## Cache Key Relationship
+
+The CDN controls the CDN cache key. ImagePipe can't make two different URLs share
+one CDN object by sending an ETag or custom header. ImagePipe normalizes plan
+material so matching URLs can produce the same ETag. A CDN that keys on the raw
+URL still stores them as separate objects unless the CDN rewrites or redirects
+them before cache lookup.
+
+ImagePipe's internal cache key and HTTP ETag are different values. The internal
+cache key includes storage concerns such as cachebuster and configured cache key
+inputs. The generated ETag identifies the client-visible representation. For
+example, `cachebuster` changes the internal cache key but leaves the generated
+ETag unchanged.
+
+`Plan.expires` is a parser validity field. It doesn't change generated
+`Cache-Control`.
+
+## Versioning
+
+Generated ETags use a visible schema prefix built from the implementation
+constant:
+
+```elixir
+"ip#{@etag_schema}-..."
+```
+
+Changing `@etag_schema` changes both the visible prefix and the hashed material.
+That invalidates validators already stored by browsers and CDNs.
+
+ImagePipe includes `@representation_version` in generated ETag material and in
+the internal cache key. Bump it when encoder behavior, output policy behavior,
+default quality, metadata handling, color handling, orientation behavior, or
+symbolic output-rule semantics can change encoded bytes without changing public
+request syntax.
+
+The same version must be in both places. If it changed only the ETag, ImagePipe
+could serve an old internal-cache body with a new validator.
+
+## Deferred In V1
+
+These are deliberate v1 boundaries:
+
+- no generated `Last-Modified`
+- no `If-Modified-Since`
+- no short public caching for mutable sources
+- no arbitrary `Vary` dimensions beyond `Accept`
+- no Client Hints variation
+- no generated ETags after source fetch
+- no source metadata probing to discover upstream validators
+- no per-route custom ETag override
+- no parser-provided `Cache-Control`
+
+Routes that need custom validators or mutable freshness policy should leave
+ImagePipe generated HTTP caching off and set response headers in their own Plug
+chain.

--- a/docs/cdn-http-cache.md
+++ b/docs/cdn-http-cache.md
@@ -45,7 +45,10 @@ identity. Files can be overwritten under the same path, so file sources need
 For `ImagePipe.Source.HTTP`, `stable: :trusted` derives byte identity from the
 URL components. ImagePipe doesn't put raw query strings into the identity. It
 stores a query SHA-256 so signed query URLs and rotating query credentials don't appear in
-ETags or telemetry.
+ETags or telemetry. ImagePipe redacts query material instead of ignoring it:
+different query strings still produce different generated ETags. If credentials
+rotate while the source bytes stay the same, use a source identity without
+credentials or a custom adapter.
 
 For `ImagePipe.Source.S3`, objects with a revision are stable under
 `stable: :auto` because the fetch includes the object version. S3 objects
@@ -76,6 +79,14 @@ Vary: Accept
 
 Configure the CDN cache key to include `Accept` for routes that use automatic
 output. Explicit output formats don't emit `Vary: Accept`.
+
+For CDN configuration:
+
+- honor origin `Cache-Control`, including `no-store`
+- forward `If-None-Match` to ImagePipe for revalidation
+- include `Accept` in the cache key when using automatic output
+- don't add Client Hints such as `Width` or `DPR` to the cache key for v1
+- expect raw URL cache keys unless the CDN rewrites or redirects before lookup
 
 ImagePipe merges an existing `Vary` header with `Accept`. If an earlier Plug set
 `Vary: Accept-Encoding`, the final header for automatic output is:
@@ -116,6 +127,16 @@ If an earlier Plug sets `Cache-Control`, ImagePipe doesn't overwrite it. If the
 source has strong byte identity and no host ETag, ImagePipe may still add a
 generated ETag.
 
+ImagePipe treats the default `Cache-Control` value set by `Plug.Conn` as unset
+before response delivery:
+
+```http
+Cache-Control: max-age=0, private, must-revalidate
+```
+
+A Plug that needs to force that exact policy should set another explicit policy
+or disable generated HTTP caching for the route.
+
 If the selected `Cache-Control` contains `no-store`, ImagePipe doesn't generate
 an ETag.
 
@@ -153,10 +174,6 @@ Metadata is low-cardinality:
   reason: :missing_byte_identity
 }
 ```
-
-The same event uses `reason: :missing_representation_material` if a future
-output mode can't fit in pre-fetch ETag material. No current output
-mode uses that branch.
 
 If a host already set `Cache-Control`, ImagePipe preserves the host policy
 instead of replacing it with `no-store`.
@@ -220,11 +237,11 @@ constant:
 Changing `@etag_schema` changes both the visible prefix and the hashed material.
 That invalidates validators already stored by browsers and CDNs.
 
-ImagePipe includes `@representation_version` in generated ETag material and in
-the internal cache key. Bump it when encoder behavior, output policy behavior,
-default quality, metadata handling, color handling, orientation behavior, or
-symbolic output-rule semantics can change encoded bytes without changing public
-request syntax.
+ImagePipe includes `@representation_version` in the shared plan material used by
+generated ETags and the internal cache key. Bump it when encoder behavior,
+output policy behavior, default quality, metadata handling, color handling,
+orientation behavior, or symbolic output-rule semantics can change encoded
+bytes without changing public request syntax.
 
 The same version must be in both places. If it changed only the ETag, ImagePipe
 could serve an old internal-cache body with a new validator.

--- a/docs/superpowers/plans/2026-05-27-cdn-http-cache-implementation.md
+++ b/docs/superpowers/plans/2026-05-27-cdn-http-cache-implementation.md
@@ -1270,6 +1270,7 @@ defmodule ImagePipe.Request.HTTPCacheTest do
     assert prepared.headers == []
     assert prepared.etag == nil
   end
+
 end
 ```
 
@@ -1344,7 +1345,7 @@ defmodule ImagePipe.Request.HTTPCache do
     effective_mode = effective_mode(resolved, opts)
     representation_headers = representation_headers(conn, plan)
 
-    {headers, etag, fallback} =
+    {headers, etag, fallback_reason} =
       generated_cache_headers(conn, plan, resolved, opts, effective_mode, representation_headers)
 
     Telemetry.execute(
@@ -1358,7 +1359,7 @@ defmodule ImagePipe.Request.HTTPCache do
       }
     )
 
-    if fallback == :no_store do
+    if fallback_reason do
       Telemetry.execute(
         Telemetry.telemetry_opts(opts),
         [:http_cache, :fallback, :no_store],
@@ -1366,7 +1367,7 @@ defmodule ImagePipe.Request.HTTPCache do
         %{
           adapter: resolved.adapter,
           source_kind: resolved.source_kind,
-          reason: :missing_byte_identity
+          reason: fallback_reason
         }
       )
     end
@@ -1385,6 +1386,21 @@ defmodule ImagePipe.Request.HTTPCache do
   @doc false
   @spec generated_cache_control() :: String.t()
   def generated_cache_control, do: @generated_cache_control
+
+  @doc false
+  @spec etag_material(Plug.Conn.t(), Plan.t(), term(), keyword()) :: {:ok, keyword()} | :omit_etag
+  def etag_material(conn, %Plan{} = plan, source_seed, opts) do
+    with {:ok, _representation_material} <- Plan.canonical_representation_material(plan) do
+      {:ok,
+       [
+         etag_schema: @etag_schema,
+         source: source_seed,
+         plan: canonical_plan_data(plan, opts),
+         accept: accept_material(conn, plan.output, opts),
+         representation_version: Key.representation_version()
+       ]}
+    end
+  end
 
   defp effective_mode(%Resolved{http_cache: :inherit}, opts),
     do: opts |> Keyword.fetch!(:http_cache) |> Keyword.fetch!(:mode)
@@ -1416,9 +1432,17 @@ defmodule ImagePipe.Request.HTTPCache do
 
   defp generated_cache_control_and_etag(conn, plan, resolved, opts) do
     case generated_etag(conn, plan, resolved, opts) do
-      nil ->
+      {:etag, etag} ->
+        {[{"cache-control", @generated_cache_control}, {"etag", etag}], etag, nil}
+
+      :omit_etag ->
+        {[{"cache-control", @no_store}], nil, :missing_representation_material}
+
+      :not_generated ->
         case resolved.cache_semantics do
-          %CacheSemantics{byte_identity: :none} -> {[{"cache-control", @no_store}], nil, :no_store}
+          %CacheSemantics{byte_identity: :none} ->
+            {[{"cache-control", @no_store}], nil, :missing_byte_identity}
+
           %CacheSemantics{byte_identity: {:strong, _seed}} ->
             if has_resp_header?(conn, "etag"),
               do: {[{"cache-control", @generated_cache_control}], nil, nil},
@@ -1427,25 +1451,24 @@ defmodule ImagePipe.Request.HTTPCache do
           _cache_semantics -> {[], nil, nil}
         end
 
-      etag ->
-        {[{"cache-control", @generated_cache_control}, {"etag", etag}], etag, nil}
     end
   end
 
   defp generated_etag_only(conn, plan, resolved, opts) do
     case generated_etag(conn, plan, resolved, opts) do
-      nil -> {[], nil, nil}
-      etag -> {[{"etag", etag}], etag, nil}
+      {:etag, etag} -> {[{"etag", etag}], etag, nil}
+      :omit_etag -> {[], nil, nil}
+      :not_generated -> {[], nil, nil}
     end
   end
 
   defp generated_etag(conn, plan, %Resolved{cache_semantics: cache_semantics}, opts) do
     cond do
       has_resp_header?(conn, "etag") ->
-        nil
+        :not_generated
 
       selected_cache_control(conn) == @no_store ->
-        nil
+        :not_generated
 
       true ->
         do_generated_etag(conn, plan, cache_semantics, opts)
@@ -1453,27 +1476,19 @@ defmodule ImagePipe.Request.HTTPCache do
   end
 
   defp do_generated_etag(conn, plan, %CacheSemantics{byte_identity: {:strong, seed}}, opts) do
-    with {:ok, output_material} <- Plan.canonical_representation_material(plan) do
-      material = [
-        etag_schema: @etag_schema,
-        source: seed,
-        plan: canonical_plan_data(plan, opts),
-        output: output_material,
-        accept: accept_material(conn, plan.output, opts),
-        representation_version: Key.representation_version()
-      ]
-
+    with {:ok, material} <- etag_material(conn, plan, seed, opts) do
       material
       |> serialize_material()
       |> :crypto.hash(:sha256)
       |> Base.url_encode64(padding: false)
-      |> then(&~s("ip#{@etag_schema}-#{&1}"))
+      |> then(&{:etag, ~s("ip#{@etag_schema}-#{&1}")})
     else
-      :omit_etag -> nil
+      :omit_etag -> :omit_etag
     end
   end
 
-  defp do_generated_etag(_conn, _plan, %CacheSemantics{byte_identity: :none}, _opts), do: nil
+  defp do_generated_etag(_conn, _plan, %CacheSemantics{byte_identity: :none}, _opts),
+    do: :not_generated
 
   defp canonical_plan_data(%Plan{} = plan, opts) do
     {:ok, material} = Key.plan_material(plan, opts)
@@ -1615,6 +1630,56 @@ selection, not encoded bytes. Add a focused test that changing
 `plan.cachebuster` changes `ImagePipe.Cache.Key.build/4` data but doesn't
 change the generated ETag.
 
+The helper needs a conn-free output material path. Split the current
+`output_data/3` shape so `build/4` still records `modern_candidates` from
+`Accept`, while `plan_material/2` records only plan/output policy fields:
+
+```elixir
+defp output_plan_data(%Output{mode: :automatic} = output, opts) do
+  {:ok,
+   [
+     mode: :automatic,
+     auto: [
+       avif: Keyword.get(opts, :auto_avif, true),
+       webp: Keyword.get(opts, :auto_webp, true)
+     ],
+     quality: output.quality,
+     format_qualities: output.format_qualities
+   ]}
+end
+
+defp output_plan_data(%Output{mode: {:explicit, format}} = output, _opts) do
+  {:ok,
+   [
+     mode: :explicit,
+     format: format,
+     quality: output.quality,
+     format_qualities: output.format_qualities
+   ]}
+end
+
+defp output_plan_data(output, _opts), do: {:error, {:invalid_output_plan, output}}
+
+defp output_data(conn, %Output{mode: :automatic} = output, opts) do
+  accept_header = conn |> get_req_header("accept") |> Enum.join(",")
+
+  with {:ok, data} <- output_plan_data(output, opts) do
+    {:ok, Keyword.put(data, :modern_candidates, Negotiation.modern_candidates(accept_header, opts))}
+  end
+end
+
+defp output_data(_conn, %Output{} = output, opts), do: output_plan_data(output, opts)
+```
+
+Use `output_plan_data/2` from `plan_material/2`. Use
+`Plan.canonical_representation_material/1` from `HTTPCache`; don't duplicate an
+extra `output:` field in generated ETag material.
+
+No current valid output mode returns `:omit_etag`. Keep the `:omit_etag`
+fallback in `HTTPCache` as `Cache-Control: no-store` with reason
+`:missing_representation_material`; add a focused test when the first output
+mode can hit that branch.
+
 - [ ] **Step 6: Add conditional parsing tests**
 
 Extend `test/image_pipe/request/http_cache_test.exs`:
@@ -1663,6 +1728,51 @@ describe "evaluate_conditional/3" do
       :get
       |> conn("/image")
       |> put_req_header("if-none-match", ~s("host"))
+
+    assert :proceed = HTTPCache.evaluate_conditional(conn, prepared, [])
+  end
+
+  test "non-matching if-none-match proceeds" do
+    prepared = %ImagePipe.Response.CacheHeaders{
+      representation_headers: [],
+      headers: [{"etag", ~s("ip1-abc")}],
+      etag: ~s("ip1-abc")
+    }
+
+    conn =
+      :get
+      |> conn("/image")
+      |> put_req_header("if-none-match", ~s("ip1-other"))
+
+    assert :proceed = HTTPCache.evaluate_conditional(conn, prepared, [])
+  end
+
+  test "malformed if-none-match proceeds" do
+    prepared = %ImagePipe.Response.CacheHeaders{
+      representation_headers: [],
+      headers: [{"etag", ~s("ip1-abc")}],
+      etag: ~s("ip1-abc")
+    }
+
+    conn =
+      :get
+      |> conn("/image")
+      |> put_req_header("if-none-match", "not-a-quoted-tag")
+
+    assert :proceed = HTTPCache.evaluate_conditional(conn, prepared, [])
+  end
+
+  test "non-cacheable methods do not use conditional response handling" do
+    prepared = %ImagePipe.Response.CacheHeaders{
+      representation_headers: [],
+      headers: [{"etag", ~s("ip1-abc")}],
+      etag: ~s("ip1-abc")
+    }
+
+    conn =
+      :post
+      |> conn("/image")
+      |> put_req_header("if-none-match", ~s("ip1-abc"))
 
     assert :proceed = HTTPCache.evaluate_conditional(conn, prepared, [])
   end
@@ -1861,6 +1971,20 @@ defmodule ImagePipe.CDNHTTPCacheWireTest do
     def abort_sink(_state, _opts), do: :ok
   end
 
+  defmodule CacheHitProbe do
+    @behaviour ImagePipe.Cache
+
+    def get(%Key{} = key, opts) do
+      send(Keyword.fetch!(opts, :test_pid), {:cache_get, key})
+      {:hit, Keyword.fetch!(opts, :entry)}
+    end
+
+    def open_sink(_key, _metadata, _opts), do: raise("cache hit should not write")
+    def write_chunk(_state, _chunk, _opts), do: raise("cache hit should not write")
+    def commit_sink(_state, _opts), do: raise("cache hit should not write")
+    def abort_sink(_state, _opts), do: :ok
+  end
+
   setup do
     opts =
       ImagePipe.Plug.init(
@@ -1905,6 +2029,79 @@ defmodule ImagePipe.CDNHTTPCacheWireTest do
     assert Plug.Conn.get_resp_header(conn, "content-type") == []
     refute_received {:cache_get, %Key{}}
     refute_received :source_fetch_called
+  end
+
+  test "existing vary is merged in the final response", %{opts: opts} do
+    conn =
+      :get
+      |> conn(signed_path("/plain/beach.jpg"))
+      |> put_req_header("accept", "image/avif,image/webp")
+      |> put_resp_header("vary", "Accept-Encoding")
+      |> ImagePipe.Plug.call(opts)
+
+    assert conn.status == 200
+    assert Plug.Conn.get_resp_header(conn, "vary") == ["Accept-Encoding, Accept"]
+  end
+
+  test "request cookie does not change generated headers or source fetch", %{opts: opts} do
+    without_cookie = ImagePipe.Plug.call(conn(:get, signed_path("/plain/beach.jpg")), opts)
+    [etag] = Plug.Conn.get_resp_header(without_cookie, "etag")
+
+    flush_messages()
+
+    with_cookie =
+      :get
+      |> conn(signed_path("/plain/beach.jpg"))
+      |> put_req_header("cookie", "session=private")
+      |> ImagePipe.Plug.call(opts)
+
+    assert Plug.Conn.get_resp_header(with_cookie, "etag") == [etag]
+    assert Plug.Conn.get_resp_header(with_cookie, "vary") != ["Cookie"]
+    assert_received :source_fetch_called
+  end
+
+  test "internal cache hit returns 200 with current prepared etag" do
+    entry = %Entry{
+      body: "cached body",
+      content_type: "image/jpeg",
+      headers: [{"cache-control", "public, max-age=60"}],
+      created_at: DateTime.utc_now()
+    }
+
+    opts =
+      ImagePipe.Plug.init(
+        parser: ImagePipe.Parser.Imgproxy,
+        sources: [path: {StableSource, test_pid: self()}],
+        cache: {CacheHitProbe, test_pid: self(), entry: entry},
+        http_cache: [mode: :enabled]
+      )
+
+    conn = ImagePipe.Plug.call(conn(:get, signed_path("/plain/beach.jpg")), opts)
+
+    assert conn.status == 200
+    assert conn.resp_body == "cached body"
+    assert [etag] = Plug.Conn.get_resp_header(conn, "etag")
+    assert String.starts_with?(etag, "\"ip1-")
+    assert Plug.Conn.get_resp_header(conn, "cache-control") == [
+             "public, max-age=31536000, immutable"
+           ]
+    refute_received :source_fetch_called
+  end
+
+  test "transform option order variants produce the same etag", %{opts: opts} do
+    left =
+      ImagePipe.Plug.call(
+        conn(:get, signed_path("/rs:fill:0:400:0/c:0.5:0.5/plain/beach.jpg")),
+        opts
+      )
+
+    right =
+      ImagePipe.Plug.call(
+        conn(:get, signed_path("/c:0.5:0.5/rs:fill:0:400:0/plain/beach.jpg")),
+        opts
+      )
+
+    assert Plug.Conn.get_resp_header(left, "etag") == Plug.Conn.get_resp_header(right, "etag")
   end
 
   defp signed_path(path) do
@@ -1956,8 +2153,12 @@ prepared_http_cache = HTTPCache.prepare(conn, plan, resolved_source, opts)
 
 case HTTPCache.evaluate_conditional(conn, prepared_http_cache, opts) do
   {:not_modified, headers} ->
-    conn = HTTPCache.send_not_modified(conn, headers)
-    {conn, %{result: :not_modified, status: conn.status}}
+    {conn, send_metadata} =
+      send_response(conn, opts, :not_modified, fn ->
+        HTTPCache.send_not_modified(conn, headers)
+      end)
+
+    {conn, Map.merge(%{result: :not_modified}, send_metadata)}
 
   :proceed ->
     result = Runner.run(conn, plan, resolved_source, prepared_http_cache, opts)
@@ -2100,6 +2301,7 @@ test "cache hits merge generated headers before cached entry headers" do
 
   assert Plug.Conn.get_resp_header(conn, "etag") == [~s("ip1-test")]
   assert Plug.Conn.get_resp_header(conn, "vary") == ["Accept"]
+  assert conn.status == 200
 end
 
 test "current host cache-control wins over generated and cached headers" do
@@ -2192,9 +2394,9 @@ Add merge helpers:
 defp merge_delivery_headers(conn, cached_or_stream_headers, %CacheHeaders{} = prepared) do
   []
   |> merge_header_list(prepared.headers)
-  |> merge_header_list(prepared.representation_headers)
+  |> merge_authoritative_header_list(prepared.representation_headers)
   |> merge_header_list(cached_or_stream_headers)
-  |> reject_existing_conn_headers(conn)
+  |> reject_existing_conn_headers(conn, authoritative_header_names(prepared.representation_headers))
 end
 
 defp merge_header_list(base, additions) do
@@ -2215,12 +2417,35 @@ defp put_header_unless_present(headers, name, value) do
   end
 end
 
-defp reject_existing_conn_headers(headers, conn) do
+defp merge_authoritative_header_list(base, additions) do
+  Enum.reduce(additions, base, fn {name, value}, headers ->
+    put_header_replacing_existing(headers, name, value)
+  end)
+end
+
+defp put_header_replacing_existing(headers, name, value) do
+  downcased = String.downcase(name)
+
+  headers
+  |> Enum.reject(fn {existing_name, _existing_value} -> String.downcase(existing_name) == downcased end)
+  |> Kernel.++([{downcased, value}])
+end
+
+defp authoritative_header_names(headers),
+  do: Enum.map(headers, fn {name, _value} -> String.downcase(name) end)
+
+defp reject_existing_conn_headers(headers, conn, authoritative_names) do
   Enum.reject(headers, fn {name, _value} ->
-    Plug.Conn.get_resp_header(conn, name) != []
+    name = String.downcase(name)
+    name not in authoritative_names and Plug.Conn.get_resp_header(conn, name) != []
   end)
 end
 ```
+
+`representation_headers` are authoritative because `HTTPCache.prepare/4`
+already merged the current conn value. This is required for `Vary`; otherwise a
+preexisting `Vary: Accept-Encoding` on the conn would cause Sender to discard
+the prepared `Vary: Accept-Encoding, Accept`.
 
 Use this in cache-hit path:
 
@@ -2329,6 +2554,99 @@ test "client hints don't enter generated vary" do
   refute Enum.any?(prepared.representation_headers, fn {_name, value} ->
            String.contains?(String.downcase(value), "width")
          end)
+end
+
+test "plan expires does not change generated cache-control" do
+  base = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
+
+  expiring =
+    HTTPCache.prepare(
+      conn(:get, "/image"),
+      %{plan() | expires: 1_899_345_600},
+      resolved(),
+      opts()
+    )
+
+  assert header(base.headers, "cache-control") == header(expiring.headers, "cache-control")
+end
+
+test "cachebuster changes internal key data but not generated etag" do
+  base_plan = plan()
+  busted_plan = %{plan() | cachebuster: "v2"}
+  plug_conn = conn(:get, "/image")
+
+  assert {:ok, base_key} = ImagePipe.Cache.Key.build(plug_conn, base_plan, resolved().identity)
+  assert {:ok, busted_key} = ImagePipe.Cache.Key.build(plug_conn, busted_plan, resolved().identity)
+  assert base_key.data[:cache] != busted_key.data[:cache]
+
+  base = HTTPCache.prepare(conn(:get, "/image"), base_plan, resolved(), opts())
+  busted = HTTPCache.prepare(conn(:get, "/image"), busted_plan, resolved(), opts())
+
+  assert base.etag == busted.etag
+end
+
+test "source revision changes generated etag" do
+  left =
+    HTTPCache.prepare(
+      conn(:get, "/image"),
+      plan(),
+      resolved(
+        cache_semantics: %CacheSemantics{
+          byte_identity: {:strong, [kind: :object, adapter: :s3, bucket: "b", key: "cat.jpg", revision: "v1"]},
+          stable?: true
+        }
+      ),
+      opts()
+    )
+
+  right =
+    HTTPCache.prepare(
+      conn(:get, "/image"),
+      plan(),
+      resolved(
+        cache_semantics: %CacheSemantics{
+          byte_identity: {:strong, [kind: :object, adapter: :s3, bucket: "b", key: "cat.jpg", revision: "v2"]},
+          stable?: true
+        }
+      ),
+      opts()
+    )
+
+  assert left.etag != right.etag
+end
+
+test "visible etag prefix comes from etag schema" do
+  prepared = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
+
+  assert String.starts_with?(prepared.etag, ~s("ip#{HTTPCache.etag_schema()}-))
+end
+
+test "etag material uses the internal cache representation version" do
+  assert {:strong, seed} = resolved().cache_semantics.byte_identity
+
+  assert {:ok, material} = HTTPCache.etag_material(conn(:get, "/image"), plan(), seed, opts())
+  assert material[:representation_version] == ImagePipe.Cache.Key.representation_version()
+end
+
+test "cookie request header does not enter generated vary or etag" do
+  without_cookie = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
+
+  with_cookie =
+    :get
+    |> conn("/image")
+    |> put_req_header("cookie", "session=private")
+    |> HTTPCache.prepare(plan(), resolved(), opts())
+
+  assert with_cookie.etag == without_cookie.etag
+  refute Enum.any?(with_cookie.representation_headers, fn {_name, value} ->
+           String.downcase(value) == "cookie"
+         end)
+end
+
+defp header(headers, name) do
+  headers
+  |> Enum.find(fn {header_name, _value} -> header_name == name end)
+  |> elem(1)
 end
 ```
 

--- a/docs/superpowers/plans/2026-05-27-cdn-http-cache-implementation.md
+++ b/docs/superpowers/plans/2026-05-27-cdn-http-cache-implementation.md
@@ -164,40 +164,6 @@ defmodule ImagePipe.SourceTest do
     assert {:error, {:source, :invalid_adapter_result}} = Source.resolve(source, opts, [])
   end
 
-  test "source validation rejects non-canonical strong byte identity material" do
-    defmodule BadByteIdentitySource do
-      @behaviour ImagePipe.Source
-
-      def validate_options(opts), do: {:ok, opts}
-
-      def resolve(%SourcePath{}, _opts, _runtime_opts) do
-        {:ok,
-         %Resolved{
-           adapter: :path,
-           source_kind: :path,
-           identity: [kind: :path, adapter: :path, root: "test", path: ["cat.jpg"]],
-           internal_cache: :enabled,
-           http_cache: :enabled,
-           cache_semantics: %CacheSemantics{
-             byte_identity: {:strong, fn -> :not_canonical end},
-             stable?: true
-           },
-           fetch: [path: "/tmp/cat.jpg"]
-         }}
-      end
-
-      def fetch(_resolved, _opts, _runtime_opts), do: raise("not used")
-    end
-
-    opts = [
-      parser: ImagePipe.Parser.Imgproxy,
-      sources: [path: {BadByteIdentitySource, []}]
-    ]
-
-    source = %SourcePath{segments: ["cat.jpg"]}
-
-    assert {:error, {:source, :invalid_adapter_result}} = Source.resolve(source, opts, [])
-  end
 end
 ```
 
@@ -336,7 +302,13 @@ Create `lib/image_pipe/source/cache_semantics.ex`:
 
 ```elixir
 defmodule ImagePipe.Source.CacheSemantics do
-  @moduledoc false
+  @moduledoc """
+  Source-owned cache facts used by internal and HTTP cache decisions.
+
+  `byte_identity` seeds must be deterministic, non-secret, and stable across
+  nodes for the same source bytes. The core validates the tagged shape but does
+  not validate seed contents structurally.
+  """
 
   @enforce_keys [:byte_identity, :stable?]
   defstruct @enforce_keys
@@ -416,54 +388,26 @@ Remove `@cache_policies`.
 Replace `valid_resolved?/1` with:
 
 ```elixir
-defp valid_resolved?(%Resolved{
-       source_kind: source_kind,
-       identity: identity,
-       internal_cache: internal_cache,
-       http_cache: http_cache,
-       cache_semantics: %CacheSemantics{} = cache_semantics
-     }) do
-  source_kind in @source_kinds and
-    internal_cache in @internal_cache_policies and
-    http_cache in @http_cache_policies and
-    valid_cache_semantics?(cache_semantics) and
-    Identity.valid?(identity)
+defp valid_resolved?(%Resolved{} = resolved) do
+  resolved.source_kind in @source_kinds and
+    resolved.internal_cache in @internal_cache_policies and
+    resolved.http_cache in @http_cache_policies and
+    valid_cache_semantics?(resolved.cache_semantics) and
+    Identity.valid?(resolved.identity)
 end
 
-defp valid_resolved?(%Resolved{}), do: false
+defp valid_cache_semantics?(%CacheSemantics{byte_identity: :none, stable?: stable?}),
+  do: is_boolean(stable?)
 
-defp valid_cache_semantics?(%CacheSemantics{
-       byte_identity: byte_identity,
-       stable?: stable?
-     }) do
-  valid_byte_identity?(byte_identity) and is_boolean(stable?)
-end
+defp valid_cache_semantics?(%CacheSemantics{byte_identity: {:strong, _seed}, stable?: stable?}),
+  do: is_boolean(stable?)
 
-defp valid_byte_identity?(:none), do: true
-defp valid_byte_identity?({:strong, seed}), do: canonical_material?(seed)
-defp valid_byte_identity?(_byte_identity), do: false
-
-defp canonical_material?(value) when is_atom(value) or is_binary(value) or is_integer(value),
-  do: true
-
-defp canonical_material?(value) when is_boolean(value) or is_nil(value), do: true
-
-defp canonical_material?(value) when is_list(value) do
-  Enum.all?(value, fn
-    {key, item} when is_atom(key) or is_binary(key) -> canonical_material?(item)
-    item -> canonical_material?(item)
-  end)
-end
-
-defp canonical_material?(value) when is_tuple(value),
-  do: value |> Tuple.to_list() |> Enum.all?(&canonical_material?/1)
-
-defp canonical_material?(_value), do: false
+defp valid_cache_semantics?(_cache_semantics), do: false
 ```
 
-This validator checks whether the seed can be turned into canonical ETag
-material. Adapters still own the non-secret rule for what they put into the
-seed.
+This validates the cache semantics shape at the adapter boundary. It doesn't
+try to prove that strong seed material is stable. Adapters own that contract,
+and adapter tests should assert the exact seed shape for trusted paths.
 
 - [ ] **Step 8: Update file source defaults**
 

--- a/docs/superpowers/plans/2026-05-27-cdn-http-cache-implementation.md
+++ b/docs/superpowers/plans/2026-05-27-cdn-http-cache-implementation.md
@@ -1447,8 +1447,6 @@ defmodule ImagePipe.Request.HTTPCache do
             if has_resp_header?(conn, "etag"),
               do: {[{"cache-control", @generated_cache_control}], nil, nil},
               else: {[], nil, nil}
-
-          _cache_semantics -> {[], nil, nil}
         end
 
     end
@@ -1595,6 +1593,11 @@ defmodule ImagePipe.Request.HTTPCache do
   defp canonicalize(value), do: value
 end
 ```
+
+Don't add a catch-all cache semantics fallback here. `Source.Resolved` enforces
+`%CacheSemantics{byte_identity: :none | {:strong, term()}}`, so any other shape
+is an internal construction bug and should fail during implementation rather
+than suppress generated headers.
 
 The goal is to reuse canonical internal key material without including source
 identity, selected headers, selected cookies, or cachebuster as ETag-only
@@ -2153,12 +2156,14 @@ prepared_http_cache = HTTPCache.prepare(conn, plan, resolved_source, opts)
 
 case HTTPCache.evaluate_conditional(conn, prepared_http_cache, opts) do
   {:not_modified, headers} ->
+    result = :not_modified
+
     {conn, send_metadata} =
-      send_response(conn, opts, :not_modified, fn ->
+      send_response(conn, opts, result, fn ->
         HTTPCache.send_not_modified(conn, headers)
       end)
 
-    {conn, Map.merge(%{result: :not_modified}, send_metadata)}
+    {conn, request_stop_metadata(result, send_metadata)}
 
   :proceed ->
     result = Runner.run(conn, plan, resolved_source, prepared_http_cache, opts)
@@ -2172,9 +2177,13 @@ case HTTPCache.evaluate_conditional(conn, prepared_http_cache, opts) do
 end
 ```
 
-Keep the parser/plan/source error branches unchanged.
+Add `request_result_metadata(:not_modified)`, returning
+`%{result: :not_modified}`, next to the existing request metadata clauses. The
+304 branch should use the same `request_stop_metadata/2` path as success and
+error deliveries so future request telemetry changes apply to conditional
+responses too.
 
-Update `request_result/1` and `request_result_metadata/1` only if the direct `304` branch needs a new result atom in request telemetry. The direct branch above returns stop metadata without calling those helpers.
+Keep the parser/plan/source error branches unchanged.
 
 - [ ] **Step 4: Write failing Runner delivery tests**
 

--- a/docs/superpowers/plans/2026-05-27-cdn-http-cache-implementation.md
+++ b/docs/superpowers/plans/2026-05-27-cdn-http-cache-implementation.md
@@ -1,0 +1,2796 @@
+# CDN HTTP Cache Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add v1 CDN-facing HTTP cache support with generated `Cache-Control`, strong pre-fetch `ETag`, `Vary: Accept`, and `If-None-Match` handling for explicitly cacheable public image routes.
+
+**Architecture:** Source adapters expose byte-identity semantics during `Source.resolve/3`. `ImagePipe.Plug` prepares HTTP cache headers after source resolution and before `Runner.run/4`, so matching conditional requests can return `304` before internal cache lookup or source fetch. Runner and Sender receive the prepared value for normal `200` delivery so cache misses and internal cache hits merge generated headers through the same path.
+
+**Tech Stack:** Elixir, Plug, ExUnit, NimbleOptions, StreamData, Boundary, ImagePipe source/request/cache/output/response modules.
+
+---
+
+## File Structure
+
+Create:
+
+- `lib/image_pipe/source/cache_semantics.ex`: source-owned byte identity struct with enforced fields.
+- `lib/image_pipe/request/http_cache.ex`: HTTP cache preparation, ETag material, `If-None-Match` parsing, `Vary` merge helpers, and direct `304` sender.
+- `lib/image_pipe/response/cache_headers.ex`: response-owned prepared header bundle passed through Runner delivery without making `ImagePipe.Response` depend on `ImagePipe.Request`.
+- `test/image_pipe/request/http_cache_test.exs`: unit coverage for prepared headers, ETags, `Vary`, conditional matching, serialization, and telemetry metadata.
+- `test/image_pipe/cdn_http_cache_wire_test.exs`: Plug-level v1 behavior with real requests, source probes, cache probes, and cache-hit parity.
+
+Modify:
+
+- `lib/image_pipe/source.ex`: export `CacheSemantics`; validate `Resolved.internal_cache` and `cache_semantics`.
+- `lib/image_pipe/source/resolved.ex`: replace `cache` with `internal_cache`; add `http_cache` and `cache_semantics` enforced fields.
+- `lib/image_pipe/source/file.ex`: validate `stable`, `internal_cache`, and `http_cache`; set default not-stable source semantics.
+- `lib/image_pipe/source/http.ex`: validate `stable`, `internal_cache`, and `http_cache`; migrate cache field usage to internal cache; avoid raw signed query material in byte identity.
+- `lib/image_pipe/source/s3.ex`: validate `stable`, `internal_cache`, and `http_cache`; mark versioned objects stable under `stable: :auto`.
+- `lib/image_pipe/request/options.ex`: add `http_cache: [mode: :disabled]` validation and keep parser-visible/runtime option boundaries unchanged.
+- `lib/image_pipe/request/runner.ex`: accept prepared HTTP cache value and return it in cache-hit and prepared-stream delivery tuples; switch `cache` pattern matches to `internal_cache`.
+- `lib/image_pipe/response/sender.ex`: merge prepared representation/cache headers into cached-entry and prepared-stream responses; preserve current host policy.
+- `lib/image_pipe/response.ex`: export `CacheHeaders`.
+- `lib/image_pipe/cache/key.ex`: include the HTTP cache representation version in internal cache key material.
+- `lib/image_pipe/plan.ex`: export canonical representation material helper if implemented in a new plan module or directly here.
+- `lib/image_pipe/output/policy.ex`: expose only the output data needed by canonical representation material if the plan layer can't derive it directly.
+- `lib/image_pipe.ex`: update Boundary exports if new public/internal modules require it through existing top-level boundaries.
+- `test/image_pipe/source/file_test.exs`, `test/image_pipe/source/http_test.exs`, `test/image_pipe/source/s3_test.exs`, `test/image_pipe/source_test.exs`: source semantics and migration coverage.
+- `test/image_pipe/request_runner_test.exs`: delivery tuple and internal cache behavior.
+- `test/image_pipe/response_sender_test.exs`: header merge behavior on cache hits and prepared streams.
+- `test/image_pipe/cache/key_test.exs`, `test/image_pipe/cache/key_property_test.exs`: representation version in internal key material.
+- `test/image_pipe/output_policy_test.exs` or `test/image_pipe/plan_test.exs`: canonical representation material.
+- `test/image_pipe/request_options_test.exs`: `http_cache` option validation.
+- `test/image_pipe/architecture_boundary_test.exs`: request/source/response/cache boundary updates.
+- `README.md` or a new focused doc under `docs/`: user-facing CDN setup, source stability configuration, and ETag schema bump notes.
+
+Don't modify:
+
+- `ImagePipe.Cache.Entry.cacheable_headers/1` allowlist for `vary` or `cache-control`; it already allows both.
+- Parser/provider modules to set response cache policy. Parser fields such as `Plan.expires` remain request validity/cache-key inputs only.
+
+## Constants
+
+Use implementation constants, not request options:
+
+```elixir
+@etag_schema 1
+@representation_version 1
+@generated_cache_control "public, max-age=31536000, immutable"
+```
+
+Build visible generated ETags from the schema constant:
+
+```elixir
+~s("ip#{@etag_schema}-#{Base.url_encode64(hash, padding: false)}")
+```
+
+The same `@representation_version` value must appear in generated ETag material and internal cache key material.
+
+## Task 1: Source Cache Semantics and Resolved Migration
+
+**Files:**
+
+- Create: `lib/image_pipe/source/cache_semantics.ex`
+- Modify: `lib/image_pipe/source.ex`
+- Modify: `lib/image_pipe/source/resolved.ex`
+- Modify: `lib/image_pipe/source/file.ex`
+- Modify: `lib/image_pipe/source/http.ex`
+- Modify: `lib/image_pipe/source/s3.ex`
+- Test: `test/image_pipe/source_test.exs`
+- Test: `test/image_pipe/source/file_test.exs`
+- Test: `test/image_pipe/source/http_test.exs`
+- Test: `test/image_pipe/source/s3_test.exs`
+- Test: `test/image_pipe/request_runner_test.exs`
+
+- [ ] **Step 1: Write the failing struct tests**
+
+Add these tests to `test/image_pipe/source_test.exs`:
+
+```elixir
+defmodule ImagePipe.SourceTest do
+  use ExUnit.Case, async: true
+
+  alias ImagePipe.Plan.Source.Path, as: SourcePath
+  alias ImagePipe.Source
+  alias ImagePipe.Source.CacheSemantics
+  alias ImagePipe.Source.Resolved
+
+  test "cache semantics requires explicit byte identity and stability" do
+    assert_raise ArgumentError, fn ->
+      struct!(CacheSemantics, byte_identity: :none)
+    end
+
+    assert %CacheSemantics{byte_identity: :none, stable?: false} =
+             struct!(CacheSemantics, byte_identity: :none, stable?: false)
+  end
+
+  test "resolved source requires internal cache mode, http cache mode, and cache semantics" do
+    assert_raise ArgumentError, fn ->
+      struct!(Resolved,
+        adapter: :path,
+        source_kind: :path,
+        identity: [kind: :path, adapter: :path, root: "test", path: ["cat.jpg"]],
+        internal_cache: :disabled,
+        fetch: [path: "/tmp/cat.jpg"]
+      )
+    end
+
+    assert %Resolved{
+             internal_cache: :disabled,
+             http_cache: :inherit,
+             cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false}
+           } =
+             struct!(Resolved,
+               adapter: :path,
+               source_kind: :path,
+               identity: [kind: :path, adapter: :path, root: "test", path: ["cat.jpg"]],
+               internal_cache: :disabled,
+               http_cache: :inherit,
+               cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false},
+               fetch: [path: "/tmp/cat.jpg"]
+             )
+  end
+
+  test "source validation rejects resolved values without cache semantics" do
+    defmodule MissingSemanticsSource do
+      @behaviour ImagePipe.Source
+
+      def validate_options(opts), do: {:ok, opts}
+
+      def resolve(%SourcePath{}, _opts, _runtime_opts) do
+        {:ok,
+         %Resolved{
+           adapter: :path,
+           source_kind: :path,
+           identity: [kind: :path, adapter: :path, root: "test", path: ["cat.jpg"]],
+           internal_cache: :disabled,
+           http_cache: :inherit,
+           cache_semantics: nil,
+           fetch: [path: "/tmp/cat.jpg"]
+         }}
+      end
+
+      def fetch(_resolved, _opts, _runtime_opts), do: raise("not used")
+    end
+
+    opts = [
+      parser: ImagePipe.Parser.Imgproxy,
+      sources: [path: {MissingSemanticsSource, []}]
+    ]
+
+    source = %SourcePath{segments: ["cat.jpg"]}
+
+    assert {:error, {:source, :invalid_adapter_result}} = Source.resolve(source, opts, [])
+  end
+
+  test "source validation rejects non-canonical strong byte identity material" do
+    defmodule BadByteIdentitySource do
+      @behaviour ImagePipe.Source
+
+      def validate_options(opts), do: {:ok, opts}
+
+      def resolve(%SourcePath{}, _opts, _runtime_opts) do
+        {:ok,
+         %Resolved{
+           adapter: :path,
+           source_kind: :path,
+           identity: [kind: :path, adapter: :path, root: "test", path: ["cat.jpg"]],
+           internal_cache: :enabled,
+           http_cache: :enabled,
+           cache_semantics: %CacheSemantics{
+             byte_identity: {:strong, fn -> :not_canonical end},
+             stable?: true
+           },
+           fetch: [path: "/tmp/cat.jpg"]
+         }}
+      end
+
+      def fetch(_resolved, _opts, _runtime_opts), do: raise("not used")
+    end
+
+    opts = [
+      parser: ImagePipe.Parser.Imgproxy,
+      sources: [path: {BadByteIdentitySource, []}]
+    ]
+
+    source = %SourcePath{segments: ["cat.jpg"]}
+
+    assert {:error, {:source, :invalid_adapter_result}} = Source.resolve(source, opts, [])
+  end
+end
+```
+
+If `test/image_pipe/source_test.exs` already has module content, merge these tests into that module instead of creating a duplicate `defmodule`.
+
+- [ ] **Step 2: Run the struct tests and verify failure**
+
+Run:
+
+```bash
+mise exec -- mix test test/image_pipe/source_test.exs
+```
+
+Expected: fail because `ImagePipe.Source.CacheSemantics` doesn't exist and `Source.Resolved` still uses `cache`.
+
+- [ ] **Step 3: Write failing source adapter behavior tests**
+
+Add to `test/image_pipe/source/file_test.exs`:
+
+```elixir
+test "file source defaults to not stable and disables internal cache in auto mode", %{root: root} do
+  assert {:ok, opts} = SourceFile.validate_options(root: root, root_id: "fixture-root")
+  source = %SourcePath{segments: ["images", "cat.jpg"]}
+
+  assert {:ok, resolved} = SourceFile.resolve(source, opts, [])
+
+  assert resolved.internal_cache == :disabled
+  assert resolved.http_cache == :inherit
+  assert resolved.cache_semantics.stable? == false
+  assert resolved.cache_semantics.byte_identity == :none
+end
+
+test "file source trusted stability derives strong byte identity", %{root: root} do
+  assert {:ok, opts} =
+           SourceFile.validate_options(root: root, root_id: "fixture-root", stable: :trusted)
+
+  source = %SourcePath{segments: ["images", "cat.jpg"]}
+
+  assert {:ok, resolved} = SourceFile.resolve(source, opts, [])
+
+  assert resolved.internal_cache == :enabled
+  assert resolved.cache_semantics.stable? == true
+  assert {:strong, seed} = resolved.cache_semantics.byte_identity
+  assert seed[:root] == "fixture-root"
+  assert seed[:path] == ["images", "cat.jpg"]
+end
+```
+
+Add to `test/image_pipe/source/http_test.exs`:
+
+```elixir
+test "http source defaults to not stable and disables internal cache in auto mode" do
+  assert {:ok, opts} = HTTP.validate_options(allowed_hosts: ["example.com"])
+  source = %URL{scheme: :https, host: "example.com", path: ["cat.jpg"]}
+
+  assert {:ok, resolved} = HTTP.resolve(source, opts, [])
+
+  assert resolved.internal_cache == :disabled
+  assert resolved.cache_semantics.byte_identity == :none
+end
+
+test "http trusted byte identity doesn't expose raw query" do
+  assert {:ok, opts} = HTTP.validate_options(allowed_hosts: ["example.com"], stable: :trusted)
+
+  source = %URL{
+    scheme: :https,
+    host: "example.com",
+    path: ["cat.jpg"],
+    query: "X-Amz-Signature=secret"
+  }
+
+  assert {:ok, resolved} = HTTP.resolve(source, opts, [])
+  assert {:strong, seed} = resolved.cache_semantics.byte_identity
+  refute inspect(seed) =~ "X-Amz-Signature=secret"
+  assert is_binary(seed[:query_sha256])
+end
+```
+
+Add to `test/image_pipe/source/s3_test.exs`:
+
+```elixir
+test "s3 revision is stable under auto mode" do
+  assert {:ok, opts} =
+           S3.validate_options(
+             default: [
+               region: "us-east-1",
+               endpoint: "https://s3.amazonaws.com",
+               credentials: {:static, access_key_id: "A", secret_access_key: "S"}
+             ]
+           )
+
+  source = %Object{adapter: :s3, scope: "bucket", key: "cat.jpg", revision: "v1"}
+
+  assert {:ok, resolved} = S3.resolve(source, opts, [])
+
+  assert resolved.internal_cache == :enabled
+  assert resolved.cache_semantics.stable? == true
+  assert {:strong, seed} = resolved.cache_semantics.byte_identity
+  assert seed[:bucket] == "bucket"
+  assert seed[:key] == "cat.jpg"
+  assert seed[:revision] == "v1"
+end
+
+test "s3 without revision isn't stable unless trusted" do
+  assert {:ok, opts} =
+           S3.validate_options(
+             default: [
+               region: "us-east-1",
+               endpoint: "https://s3.amazonaws.com",
+               credentials: {:static, access_key_id: "A", secret_access_key: "S"}
+             ]
+           )
+
+  source = %Object{adapter: :s3, scope: "bucket", key: "cat.jpg", revision: nil}
+
+  assert {:ok, resolved} = S3.resolve(source, opts, [])
+
+  assert resolved.internal_cache == :disabled
+  assert resolved.cache_semantics.byte_identity == :none
+end
+```
+
+- [ ] **Step 4: Run source adapter tests and verify failure**
+
+Run:
+
+```bash
+mise exec -- mix test test/image_pipe/source/file_test.exs test/image_pipe/source/http_test.exs test/image_pipe/source/s3_test.exs
+```
+
+Expected: fail because adapter options and resolved fields still use `cache`.
+
+- [ ] **Step 5: Add `ImagePipe.Source.CacheSemantics`**
+
+Create `lib/image_pipe/source/cache_semantics.ex`:
+
+```elixir
+defmodule ImagePipe.Source.CacheSemantics do
+  @moduledoc false
+
+  @enforce_keys [:byte_identity, :stable?]
+  defstruct @enforce_keys
+
+  @type byte_identity :: {:strong, term()} | :none
+
+  @type t :: %__MODULE__{
+          byte_identity: byte_identity(),
+          stable?: boolean()
+        }
+end
+```
+
+- [ ] **Step 6: Migrate `Source.Resolved` fields**
+
+Replace `lib/image_pipe/source/resolved.ex` with:
+
+```elixir
+defmodule ImagePipe.Source.Resolved do
+  @moduledoc false
+
+  alias ImagePipe.Source.CacheSemantics
+
+  @enforce_keys [
+    :adapter,
+    :source_kind,
+    :identity,
+    :internal_cache,
+    :http_cache,
+    :cache_semantics,
+    :fetch
+  ]
+  defstruct @enforce_keys
+
+  @type internal_cache :: :enabled | :disabled
+  @type http_cache :: :inherit | :disabled | :enabled
+
+  @type t :: %__MODULE__{
+          adapter: atom(),
+          source_kind: :path | :url | :object | :reference,
+          identity: term(),
+          internal_cache: internal_cache(),
+          http_cache: http_cache(),
+          cache_semantics: CacheSemantics.t(),
+          fetch: term()
+        }
+end
+```
+
+- [ ] **Step 7: Update source validation for new fields**
+
+In `lib/image_pipe/source.ex`, add `CacheSemantics` to the Boundary export list:
+
+```elixir
+exports: [
+  CacheSemantics,
+  Resolved,
+  Response,
+  StreamError,
+  HTTP,
+  File,
+  S3
+]
+```
+
+Add aliases and policies near the existing aliases/constants:
+
+```elixir
+alias ImagePipe.Source.CacheSemantics
+
+@internal_cache_policies [:enabled, :disabled]
+@http_cache_policies [:inherit, :enabled, :disabled]
+```
+
+Remove `@cache_policies`.
+
+Replace `valid_resolved?/1` with:
+
+```elixir
+defp valid_resolved?(%Resolved{
+       source_kind: source_kind,
+       identity: identity,
+       internal_cache: internal_cache,
+       http_cache: http_cache,
+       cache_semantics: %CacheSemantics{} = cache_semantics
+     }) do
+  source_kind in @source_kinds and
+    internal_cache in @internal_cache_policies and
+    http_cache in @http_cache_policies and
+    valid_cache_semantics?(cache_semantics) and
+    Identity.valid?(identity)
+end
+
+defp valid_resolved?(%Resolved{}), do: false
+
+defp valid_cache_semantics?(%CacheSemantics{
+       byte_identity: byte_identity,
+       stable?: stable?
+     }) do
+  valid_byte_identity?(byte_identity) and is_boolean(stable?)
+end
+
+defp valid_byte_identity?(:none), do: true
+defp valid_byte_identity?({:strong, seed}), do: canonical_material?(seed)
+defp valid_byte_identity?(_byte_identity), do: false
+
+defp canonical_material?(value) when is_atom(value) or is_binary(value) or is_integer(value),
+  do: true
+
+defp canonical_material?(value) when is_boolean(value) or is_nil(value), do: true
+
+defp canonical_material?(value) when is_list(value) do
+  Enum.all?(value, fn
+    {key, item} when is_atom(key) or is_binary(key) -> canonical_material?(item)
+    item -> canonical_material?(item)
+  end)
+end
+
+defp canonical_material?(value) when is_tuple(value),
+  do: value |> Tuple.to_list() |> Enum.all?(&canonical_material?/1)
+
+defp canonical_material?(_value), do: false
+```
+
+This validator checks whether the seed can be turned into canonical ETag
+material. Adapters still own the non-secret rule for what they put into the
+seed.
+
+- [ ] **Step 8: Update file source defaults**
+
+In `lib/image_pipe/source/file.ex`, add `CacheSemantics` alias:
+
+```elixir
+alias ImagePipe.Source.CacheSemantics
+```
+
+Replace the options schema `cache:` entry with:
+
+```elixir
+stable: [type: {:in, [:auto, :trusted]}, default: :auto],
+internal_cache: [type: {:in, [:auto, :enabled, :disabled]}, default: :auto],
+http_cache: [type: {:in, [:inherit, :disabled, :enabled]}, default: :inherit]
+```
+
+Update the resolved struct fields:
+
+```elixir
+stable? = Keyword.fetch!(opts, :stable) == :trusted
+
+{:ok,
+ %Resolved{
+   adapter: :path,
+   source_kind: :path,
+   identity: [
+     kind: :path,
+     adapter: :path,
+     root: Keyword.fetch!(opts, :root_id),
+     path: segments
+   ],
+   internal_cache: internal_cache_mode(opts, stable?),
+   http_cache: Keyword.fetch!(opts, :http_cache),
+   cache_semantics: cache_semantics(opts, stable?, [
+     kind: :path,
+     adapter: :path,
+     root: Keyword.fetch!(opts, :root_id),
+     path: segments
+   ]),
+   fetch: [path: path, root: Keyword.fetch!(opts, :root), segments: segments]
+ }}
+```
+
+Add helpers:
+
+```elixir
+defp internal_cache_mode(opts, stable?) do
+  case Keyword.fetch!(opts, :internal_cache) do
+    :enabled -> :enabled
+    :disabled -> :disabled
+    :auto -> if stable?, do: :enabled, else: :disabled
+  end
+end
+
+defp cache_semantics(opts, stable?, identity) do
+  byte_identity =
+    if Keyword.fetch!(opts, :stable) == :trusted do
+      {:strong, identity}
+    else
+      :none
+    end
+
+  %CacheSemantics{byte_identity: byte_identity, stable?: stable?}
+end
+```
+
+Keep file sources not stable by default; don't add `File.stat/2` byte identity.
+
+- [ ] **Step 9: Update HTTP source defaults and header stripping**
+
+In `lib/image_pipe/source/http.ex`, add `CacheSemantics` alias:
+
+```elixir
+alias ImagePipe.Source.CacheSemantics
+```
+
+Replace the options schema `cache:` entry with:
+
+```elixir
+stable: [type: {:in, [:auto, :trusted]}, default: :auto],
+internal_cache: [type: {:in, [:auto, :enabled, :disabled]}, default: :auto],
+http_cache: [type: {:in, [:inherit, :disabled, :enabled]}, default: :inherit]
+```
+
+In `resolve/3`, build identity once:
+
+```elixir
+identity = [
+  kind: :url,
+  adapter: scheme,
+  scheme: scheme,
+  host: host,
+  port: port,
+  path: source.path,
+  query: source.query
+]
+
+stable? = Keyword.fetch!(opts, :stable) == :trusted
+internal_cache = internal_cache_mode(opts, stable?)
+```
+
+Use these fields in `%Resolved{}`:
+
+```elixir
+identity: identity,
+internal_cache: internal_cache,
+http_cache: Keyword.fetch!(opts, :http_cache),
+cache_semantics: cache_semantics(opts, stable?, identity),
+fetch: [
+  url: build_url(%{source | host: host, port: port}),
+  internal_cache: internal_cache
+]
+```
+
+In `fetch/3`, use `fetch[:internal_cache]`:
+
+```elixir
+|> sanitize_req_options(fetch[:internal_cache])
+```
+
+Replace `denied_header_names/1` clauses:
+
+```elixir
+defp denied_header_names(:enabled), do: @host_header_names ++ @cacheable_byte_header_names
+defp denied_header_names(:disabled), do: @host_header_names
+```
+
+Add the same `internal_cache_mode/2` helper as in `File`.
+
+Add `cache_semantics/3`:
+
+```elixir
+defp cache_semantics(opts, stable?, identity) do
+  byte_identity =
+    if Keyword.fetch!(opts, :stable) == :trusted do
+      {:strong, redacted_http_identity(identity)}
+    else
+      :none
+    end
+
+  %CacheSemantics{byte_identity: byte_identity, stable?: stable?}
+end
+
+defp redacted_http_identity(identity) do
+  case Keyword.fetch!(identity, :query) do
+    nil ->
+      Keyword.delete(identity, :query)
+
+    query ->
+      identity
+      |> Keyword.delete(:query)
+      |> Keyword.put(:query_sha256, :crypto.hash(:sha256, query) |> Base.encode16(case: :lower))
+  end
+end
+```
+
+This keeps raw signed query strings out of byte-identity material.
+
+- [ ] **Step 10: Update S3 source defaults**
+
+In `lib/image_pipe/source/s3.ex`, add `CacheSemantics` alias:
+
+```elixir
+alias ImagePipe.Source.CacheSemantics
+```
+
+Replace the config schema `cache:` entry with:
+
+```elixir
+stable: [type: {:in, [:auto, :trusted]}, default: :auto],
+internal_cache: [type: {:in, [:auto, :enabled, :disabled]}, default: :auto],
+http_cache: [type: {:in, [:inherit, :disabled, :enabled]}, default: :inherit],
+```
+
+In `resolve/3`, build identity once:
+
+```elixir
+identity = [
+  kind: :object,
+  adapter: :s3,
+  endpoint: endpoint,
+  bucket: bucket,
+  key: key,
+  revision: revision
+]
+
+stable? = s3_stable?(config, revision)
+internal_cache = internal_cache_mode(config, stable?)
+```
+
+Use these fields in `%Resolved{}`:
+
+```elixir
+identity: identity,
+internal_cache: internal_cache,
+http_cache: Keyword.fetch!(config, :http_cache),
+cache_semantics: cache_semantics(stable?, identity),
+fetch:
+  [
+    endpoint: endpoint,
+    bucket: bucket,
+    key: key,
+    revision: revision,
+    region: Keyword.fetch!(config, :region),
+    credentials: Keyword.get(config, :credentials),
+    req_options: Keyword.fetch!(config, :req_options),
+    internal_cache: internal_cache
+  ]
+  |> Keyword.merge(Keyword.take(config, @timeout_keys))
+```
+
+In `fetch/3`, use:
+
+```elixir
+|> sanitize_req_options(fetch[:internal_cache])
+```
+
+Replace `denied_header_names/1` clauses:
+
+```elixir
+defp denied_header_names(:enabled), do: @signed_header_names ++ @cacheable_byte_header_names
+defp denied_header_names(:disabled), do: @signed_header_names
+```
+
+Add helpers:
+
+```elixir
+defp s3_stable?(config, revision) do
+  Keyword.fetch!(config, :stable) == :trusted or is_binary(revision)
+end
+
+defp internal_cache_mode(config, stable?) do
+  case Keyword.fetch!(config, :internal_cache) do
+    :enabled -> :enabled
+    :disabled -> :disabled
+    :auto -> if stable?, do: :enabled, else: :disabled
+  end
+end
+
+defp cache_semantics(true, identity),
+  do: %CacheSemantics{byte_identity: {:strong, identity}, stable?: true}
+
+defp cache_semantics(false, _identity),
+  do: %CacheSemantics{byte_identity: :none, stable?: false}
+```
+
+- [ ] **Step 11: Update Runner pattern matches**
+
+In `lib/image_pipe/request/runner.ex`, replace:
+
+```elixir
+%Source.Resolved{cache: :skip}
+%Source.Resolved{cache: :normal}
+```
+
+with:
+
+```elixir
+%Source.Resolved{internal_cache: :disabled}
+%Source.Resolved{internal_cache: :enabled}
+```
+
+Don't change the delivery tuple shape in this task. That comes later.
+
+- [ ] **Step 12: Update tests and fixtures that build `Source.Resolved`**
+
+Search:
+
+```bash
+rg "%Source\\.Resolved|SourceResolved|cache: :normal|cache: :skip|fetch\\[:cache\\]" lib test
+```
+
+For each hand-built `%Source.Resolved{}`, add:
+
+```elixir
+internal_cache: :enabled,
+http_cache: :inherit,
+cache_semantics: %ImagePipe.Source.CacheSemantics{
+  byte_identity: :none,
+  stable?: false
+}
+```
+
+Use `internal_cache: :disabled` where the old fixture used `cache: :skip`.
+
+- [ ] **Step 13: Run source and runner tests**
+
+Run:
+
+```bash
+mise exec -- mix test test/image_pipe/source_test.exs test/image_pipe/source/file_test.exs test/image_pipe/source/http_test.exs test/image_pipe/source/s3_test.exs test/image_pipe/request_runner_test.exs
+```
+
+Expected: pass.
+
+- [ ] **Step 14: Commit source semantics migration**
+
+Run:
+
+```bash
+mise exec -- git add lib/image_pipe/source.ex lib/image_pipe/source/cache_semantics.ex lib/image_pipe/source/resolved.ex lib/image_pipe/source/file.ex lib/image_pipe/source/http.ex lib/image_pipe/source/s3.ex lib/image_pipe/request/runner.ex test/image_pipe/source_test.exs test/image_pipe/source/file_test.exs test/image_pipe/source/http_test.exs test/image_pipe/source/s3_test.exs test/image_pipe/request_runner_test.exs
+mise exec -- git commit -m "Add source cache semantics"
+```
+
+## Task 2: Request Options and Internal Cache Key Version
+
+**Files:**
+
+- Modify: `lib/image_pipe/request/options.ex`
+- Modify: `lib/image_pipe/cache/key.ex`
+- Test: `test/image_pipe/request_options_test.exs`
+- Test: `test/image_pipe/cache/key_test.exs`
+- Test: `test/image_pipe/cache/key_property_test.exs`
+
+- [ ] **Step 1: Write failing option validation tests**
+
+Add to `test/image_pipe/request_options_test.exs`:
+
+```elixir
+test "http_cache defaults to disabled" do
+  opts = ImagePipe.Request.Options.validate!(parser: ImagePipe.Parser.Imgproxy)
+
+  assert Keyword.fetch!(opts, :http_cache) == [mode: :disabled]
+end
+
+test "http_cache accepts enabled mode" do
+  opts =
+    ImagePipe.Request.Options.validate!(
+      parser: ImagePipe.Parser.Imgproxy,
+      http_cache: [mode: :enabled]
+    )
+
+  assert Keyword.fetch!(opts, :http_cache) == [mode: :enabled]
+end
+
+test "http_cache rejects unknown mode" do
+  assert_raise ArgumentError, ~r/invalid ImagePipe options/, fn ->
+    ImagePipe.Request.Options.validate!(
+      parser: ImagePipe.Parser.Imgproxy,
+      http_cache: [mode: :public]
+    )
+  end
+end
+```
+
+- [ ] **Step 2: Run option tests and verify failure**
+
+Run:
+
+```bash
+mise exec -- mix test test/image_pipe/request_options_test.exs
+```
+
+Expected: fail because `:http_cache` isn't a known option.
+
+- [ ] **Step 3: Implement request option validation**
+
+In `lib/image_pipe/request/options.ex`, add to `@options_schema`:
+
+```elixir
+http_cache: [
+  type: :keyword_list,
+  default: [mode: :disabled],
+  keys: [
+    mode: [type: {:in, [:disabled, :enabled]}, default: :disabled]
+  ]
+],
+```
+
+Keep `:http_cache` out of `@parser_visible_option_keys` and `@source_runtime_option_keys`.
+
+- [ ] **Step 4: Run option tests**
+
+Run:
+
+```bash
+mise exec -- mix test test/image_pipe/request_options_test.exs
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Write cache key version tests**
+
+Add to `test/image_pipe/cache/key_test.exs`:
+
+```elixir
+test "cache key contains representation version" do
+  plan = plan(output: %ImagePipe.Plan.Output{mode: {:explicit, :webp}})
+  conn = Plug.Test.conn(:get, "/image")
+
+  assert {:ok, key} = ImagePipe.Cache.Key.build(conn, plan, source_identity())
+
+  assert key.data[:representation] == [version: ImagePipe.Cache.Key.representation_version()]
+end
+```
+
+If the helpers `plan/1` and `source_identity/0` don't exist in the file, add local versions:
+
+```elixir
+defp plan(overrides) do
+  struct!(
+    %ImagePipe.Plan{
+      source: %ImagePipe.Plan.Source.Path{segments: ["cat.jpg"]},
+      pipelines: [%ImagePipe.Plan.Pipeline{operations: []}],
+      output: %ImagePipe.Plan.Output{mode: {:explicit, :jpeg}}
+    },
+    overrides
+  )
+end
+
+defp source_identity do
+  [kind: :path, adapter: :path, root: "test", path: ["cat.jpg"]]
+end
+```
+
+- [ ] **Step 6: Run cache key test and verify failure**
+
+Run:
+
+```bash
+mise exec -- mix test test/image_pipe/cache/key_test.exs
+```
+
+Expected: fail because `representation_version/0` and `key.data[:representation]` don't exist.
+
+- [ ] **Step 7: Add representation version to internal key material**
+
+In `lib/image_pipe/cache/key.ex`, add:
+
+```elixir
+@representation_version 1
+```
+
+Add public internal function:
+
+```elixir
+@doc false
+@spec representation_version() :: pos_integer()
+def representation_version, do: @representation_version
+```
+
+Add to `data` in `build/4`:
+
+```elixir
+representation: representation_data(),
+```
+
+Add helper:
+
+```elixir
+defp representation_data, do: [version: @representation_version]
+```
+
+Update existing tests that assert the full `key.data` shape so their expected
+keyword list includes `representation: [version: 1]`. Update any hand-built
+fixtures that mirror the complete cache key data. Don't increment
+`@schema_version` for this greenfield internal key shape change.
+
+- [ ] **Step 8: Run cache key tests**
+
+Run:
+
+```bash
+mise exec -- mix test test/image_pipe/cache/key_test.exs test/image_pipe/cache/key_property_test.exs
+```
+
+Expected: pass.
+
+- [ ] **Step 9: Commit options and key version**
+
+Run:
+
+```bash
+mise exec -- git add lib/image_pipe/request/options.ex lib/image_pipe/cache/key.ex test/image_pipe/request_options_test.exs test/image_pipe/cache/key_test.exs test/image_pipe/cache/key_property_test.exs
+mise exec -- git commit -m "Add HTTP cache options"
+```
+
+## Task 3: Canonical Representation Material
+
+**Files:**
+
+- Modify: `lib/image_pipe/plan.ex`
+- Modify: `lib/image_pipe/output/policy.ex`
+- Test: `test/image_pipe/plan_test.exs`
+- Test: `test/image_pipe/output_policy_test.exs`
+
+- [ ] **Step 1: Write failing representation material tests**
+
+Add to `test/image_pipe/plan_test.exs`:
+
+```elixir
+describe "canonical_representation_material/1" do
+  test "explicit output contains output rule and quality material" do
+    plan = %ImagePipe.Plan{
+      source: %ImagePipe.Plan.Source.Path{segments: ["cat.jpg"]},
+      pipelines: [%ImagePipe.Plan.Pipeline{operations: []}],
+      output: %ImagePipe.Plan.Output{
+        mode: {:explicit, :webp},
+        quality: {:quality, 82},
+        format_qualities: %{webp: {:quality, 80}}
+      }
+    }
+
+    assert {:ok,
+            [
+              output: [
+                mode: :explicit,
+                format: :webp,
+                quality: {:quality, 82},
+                format_qualities: [webp: {:quality, 80}]
+              ]
+            ]} = ImagePipe.Plan.canonical_representation_material(plan)
+  end
+
+  test "automatic output contains symbolic automatic rule" do
+    plan = %ImagePipe.Plan{
+      source: %ImagePipe.Plan.Source.Path{segments: ["cat.jpg"]},
+      pipelines: [%ImagePipe.Plan.Pipeline{operations: []}],
+      output: %ImagePipe.Plan.Output{mode: :automatic}
+    }
+
+    assert {:ok,
+            [
+              output: [
+                mode: :automatic,
+                quality: :default,
+                format_qualities: []
+              ]
+            ]} = ImagePipe.Plan.canonical_representation_material(plan)
+  end
+end
+```
+
+- [ ] **Step 2: Run representation tests and verify failure**
+
+Run:
+
+```bash
+mise exec -- mix test test/image_pipe/plan_test.exs
+```
+
+Expected: fail because `ImagePipe.Plan.canonical_representation_material/1` doesn't exist.
+
+- [ ] **Step 3: Implement plan representation material**
+
+In `lib/image_pipe/plan.ex`, add:
+
+```elixir
+@spec canonical_representation_material(t()) :: {:ok, keyword()} | :omit_etag
+def canonical_representation_material(%__MODULE__{output: %Output{} = output}) do
+  {:ok, [output: output_material(output)]}
+end
+
+defp output_material(%Output{
+       mode: {:explicit, format},
+       quality: quality,
+       format_qualities: format_qualities
+     }) do
+  [
+    mode: :explicit,
+    format: format,
+    quality: quality,
+    format_qualities: sorted_format_qualities(format_qualities)
+  ]
+end
+
+defp output_material(%Output{
+       mode: :automatic,
+       quality: quality,
+       format_qualities: format_qualities
+     }) do
+  [
+    mode: :automatic,
+    quality: quality,
+    format_qualities: sorted_format_qualities(format_qualities)
+  ]
+end
+
+defp sorted_format_qualities(format_qualities) when is_map(format_qualities) do
+  format_qualities
+  |> Map.to_list()
+  |> Enum.sort_by(fn {format, _quality} -> format end)
+end
+```
+
+If current output modes later add `:source` or source-compatible fallback, encode the rule symbolically here. Don't add a per-rule version field; use `@representation_version` in HTTP cache/key material when rule behavior changes.
+
+- [ ] **Step 4: Add output policy material tests**
+
+Add to `test/image_pipe/output_policy_test.exs`:
+
+```elixir
+test "automatic output policy exposes Vary Accept and selected candidates from Accept" do
+  conn =
+    Plug.Test.conn(:get, "/image")
+    |> Plug.Conn.put_req_header("accept", "image/webp,image/avif;q=0.1")
+
+  policy =
+    ImagePipe.Output.Policy.from_output_plan(
+      conn,
+      %ImagePipe.Plan.Output{mode: :automatic},
+      []
+    )
+
+  assert policy.headers == [{"vary", "Accept"}]
+  assert policy.modern_candidates != []
+end
+```
+
+This is a characterization test for the existing boundary. Don't add a new output-policy API unless `HTTPCache` can't derive material from the plan and normalized Accept in Task 4.
+
+- [ ] **Step 5: Run plan/output tests**
+
+Run:
+
+```bash
+mise exec -- mix test test/image_pipe/plan_test.exs test/image_pipe/output_policy_test.exs
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit representation material**
+
+Run:
+
+```bash
+mise exec -- git add lib/image_pipe/plan.ex lib/image_pipe/output/policy.ex test/image_pipe/plan_test.exs test/image_pipe/output_policy_test.exs
+mise exec -- git commit -m "Add representation cache material"
+```
+
+## Task 4: HTTP Cache Preparation Module
+
+**Files:**
+
+- Create: `lib/image_pipe/request/http_cache.ex`
+- Create: `lib/image_pipe/response/cache_headers.ex`
+- Modify: `lib/image_pipe/request.ex` if Boundary exports need updating
+- Modify: `lib/image_pipe/response.ex`
+- Test: `test/image_pipe/request/http_cache_test.exs`
+- Test: `test/image_pipe/architecture_boundary_test.exs`
+
+- [ ] **Step 1: Write failing preparation tests**
+
+Create `test/image_pipe/request/http_cache_test.exs`:
+
+```elixir
+defmodule ImagePipe.Request.HTTPCacheTest do
+  use ExUnit.Case, async: true
+
+  import Plug.Conn
+  import Plug.Test
+
+  alias ImagePipe.Plan
+  alias ImagePipe.Plan.Output
+  alias ImagePipe.Plan.Pipeline
+  alias ImagePipe.Plan.Source.Path, as: SourcePath
+  alias ImagePipe.Request.HTTPCache
+  alias ImagePipe.Source.CacheSemantics
+  alias ImagePipe.Source.Resolved
+
+  defp plan(output \\ %Output{mode: {:explicit, :webp}}) do
+    %Plan{
+      source: %SourcePath{segments: ["cat.jpg"]},
+      pipelines: [%Pipeline{operations: []}],
+      output: output
+    }
+  end
+
+  defp resolved(overrides \\ []) do
+    struct!(
+      %Resolved{
+        adapter: :path,
+        source_kind: :path,
+        identity: [kind: :path, adapter: :path, root: "test", path: ["cat.jpg"]],
+        internal_cache: :enabled,
+        http_cache: :inherit,
+        cache_semantics: %CacheSemantics{
+          byte_identity: {:strong, [kind: :path, root: "test", path: ["cat.jpg"]]},
+          stable?: true
+        },
+        fetch: [path: "/tmp/cat.jpg"]
+      },
+      overrides
+    )
+  end
+
+  defp opts(overrides \\ []) do
+    Keyword.merge(
+      [
+        http_cache: [mode: :enabled],
+        telemetry_prefix: [:image_pipe]
+      ],
+      overrides
+    )
+  end
+
+  test "enabled mode with strong byte identity emits cache-control and strong etag" do
+    prepared = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
+
+    assert %ImagePipe.Response.CacheHeaders{
+             representation_headers: [],
+             headers: headers,
+             etag: etag
+           } = prepared
+
+    assert {"cache-control", "public, max-age=31536000, immutable"} in headers
+    assert {"etag", etag} in headers
+    assert etag =~ ~r/^"ip1-[A-Za-z0-9_-]+"$/
+  end
+
+  test "disabled mode emits no generated cache headers" do
+    prepared =
+      HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), http_cache: [mode: :disabled])
+
+    assert prepared.headers == []
+    assert prepared.etag == nil
+  end
+
+  test "missing byte identity emits no-store fallback without generated etag" do
+    prepared =
+      HTTPCache.prepare(
+        conn(:get, "/image"),
+        plan(),
+        resolved(
+          cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false}
+        ),
+        opts()
+      )
+
+    assert prepared.headers == [{"cache-control", "no-store"}]
+    assert prepared.etag == nil
+  end
+
+  test "host cache-control suppresses generated cache-control and no-store fallback" do
+    conn = put_resp_header(conn(:get, "/image"), "cache-control", "public, max-age=60")
+
+    prepared =
+      HTTPCache.prepare(
+        conn,
+        plan(),
+        resolved(
+          cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false}
+        ),
+        opts()
+      )
+
+    assert prepared.headers == []
+    assert prepared.etag == nil
+  end
+
+  test "host etag suppresses generated etag" do
+    conn = put_resp_header(conn(:get, "/image"), "etag", ~s("host"))
+
+    prepared = HTTPCache.prepare(conn, plan(), resolved(), opts())
+
+    refute Enum.any?(prepared.headers, fn {name, _value} -> name == "etag" end)
+    assert {"cache-control", "public, max-age=31536000, immutable"} in prepared.headers
+    assert prepared.etag == nil
+  end
+
+  test "automatic output emits representation Vary Accept" do
+    prepared =
+      HTTPCache.prepare(
+        conn(:get, "/image") |> put_req_header("accept", "image/avif,image/webp"),
+        plan(%Output{mode: :automatic}),
+        resolved(),
+        opts()
+      )
+
+    assert prepared.representation_headers == [{"vary", "Accept"}]
+  end
+
+  test "existing vary merges accept without duplicates" do
+    conn =
+      conn(:get, "/image")
+      |> put_resp_header("vary", "Accept-Encoding, Accept")
+
+    prepared =
+      HTTPCache.prepare(
+        conn,
+        plan(%Output{mode: :automatic}),
+        resolved(),
+        opts()
+      )
+
+    assert prepared.representation_headers == [{"vary", "Accept-Encoding, Accept"}]
+  end
+
+  test "existing vary star suppresses generated public cache headers but keeps representation headers" do
+    conn =
+      conn(:get, "/image")
+      |> put_resp_header("vary", "*")
+
+    prepared =
+      HTTPCache.prepare(
+        conn,
+        plan(%Output{mode: :automatic}),
+        resolved(),
+        opts()
+      )
+
+    assert prepared.representation_headers == [{"vary", "*"}]
+    assert prepared.headers == []
+    assert prepared.etag == nil
+  end
+end
+```
+
+- [ ] **Step 2: Run preparation tests and verify failure**
+
+Run:
+
+```bash
+mise exec -- mix test test/image_pipe/request/http_cache_test.exs
+```
+
+Expected: fail because `ImagePipe.Request.HTTPCache` doesn't exist.
+
+- [ ] **Step 3: Add the response-owned cache header bundle**
+
+Create `lib/image_pipe/response/cache_headers.ex`:
+
+```elixir
+defmodule ImagePipe.Response.CacheHeaders do
+  @moduledoc false
+
+  @enforce_keys [:representation_headers, :headers, :etag]
+  defstruct @enforce_keys
+
+  @type header :: {String.t(), String.t()}
+  @type t :: %__MODULE__{
+          representation_headers: [header()],
+          headers: [header()],
+          etag: String.t() | nil
+        }
+end
+```
+
+Add `CacheHeaders` to the exports list in `lib/image_pipe/response.ex`:
+
+```elixir
+exports: [
+  CacheHeaders,
+  PreparedStream,
+  Sender
+]
+```
+
+This keeps `ImagePipe.Response` independent from `ImagePipe.Request`. `HTTPCache`
+builds the value, but Sender only sees a response-owned struct.
+
+- [ ] **Step 4: Implement `HTTPCache.prepare/4`**
+
+Create `lib/image_pipe/request/http_cache.ex`:
+
+```elixir
+defmodule ImagePipe.Request.HTTPCache do
+  @moduledoc false
+
+  import Plug.Conn, only: [get_req_header: 2, get_resp_header: 2]
+
+  alias ImagePipe.Cache.Key
+  alias ImagePipe.Output.Negotiation
+  alias ImagePipe.Plan
+  alias ImagePipe.Plan.Output
+  alias ImagePipe.Response.CacheHeaders
+  alias ImagePipe.Source.CacheSemantics
+  alias ImagePipe.Source.Resolved
+  alias ImagePipe.Telemetry
+
+  @etag_schema 1
+  @generated_cache_control "public, max-age=31536000, immutable"
+  @no_store "no-store"
+
+  @spec prepare(Plug.Conn.t(), Plan.t(), Resolved.t(), keyword()) :: CacheHeaders.t()
+  def prepare(%Plug.Conn{} = conn, %Plan{} = plan, %Resolved{} = resolved, opts) do
+    effective_mode = effective_mode(resolved, opts)
+    representation_headers = representation_headers(conn, plan)
+
+    {headers, etag, fallback} =
+      generated_cache_headers(conn, plan, resolved, opts, effective_mode, representation_headers)
+
+    Telemetry.execute(
+      Telemetry.telemetry_opts(opts),
+      [:http_cache, :prepare],
+      %{},
+      %{
+        effective_mode: effective_mode,
+        byte_identity: byte_identity_kind(resolved.cache_semantics),
+        etag: etag_emitted?(etag)
+      }
+    )
+
+    if fallback == :no_store do
+      Telemetry.execute(
+        Telemetry.telemetry_opts(opts),
+        [:http_cache, :fallback, :no_store],
+        %{},
+        %{
+          adapter: resolved.adapter,
+          source_kind: resolved.source_kind,
+          reason: :missing_byte_identity
+        }
+      )
+    end
+
+    %CacheHeaders{
+      representation_headers: representation_headers,
+      headers: headers,
+      etag: etag
+    }
+  end
+
+  @doc false
+  @spec etag_schema() :: pos_integer()
+  def etag_schema, do: @etag_schema
+
+  @doc false
+  @spec generated_cache_control() :: String.t()
+  def generated_cache_control, do: @generated_cache_control
+
+  defp effective_mode(%Resolved{http_cache: :inherit}, opts),
+    do: opts |> Keyword.fetch!(:http_cache) |> Keyword.fetch!(:mode)
+
+  defp effective_mode(%Resolved{http_cache: mode}, _opts) when mode in [:enabled, :disabled],
+    do: mode
+
+  defp generated_cache_headers(_conn, _plan, _resolved, _opts, :disabled, _representation_headers),
+    do: {[], nil, nil}
+
+  defp generated_cache_headers(conn, plan, resolved, opts, :enabled, representation_headers) do
+    cond do
+      has_resp_header?(conn, "set-cookie") ->
+        {[], nil, nil}
+
+      vary_star?(representation_headers) ->
+        {[], nil, nil}
+
+      selected_cache_control(conn) == @no_store ->
+        {[], nil, nil}
+
+      has_resp_header?(conn, "cache-control") ->
+        generated_etag_only(conn, plan, resolved, opts)
+
+      true ->
+        generated_cache_control_and_etag(conn, plan, resolved, opts)
+    end
+  end
+
+  defp generated_cache_control_and_etag(conn, plan, resolved, opts) do
+    case generated_etag(conn, plan, resolved, opts) do
+      nil ->
+        case resolved.cache_semantics do
+          %CacheSemantics{byte_identity: :none} -> {[{"cache-control", @no_store}], nil, :no_store}
+          %CacheSemantics{byte_identity: {:strong, _seed}} ->
+            if has_resp_header?(conn, "etag"),
+              do: {[{"cache-control", @generated_cache_control}], nil, nil},
+              else: {[], nil, nil}
+
+          _cache_semantics -> {[], nil, nil}
+        end
+
+      etag ->
+        {[{"cache-control", @generated_cache_control}, {"etag", etag}], etag, nil}
+    end
+  end
+
+  defp generated_etag_only(conn, plan, resolved, opts) do
+    case generated_etag(conn, plan, resolved, opts) do
+      nil -> {[], nil, nil}
+      etag -> {[{"etag", etag}], etag, nil}
+    end
+  end
+
+  defp generated_etag(conn, plan, %Resolved{cache_semantics: cache_semantics}, opts) do
+    cond do
+      has_resp_header?(conn, "etag") ->
+        nil
+
+      selected_cache_control(conn) == @no_store ->
+        nil
+
+      true ->
+        do_generated_etag(conn, plan, cache_semantics, opts)
+    end
+  end
+
+  defp do_generated_etag(conn, plan, %CacheSemantics{byte_identity: {:strong, seed}}, opts) do
+    with {:ok, output_material} <- Plan.canonical_representation_material(plan) do
+      material = [
+        etag_schema: @etag_schema,
+        source: seed,
+        plan: canonical_plan_data(plan, opts),
+        output: output_material,
+        accept: accept_material(conn, plan.output, opts),
+        representation_version: Key.representation_version()
+      ]
+
+      material
+      |> serialize_material()
+      |> :crypto.hash(:sha256)
+      |> Base.url_encode64(padding: false)
+      |> then(&~s("ip#{@etag_schema}-#{&1}"))
+    else
+      :omit_etag -> nil
+    end
+  end
+
+  defp do_generated_etag(_conn, _plan, %CacheSemantics{byte_identity: :none}, _opts), do: nil
+
+  defp canonical_plan_data(%Plan{} = plan, opts) do
+    {:ok, material} = Key.plan_material(plan, opts)
+    Keyword.drop(material, [:cache])
+  end
+
+  defp accept_material(conn, %Output{mode: :automatic}, opts) do
+    conn
+    |> get_req_header("accept")
+    |> Enum.join(",")
+    |> Negotiation.modern_candidates(opts)
+  end
+
+  defp accept_material(_conn, %Output{}, _opts), do: []
+
+  defp representation_headers(conn, %Plan{output: %Output{mode: :automatic}}),
+    do: merge_vary(conn, "Accept")
+
+  defp representation_headers(_conn, %Plan{}), do: []
+
+  defp merge_vary(conn, added_name) do
+    existing =
+      conn
+      |> get_resp_header("vary")
+      |> Enum.flat_map(&split_vary/1)
+
+    values =
+      (existing ++ [added_name])
+      |> dedupe_tokens()
+
+    if values == [], do: [], else: [{"vary", Enum.join(values, ", ")}]
+  end
+
+  defp split_vary(value) do
+    value
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp dedupe_tokens(tokens) do
+    tokens
+    |> Enum.reduce([], fn token, acc ->
+      if Enum.any?(acc, &(String.downcase(&1) == String.downcase(token))),
+        do: acc,
+        else: acc ++ [token]
+    end)
+  end
+
+  defp vary_star?(headers) do
+    Enum.any?(headers, fn
+      {"vary", value} -> "*" in split_vary(value)
+      _header -> false
+    end)
+  end
+
+  defp selected_cache_control(conn) do
+    conn
+    |> get_resp_header("cache-control")
+    |> Enum.join(",")
+    |> String.downcase()
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.find(&(&1 == "no-store"))
+  end
+
+  defp has_resp_header?(conn, name), do: get_resp_header(conn, name) != []
+
+  defp byte_identity_kind(%CacheSemantics{byte_identity: {:strong, _seed}}), do: :strong
+  defp byte_identity_kind(%CacheSemantics{byte_identity: :none}), do: :none
+
+  defp etag_emitted?(nil), do: false
+  defp etag_emitted?(_etag), do: true
+
+  defp serialize_material(material) do
+    material
+    |> canonicalize()
+    |> :erlang.term_to_binary([:deterministic])
+  end
+
+  defp canonicalize(value) when is_list(value) do
+    if Keyword.keyword?(value) do
+      value
+      |> Enum.map(fn {key, item} -> {canonicalize(key), canonicalize(item)} end)
+      |> Enum.sort_by(fn {key, _item} -> key end)
+    else
+      Enum.map(value, &canonicalize/1)
+    end
+  end
+
+  defp canonicalize(value) when is_map(value) do
+    value
+    |> Enum.map(fn {key, item} -> {canonicalize(key), canonicalize(item)} end)
+    |> Enum.sort()
+  end
+
+  defp canonicalize(value) when is_tuple(value) do
+    value
+    |> Tuple.to_list()
+    |> Enum.map(&canonicalize/1)
+    |> List.to_tuple()
+  end
+
+  defp canonicalize(value), do: value
+end
+```
+
+The goal is to reuse canonical internal key material without including source
+identity, selected headers, selected cookies, or cachebuster as ETag-only
+inputs.
+
+- [ ] **Step 5: Add production plan material helper**
+
+Add a new `ImagePipe.Cache.Key.plan_material/2` helper that returns canonical
+plan/output/transform material without requiring a conn. Don't call
+`Plug.Test.conn/2` from production code.
+
+The replacement shape should be:
+
+```elixir
+@spec plan_material(Plan.t(), keyword()) :: {:ok, keyword()} | {:error, term()}
+def plan_material(%Plan{} = plan, opts) do
+  with {:ok, pipelines} <- pipelines_data(plan.pipelines),
+       {:ok, output} <- output_data_without_conn(plan.output, opts),
+       {:ok, cache} <- cache_data(plan.cachebuster) do
+    {:ok,
+     [
+       pipelines: pipelines,
+       transform: transform_data(),
+       output: output,
+       cache: cache
+     ]}
+  end
+end
+```
+
+`cachebuster` stays out of ETag material because it changes URL/cache-key
+selection, not encoded bytes. Add a focused test that changing
+`plan.cachebuster` changes `ImagePipe.Cache.Key.build/4` data but doesn't
+change the generated ETag.
+
+- [ ] **Step 6: Add conditional parsing tests**
+
+Extend `test/image_pipe/request/http_cache_test.exs`:
+
+```elixir
+describe "evaluate_conditional/3" do
+  test "weak request tag matches generated strong etag for GET" do
+    prepared = %ImagePipe.Response.CacheHeaders{
+      representation_headers: [],
+      headers: [{"etag", ~s("ip1-abc")}],
+      etag: ~s("ip1-abc")
+    }
+
+    conn =
+      :get
+      |> conn("/image")
+      |> put_req_header("if-none-match", ~s(W/"ip1-abc"))
+
+    assert {:not_modified, headers} = HTTPCache.evaluate_conditional(conn, prepared, [])
+    assert {"etag", ~s("ip1-abc")} in headers
+  end
+
+  test "wildcard form is ignored in v1" do
+    prepared = %ImagePipe.Response.CacheHeaders{
+      representation_headers: [],
+      headers: [{"etag", ~s("ip1-abc")}],
+      etag: ~s("ip1-abc")
+    }
+
+    conn =
+      :get
+      |> conn("/image")
+      |> put_req_header("if-none-match", ~s("ip1-abc", *))
+
+    assert :proceed = HTTPCache.evaluate_conditional(conn, prepared, [])
+  end
+
+  test "host etag isn't interpreted when prepared etag is nil" do
+    prepared = %ImagePipe.Response.CacheHeaders{
+      representation_headers: [],
+      headers: [],
+      etag: nil
+    }
+
+    conn =
+      :get
+      |> conn("/image")
+      |> put_req_header("if-none-match", ~s("host"))
+
+    assert :proceed = HTTPCache.evaluate_conditional(conn, prepared, [])
+  end
+end
+```
+
+- [ ] **Step 7: Implement conditional evaluation**
+
+Add to `lib/image_pipe/request/http_cache.ex`:
+
+```elixir
+import Plug.Conn, only: [get_req_header: 2, get_resp_header: 2, put_resp_header: 3, send_resp: 3]
+
+@not_modified_header_allowlist ~w(cache-control date etag expires vary)
+
+@spec evaluate_conditional(Plug.Conn.t(), CacheHeaders.t(), keyword()) ::
+        :proceed | {:not_modified, [{String.t(), String.t()}]}
+def evaluate_conditional(%Plug.Conn{method: "GET"} = conn, %CacheHeaders{etag: etag} = prepared, opts)
+    when is_binary(etag) do
+  if if_none_match?(conn, etag) do
+    headers = not_modified_headers(prepared)
+
+    Telemetry.execute(
+      Telemetry.telemetry_opts(opts),
+      [:http_cache, :conditional, :match],
+      %{},
+      %{method: :get}
+    )
+
+    {:not_modified, headers}
+  else
+    :proceed
+  end
+end
+
+def evaluate_conditional(%Plug.Conn{}, %CacheHeaders{}, _opts), do: :proceed
+
+@spec send_not_modified(Plug.Conn.t(), [{String.t(), String.t()}]) :: Plug.Conn.t()
+def send_not_modified(conn, headers) do
+  conn =
+    Enum.reduce(headers, conn, fn {name, value}, conn ->
+      put_resp_header(conn, name, value)
+    end)
+
+  send_resp(conn, 304, "")
+end
+
+defp if_none_match?(conn, etag) do
+  conn
+  |> get_req_header("if-none-match")
+  |> Enum.join(",")
+  |> parse_if_none_match()
+  |> tags_match?(etag)
+end
+
+defp parse_if_none_match(""), do: []
+
+defp parse_if_none_match(value) do
+  tags =
+    value
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+
+  if "*" in tags, do: :wildcard, else: tags
+end
+
+defp tags_match?(:wildcard, _etag), do: false
+defp tags_match?(tags, etag), do: Enum.any?(tags, &weak_entity_match?(&1, etag))
+
+defp weak_entity_match?(candidate, etag), do: strip_weak(candidate) == strip_weak(etag)
+
+defp strip_weak("W/" <> rest), do: rest
+defp strip_weak(value), do: value
+
+defp not_modified_headers(%CacheHeaders{} = prepared) do
+  prepared.headers
+  |> Kernel.++(prepared.representation_headers)
+  |> Enum.filter(fn {name, _value} -> String.downcase(name) in @not_modified_header_allowlist end)
+end
+```
+
+Keep wildcard handling simple: if `*` appears anywhere, ignore the conditional request in v1.
+
+- [ ] **Step 8: Run HTTP cache unit tests**
+
+Run:
+
+```bash
+mise exec -- mix test test/image_pipe/request/http_cache_test.exs
+```
+
+Expected: pass.
+
+- [ ] **Step 9: Run architecture tests**
+
+Run:
+
+```bash
+mise exec -- mix test test/image_pipe/architecture_boundary_test.exs
+```
+
+Expected: pass. If Boundary reports `ImagePipe.Request.HTTPCache` isn't exported inside the request boundary, update the relevant `use Boundary` declaration with the narrowest export needed.
+
+- [ ] **Step 10: Commit HTTP cache preparation**
+
+Run:
+
+```bash
+mise exec -- git add lib/image_pipe/request/http_cache.ex lib/image_pipe/request.ex test/image_pipe/request/http_cache_test.exs test/image_pipe/architecture_boundary_test.exs
+mise exec -- git commit -m "Prepare HTTP cache headers"
+```
+
+## Task 5: Plug, Runner, and Sender Integration
+
+**Files:**
+
+- Modify: `lib/image_pipe/plug.ex`
+- Modify: `lib/image_pipe/request/runner.ex`
+- Modify: `lib/image_pipe/response/sender.ex`
+- Test: `test/image_pipe/cdn_http_cache_wire_test.exs`
+- Test: `test/image_pipe/plug_test.exs`
+- Test: `test/image_pipe/request_runner_test.exs`
+- Test: `test/image_pipe/response_sender_test.exs`
+
+- [ ] **Step 1: Write failing wire tests for generated headers and 304**
+
+Create `test/image_pipe/cdn_http_cache_wire_test.exs`:
+
+```elixir
+defmodule ImagePipe.CDNHTTPCacheWireTest do
+  use ExUnit.Case, async: true
+
+  import Plug.Conn
+  import Plug.Test
+
+  alias ImagePipe.Cache.Entry
+  alias ImagePipe.Cache.Key
+  alias ImagePipe.Parser.Imgproxy.Signature
+  alias ImagePipe.Source.CacheSemantics
+  alias ImagePipe.Source.Resolved
+  alias ImagePipe.Source.Response
+
+  defmodule StableSource do
+    @behaviour ImagePipe.Source
+
+    def validate_options(opts), do: {:ok, Keyword.put_new(opts, :telemetry_kind, :stable_test)}
+
+    def resolve(source, _opts, _runtime_opts) do
+      path = source.segments
+
+      {:ok,
+       %Resolved{
+         adapter: :path,
+         source_kind: :path,
+         identity: [kind: :path, adapter: :path, root: "wire", path: path],
+         internal_cache: :enabled,
+         http_cache: :enabled,
+         cache_semantics: %CacheSemantics{
+           byte_identity: {:strong, [kind: :path, root: "wire", path: path]},
+           stable?: true
+         },
+         fetch: [path: path]
+       }}
+    end
+
+    def fetch(_resolved, opts, _runtime_opts) do
+      send(Keyword.fetch!(opts, :test_pid), :source_fetch_called)
+      {:ok, %Response{stream: [File.read!("priv/static/images/beach.jpg")]}}
+    end
+  end
+
+  defmodule CacheProbe do
+    @behaviour ImagePipe.Cache
+
+    def get(%Key{} = key, opts) do
+      send(Keyword.fetch!(opts, :test_pid), {:cache_get, key})
+      :miss
+    end
+
+    def open_sink(%Key{}, metadata, opts), do: {:ok, %{metadata: metadata, chunks: [], opts: opts}}
+    def write_chunk(state, chunk, _opts), do: {:ok, %{state | chunks: [chunk | state.chunks]}}
+
+    def commit_sink(state, _opts) do
+      entry = %Entry{
+        body: state.chunks |> Enum.reverse() |> IO.iodata_to_binary(),
+        content_type: state.metadata.content_type,
+        headers: state.metadata.headers,
+        created_at: state.metadata.created_at
+      }
+
+      send(Keyword.fetch!(state.opts, :test_pid), {:cache_put, entry})
+      :ok
+    end
+
+    def abort_sink(_state, _opts), do: :ok
+  end
+
+  setup do
+    opts =
+      ImagePipe.Plug.init(
+        parser: ImagePipe.Parser.Imgproxy,
+        sources: [path: {StableSource, test_pid: self()}],
+        cache: {CacheProbe, test_pid: self()},
+        test_pid: self(),
+        http_cache: [mode: :enabled]
+      )
+
+    [opts: opts]
+  end
+
+  test "stable public route emits cache-control and etag", %{opts: opts} do
+    conn = ImagePipe.Plug.call(conn(:get, signed_path("/plain/beach.jpg")), opts)
+
+    assert conn.status == 200
+    assert Plug.Conn.get_resp_header(conn, "cache-control") == [
+             "public, max-age=31536000, immutable"
+           ]
+
+    assert [etag] = Plug.Conn.get_resp_header(conn, "etag")
+    assert etag =~ ~r/^"ip1-[A-Za-z0-9_-]+"$/
+  end
+
+  test "matching if-none-match returns before cache lookup and source fetch", %{opts: opts} do
+    first = ImagePipe.Plug.call(conn(:get, signed_path("/plain/beach.jpg")), opts)
+    [etag] = Plug.Conn.get_resp_header(first, "etag")
+
+    assert_received :source_fetch_called
+    flush_messages()
+
+    conn =
+      :get
+      |> conn(signed_path("/plain/beach.jpg"))
+      |> put_req_header("if-none-match", etag)
+      |> ImagePipe.Plug.call(opts)
+
+    assert conn.status == 304
+    assert conn.resp_body == ""
+    assert Plug.Conn.get_resp_header(conn, "etag") == [etag]
+    assert Plug.Conn.get_resp_header(conn, "content-type") == []
+    refute_received {:cache_get, %Key{}}
+    refute_received :source_fetch_called
+  end
+
+  defp signed_path(path) do
+    salt = "secret"
+    signature = Signature.sign_path(path, salt: salt)
+    "/" <> signature <> path
+  end
+
+  defp flush_messages do
+    receive do
+      _message -> flush_messages()
+    after
+      0 -> :ok
+    end
+  end
+end
+```
+
+Adjust signing helper to match current parser test conventions if `Signature.sign_path/2` differs.
+
+- [ ] **Step 2: Run wire tests and verify failure**
+
+Run:
+
+```bash
+mise exec -- mix test test/image_pipe/cdn_http_cache_wire_test.exs
+```
+
+Expected: fail because Plug doesn't prepare HTTP cache headers or return `304`.
+
+- [ ] **Step 3: Prepare HTTP cache in the Plug**
+
+In `lib/image_pipe/plug.ex`, add alias:
+
+```elixir
+alias ImagePipe.Request.HTTPCache
+```
+
+Inside the success branch of `do_call/2`, replace:
+
+```elixir
+result = Runner.run(conn, plan, resolved_source, opts)
+```
+
+with:
+
+```elixir
+prepared_http_cache = HTTPCache.prepare(conn, plan, resolved_source, opts)
+
+case HTTPCache.evaluate_conditional(conn, prepared_http_cache, opts) do
+  {:not_modified, headers} ->
+    conn = HTTPCache.send_not_modified(conn, headers)
+    {conn, %{result: :not_modified, status: conn.status}}
+
+  :proceed ->
+    result = Runner.run(conn, plan, resolved_source, prepared_http_cache, opts)
+
+    {conn, send_metadata} =
+      send_response(conn, opts, request_result(result), fn ->
+        Sender.send_result(conn, result, opts)
+      end)
+
+    {conn, request_stop_metadata(result, send_metadata)}
+end
+```
+
+Keep the parser/plan/source error branches unchanged.
+
+Update `request_result/1` and `request_result_metadata/1` only if the direct `304` branch needs a new result atom in request telemetry. The direct branch above returns stop metadata without calling those helpers.
+
+- [ ] **Step 4: Write failing Runner delivery tests**
+
+Add to `test/image_pipe/request_runner_test.exs`:
+
+```elixir
+test "cache hit delivery carries prepared HTTP cache value" do
+  prepared_http_cache = %ImagePipe.Response.CacheHeaders{
+    representation_headers: [],
+    headers: [{"cache-control", "public, max-age=31536000, immutable"}],
+    etag: nil
+  }
+
+  entry = %Entry{
+    body: "cached",
+    content_type: "image/jpeg",
+    headers: [],
+    created_at: DateTime.utc_now()
+  }
+
+  resolved_source =
+    source_resolved(
+      internal_cache: :enabled,
+      cache_semantics: %ImagePipe.Source.CacheSemantics{byte_identity: :none, stable?: false}
+    )
+
+  assert {:ok, {:cache_entry, ^entry, %Response{}, ^prepared_http_cache}} =
+           Runner.run(
+             conn(:get, "/image"),
+             plan(),
+             resolved_source,
+             prepared_http_cache,
+             cache: {CacheHit, entry: entry}
+           )
+end
+```
+
+If helper names differ, use the existing helper functions in `request_runner_test.exs` and update only the expected tuple shape.
+
+- [ ] **Step 5: Update Runner API and delivery tuples**
+
+In `lib/image_pipe/request/runner.ex`, add alias:
+
+```elixir
+alias ImagePipe.Response.CacheHeaders
+```
+
+Update type:
+
+```elixir
+@type delivery() ::
+        {:cache_entry, Entry.t(), Response.t(), CacheHeaders.t()}
+        | {:prepared_stream, PreparedStream.t(), Response.t(), CacheHeaders.t()}
+```
+
+Update spec and function head:
+
+```elixir
+@spec run(
+        Plug.Conn.t(),
+        Plan.t(),
+        Source.Resolved.t(),
+        CacheHeaders.t(),
+        keyword()
+      ) ::
+        {:ok, delivery()} | {:error, error()}
+def run(conn, %Plan{} = plan, %Source.Resolved{} = resolved_source, %CacheHeaders{} = prepared_http_cache, opts) do
+  run_with_cache_config(conn, plan, resolved_source, prepared_http_cache, opts)
+end
+```
+
+Thread `prepared_http_cache` through private functions. The cache-hit branch
+must return the prepared value:
+
+```elixir
+defp run_with_cache_config(conn, plan, %Source.Resolved{internal_cache: :disabled} = resolved_source, prepared_http_cache, opts),
+  do: process_prepared_stream(conn, plan, resolved_source, nil, prepared_http_cache, opts)
+
+{:hit, %Key{}, %Entry{} = entry} ->
+  {:ok, {:cache_entry, entry, plan.response, prepared_http_cache}}
+```
+
+Update cache miss and prepared stream returns:
+
+```elixir
+process_prepared_stream(conn, plan, resolved_source, key, prepared_http_cache, opts)
+```
+
+and:
+
+```elixir
+{:ok, {:prepared_stream, prepared_stream, response, prepared_http_cache}}
+```
+
+- [ ] **Step 6: Write failing Sender merge tests**
+
+Add to `test/image_pipe/response_sender_test.exs`:
+
+```elixir
+test "cache hits merge generated headers before cached entry headers" do
+  entry = %Entry{
+    body: "body",
+    content_type: "image/webp",
+    headers: [{"cache-control", "public, max-age=60"}, {"vary", "Accept"}],
+    created_at: DateTime.utc_now()
+  }
+
+  prepared = %ImagePipe.Response.CacheHeaders{
+    representation_headers: [{"vary", "Accept"}],
+    headers: [{"cache-control", "public, max-age=31536000, immutable"}, {"etag", ~s("ip1-test")}],
+    etag: ~s("ip1-test")
+  }
+
+  conn =
+    Sender.send_result(
+      conn(:get, "/image"),
+      {:ok, {:cache_entry, entry, %Response{}, prepared}},
+      []
+    )
+
+  assert Plug.Conn.get_resp_header(conn, "cache-control") == [
+           "public, max-age=31536000, immutable"
+         ]
+
+  assert Plug.Conn.get_resp_header(conn, "etag") == [~s("ip1-test")]
+  assert Plug.Conn.get_resp_header(conn, "vary") == ["Accept"]
+end
+
+test "current host cache-control wins over generated and cached headers" do
+  entry = %Entry{
+    body: "body",
+    content_type: "image/webp",
+    headers: [{"cache-control", "public, max-age=60"}],
+    created_at: DateTime.utc_now()
+  }
+
+  prepared = %ImagePipe.Response.CacheHeaders{
+    representation_headers: [],
+    headers: [{"cache-control", "public, max-age=31536000, immutable"}],
+    etag: nil
+  }
+
+  conn =
+    :get
+    |> conn("/image")
+    |> Plug.Conn.put_resp_header("cache-control", "private, max-age=30")
+    |> Sender.send_result({:ok, {:cache_entry, entry, %Response{}, prepared}}, [])
+
+  assert Plug.Conn.get_resp_header(conn, "cache-control") == ["private, max-age=30"]
+end
+
+test "prepared streams merge generated headers before stream headers" do
+  prepared_stream =
+    prepared_stream(headers: [{"cache-control", "public, max-age=60"}])
+
+  prepared = %ImagePipe.Response.CacheHeaders{
+    representation_headers: [],
+    headers: [{"cache-control", "public, max-age=31536000, immutable"}],
+    etag: nil
+  }
+
+  conn =
+    Sender.send_result(
+      conn(:get, "/image"),
+      {:ok, {:prepared_stream, prepared_stream, %Response{}, prepared}},
+      []
+    )
+
+  assert Plug.Conn.get_resp_header(conn, "cache-control") == [
+           "public, max-age=31536000, immutable"
+         ]
+end
+```
+
+- [ ] **Step 7: Update Sender delivery types and merge logic**
+
+In `lib/image_pipe/response/sender.ex`, add alias:
+
+```elixir
+alias ImagePipe.Response.CacheHeaders
+```
+
+Update delivery type:
+
+```elixir
+@type delivery() ::
+        {:cache_entry, Entry.t(), Response.t(), CacheHeaders.t()}
+        | {:prepared_stream, PreparedStream.t(), Response.t(), CacheHeaders.t()}
+```
+
+Update `send_result/3` clauses:
+
+```elixir
+def send_result(
+      %Plug.Conn{} = conn,
+      {:ok, {:cache_entry, %Entry{} = entry, %Response{} = response, %CacheHeaders{} = prepared_http_cache}},
+      opts
+    ) do
+  send_cache_entry(conn, entry, response, prepared_http_cache, opts)
+end
+
+def send_result(
+      %Plug.Conn{} = conn,
+      {:ok,
+       {:prepared_stream, %PreparedStream{} = prepared_stream, %Response{} = response,
+        %CacheHeaders{} = prepared_http_cache}},
+      opts
+    ) do
+  send_prepared_stream(conn, prepared_stream, response, prepared_http_cache, opts)
+end
+```
+
+Add merge helpers:
+
+```elixir
+defp merge_delivery_headers(conn, cached_or_stream_headers, %CacheHeaders{} = prepared) do
+  []
+  |> merge_header_list(prepared.headers)
+  |> merge_header_list(prepared.representation_headers)
+  |> merge_header_list(cached_or_stream_headers)
+  |> reject_existing_conn_headers(conn)
+end
+
+defp merge_header_list(base, additions) do
+  Enum.reduce(additions, base, fn {name, value}, headers ->
+    put_header_unless_present(headers, name, value)
+  end)
+end
+
+defp put_header_unless_present(headers, name, value) do
+  downcased = String.downcase(name)
+
+  if Enum.any?(headers, fn {existing_name, _existing_value} ->
+       String.downcase(existing_name) == downcased
+     end) do
+    headers
+  else
+    headers ++ [{downcased, value}]
+  end
+end
+
+defp reject_existing_conn_headers(headers, conn) do
+  Enum.reject(headers, fn {name, _value} ->
+    Plug.Conn.get_resp_header(conn, name) != []
+  end)
+end
+```
+
+Use this in cache-hit path:
+
+```elixir
+defp send_cache_entry(%Plug.Conn{} = conn, %Entry{} = entry, %Response{} = response, %CacheHeaders{} = prepared_http_cache, opts) do
+  with {:ok, headers} <- Entry.cacheable_headers(entry.headers),
+       headers <- merge_delivery_headers(conn, headers, prepared_http_cache),
+       {:ok, headers} <- delivery_headers(headers, response, entry.content_type) do
+    Telemetry.execute(
+      Telemetry.telemetry_opts(opts),
+      [:http_cache, :cache_hit, :headers],
+      %{},
+      %{etag: not is_nil(prepared_http_cache.etag)}
+    )
+
+    send_normalized_cache_entry(conn, entry, headers)
+  else
+    {:error, error} -> send_cache_error(conn, error)
+  end
+end
+```
+
+Use this in prepared stream path before `put_resp_headers/2`:
+
+```elixir
+headers = merge_delivery_headers(conn, prepared_stream.headers, prepared_http_cache)
+prepared_stream = %{prepared_stream | headers: headers}
+```
+
+Don't store generated `etag` in cache entries.
+
+- [ ] **Step 8: Run Runner/Sender focused tests**
+
+Run:
+
+```bash
+mise exec -- mix test test/image_pipe/request_runner_test.exs test/image_pipe/response_sender_test.exs
+```
+
+Expected: pass.
+
+- [ ] **Step 9: Run Plug wire tests**
+
+Run:
+
+```bash
+mise exec -- mix test test/image_pipe/cdn_http_cache_wire_test.exs test/image_pipe/plug_test.exs
+```
+
+Expected: pass.
+
+- [ ] **Step 10: Commit Plug, Runner, and Sender integration**
+
+Run:
+
+```bash
+mise exec -- git add lib/image_pipe/plug.ex lib/image_pipe/request/runner.ex lib/image_pipe/response/sender.ex test/image_pipe/cdn_http_cache_wire_test.exs test/image_pipe/plug_test.exs test/image_pipe/request_runner_test.exs test/image_pipe/response_sender_test.exs
+mise exec -- git commit -m "Integrate HTTP cache delivery"
+```
+
+## Task 6: HTTP Cache Edge Cases and Properties
+
+**Files:**
+
+- Modify: `test/image_pipe/request/http_cache_test.exs`
+- Modify: `test/image_pipe/cdn_http_cache_wire_test.exs`
+
+- [ ] **Step 1: Add focused edge-case tests**
+
+Add to `test/image_pipe/request/http_cache_test.exs`:
+
+```elixir
+test "set-cookie suppresses generated public cache headers" do
+  conn = put_resp_header(conn(:get, "/image"), "set-cookie", "a=b")
+
+  prepared = HTTPCache.prepare(conn, plan(), resolved(), opts())
+
+  assert prepared.headers == []
+  assert prepared.etag == nil
+end
+
+test "cache-control no-store suppresses generated etag" do
+  conn = put_resp_header(conn(:get, "/image"), "cache-control", "no-store")
+
+  prepared = HTTPCache.prepare(conn, plan(), resolved(), opts())
+
+  assert prepared.headers == []
+  assert prepared.etag == nil
+end
+
+test "explicit output doesn't emit Vary Accept" do
+  prepared = HTTPCache.prepare(conn(:get, "/image"), plan(%Output{mode: {:explicit, :jpeg}}), resolved(), opts())
+
+  assert prepared.representation_headers == []
+end
+
+test "client hints don't enter generated vary" do
+  conn =
+    conn(:get, "/image")
+    |> put_req_header("width", "600")
+    |> put_req_header("dpr", "2")
+    |> put_req_header("sec-ch-width", "600")
+
+  prepared = HTTPCache.prepare(conn, plan(), resolved(), opts())
+
+  refute Enum.any?(prepared.representation_headers, fn {_name, value} ->
+           String.contains?(String.downcase(value), "width")
+         end)
+end
+```
+
+- [ ] **Step 2: Add property tests for ETag determinism**
+
+If `test/image_pipe/request/http_cache_test.exs` doesn't use StreamData yet, create a property section with:
+
+```elixir
+use ExUnitProperties
+
+property "whitespace around if-none-match tags doesn't change matching" do
+  check all left <- member_of(["", " ", "  ", "\t"]),
+            right <- member_of(["", " ", "  ", "\t"]) do
+    prepared = %ImagePipe.Response.CacheHeaders{
+      representation_headers: [],
+      headers: [{"etag", ~s("ip1-token")}],
+      etag: ~s("ip1-token")
+    }
+
+    header = left <> ~s(W/"ip1-token") <> right
+
+    conn =
+      :get
+      |> conn("/image")
+      |> put_req_header("if-none-match", header)
+
+    assert {:not_modified, _headers} = HTTPCache.evaluate_conditional(conn, prepared, [])
+  end
+end
+```
+
+Add comma-separated and generated ETag material properties:
+
+```elixir
+test "comma-separated weak and strong tags can match generated etag" do
+  prepared = %ImagePipe.Response.CacheHeaders{
+    representation_headers: [],
+    headers: [{"etag", ~s("ip1-token")}],
+    etag: ~s("ip1-token")
+  }
+
+  conn =
+    :get
+    |> conn("/image")
+    |> put_req_header("if-none-match", ~s("other", W/"ip1-token"))
+
+  assert {:not_modified, _headers} = HTTPCache.evaluate_conditional(conn, prepared, [])
+end
+
+test "equivalent Accept capability material produces the same generated etag" do
+  left =
+    :get
+    |> conn("/image")
+    |> put_req_header("accept", "image/avif,image/webp")
+    |> HTTPCache.prepare(plan(%Output{mode: :automatic}), resolved(), opts())
+
+  right =
+    :get
+    |> conn("/image")
+    |> put_req_header("accept", "image/avif;q=1.0,image/webp;q=0.8")
+    |> HTTPCache.prepare(plan(%Output{mode: :automatic}), resolved(), opts())
+
+  assert left.etag == right.etag
+end
+
+test "different source byte identities produce different generated etags" do
+  left = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
+
+  right =
+    HTTPCache.prepare(
+      conn(:get, "/image"),
+      plan(),
+      resolved(
+        cache_semantics: %CacheSemantics{
+          byte_identity: {:strong, [kind: :path, root: "test", path: ["other.jpg"]]},
+          stable?: true
+        }
+      ),
+      opts()
+    )
+
+  assert left.etag != right.etag
+end
+
+test "etag serialization is deterministic for the same prepared inputs" do
+  first = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
+  second = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
+
+  assert first.etag == second.etag
+end
+```
+
+- [ ] **Step 3: Add symbolic rule material tests**
+
+Add to `test/image_pipe/plan_test.exs` when source-compatible output exists. If it doesn't exist yet, add a comment-free test for the existing source-preserving automatic rule:
+
+```elixir
+test "automatic output material contains the symbolic rule instead of a resolved branch" do
+  plan = %ImagePipe.Plan{
+    source: %ImagePipe.Plan.Source.Path{segments: ["alpha.png"]},
+    pipelines: [%ImagePipe.Plan.Pipeline{operations: []}],
+    output: %ImagePipe.Plan.Output{mode: :automatic}
+  }
+
+  assert {:ok, [output: output]} = ImagePipe.Plan.canonical_representation_material(plan)
+  assert output[:mode] == :automatic
+  refute Keyword.has_key?(output, :resolved_format)
+end
+```
+
+- [ ] **Step 4: Run edge/property tests**
+
+Run:
+
+```bash
+mise exec -- mix test test/image_pipe/request/http_cache_test.exs test/image_pipe/cdn_http_cache_wire_test.exs test/image_pipe/plan_test.exs
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit HTTP cache edge tests**
+
+Run:
+
+```bash
+mise exec -- git add test/image_pipe/request/http_cache_test.exs test/image_pipe/cdn_http_cache_wire_test.exs test/image_pipe/plan_test.exs
+mise exec -- git commit -m "Cover HTTP cache edge cases"
+```
+
+## Task 7: Telemetry Coverage
+
+**Files:**
+
+- Modify: `test/image_pipe/telemetry_test.exs`
+- Modify: `test/image_pipe/request/http_cache_test.exs`
+- Modify: `lib/image_pipe/request/http_cache.ex`
+- Modify: `lib/image_pipe/response/sender.ex`
+
+- [ ] **Step 1: Add telemetry metadata tests**
+
+Add to `test/image_pipe/request/http_cache_test.exs`:
+
+```elixir
+test "prepare telemetry is low-cardinality" do
+  attach_telemetry([[:image_pipe, :http_cache, :prepare]])
+
+  _prepared = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
+
+  assert_receive {:telemetry_event, [:image_pipe, :http_cache, :prepare], %{},
+                  %{effective_mode: :enabled, byte_identity: :strong, etag: true} = metadata}
+
+  refute Map.has_key?(metadata, :path)
+  refute Map.has_key?(metadata, :etag_value)
+  refute Map.has_key?(metadata, :source_identity)
+end
+
+test "no-store fallback telemetry is required and low-cardinality" do
+  attach_telemetry([[:image_pipe, :http_cache, :fallback, :no_store]])
+
+  _prepared =
+    HTTPCache.prepare(
+      conn(:get, "/image"),
+      plan(),
+      resolved(cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false}),
+      opts()
+    )
+
+  assert_receive {:telemetry_event, [:image_pipe, :http_cache, :fallback, :no_store], %{},
+                  %{adapter: :path, source_kind: :path, reason: :missing_byte_identity} = metadata}
+
+  refute Map.has_key?(metadata, :path)
+  refute Map.has_key?(metadata, :url)
+  refute Map.has_key?(metadata, :etag)
+end
+```
+
+If no `attach_telemetry/1` helper exists in this test module, copy the helper from existing telemetry tests:
+
+```elixir
+defp attach_telemetry(events) do
+  test_pid = self()
+  handler_id = {__MODULE__, make_ref()}
+
+  :ok =
+    :telemetry.attach_many(
+      handler_id,
+      events,
+      fn event, measurements, metadata, _config ->
+        send(test_pid, {:telemetry_event, event, measurements, metadata})
+      end,
+      nil
+    )
+
+  on_exit(fn -> :telemetry.detach(handler_id) end)
+end
+```
+
+- [ ] **Step 2: Add conditional and cache-hit telemetry tests**
+
+Add to `test/image_pipe/request/http_cache_test.exs`:
+
+```elixir
+test "conditional match telemetry omits etag and path" do
+  attach_telemetry([[:image_pipe, :http_cache, :conditional, :match]])
+
+  prepared = %ImagePipe.Response.CacheHeaders{
+    representation_headers: [],
+    headers: [{"etag", ~s("ip1-token")}],
+    etag: ~s("ip1-token")
+  }
+
+  conn =
+    :get
+    |> conn("/image")
+    |> put_req_header("if-none-match", ~s("ip1-token"))
+
+  assert {:not_modified, _headers} = HTTPCache.evaluate_conditional(conn, prepared, opts())
+
+  assert_receive {:telemetry_event, [:image_pipe, :http_cache, :conditional, :match], %{},
+                  %{method: :get} = metadata}
+
+  refute Map.has_key?(metadata, :etag)
+  refute Map.has_key?(metadata, :path)
+end
+```
+
+Add cache-hit telemetry coverage to `test/image_pipe/response_sender_test.exs`:
+
+```elixir
+test "cache hit header telemetry is low-cardinality" do
+  attach_telemetry([[:image_pipe, :http_cache, :cache_hit, :headers]])
+
+  entry = %Entry{
+    body: "body",
+    content_type: "image/webp",
+    headers: [],
+    created_at: DateTime.utc_now()
+  }
+
+  prepared = %ImagePipe.Response.CacheHeaders{
+    representation_headers: [],
+    headers: [{"etag", ~s("ip1-token")}],
+    etag: ~s("ip1-token")
+  }
+
+  _conn =
+    Sender.send_result(
+      conn(:get, "/image"),
+      {:ok, {:cache_entry, entry, %Response{}, prepared}},
+      []
+    )
+
+  assert_receive {:telemetry_event, [:image_pipe, :http_cache, :cache_hit, :headers], %{},
+                  %{etag: true} = metadata}
+
+  refute Map.has_key?(metadata, :path)
+  refute Map.has_key?(metadata, :etag_value)
+end
+```
+
+- [ ] **Step 3: Run telemetry tests**
+
+Run:
+
+```bash
+mise exec -- mix test test/image_pipe/request/http_cache_test.exs test/image_pipe/response_sender_test.exs test/image_pipe/telemetry_test.exs
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Commit telemetry coverage**
+
+Run:
+
+```bash
+mise exec -- git add lib/image_pipe/request/http_cache.ex lib/image_pipe/response/sender.ex test/image_pipe/request/http_cache_test.exs test/image_pipe/response_sender_test.exs test/image_pipe/telemetry_test.exs
+mise exec -- git commit -m "Add HTTP cache telemetry"
+```
+
+## Task 8: User Documentation
+
+**Files:**
+
+- Modify: `README.md` or create `docs/cdn-http-cache.md`
+- Modify: `README.md` if a new doc is created and needs linking
+
+- [ ] **Step 1: Draft user-facing CDN cache docs**
+
+If the README is already long, create `docs/cdn-http-cache.md` with:
+
+```markdown
+# CDN HTTP Caching
+
+ImagePipe can emit HTTP cache headers for public image routes when the source
+identity names stable bytes. This is opt-in.
+
+```elixir
+plug ImagePipe.Plug,
+  parser: MyApp.ImageParser,
+  sources: [
+    s3:
+      {ImagePipe.Source.S3,
+       default: [
+         endpoint: "https://s3.example.test",
+         region: "us-east-1",
+         credentials: credentials,
+         http_cache: :enabled,
+         stable: :trusted
+       ]}
+  ],
+  http_cache: [mode: :enabled]
+```
+
+`http_cache: :enabled` allows generated shared-cache headers. `stable:
+:trusted` tells the source adapter that the resolved source identity names bytes
+that don't change under that identity.
+
+For S3 objects with a revision, ImagePipe can infer stability because the
+resolved fetch includes `versionId`.
+
+Generated successful responses can include:
+
+```http
+Cache-Control: public, max-age=31536000, immutable
+ETag: "ip1-..."
+Vary: Accept
+```
+
+`Vary: Accept` appears only when automatic output format selection uses the
+request `Accept` header. Configure the CDN cache key to include `Accept` for
+automatic output routes.
+
+If a route enables HTTP caching but the resolved source doesn't provide byte
+identity, ImagePipe emits:
+
+```http
+Cache-Control: no-store
+```
+
+and doesn't emit a generated ETag. The telemetry event
+`[:image_pipe, :http_cache, :fallback, :no_store]` marks this configuration.
+
+ImagePipe doesn't generate public cache headers for responses with `Set-Cookie`
+or `Vary: *`, and it doesn't interpret host-supplied ETags for conditional
+requests. Routes that need custom validators should leave ImagePipe generated
+HTTP caching off and set their own headers.
+
+`Plan.expires` is a parser-level validity field. It doesn't change generated
+`Cache-Control`.
+
+Changing the ETag schema prefix, for example from `ip1-` to `ip2-`, invalidates
+validators previously stored by browsers and CDNs. Treat that as a deploy-time
+cache invalidation.
+
+Changing `representation_version` changes generated ETag hashes without changing
+the visible `ip1-` prefix. It also changes internal cache keys, so ImagePipe
+doesn't serve an old encoded body with a validator derived from new encoder or
+output-policy behavior.
+```
+
+Don't mention external projects.
+
+- [ ] **Step 2: Run Vale**
+
+Run:
+
+```bash
+mise exec -- vale docs/cdn-http-cache.md README.md
+```
+
+If the doc is only in README, run:
+
+```bash
+mise exec -- vale README.md
+```
+
+Expected: no Vale errors. Fix any flagged prose with concrete wording.
+
+- [ ] **Step 3: Commit documentation**
+
+Run:
+
+```bash
+mise exec -- git add README.md docs/cdn-http-cache.md
+mise exec -- git commit -m "Document CDN HTTP caching"
+```
+
+If `docs/cdn-http-cache.md` wasn't created, omit it from `git add`.
+
+## Task 9: Full Verification
+
+**Files:**
+
+- Verify all changed source, tests, and docs.
+
+- [ ] **Step 1: Format**
+
+Run:
+
+```bash
+mise exec -- mix format
+```
+
+Expected: no errors.
+
+- [ ] **Step 2: Compile with warnings as errors**
+
+Run:
+
+```bash
+VIX_COMPILATION_MODE=PRECOMPILED_LIBVIPS mise exec -- mix compile --warnings-as-errors
+```
+
+Expected: compile succeeds with no warnings.
+
+- [ ] **Step 3: Run full test suite**
+
+Run:
+
+```bash
+VIX_COMPILATION_MODE=PRECOMPILED_LIBVIPS mise exec -- mix test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Run Vale on touched docs**
+
+Run:
+
+```bash
+mise exec -- vale docs/superpowers/plans/2026-05-27-cdn-http-cache-implementation.md docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md README.md docs/cdn-http-cache.md
+```
+
+If `docs/cdn-http-cache.md` wasn't created, omit it.
+
+Expected: no Vale errors.
+
+- [ ] **Step 5: Check git diff**
+
+Run:
+
+```bash
+mise exec -- git status --short
+mise exec -- git diff --stat
+```
+
+Expected: only intentional files are modified.
+
+- [ ] **Step 6: Final commit if formatting or docs changed**
+
+Run:
+
+```bash
+mise exec -- git add .
+mise exec -- git commit -m "Verify CDN HTTP cache implementation"
+```
+
+Only commit if Step 1 or later verification changed files.
+
+## Self-Review
+
+- Spec coverage: tasks cover source semantics, source adapter options, `Source.Resolved.cache` migration, request options, canonical representation material, ETag material, pre-fetch conditional `304`, `Vary: Accept`, Runner/Sender delivery, internal cache key representation version, telemetry, docs, and full verification.
+- Deferred behaviors remain out of scope: no mutable probing, no `Last-Modified`, no arbitrary `Vary`, no Client Hints, no non-pre-fetch ETags, no HEAD-specific behavior, no source-provided cache-control.
+- Placeholder scan: no task uses placeholder markers. Steps that depend on existing helper names include exact fallback code or a command to locate/update call sites.
+- Type consistency: `CacheSemantics.byte_identity`, `Source.Resolved.internal_cache`, `Source.Resolved.http_cache`, and `ImagePipe.Response.CacheHeaders` fields match across tasks.

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -37,8 +37,8 @@ The missing CDN-facing behavior is:
 - source adapters don't expose HTTP cache semantics;
 - `Last-Modified` isn't represented;
 - `If-None-Match` can't return `304 Not Modified`;
-- internal cache hits can't preserve or check validators because cached
-  entries don't store `etag` or `last-modified`.
+- internal cache hits can't prepare generated validators or return
+  `304 Not Modified`.
 
 ## Design Goals
 
@@ -477,24 +477,42 @@ the ETag material. Otherwise omit the generated ETag for that response.
 
 ## Internal Cache Interaction
 
-The internal cache should store the CDN-facing headers with successful encoded
-entries.
+The internal cache stores encoded response bodies. It shouldn't become the
+source of truth for generated HTTP cache headers.
+
+`ImagePipe.Request.Runner` already receives `Source.Resolved` before internal
+cache lookup, so cache-hit delivery has the same source cache semantics, plan,
+request headers, and runtime options as cache-miss delivery. Use those inputs to
+prepare generated HTTP cache headers on every request, including internal cache
+hits.
+
+That keeps old internal entries usable after header-policy changes. It also
+avoids replaying stale `ETag` or `Cache-Control` values from metadata written by
+an older version.
 
 Extend `ImagePipe.Cache.Entry.cacheable_headers/1` to accept these names:
 
 - `vary`
 - `cache-control`
-- `etag`
-- `last-modified`
+
+These are output-owned headers that already exist today or that host policy may
+set before cache storage. Generated `etag`, generated `last-modified`, and
+generated `cache-control` should come from `ImagePipe.Request.HTTPCache` at
+delivery time, not from the cached entry.
 
 On internal cache hit:
 
-1. Check the cached entry and headers.
-2. If the request has `If-None-Match` matching the cached `etag`, return
+1. Check and normalize the cached entry headers.
+2. Prepare generated HTTP cache headers from current source semantics, plan,
+   request headers, and options.
+3. Merge cached output headers with generated HTTP cache headers. Generated
+   headers must not overwrite explicit host policy without the conflict rules
+   described in "Plug Chain Boundaries."
+4. If the request has `If-None-Match` matching the prepared `etag`, return
    `304 Not Modified` with the cache metadata header allowlist and no body.
    `If-None-Match: *` can match here because the cache entry proves the current
    representation exists.
-3. Otherwise return `200` with the cached body and cached response headers.
+5. Otherwise return `200` with the cached body and merged response headers.
 
 This preserves header behavior between cache misses and cache hits.
 
@@ -502,12 +520,11 @@ This preserves header behavior between cache misses and cache hits.
 shouldn't own conditional request behavior. The request runner or response
 sender should branch to a delivery shape that represents `304`.
 
-Cached HTTP headers must not survive an incompatible representation change. The
-internal cache key should include the same representation version and ETag
-schema version used for generated validators. As another option, cached entry
-metadata can carry those versions and ImagePipe can reject entries that don't
-match current options. The first implementation should use one of those checks
-before replaying stored `etag` or `cache-control`.
+The internal cache key doesn't need to include `etag_schema` or
+`representation_version` just to protect generated headers, because those
+headers come from current request inputs on hit. It only needs those versions if
+they also affect encoded bytes. In that case they belong in the existing
+canonical key data for output or transform material.
 
 ## Error Responses
 
@@ -583,15 +600,16 @@ Add focused tests at the request boundary:
   headers as `GET` without a body;
 - when ImagePipe supports `HEAD`, matching conditionals return `304` without a
   body;
-- internal cache hits preserve `etag`, `cache-control`, `vary`, and
-  `last-modified`;
-- internal cache hits can return `304` from stored `etag`;
+- internal cache hits preserve cached output headers such as `vary`;
+- internal cache hits prepare generated `etag`, `cache-control`, and
+  `last-modified` from current request inputs;
+- internal cache hits can return `304` from the prepared `etag`;
 - transform option order variants produce the same ETag;
 - changing source revision changes ETag;
 - changing `etag_schema` changes ETag;
 - changing representation version changes ETag;
-- old internal cache entries don't replay stale ETags after representation
-  version changes.
+- old internal cache entries don't replay stale generated ETags after
+  representation version changes.
 
 Add source adapter tests:
 
@@ -625,9 +643,9 @@ Build this in small steps:
 2. Add request-owned HTTP cache header computation and unit tests.
 3. Add pre-run conditional handling after source resolution and before
    `Runner.run/4`.
-4. Attach headers to cache misses and store the same headers in internal cache
-   entries in the same change.
-5. Replay headers and support cached `304` on internal cache hits.
+4. Attach generated headers to cache misses while continuing to store only
+   cacheable output headers in internal cache entries.
+5. Recompute generated headers and support cached `304` on internal cache hits.
 6. Document CDN behavior and source immutability configuration.
 
 The first implementation shouldn't add post-transform conditional validation.

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -170,11 +170,11 @@ Each source adapter should accept:
 
 ```elixir
 source_bytes_immutable?: boolean()
-cache_control: String.t() | nil
+response_cache_control: String.t() | nil
 ```
 
-`cache_control` is host response policy copied through the resolved source. It's
-not a source identity fact. The implementation should store it as
+`response_cache_control` is host response policy copied through the resolved
+source. It's not a source identity fact. The implementation should store it as
 `response_cache_control_override` to keep that distinction visible.
 
 When set, ImagePipe emits it only after two checks:
@@ -185,8 +185,10 @@ When set, ImagePipe emits it only after two checks:
 Header validation rejects CR, LF, invalid binaries, and values the configured
 server adapter can't represent. Policy validation parses directives that
 ImagePipe reasons about, including `public`, `private`, `no-store`, `max-age`,
-`stale-while-revalidate`, and `immutable`. A `public` override requires a public
-cache-safety proof or explicit configuration.
+`s-maxage`, `stale-while-revalidate`, `immutable`, `must-revalidate`,
+`proxy-revalidate`, and `no-transform`. Unknown extension directives pass
+through after syntax validation, but they can't prove public-cache safety. A
+`public` override requires a public cache-safety proof or explicit configuration.
 
 If a source uses `internal_cache: :disabled`, ImagePipe shouldn't emit public
 cache validators or generated `Cache-Control` by default. `internal_cache: :disabled`
@@ -195,6 +197,12 @@ fetch. Those headers can affect source bytes. The first implementation should
 not provide an opt-back-in path for `internal_cache: :disabled`. A future opt-in
 must require a strong source validator and an explicit complete `Vary`
 declaration for every representation-changing request input.
+
+This is a v1 implementation boundary, not a permanent coupling between the
+internal cache and HTTP caching. A source can be safe for CDN caching while
+opting out of ImagePipe's internal cache. Supporting that path requires the
+source resolver to return a strong validator and complete `Vary`/ETag material
+for every request input that can change bytes.
 
 ## Internal Source Cache Policy
 
@@ -208,11 +216,19 @@ the identity is safe only when it includes byte-version material. Examples are
 an S3 revision, content-addressed path, upstream validator, or host-provided
 cachebuster that changes when bytes change.
 
+Byte-stable means one of three things:
+
+- the source identity names immutable bytes;
+- the source identity includes explicit byte-version material;
+- the host explicitly asserts stability with `internal_cache: :enabled`.
+
 Adapt source adapters to choose internal cache policy from source semantics:
 
 - `internal_cache: :auto` should be the source adapter configuration default. It
-  resolves to `:enabled` only when the source identity is byte-stable or includes
-  byte-version material. Otherwise it resolves to `:disabled`.
+  resolves to `:enabled` when the source identity is byte-stable or includes
+  byte-version material. That includes future mutable sources whose resolver
+  obtains a strong upstream byte validator during source resolution. Otherwise it
+  resolves to `:disabled`.
 - `internal_cache: :disabled` always bypasses the internal encoded-response
   cache.
 - `internal_cache: :enabled` is an explicit host assertion that the resolved
@@ -277,17 +293,27 @@ When `last_modified` is present:
 ```
 
 ImagePipe emits `Last-Modified` as response metadata and for downstream cache
-visibility. The first implementation doesn't use it as a validator. If a CDN or
-client sends `If-Modified-Since`, ImagePipe returns the normal `200` path until
-explicit `If-Modified-Since` support lands. After that, `If-None-Match` takes
-precedence when a request sends both validators.
+visibility. It describes the source byte version used to generate the
+representation, not the time ImagePipe encoded the response. The first
+implementation doesn't use it as a validator. If a CDN or client sends
+`If-Modified-Since`, ImagePipe returns the normal `200` path until explicit
+`If-Modified-Since` support lands. After that, `If-None-Match` takes precedence
+when a request sends both validators.
 
 Generated public cache headers require an explicit safety decision:
 
 ```elixir
 representation_publicly_cacheable? =
-  public_route_or_source? and complete_vary_material?
+  allow_public_cache? and
+    public_route_or_source? and
+    complete_vary_material? and
+    no_disqualifying_request_state?
 ```
+
+`allow_public_cache?` is the global option. It permits generated public defaults
+but never forces them. `public_route_or_source?` is host configuration on the
+mount, route, or source adapter. It means the host permits shared caches to store
+responses for this request class.
 
 Default generated `Cache-Control` when the representation is public-safe:
 
@@ -295,7 +321,12 @@ Default generated `Cache-Control` when the representation is public-safe:
 - source bytes mutable: `public, max-age=300, stale-while-revalidate=3600`
 
 The mutable default is intentionally conservative. Hosts that want a different
-policy can set `cache_control` on the source adapter.
+policy can set `response_cache_control` on the source adapter.
+
+Short public caching for mutable sources is a freshness policy, not a validator
+guarantee. These responses must omit generated ETags unless the source resolver
+provides byte-version material. A CDN may serve stale bytes within the configured
+freshness window.
 
 If public safety isn't proven, ImagePipe should omit generated public
 `Cache-Control` by default. A host may explicitly configure a private policy,
@@ -307,6 +338,20 @@ If the request contains `Authorization`, ImagePipe must not emit generated
 public cache headers by default. Configuration must explicitly mark the route or
 source as public-cache-safe. It must also include every authorization-derived
 representation-changing input in the cache and validator model.
+
+Header conflict behavior:
+
+| Existing or source header | Generated header | Behavior |
+| --- | --- | --- |
+| no existing `Cache-Control` | generated default | emit generated value |
+| existing host `Cache-Control` | generated default | preserve host value after validation |
+| source `response_cache_control` | generated default | source value wins after header and policy validation |
+| existing host `ETag` | generated ETag | preserve host value and suppress generated ETag, or fail configuration |
+| existing host `Last-Modified` | generated `Last-Modified` | preserve host value and suppress generated value, or fail configuration |
+| existing `Vary` | generated `Vary` | merge deterministically after validating values |
+
+Don't merge `Cache-Control` values. Directives can conflict, such as `private`
+with `public`, or two different `max-age` values. Pick one policy source.
 
 ## ETag Material
 
@@ -329,13 +374,45 @@ Use separate ETag material:
 ]
 ```
 
+`representation_request_material` contains normalized request inputs that affect
+the response but aren't encoded in the URL. It should use lower-case field names
+and canonical values. Examples:
+
+```elixir
+[
+  accept: [selected_format: :avif, capability: [:avif, :webp]],
+  headers: [{"x-tenant", ["tenant-a"]}],
+  cookies: []
+]
+```
+
+For explicit output with no request-varying inputs, use an empty list. The
+material must match the generated `Vary` header. Every non-URL input represented
+in ETag material must appear in `Vary`. Every generated `Vary` input that can
+change bytes must appear in ETag material.
+
 Only generate an ETag when source cache semantics contain `{:strong, seed}`.
 For `:none`, omit `ETag` and skip conditional `If-None-Match` handling.
+
+V1 only expects strong validators from source identities that name immutable
+bytes. Future adapters may provide strong validators for mutable sources when
+source resolution obtains byte-version freshness material before fetch. A weak
+upstream validator, such as an HTTP `W/"..."` ETag, must not become
+`{:strong, seed}` unless the adapter has other material that proves byte
+identity. Future upstream validator support should preserve validator strength.
 
 Generated ETags are instruction-derived strong validators, not body-hash ETags.
 They're correct only if the material includes every byte-changing input. That
 means source byte identity, transform instructions, output decisions, encoder
 settings, normalized request inputs, and versioned dependencies.
+
+Serialize ETag material with a deterministic encoder, such as canonical Erlang
+terms, then hash it with SHA-256. Don't expose raw material in the
+header. The visible tag shape should include a schema prefix:
+
+```http
+ETag: "ip1-<base64url-sha256>"
+```
 
 Use a strong ETag, not a weak ETag, for generated validators. A weak ETag would
 say the response has the same meaning but not necessarily the same bytes.
@@ -448,15 +525,20 @@ public caching for that representation.
 
 ## Pre-Fetch Conditional GET
 
-For cacheable source-byte-immutable responses with a strong source validator,
-ImagePipe should compute the ETag before source fetch whenever these inputs
-define output selection material:
+For cacheable responses with a strong source validator, ImagePipe should compute
+the ETag before source fetch whenever these inputs define output selection
+material:
 
 - the parsed plan;
 - source cache semantics from `Source.resolve/3`;
 - normalized `Accept`;
 - runtime output options;
 - deterministic policy versions.
+
+The eligibility rule is: strong validator, plus deterministic representation
+selection before fetch. Source byte immutability is one way to get a strong
+validator. Future mutable sources can also qualify if source resolution obtains
+byte-version material before fetch.
 
 This pre-run conditional decision belongs after `Source.resolve/3` and before
 `Runner.run/4`. A matching validator must skip internal cache lookup and
@@ -507,11 +589,14 @@ The first implementation only emits the subset ImagePipe can produce. The server
 adapter normally generates `Date`. Don't replay encoded-body headers such as
 `Content-Length`, `Content-Type`, or `Content-Disposition` on `304`. Avoid
 representing `304` as a normal encoded response with an empty binary body. Use a
-delivery shape such as `{:not_modified, headers}`.
+delivery shape such as `{:not_modified, headers}`. `Surrogate-Control` is
+CDN-specific. Include it only when a host or earlier layer set it.
 
-If ImagePipe supports `HEAD`, a non-matching `HEAD` response should send the
-headers that the corresponding `GET` would send, without a body. A matching
-conditional `HEAD` should return `304` without a body.
+HEAD response support isn't a v1 deliverable unless the current Plug path
+already serves HEAD. If ImagePipe adds or already supports HEAD, a non-matching
+`HEAD` response should send the headers that the corresponding `GET` would send,
+without a body. A matching conditional `HEAD` should return `304` without a
+body.
 
 HTTP rules used here come from RFC 9110:
 
@@ -553,6 +638,8 @@ Keep v1 small. These omissions are intentional:
   and policy inputs on each request.
 - Pre-fetch `If-None-Match: *`: omitted for correctness. `*` can match on an
   internal cache hit, where a cached successful representation proves existence.
+- HEAD response support: out of scope unless the current Plug path already
+  serves HEAD. The conditional matcher still needs explicit method gates.
 - Public `Vary: Cookie`: off by default. Hosts must opt into this with
   explicit cache policy.
 - Surrogate keys and CDN tag purge headers: out of scope for v1. Hosts can set
@@ -629,7 +716,7 @@ http_cache: [
   mutable_cache_control: "public, max-age=300, stale-while-revalidate=3600",
   etag_version: 1,
   representation_version: 1,
-  public_cache?: false
+  allow_public_cache?: false
 ]
 ```
 
@@ -640,7 +727,7 @@ Source adapter options:
 ```elixir
 source_bytes_immutable?: false,
 internal_cache: :auto,
-cache_control: nil
+response_cache_control: nil
 ```
 
 For S3, if `revision` is present, the source can treat the object as immutable
@@ -656,44 +743,51 @@ Add focused tests at the request boundary:
 - non-public-safe source omits generated public `Cache-Control`;
 - request with `Authorization` doesn't get generated public cache headers by
   default;
-- source `cache_control` overrides defaults only after header and policy
+- source `response_cache_control` overrides defaults only after header and policy
   validation;
 - mutable sources without validators omit `ETag` and never return `304` from
   generated validators;
+- mutable public-safe sources with `Last-Modified` and no ETag return `200` for
+  `If-Modified-Since` in v1;
 - `internal_cache: :auto` resolves to `:enabled` for source-byte-immutable
   identities;
+- `internal_cache: :auto` resolves to `:enabled` for mutable identities that
+  include byte-version material;
 - `internal_cache: :auto` resolves to `:disabled` for mutable identities without
   byte-version material;
 - `internal_cache: :enabled` accepts mutable identities without byte-version
   material as an explicit host policy promise;
-- `internal_cache: :disabled` omits generated HTTP cache headers;
+- `internal_cache: :disabled` omits generated HTTP cache headers in v1;
 - automatic output emits `Vary: Accept`;
 - explicit output doesn't emit `Vary: Accept`;
 - configured header-varying output includes that header in `Vary`;
 - representation-changing headers missing from `Vary` turn off generated public
   caching or fail configuration;
 - cookie-varying output doesn't get public defaults;
-- matching `If-None-Match` returns `304` before source fetch for
-  source-byte-immutable pre-fetch output;
+- matching `If-None-Match` returns `304` before source fetch for output with a
+  strong source validator;
 - matching `If-None-Match` returns before internal cache lookup for
-  source-byte-immutable pre-fetch output;
+  output with a strong source validator;
 - non-matching `If-None-Match` proceeds normally;
 - malformed `If-None-Match` doesn't match;
-- weak request tags match generated strong ETags for `GET` and `HEAD`;
+- weak request tags match generated strong ETags for `GET`;
 - non-`GET` and non-`HEAD` requests don't use conditional response handling;
 - `If-None-Match: *` doesn't trigger pre-fetch `304`;
 - `If-None-Match: *` can trigger cached `304` on internal cache hit;
 - `304` responses include only the cache metadata allowlist and no body;
 - `304` responses don't include `Content-Type`, `Content-Length`, or
   `Content-Disposition`;
-- when ImagePipe supports `HEAD`, `HEAD` cache misses emit the same cache
-  headers as `GET` without a body;
-- when ImagePipe supports `HEAD`, matching conditionals return `304` without a
-  body;
 - internal cache hits preserve cached output headers such as `vary`;
 - internal cache hits prepare generated `etag`, `cache-control`, and
   `last-modified` from current request inputs;
 - internal cache hits can return `304` from the prepared `etag`;
+- internal cache hits recompute ETags with the current representation version;
+- existing host `ETag` suppresses generated ETag or fails configuration;
+- ImagePipe preserves existing host `Cache-Control` instead of merging it with
+  generated defaults;
+- ImagePipe preserves existing host `Last-Modified` or conflicts
+  deterministically;
+- existing `Vary` merges with generated `Accept` and configured vary headers;
 - transform option order variants produce the same ETag;
 - changing source revision changes ETag;
 - changing `etag_schema` changes ETag;
@@ -716,6 +810,8 @@ Add property tests for ETag material:
 
 - raw `Accept` spelling differences that normalize to the same capability
   produce the same ETag material;
+- raw `Accept` spelling differences that normalize to the same selected output
+  produce the same internal cache output material;
 - `If-None-Match` matching handles weak tags, comma-separated tags, and
   whitespace;
 - ImagePipe rejects unsupported or non-cacheable header values before response

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -30,10 +30,10 @@ plan operation data, output negotiation inputs, configured key headers,
 configured key cookies, cachebuster data, schema version, and transform key data
 version.
 
-`Plan.expires` isn't HTTP cache freshness. It's a parser-level request
-validity timestamp. The imgproxy parser should keep rejecting expired URLs
-before source resolution, but generated `Cache-Control` must not derive
-`max-age` from `Plan.expires`.
+`Plan.expires` doesn't exist yet. If ImagePipe adds it for signed URL
+compatibility, it should be a parser-level request validity timestamp, not HTTP
+cache freshness. A parser should reject expired URLs before source resolution,
+but generated `Cache-Control` must not derive `max-age` from `Plan.expires`.
 
 ImagePipe already emits `Vary: Accept` for automatic output and stores selected
 response headers in internal cache entries.
@@ -104,9 +104,9 @@ If the response has `Set-Cookie`, v1 suppresses generated public cache headers.
 That shouldn't occur on a normal public image route, but the rule keeps the
 failure mode conservative.
 
-Provider and parser modules don't set HTTP cache policy. Parser-level fields
-such as `Plan.expires` and URL cachebuster values affect request validity and cache
-keys, not response `Cache-Control`.
+Provider and parser modules don't set HTTP cache policy. Future parser-level
+fields such as `Plan.expires`, plus URL cachebuster values, affect request
+validity and cache keys, not response `Cache-Control`.
 
 ## Source Cache Semantics
 

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -356,8 +356,15 @@ instructions:
 ]
 ```
 
-For automatic or best-format output when the policy can select the format before
-source fetch:
+For automatic or best-format output, the policy should select the output format
+from normalized `Accept` and configured format preference when possible. Browser
+headers such as this are enough to choose AVIF or WebP before source fetch:
+
+```http
+Accept: image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
+```
+
+That path is pre-fetch ETag eligible:
 
 ```elixir
 [
@@ -368,6 +375,10 @@ source fetch:
   quality: :default
 ]
 ```
+
+Source alpha doesn't need separate ETag material when the selected target
+format supports transparency. AVIF and WebP do. Alpha affects the encoded bytes,
+but the source validator already represents the source bytes.
 
 For future automatic quality:
 
@@ -511,14 +522,37 @@ HTTP rules used here come from RFC 9110:
   carries cache metadata for the matching `200` response and no response
   content.
 
-Source-dependent output decisions opt out of pre-fetch conditional handling in
-the first implementation. This includes automatic fallback paths that need the
-source format or final alpha state before choosing JPEG or PNG. Those requests
-may still use internal cache hits and normal CDN freshness, but ImagePipe
-shouldn't claim a pre-fetch `304` path for them. A later implementation may emit
-ETags for these paths after source resolution or processing. If it does, it must
-include the selected output format and any source-dependent fallback decision in
-the ETag material. Otherwise omit the generated ETag for that response.
+Source-dependent output-format decisions opt out of pre-fetch conditional
+handling in the first implementation. This applies to modes where the selected
+output format depends on source metadata, such as source-format preservation or
+source-compatible fallback. Those requests may still use internal cache hits and
+normal CDN freshness, but ImagePipe shouldn't claim a pre-fetch `304` path for
+them.
+
+## Deferred Behaviors
+
+Keep v1 small. These omissions are intentional:
+
+- `If-Modified-Since`: omitted for scope. ImagePipe may emit `Last-Modified` as
+  metadata, but `If-None-Match` is the only conditional validator v1 acts on.
+- Late ETags: omitted for scope. If ETag material or selected output format is
+  only known after source fetch, decode, or transform, v1 omits the generated
+  ETag for that response.
+- Source metadata probing for mutable freshness: omitted for scope. Mutable
+  sources without revisions use short cache headers, no generated validators, or an
+  explicit host promise through `internal_cache: :enabled`.
+- Alpha-specific validator material: omitted because source bytes already cover
+  alpha. When the chosen output format supports transparency, alpha shouldn't
+  add a separate ETag input.
+- Stored generated ETags in the internal cache: omitted for correctness.
+  ImagePipe prepares generated HTTP cache headers from current source, request,
+  and policy inputs on each request.
+- Pre-fetch `If-None-Match: *`: omitted for correctness. `*` can match on an
+  internal cache hit, where a cached successful representation proves existence.
+- Public `Vary: Cookie`: off by default. Hosts must opt into this with
+  explicit cache policy.
+- Surrogate keys and CDN tag purge headers: out of scope for v1. Hosts can set
+  those headers outside ImagePipe if they need them.
 
 ## Internal Cache Interaction
 

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -54,6 +54,10 @@ Don't make mutable sources long-lived by default. A source adapter should mark a
 source's bytes immutable only when its resolved identity names stable bytes or
 when host configuration explicitly promises immutability.
 
+Generated public caching is for public image routes whose source identity and
+output bytes come from the image request model. Authenticated and
+cookie-selected representations are out of scope for generated public headers.
+
 Keep HTTP validators separate from internal cache keys. The internal cache key
 identifies an ImagePipe storage entry. The `ETag` identifies a client-visible
 representation.
@@ -68,23 +72,26 @@ material must not emit a generated `ETag` and must not match
 
 ImagePipe is a Plug, so the cache decision sees the `Plug.Conn` after earlier
 plugs have run. Earlier plugs may authenticate the request, rewrite path
-information, add request headers, load tenant state into assigns, or reject the
+information, add request headers, load host state into assigns, or reject the
 request before ImagePipe runs.
 
-ImagePipe should only generate public cache headers from inputs it models
-explicitly:
+ImagePipe should only generate shared-cache headers when `http_cache` is
+`:enabled`. That mode is a host promise about the route. The request should
+already be suitable for a CDN cache key.
+
+The generated validator model can include:
 
 - the request path and query that parser code consumes;
-- normalized request headers and cookies configured as cache inputs;
+- normalized request headers configured as cache inputs;
 - source identity and source cache semantics returned by the source adapter;
 - output policy and representation versions;
 - existing response headers that ImagePipe owns or validates.
 
 Plug assigns and `conn.private` are server-side state. A CDN can't vary on them
-directly. When they affect source identity or output bytes, the host has three
-choices. It can encode the decision into the URL, include it in resolved source
-identity, or map it back to explicit `Vary` material. Otherwise it must disable
-generated public caching for that route.
+directly. If they affect source identity or output bytes, generated public
+caching is out of scope for that route. Use `http_cache: :disabled`. ImagePipe
+shouldn't try to inspect assigns or infer whether arbitrary host state can use
+shared caches.
 
 Existing response cache headers on the conn are host policy. ImagePipe shouldn't
 overwrite an existing `Cache-Control`, `ETag`, `Vary`, or `Last-Modified`
@@ -121,17 +128,20 @@ Add `cache_semantics` to `ImagePipe.Source.Resolved`:
   adapter: :path,
   source_kind: :path,
   identity: [...],
+  http_cache: :inherit,
   internal_cache: :enabled,
   fetch: [...],
   cache_semantics: %ImagePipe.Source.CacheSemantics{...}
 }
 ```
 
-`source_bytes_immutable?` only describes the source bytes. It doesn't mean the
-generated response is safe for a shared cache. A private avatar source can be
-byte-immutable and still require `private`. It may also need no generated HTTP
-cache policy when the response depends on authorization, cookies, tenant
-routing, or other non-URL request state.
+`http_cache` on `Source.Resolved` is the source adapter's response-cache
+override. `:inherit` uses the request option. `:disabled` and `:enabled`
+override the request option for that resolved source.
+
+`source_bytes_immutable?` only describes the source bytes. It doesn't select an
+HTTP caching policy. A private avatar source can be byte-immutable and still
+use `http_cache: :disabled`.
 
 `validator` is either `{:strong, seed}` or `:none`. The seed must be
 deterministic, canonical, and non-secret. Immutable sources can use a canonical
@@ -170,6 +180,8 @@ Each source adapter should accept:
 
 ```elixir
 source_bytes_immutable?: boolean()
+http_cache: :inherit | :disabled | :enabled
+internal_cache: :auto | :enabled | :disabled
 response_cache_control: String.t() | nil
 ```
 
@@ -187,12 +199,13 @@ server adapter can't represent. Policy validation parses directives that
 ImagePipe reasons about, including `public`, `private`, `no-store`, `max-age`,
 `s-maxage`, `stale-while-revalidate`, `immutable`, `must-revalidate`,
 `proxy-revalidate`, and `no-transform`. Unknown extension directives pass
-through after syntax validation, but they can't prove public-cache safety. A
-`public` override requires a public cache-safety proof or explicit configuration.
-`s-maxage` also requires public-cache safety because it targets shared caches.
+through after syntax validation. A `private` override isn't part of generated
+HTTP caching. Hosts that need browser-private caching should set explicit
+headers outside this feature. A `public` or `s-maxage` override is only valid
+when `http_cache` is `:enabled`.
 
-If a source uses `internal_cache: :disabled`, ImagePipe shouldn't emit public
-cache validators or generated `Cache-Control` by default. `internal_cache: :disabled`
+If a source uses `internal_cache: :disabled`, ImagePipe shouldn't emit generated
+validators or generated `Cache-Control` in v1. `internal_cache: :disabled`
 currently passes request headers that normal cacheable sources strip before
 fetch. Those headers can affect source bytes. The first implementation should
 not provide an opt-back-in path for `internal_cache: :disabled`. A future opt-in
@@ -301,63 +314,46 @@ implementation doesn't use it as a validator. If a CDN or client sends
 `If-Modified-Since` support lands. After that, `If-None-Match` takes precedence
 when a request sends both validators.
 
-Generated public cache headers require an explicit safety decision:
+An explicit mode controls generated HTTP cache headers:
 
-```elixir
-representation_publicly_cacheable? =
-  allow_public_cache? and
-    public_route_or_source? and
-    complete_vary_material? and
-    no_disqualifying_request_state?
-```
+- `:disabled`: emit no generated `Cache-Control`, `ETag`, or `Last-Modified`.
+  Preserve explicit host headers that already exist on the conn.
+- `:enabled`: emit public shared-cache headers and validators when validator
+  material is complete.
 
-`allow_public_cache?` is the global option. It permits generated public defaults
-but never forces them. `public_route_or_source?` is host configuration on the
-mount, route, or source adapter. The source adapter option is
-`public_cache_safe?: true`. It means the host permits shared caches to store
-responses for this request class.
+The effective mode comes from request options, with source adapters allowed to
+override it with `http_cache: :disabled | :enabled`. The adapter default is
+`:inherit`.
 
-`no_disqualifying_request_state?` is true only when these are true:
+Default generated `Cache-Control`:
 
-- the request doesn't contain `Authorization`;
-- the response doesn't set `Set-Cookie`;
-- no configured cookie changes the representation unless the host explicitly
-  opts into `Vary: Cookie`;
-- no upstream or downstream Plug state outside URL, source identity, headers,
-  cookies, and output policy can change response bytes;
-- the selected `Cache-Control` policy doesn't contain `no-store`;
-- the selected `Cache-Control` policy doesn't contain shared-cache directives,
-  such as `public` or `s-maxage`, without public-cache safety.
+- `:enabled` with immutable source bytes: `public, max-age=31536000, immutable`
+- `:enabled` with mutable source bytes: `public, max-age=300, stale-while-revalidate=3600`
 
-Default generated `Cache-Control` when the representation is public-safe:
-
-- source bytes immutable: `public, max-age=31536000, immutable`
-- source bytes mutable: `public, max-age=300, stale-while-revalidate=3600`
-
-The mutable default is intentionally conservative. Hosts that want a different
-policy can set `response_cache_control` on the source adapter.
-
-Short public caching for mutable sources is a freshness policy, not a validator
-guarantee. These responses must omit generated ETags unless the source resolver
-provides byte-version material. A CDN may serve stale bytes within the configured
+The mutable default is a freshness policy, not a validator guarantee.
+These responses must omit generated ETags unless the source resolver provides
+byte-version material. A CDN may serve stale bytes within the configured
 freshness window.
 
-If public safety isn't proven, ImagePipe should omit generated public
-`Cache-Control` by default. A host may explicitly configure a private policy,
-such as `private, max-age=300`, for browser-side reuse. Cookie-varying responses
-should stay private or opt out of generated HTTP caching unless the host
-explicitly accepts `Vary: Cookie` behavior at the CDN.
+ImagePipe doesn't forward incoming `Cookie` to source requests and doesn't place
+raw cookies in generated HTTP cache material. A cookie on the browser request
+doesn't change public cache behavior by itself.
 
-V1 only generates ETags for responses eligible for generated HTTP cache headers.
-Non-public-safe responses omit generated ETags unless a host-supplied private
-cache policy explicitly enables them. If the selected `Cache-Control` policy
-contains `no-store`, ImagePipe must suppress generated ETags and
-`Last-Modified`.
+If a host or earlier plug uses a cookie to choose source identity, grant access,
+or change output bytes, generated public caching is out of scope for that route.
+Use `http_cache: :disabled`.
 
-If the request contains `Authorization`, ImagePipe must not emit generated
-public cache headers by default. Configuration must explicitly mark the route or
-source as public-cache-safe. It must also include every authorization-derived
-representation-changing input in the cache and validator model.
+V1 enabled mode has hard stops:
+
+- response `Set-Cookie` disables generated public headers;
+- existing or generated `Vary: *` disables generated public headers;
+- selected `Cache-Control: no-store` suppresses generated validators and
+  `Last-Modified`;
+- `public` or `s-maxage` in `response_cache_control` is only valid in
+  `http_cache: :enabled`.
+
+Per-user and per-tenant image behavior is out of scope for generated public
+headers.
 
 Header conflict behavior:
 
@@ -373,7 +369,7 @@ Header conflict behavior:
 Don't merge `Cache-Control` values. Directives can conflict, such as `private`
 with `public`, or two different `max-age` values. Pick one policy source.
 If an existing host `Vary` contains `*`, v1 must turn off generated public
-caching for that response instead of merging generated `Vary` values into it.
+headers for that response instead of merging generated `Vary` values into it.
 
 ## ETag Material
 
@@ -403,8 +399,7 @@ and canonical values. Examples:
 ```elixir
 [
   accept: [selected_format: :avif, capability: [:avif, :webp]],
-  headers: [{"x-tenant", ["tenant-a"]}],
-  cookies: []
+  headers: [{"x-image-profile", ["catalog"]}]
 ]
 ```
 
@@ -413,8 +408,10 @@ material must match the generated `Vary` header. Every non-URL input represented
 in ETag material must appear in `Vary`. Every generated `Vary` input that can
 change bytes must appear in ETag material.
 
-Only generate an ETag when source cache semantics contain `{:strong, seed}`.
-For `:none`, omit `ETag` and skip conditional `If-None-Match` handling.
+Only generate an ETag when the effective `http_cache` mode is `:enabled`, source
+cache semantics contain `{:strong, seed}`, and the selected cache policy doesn't
+contain `no-store`. For `:none`, omit `ETag` and skip conditional
+`If-None-Match` handling.
 
 V1 only expects strong validators from source identities that name immutable
 bytes. Future adapters may provide strong validators for mutable sources when
@@ -538,20 +535,21 @@ depends on `Accept`. CDN cache keys are URL-oriented unless configured
 otherwise.
 
 Any non-URL request input that can affect source identity, output bytes, format
-selection, or quality selection must appear in `Vary` and ETag material. If it
-doesn't, ImagePipe must turn off generated public HTTP caching. This includes
-tenant headers, authorization-derived routing, locale, device class, DPR, width
-hints, custom source-routing headers, and configured cookies.
+selection, or quality selection must appear in `Vary` and ETag material when
+`http_cache` is `:enabled`. ImagePipe doesn't infer those inputs from Plug state.
+If the host can't declare them, use `http_cache: :disabled` for that route. This
+includes image profile headers, locale, device class, DPR, width hints, and
+custom source-routing headers.
 
 `Vary: *` means a cache can't reuse the response for later requests. ImagePipe
-should reject it for generated public cache responses or turn off generated
-public caching for that representation.
+should reject it for generated public-header responses or turn off generated
+public headers for that representation.
 
 ## Pre-Fetch Conditional GET
 
-For cacheable responses with a strong source validator, ImagePipe should compute
-the ETag before source fetch whenever these inputs define output selection
-material:
+For requests whose effective `http_cache` mode is `:enabled` and whose source
+semantics contain a strong validator, ImagePipe should compute the ETag before
+source fetch whenever these inputs define output selection material:
 
 - the parsed plan;
 - source cache semantics from `Source.resolve/3`;
@@ -664,8 +662,9 @@ Keep v1 small. These omissions are intentional:
   internal cache hit, where a cached successful representation proves existence.
 - HEAD response support: out of scope unless the current Plug path already
   serves HEAD. The conditional matcher still needs explicit method gates.
-- Public `Vary: Cookie`: off by default. Hosts must opt into this with
-  explicit cache policy.
+- Cookie-varying public output: out of scope. ImagePipe ignores incoming request
+  cookies for generated HTTP caching and source fetches. Hosts that use cookies
+  to choose image bytes should use `http_cache: :disabled`.
 - Surrogate keys and CDN tag purge headers: out of scope for v1. Hosts can set
   those headers outside ImagePipe if they need them.
 
@@ -730,17 +729,17 @@ headers, if a host or later layer sets them, are outside this design.
 
 The first implementation shouldn't add error caching behavior.
 
-## Public Options
+## Options
 
 Add request options:
 
 ```elixir
 http_cache: [
+  mode: :disabled,
   immutable_cache_control: "public, max-age=31536000, immutable",
   mutable_cache_control: "public, max-age=300, stale-while-revalidate=3600",
   etag_version: 1,
-  representation_version: 1,
-  allow_public_cache?: false
+  representation_version: 1
 ]
 ```
 
@@ -750,8 +749,8 @@ Source adapter options:
 
 ```elixir
 source_bytes_immutable?: false,
-public_cache_safe?: false,
 internal_cache: :auto,
+http_cache: :inherit,
 response_cache_control: nil
 ```
 
@@ -762,22 +761,22 @@ even when `source_bytes_immutable?` isn't set.
 
 Add focused tests at the request boundary:
 
-- source-byte-immutable public-safe response emits `ETag` and long
-  `Cache-Control`;
-- public-safe mutable source emits short `Cache-Control`;
-- non-public-safe source omits generated public `Cache-Control`;
-- request with `Authorization` doesn't get generated public cache headers by
-  default;
-- response with `Set-Cookie` doesn't get generated public cache headers in v1;
+- `http_cache: :disabled` emits no generated `Cache-Control`, `ETag`, or
+  `Last-Modified`;
+- source-byte-immutable `http_cache: :enabled` response emits `ETag` and long
+  public `Cache-Control`;
+- mutable `http_cache: :enabled` response emits short public `Cache-Control`;
+- request `Cookie` doesn't enter generated `Vary`, ETag material, or source
+  fetches;
+- response with `Set-Cookie` disables generated public cache headers in v1;
 - source `response_cache_control` overrides defaults only after header and policy
   validation;
 - `response_cache_control` containing `no-store` suppresses generated validators;
-- `response_cache_control` containing `s-maxage` requires public-cache safety;
+- `response_cache_control` containing `public` or `s-maxage` is only valid in
+  `http_cache: :enabled`;
 - mutable sources without validators omit `ETag` and never return `304` from
   generated validators;
-- non-public-safe responses omit generated ETags unless a private cache policy
-  explicitly enables them;
-- mutable public-safe sources with `Last-Modified` and no ETag return `200` for
+- mutable cache-enabled sources with `Last-Modified` and no ETag return `200` for
   `If-Modified-Since` in v1;
 - `internal_cache: :auto` resolves to `:enabled` for source-byte-immutable
   identities;
@@ -791,9 +790,9 @@ Add focused tests at the request boundary:
 - automatic output emits `Vary: Accept`;
 - explicit output doesn't emit `Vary: Accept`;
 - configured header-varying output includes that header in `Vary`;
-- representation-changing headers missing from `Vary` turn off generated public
-  caching or fail configuration;
-- cookie-varying output doesn't get public defaults;
+- `http_cache: :enabled` requires configured header-varying output to include
+  that header in `Vary`;
+- cookie-varying output uses `http_cache: :disabled`;
 - matching `If-None-Match` returns `304` before source fetch for output with a
   strong source validator;
 - matching `If-None-Match` returns before internal cache lookup for
@@ -818,7 +817,7 @@ Add focused tests at the request boundary:
 - ImagePipe preserves existing host `Last-Modified` or conflicts
   deterministically;
 - existing `Vary` merges with generated `Accept` and configured vary headers;
-- existing `Vary: *` turns off generated public caching in v1;
+- existing `Vary: *` turns off generated public headers in v1;
 - transform option order variants produce the same ETag;
 - changing source revision changes ETag;
 - changing `etag_schema` changes ETag;
@@ -848,9 +847,9 @@ Add property tests for ETag material:
 - ImagePipe rejects unsupported or non-cacheable header values before response
   send;
 - ImagePipe rejects `Cache-Control` overrides containing CR or LF;
-- ImagePipe rejects invalid `Vary` values or turns off generated public caching;
+- ImagePipe rejects invalid `Vary` values or turns off generated public headers;
 - duplicate `Vary` values merge deterministically;
-- `Vary: *` turns off generated public caching;
+- `Vary: *` turns off generated public headers;
 - ETag material serialization is deterministic.
 
 ## Rollout

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -332,15 +332,24 @@ If `http_cache: :enabled` but `byte_identity` is `:none`, v1 emits
 `Cache-Control`. This avoids a half-cacheable mutable path where the CDN can
 store bytes but ImagePipe can't produce a validator. Treat `no-store` here as a
 safety signal: the route opted into generated HTTP caching, but the source did
-not produce byte identity. Emit telemetry or a low-cardinality log event for
-this fallback so operators can spot a bad route configuration.
+not produce byte identity. Emit telemetry for this fallback so operators can
+spot a bad route configuration. A low-cardinality log event can supplement
+telemetry, but it isn't a substitute.
 
 Emit low-cardinality HTTP cache telemetry for:
 
-- effective mode, byte identity kind, and whether ImagePipe emitted an ETag;
-- conditional request matches;
-- the `no-store` fallback;
-- cache-hit delivery using freshly prepared HTTP cache headers.
+- `[:image_pipe, :http_cache, :prepare]`: effective mode, byte identity kind,
+  and whether ImagePipe emitted an ETag;
+- `[:image_pipe, :http_cache, :conditional, :match]`: conditional request
+  matches;
+- `[:image_pipe, :http_cache, :fallback, :no_store]`: the `no-store` fallback,
+  with `%{adapter: resolved.adapter, source_kind: resolved.source_kind,
+  reason: :missing_byte_identity}`;
+- `[:image_pipe, :http_cache, :cache_hit, :headers]`: cache-hit delivery using
+  freshly prepared HTTP cache headers.
+
+Keep metadata low-cardinality. Don't include source identity, paths, URLs, ETag
+values, or request header values.
 
 Don't merge `Cache-Control` values. Directives can conflict, such as `private`
 with `public`, or two different `max-age` values. If a host already set
@@ -416,11 +425,19 @@ ETag: "ip1-<base64url-sha256>"
 Build the visible prefix from `@etag_schema`, for example
 `"ip#{@etag_schema}-..."`, so the prefix and hashed material can't disagree.
 
+Keep ETag material canonical before encoding. Don't use
+`:erlang.term_to_binary/1` over maps unless ImagePipe first turns those maps into
+sorted lists. The material should stay as ordered lists with primitive values so
+the same logical material encodes the same way across nodes and supported OTP
+versions.
+
 Use a strong ETag, not a weak ETag, for generated ETags. A weak ETag would say
 the response has the same meaning but not necessarily the same bytes. The
 representation version must change whenever an encoder, codec, libvips behavior,
 metadata policy, default quality, orientation handling, color-profile behavior,
 animation handling, or output timestamp behavior can change bytes.
+Changing symbolic output rule behavior is an output policy change, so it uses
+`representation_version`. Don't add per-rule version fields to plan material.
 
 It's acceptable for two byte-identical responses to have different ETags when
 their deterministic instruction material differs. It isn't acceptable for the

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -181,6 +181,24 @@ internal_cache: :auto | :enabled | :disabled
 override. `:inherit` uses the request option. `:disabled` and `:enabled`
 override the request option for that resolved source.
 
+Resolve the effective mode with source precedence:
+
+```elixir
+case resolved.http_cache do
+  :inherit -> request_options.http_cache.mode
+  override -> override
+end
+```
+
+Source-level `http_cache: :enabled` is the force switch for generated HTTP cache
+headers on that source. It still requires byte identity. When the host promises
+that source bytes are stable by policy, configure `stable?: true`. The adapter
+then derives `byte_identity: {:strong, seed}` from the resolved source identity.
+With both `stable?: true` and `http_cache: :enabled`, ImagePipe can generate the
+long `Cache-Control` and ETag. `http_cache: :enabled` alone doesn't force
+cacheable headers when `byte_identity` is `:none`, when the response has
+`Set-Cookie`, or when another v1 suppression rule applies.
+
 ## Internal Source Cache Policy
 
 The current internal cache assumes a cache key names stable output bytes. It has
@@ -230,7 +248,8 @@ An explicit mode controls generated HTTP cache headers:
 - `:enabled`: emit generated public shared-cache headers when byte identity
   material is complete.
 
-For v1, `:enabled` with `byte_identity: {:strong, seed}` emits:
+For v1, `:enabled` with `byte_identity: {:strong, seed}` emits generated public
+cache headers:
 
 ```elixir
 [
@@ -249,13 +268,16 @@ The request or mount options should configure the default `Cache-Control`.
 V1 has one generated cache-control value. Mutable short public caching stays
 deferred.
 
-If `http_cache: :enabled` but `byte_identity` is `:none`, v1 emits no generated
-`Cache-Control` and no generated `ETag`. This avoids a half-cacheable mutable
-path where the CDN can store bytes but ImagePipe can't produce a validator.
+If `http_cache: :enabled` but `byte_identity` is `:none`, v1 emits
+`Cache-Control: no-store` and no generated `ETag`, unless a host already set
+`Cache-Control`. This avoids a half-cacheable mutable path where the CDN can
+store bytes but ImagePipe can't produce a validator.
 
 Don't merge `Cache-Control` values. Directives can conflict, such as `private`
 with `public`, or two different `max-age` values. If a host already set
 `Cache-Control`, preserve it and suppress generated `Cache-Control`.
+If the selected or existing `Cache-Control` contains `no-store`, suppress the
+generated ETag.
 
 ## ETag Material
 
@@ -287,6 +309,9 @@ Only generate an ETag when:
 - automatic quality, if used later, has complete deterministic version material;
 - the response doesn't already have an `ETag`;
 - the selected cache policy isn't `no-store`.
+
+V1 conditional handling only uses ImagePipe-generated ETags. ImagePipe keeps
+existing host ETags but doesn't interpret them for `If-None-Match`.
 
 V1 only expects strong byte identity from source identities that name stable
 bytes. Future adapters may provide strong byte identity for mutable sources when
@@ -379,6 +404,8 @@ ETag: "ip1-..."
 Cache-Control: public, max-age=31536000, immutable
 Vary: Accept
 ```
+
+`Vary: Accept` appears only when automatic output depends on `Accept`.
 
 No source fetch, decode, transform, encode, internal cache lookup, or internal
 cache write should occur after the match.
@@ -487,12 +514,12 @@ Add request options:
 http_cache: [
   mode: :disabled,
   cache_control: "public, max-age=31536000, immutable",
-  etag_schema: 1,
   representation_version: 1
 ]
 ```
 
 Keep defaults small and explicit inside `ImagePipe.Request.Options`.
+Keep `etag_schema` as an implementation constant, not a request option.
 
 Source adapter options:
 
@@ -543,8 +570,8 @@ Add focused tests at the request boundary:
 - `http_cache: :disabled` emits no generated `Cache-Control` or `ETag`;
 - stable `http_cache: :enabled` response emits `ETag` and configured
   `Cache-Control`;
-- `http_cache: :enabled` with `byte_identity: :none` emits no generated
-  `Cache-Control` or `ETag`;
+- `http_cache: :enabled` with `byte_identity: :none` emits
+  `Cache-Control: no-store` and no generated `ETag`;
 - request `Cookie` doesn't enter generated `Vary`, ETag material, or source
   fetches;
 - response with `Set-Cookie` disables generated public cache headers in v1;
@@ -572,12 +599,15 @@ Add focused tests at the request boundary:
 - internal cache hits can return `304` from the prepared `etag`;
 - internal cache hits recompute ETags with the current representation version;
 - existing host `ETag` suppresses generated ETag;
+- ImagePipe preserves existing host `ETag`, but it doesn't trigger generated
+  `304` handling in v1;
 - existing host `Cache-Control` suppresses generated `Cache-Control`;
+- existing host `Cache-Control: no-store` suppresses generated ETags;
 - existing `Vary` merges with generated `Accept`;
 - existing `Vary: *` turns off generated public headers in v1;
 - transform option order variants produce the same ETag;
 - changing source revision changes ETag;
-- changing `etag_schema` changes ETag;
+- changing the implementation `etag_schema` constant changes ETag;
 - changing representation version changes ETag;
 - old internal cache entries don't replay stale generated ETags after
   representation version changes.
@@ -615,7 +645,8 @@ Build this in small steps:
    Splitting this across rolling deploys can produce nodes with different header
    behavior.
 5. Add cached `304` handling after generated headers are available on hits.
-6. Document CDN behavior and source stability configuration.
+6. Document how to enable `http_cache: :enabled`, how to mark sources stable,
+   expected CDN cache-key settings, and stable-versus-mutable source behavior.
 
 The first implementation shouldn't add post-transform conditional validation.
 If deterministic instruction material can't describe a future output mode, that

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -27,6 +27,11 @@ plan operation data, output negotiation inputs, configured key headers,
 configured key cookies, cachebuster data, schema version, and transform key data
 version.
 
+`Plan.expires` isn't HTTP cache freshness. It's a parser-level request
+validity timestamp. The imgproxy parser should keep rejecting expired URLs before
+source resolution, but generated `Cache-Control` shouldn't derive max-age from
+`Plan.expires`.
+
 ImagePipe also preserves `Vary: Accept` for automatic output and stores
 `vary`/`cache-control` headers in internal cache entries.
 
@@ -538,8 +543,14 @@ Any non-URL request input that can affect source identity, output bytes, format
 selection, or quality selection must appear in `Vary` and ETag material when
 `http_cache` is `:enabled`. ImagePipe doesn't infer those inputs from Plug state.
 If the host can't declare them, use `http_cache: :disabled` for that route. This
-includes image profile headers, locale, device class, DPR, width hints, and
-custom source-routing headers.
+includes image profile headers, locale, device class, and custom source-routing
+headers.
+
+Client Hints such as `DPR`, `Width`, `Viewport-Width`, `Sec-CH-DPR`, and
+`Sec-CH-Width` are out of scope for v1 generated public caching. They're
+client-controlled headers. Supporting them later requires a bounded model:
+explicit opt-in, accepted header names, normalization or clamping, `Vary` emission,
+CDN cache-key documentation, and ETag material that uses the normalized value.
 
 `Vary: *` means a cache can't reuse the response for later requests. ImagePipe
 should reject it for generated public-header responses or turn off generated
@@ -665,6 +676,10 @@ Keep v1 small. These omissions are intentional:
 - Cookie-varying public output: out of scope. ImagePipe ignores incoming request
   cookies for generated HTTP caching and source fetches. Hosts that use cookies
   to choose image bytes should use `http_cache: :disabled`.
+- Client Hints for generated public caching: out of scope. Unsigned headers such
+  as `DPR`, `Width`, and `Sec-CH-Width` can fragment a CDN cache if clients vary
+  them. Add a normalization design before using them in public cache
+  keys.
 - Surrogate keys and CDN tag purge headers: out of scope for v1. Hosts can set
   those headers outside ImagePipe if they need them.
 
@@ -792,6 +807,10 @@ Add focused tests at the request boundary:
 - configured header-varying output includes that header in `Vary`;
 - `http_cache: :enabled` requires configured header-varying output to include
   that header in `Vary`;
+- Client Hints don't enter generated public cache headers, `Vary`, ETag
+  material, or CDN documentation in v1;
+- `Plan.expires` doesn't change generated `Cache-Control`;
+- `cachebuster` remains URL/cache-key material, not response cache policy;
 - cookie-varying output uses `http_cache: :disabled`;
 - matching `If-None-Match` returns `304` before source fetch for output with a
   strong source byte identity;

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -544,6 +544,10 @@ Keep v1 small. These omissions are intentional:
 - Alpha-specific validator material: omitted because source bytes already cover
   alpha. When the chosen output format supports transparency, alpha shouldn't
   add a separate ETag input.
+- Static final-alpha inference: omitted for scope. Some transform chains can
+  prove final opacity before source fetch, such as an opaque background after
+  canvas-changing operations. v1 keeps source-format fallback on the existing
+  runtime final-alpha path instead of adding a transform effect system.
 - Stored generated ETags in the internal cache: omitted for correctness.
   ImagePipe prepares generated HTTP cache headers from current source, request,
   and policy inputs on each request.

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -717,8 +717,17 @@ Add focused tests at the request boundary:
   `Cache-Control`;
 - `http_cache: :enabled` with `byte_identity: :none` emits
   `Cache-Control: no-store` and no generated `ETag`;
-- `http_cache: :enabled` with `byte_identity: :none` emits telemetry or a
-  low-cardinality log event for the safety fallback;
+- `http_cache: :enabled` with `byte_identity: :none` emits
+  `[:image_pipe, :http_cache, :fallback, :no_store]` telemetry with
+  low-cardinality metadata: `adapter`, `source_kind`, and `reason`;
+- `[:image_pipe, :http_cache, :prepare]` telemetry includes effective mode,
+  byte-identity kind, and whether ImagePipe emitted an ETag, with no
+  high-cardinality fields;
+- `[:image_pipe, :http_cache, :conditional, :match]` telemetry emits on `304`
+  responses without ETag values, paths, or other high-cardinality fields;
+- `[:image_pipe, :http_cache, :cache_hit, :headers]` telemetry emits on
+  cache-hit delivery using freshly prepared headers, with no high-cardinality
+  fields;
 - request `Cookie` doesn't enter generated `Vary`, ETag material, or source
   fetches;
 - response with `Set-Cookie` disables generated public cache headers in v1;

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -64,6 +64,42 @@ freshness metadata during source resolution. A mutable source without freshness
 material must not emit a generated `ETag` and must not match
 `If-None-Match`.
 
+## Plug Chain Boundaries
+
+ImagePipe is a Plug, so the cache decision sees the `Plug.Conn` after earlier
+plugs have run. Earlier plugs may authenticate the request, rewrite path
+information, add request headers, load tenant state into assigns, or reject the
+request before ImagePipe runs.
+
+ImagePipe should only generate public cache headers from inputs it models
+explicitly:
+
+- the request path and query that parser code consumes;
+- normalized request headers and cookies configured as cache inputs;
+- source identity and source cache semantics returned by the source adapter;
+- output policy and representation versions;
+- existing response headers that ImagePipe owns or validates.
+
+Plug assigns and `conn.private` are server-side state. A CDN can't vary on them
+directly. When they affect source identity or output bytes, the host has three
+choices. It can encode the decision into the URL, include it in resolved source
+identity, or map it back to explicit `Vary` material. Otherwise it must disable
+generated public caching for that route.
+
+Existing response cache headers on the conn are host policy. ImagePipe shouldn't
+overwrite an existing `Cache-Control`, `ETag`, `Vary`, or `Last-Modified`
+without a decision. It should either check and preserve the host value, merge
+where HTTP permits merging, or fail configuration before sending a cacheable
+response.
+
+Downstream plugs are outside ImagePipe's validator model. If a later plug can
+change the response body, content encoding, `Content-Disposition`,
+`Cache-Control`, `ETag`, `Vary`, cookies, or representation metadata, ImagePipe's
+generated validators may no longer describe the bytes that reach the client.
+For cacheable image responses, route the request so ImagePipe sends the terminal
+response. If the host keeps downstream response mutation, host documentation must
+state that this turns off generated HTTP cache headers.
+
 ## Source Cache Semantics
 
 Add a small source-owned struct:

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -4,8 +4,8 @@
 
 ImagePipe should act as a cacheable image origin behind a CDN or local HTTP
 cache. The CDN should cache successful transformed responses and serve fresh
-entries without contacting ImagePipe. When the source identity is immutable, the
-CDN should revalidate stale entries with a conditional request.
+entries without contacting ImagePipe. When the source identity names immutable
+bytes, the CDN should revalidate stale entries with a conditional request.
 
 This design covers response headers and request handling for:
 
@@ -44,14 +44,15 @@ The missing CDN-facing behavior is:
 
 Keep the cache contract path-oriented and deterministic.
 
-Prefer pre-fetch validators for immutable sources. A request with a matching
-`If-None-Match` should return `304 Not Modified` before source fetch, decode,
-transform, or encode. This path applies when the parsed plan, request headers,
-runtime options, and resolved source identity provide all validator inputs.
+Prefer pre-fetch validators for source identities that name immutable bytes. A
+request with a matching `If-None-Match` should return `304 Not Modified` before
+source fetch, decode, transform, or encode. This path applies when the parsed
+plan, request headers, runtime options, and resolved source identity provide all
+validator inputs.
 
 Don't make mutable sources long-lived by default. A source adapter should mark a
-source immutable only when its resolved identity names stable bytes or when host
-configuration explicitly promises immutability.
+source's bytes immutable only when its resolved identity names stable bytes or
+when host configuration explicitly promises immutability.
 
 Keep HTTP validators separate from internal cache keys. The internal cache key
 identifies an ImagePipe storage entry. The `ETag` identifies a client-visible
@@ -69,10 +70,10 @@ Add a small source-owned struct:
 
 ```elixir
 defmodule ImagePipe.Source.CacheSemantics do
-  @enforce_keys [:validator, :immutable?]
+  @enforce_keys [:validator, :source_bytes_immutable?]
   defstruct validator: :none,
-            immutable?: false,
-            cache_control_override: nil,
+            source_bytes_immutable?: false,
+            response_cache_control_override: nil,
             last_modified: nil
 end
 ```
@@ -90,12 +91,20 @@ Add `cache_semantics` to `ImagePipe.Source.Resolved`:
 }
 ```
 
+`source_bytes_immutable?` only describes the source bytes. It doesn't mean the
+generated response is safe for a shared cache. A private avatar source can be
+byte-immutable and still require `private`. It may also need no generated HTTP
+cache policy when the response depends on authorization, cookies, tenant
+routing, or other non-URL request state.
+
 `validator` is either `{:strong, seed}` or `:none`. The seed must be
-deterministic and safe to serialize. Immutable sources can use the resolved
-source identity as the seed. Mutable sources must include freshness material,
-such as an upstream validator or version identifier. If the adapter can't
-provide byte-version material during resolution, it must use
-`:none`.
+deterministic, canonical, and non-secret. Immutable sources can use a canonical
+resolved source identity as the seed. If that identity contains credentials,
+signed query parameters, temporary tokens, or filesystem details, don't log it.
+The adapter must use a stable digest or redacted identity component instead.
+Mutable sources must include freshness material, such as an upstream validator or
+version identifier. If the adapter can't provide byte-version material during
+resolution, it must use `:none`.
 
 `last_modified` is an optional UTC `DateTime` truncated to seconds. ImagePipe
 emits it as an IMF-fixdate `Last-Modified` response header. The first
@@ -103,35 +112,52 @@ implementation doesn't check `If-Modified-Since`.
 
 Adapter defaults:
 
-- S3 object with `revision`: immutable. The fetch URL already includes
-  `versionId`, so the resolved source names specific bytes.
+- S3 object with `revision`: source bytes immutable. The fetch URL already
+  includes `versionId`, so the resolved source names specific bytes. The
+  validator seed should include the adapter name and version, endpoint or bucket
+  identity, key, and revision. It shouldn't rely on `versionId` being globally
+  unique.
 - S3 object without `revision`: mutable by default. Hosts can opt into
   immutability if their bucket keys are content-addressed or never overwritten.
 - File path: mutable by default and has no validator by default. Hosts can opt
   into immutability when the path space is content-addressed. Skip mutable file
   validators from `mtime` and size in the first implementation. They would add a
-  stat/fetch race unless fetch uses the same opened file.
+  stat/fetch race unless fetch uses the same opened file. Immutable file seeds
+  should use a canonical non-secret source identity, not a raw private path.
 - HTTP URL: mutable by default. Hosts can opt into immutability when URLs are
   content-addressed or versioned. Mutable HTTP URLs have no generated validator
   unless the adapter later adds explicit upstream freshness metadata during
-  resolution.
+  resolution. Immutable HTTP URL seeds must not include credentials, signed
+  query parameters, or temporary tokens.
 
 Each source adapter should accept:
 
 ```elixir
-immutable?: boolean()
+source_bytes_immutable?: boolean()
 cache_control: String.t() | nil
 ```
 
-`cache_control` is host policy copied through the resolved source. It's not a
-source identity fact. When set, ImagePipe emits it exactly after validating that
-it's a legal HTTP header value.
+`cache_control` is host response policy copied through the resolved source. It's
+not a source identity fact. The implementation should store it as
+`response_cache_control_override` to keep that distinction visible.
+
+When set, ImagePipe emits it only after two checks:
+
+1. The value is safe to send as an HTTP header value.
+2. ImagePipe permits the policy for this representation.
+
+Header validation rejects CR, LF, invalid binaries, and values the configured
+server adapter can't represent. Policy validation parses directives that
+ImagePipe reasons about, including `public`, `private`, `no-store`, `max-age`,
+`stale-while-revalidate`, and `immutable`. A `public` override requires a public
+cache-safety proof or explicit configuration.
 
 If a source uses `cache: :skip`, ImagePipe shouldn't emit public
 cache validators or generated `Cache-Control` by default. `cache: :skip`
 currently passes request headers that normal cacheable sources strip before
-fetch. Those headers can affect source bytes. Hosts can opt back into HTTP cache
-headers only by supplying deterministic identity and `Vary` material for every
+fetch. Those headers can affect source bytes. The first implementation should
+not provide an opt-back-in path for `cache: :skip`. A future opt-in must require
+a strong source validator and an explicit complete `Vary` declaration for every
 representation-changing request input.
 
 ## Response Cache Headers
@@ -169,18 +195,37 @@ When `last_modified` is present:
 {"last-modified", "Mon, 25 May 2026 12:00:00 GMT"}
 ```
 
-Default `Cache-Control`:
+ImagePipe emits `Last-Modified` as response metadata and for downstream cache
+visibility. The first implementation doesn't use it as a validator. If a CDN or
+client sends `If-Modified-Since`, ImagePipe returns the normal `200` path until
+explicit `If-Modified-Since` support lands. After that, `If-None-Match` takes
+precedence when a request sends both validators.
 
-- immutable source: `public, max-age=31536000, immutable`
-- mutable source: `public, max-age=300, stale-while-revalidate=3600`
+Generated public cache headers require an explicit safety decision:
+
+```elixir
+representation_publicly_cacheable? =
+  public_route_or_source? and complete_vary_material?
+```
+
+Default generated `Cache-Control` when the representation is public-safe:
+
+- source bytes immutable: `public, max-age=31536000, immutable`
+- source bytes mutable: `public, max-age=300, stale-while-revalidate=3600`
 
 The mutable default is intentionally conservative. Hosts that want a different
 policy can set `cache_control` on the source adapter.
 
-The `public` defaults apply only when the representation is independent of
-user-specific request state, or when the response declares all
-representation-changing request headers in `Vary` and ETag material.
-Cookie-varying responses shouldn't be public by default.
+If public safety isn't proven, ImagePipe should omit generated public
+`Cache-Control` by default. A host may explicitly configure a private policy,
+such as `private, max-age=300`, for browser-side reuse. Cookie-varying responses
+should stay private or opt out of generated HTTP caching unless the host
+explicitly accepts `Vary: Cookie` behavior at the CDN.
+
+If the request contains `Authorization`, ImagePipe must not emit generated
+public cache headers by default. Configuration must explicitly mark the route or
+source as public-cache-safe. It must also include every authorization-derived
+representation-changing input in the cache and validator model.
 
 ## ETag Material
 
@@ -198,12 +243,26 @@ Use separate ETag material:
   source: source_validator_seed,
   plan: canonical_plan_key_data,
   output: output_selection_material,
-  pipeline: output_pipeline_version_material
+  vary: representation_request_material,
+  pipeline: representation_version_material
 ]
 ```
 
 Only generate an ETag when source cache semantics contain `{:strong, seed}`.
 For `:none`, omit `ETag` and skip conditional `If-None-Match` handling.
+
+Generated ETags are instruction-derived strong validators, not body-hash ETags.
+They're correct only if the material includes every byte-changing input. That
+means source byte identity, transform instructions, output decisions, encoder
+settings, normalized request inputs, and versioned dependencies.
+
+Use a strong ETag, not a weak ETag, for generated validators. A weak ETag would
+say the response has the same meaning but not necessarily the same bytes.
+ImagePipe can treat the encoded image response as byte-identical only when the
+ETag material is complete. The representation version must change whenever an
+encoder, codec, libvips behavior, metadata policy, default quality, orientation
+handling, color-profile behavior, animation handling, or output timestamp
+behavior can change bytes.
 
 `output_selection_material` should describe the deterministic representation
 instructions:
@@ -244,8 +303,10 @@ For future automatic quality:
 
 If automatic quality uses ML, the model artifact version must be present. If a
 quality strategy depends on libvips or codec behavior, it may change output
-bytes across deploys. In that case, the strategy version or output pipeline
-version must change with the deploy.
+bytes across deploys. In that case, the strategy version or representation
+version must change with the deploy. For ML-based quality, `model_version: nil`
+must suppress generated ETags rather than reuse a validator across model
+artifact changes.
 
 Automatic quality can still use a pre-fetch ETag when ImagePipe knows the
 selected output format before source fetch. The quality algorithm must be a
@@ -256,6 +317,10 @@ that case.
 It's acceptable for two byte-identical responses to have different ETags when
 their deterministic instruction material differs. It's not acceptable for the
 same ETag to survive a change that may change bytes.
+
+Increment `etag_schema` only when the shape or interpretation of ETag material
+changes. Increment `representation_version` when the encoded bytes may change
+while the material shape stays the same.
 
 ## Accept Normalization
 
@@ -279,17 +344,21 @@ ImagePipe must still emit `Vary: Accept` whenever response format selection
 depends on `Accept`. CDN cache keys are URL-oriented unless configured
 otherwise.
 
-Any other request header that can affect source identity, output bytes, format
-selection, or quality selection must also appear in `Vary` and ETag material.
-Cookie-varying representations should stay private or opt out of generated
-public HTTP caching unless the host explicitly accepts `Vary: Cookie` behavior
-at the CDN.
+Any non-URL request input that can affect source identity, output bytes, format
+selection, or quality selection must appear in `Vary` and ETag material. If it
+doesn't, ImagePipe must turn off generated public HTTP caching. This includes
+tenant headers, authorization-derived routing, locale, device class, DPR, width
+hints, custom source-routing headers, and configured cookies.
+
+`Vary: *` means a cache can't reuse the response for later requests. ImagePipe
+should reject it for generated public cache responses or turn off generated
+public caching for that representation.
 
 ## Pre-Fetch Conditional GET
 
-For cacheable immutable sources with a strong source validator, ImagePipe should
-compute the ETag before source fetch whenever these inputs define output
-selection material:
+For cacheable source-byte-immutable responses with a strong source validator,
+ImagePipe should compute the ETag before source fetch whenever these inputs
+define output selection material:
 
 - the parsed plan;
 - source cache semantics from `Source.resolve/3`;
@@ -315,20 +384,60 @@ cache write should occur after the match.
 
 `If-None-Match` parsing must handle `*` and comma-separated entity tags. For
 `GET` and `HEAD`, use weak comparison with ImagePipe's generated strong ETag:
-`W/"abc"` and `"abc"` both match `"abc"`. The first implementation only needs
-conditional behavior for methods ImagePipe already serves.
+`W/"abc"` and `"abc"` both match `"abc"`. ImagePipe must gate conditional
+behavior to `GET` and `HEAD`.
+
+The pre-fetch path must not treat `If-None-Match: *` as a match in the first
+implementation. For `GET` and `HEAD`, `*` means any current representation
+exists. Before source fetch, ImagePipe hasn't proven that the requested source
+exists, that the transform can run, or that output negotiation can succeed. `*`
+can return `304` on an internal cache hit because the cached successful entry
+proves that a current representation exists for the internal cache key.
 
 A `304 Not Modified` response must have no body and must include the cache
-metadata that ImagePipe would send on the corresponding `200`: `ETag`,
-`Cache-Control`, `Vary`, and `Last-Modified` when present. Don't replay
-encoded-body headers such as `Content-Length`, `Content-Type`, or
-`Content-Disposition` on `304`.
+metadata that ImagePipe would send on the corresponding `200`. Use a cache
+metadata allowlist:
+
+```elixir
+[
+  "cache-control",
+  "content-location",
+  "date",
+  "etag",
+  "expires",
+  "last-modified",
+  "surrogate-control",
+  "vary"
+]
+```
+
+The first implementation only emits the subset ImagePipe can produce. The server
+adapter normally generates `Date`. Don't replay encoded-body headers such as
+`Content-Length`, `Content-Type`, or `Content-Disposition` on `304`. Avoid
+representing `304` as a normal encoded response with an empty binary body. Use a
+delivery shape such as `{:not_modified, headers}`.
+
+If ImagePipe supports `HEAD`, a non-matching `HEAD` response should send the
+headers that the corresponding `GET` would send, without a body. A matching
+conditional `HEAD` should return `304` without a body.
+
+HTTP rules used here come from RFC 9110:
+
+- [`If-None-Match`](https://www.rfc-editor.org/rfc/rfc9110.html#name-if-none-match)
+  uses weak comparison for `GET` and `HEAD`; `*` matches when a current
+  representation exists.
+- [`304 Not Modified`](https://www.rfc-editor.org/rfc/rfc9110.html#name-304-not-modified)
+  carries cache metadata for the matching `200` response and no response
+  content.
 
 Source-dependent output decisions opt out of pre-fetch conditional handling in
 the first implementation. This includes automatic fallback paths that need the
 source format or final alpha state before choosing JPEG or PNG. Those requests
-may still use internal cache hits and normal CDN freshness, but ImagePipe should
-not claim a pre-fetch `304` path for them.
+may still use internal cache hits and normal CDN freshness, but ImagePipe
+shouldn't claim a pre-fetch `304` path for them. A later implementation may emit
+ETags for these paths after source resolution or processing. If it does, it must
+include the selected output format and any source-dependent fallback decision in
+the ETag material. Otherwise omit the generated ETag for that response.
 
 ## Internal Cache Interaction
 
@@ -347,6 +456,8 @@ On internal cache hit:
 1. Check the cached entry and headers.
 2. If the request has `If-None-Match` matching the cached `etag`, return
    `304 Not Modified` with the cache metadata header allowlist and no body.
+   `If-None-Match: *` can match here because the cache entry proves the current
+   representation exists.
 3. Otherwise return `200` with the cached body and cached response headers.
 
 This preserves header behavior between cache misses and cache hits.
@@ -355,15 +466,22 @@ This preserves header behavior between cache misses and cache hits.
 shouldn't own conditional request behavior. The request runner or response
 sender should branch to a delivery shape that represents `304`.
 
+Cached HTTP headers must not survive an incompatible representation change. The
+internal cache key should include the same representation version and ETag
+schema version used for generated validators. As another option, cached entry
+metadata can carry those versions and ImagePipe can reject entries that don't
+match current options. The first implementation should use one of those checks
+before replaying stored `etag` or `cache-control`.
+
 ## Error Responses
 
 Only successful encoded responses are cacheable by default.
 
 Parser, planner, source, decode, transform, output negotiation, and encode
-errors shouldn't receive public long-lived cache headers. If an error response
-gets cache headers, it should use `Cache-Control: no-store`.
+errors shouldn't receive generated HTTP cache headers. Explicit error-policy
+headers, if a host or later layer sets them, are outside this design.
 
-The first implementation doesn't need to add error caching behavior.
+The first implementation shouldn't add error caching behavior.
 
 ## Public Options
 
@@ -374,7 +492,8 @@ http_cache: [
   immutable_cache_control: "public, max-age=31536000, immutable",
   mutable_cache_control: "public, max-age=300, stale-while-revalidate=3600",
   etag_version: 1,
-  output_version: 1
+  representation_version: 1,
+  public_cache?: false
 ]
 ```
 
@@ -383,55 +502,83 @@ Keep defaults small and explicit inside `ImagePipe.Request.Options`.
 Source adapter options:
 
 ```elixir
-immutable?: false,
+source_bytes_immutable?: false,
 cache_control: nil
 ```
 
 For S3, if `revision` is present, the source can treat the object as immutable
-even when `immutable?` isn't set.
+even when `source_bytes_immutable?` isn't set.
 
 ## Test Plan
 
 Add focused tests at the request boundary:
 
-- immutable source emits `ETag` and long `Cache-Control`;
-- mutable source emits short `Cache-Control`;
-- source `cache_control` overrides defaults;
+- source-byte-immutable public-safe response emits `ETag` and long
+  `Cache-Control`;
+- public-safe mutable source emits short `Cache-Control`;
+- non-public-safe source omits generated public `Cache-Control`;
+- request with `Authorization` doesn't get generated public cache headers by
+  default;
+- source `cache_control` overrides defaults only after header and policy
+  validation;
 - mutable sources without validators omit `ETag` and never return `304` from
   generated validators;
-- `cache: :skip` omits generated public cache headers unless explicitly opted
-  back in;
+- `cache: :skip` omits generated HTTP cache headers;
 - automatic output emits `Vary: Accept`;
 - explicit output doesn't emit `Vary: Accept`;
-- matching `If-None-Match` returns `304` before source fetch for immutable
-  pre-fetch output;
-- matching `If-None-Match` returns before internal cache lookup for immutable
-  pre-fetch output;
+- configured header-varying output includes that header in `Vary`;
+- representation-changing headers missing from `Vary` turn off generated public
+  caching or fail configuration;
+- cookie-varying output doesn't get public defaults;
+- matching `If-None-Match` returns `304` before source fetch for
+  source-byte-immutable pre-fetch output;
+- matching `If-None-Match` returns before internal cache lookup for
+  source-byte-immutable pre-fetch output;
 - non-matching `If-None-Match` proceeds normally;
+- malformed `If-None-Match` doesn't match;
+- weak request tags match generated strong ETags for `GET` and `HEAD`;
+- non-`GET` and non-`HEAD` requests don't use conditional response handling;
+- `If-None-Match: *` doesn't trigger pre-fetch `304`;
+- `If-None-Match: *` can trigger cached `304` on internal cache hit;
+- `304` responses include only the cache metadata allowlist and no body;
+- `304` responses don't include `Content-Type`, `Content-Length`, or
+  `Content-Disposition`;
+- when ImagePipe supports `HEAD`, `HEAD` cache misses emit the same cache
+  headers as `GET` without a body;
+- when ImagePipe supports `HEAD`, matching conditionals return `304` without a
+  body;
 - internal cache hits preserve `etag`, `cache-control`, `vary`, and
   `last-modified`;
 - internal cache hits can return `304` from stored `etag`;
 - transform option order variants produce the same ETag;
 - changing source revision changes ETag;
-- changing output policy version changes ETag.
+- changing `etag_schema` changes ETag;
+- changing representation version changes ETag;
+- old internal cache entries don't replay stale ETags after representation
+  version changes.
 
 Add source adapter tests:
 
-- S3 with revision marks cache semantics immutable and keeps `versionId` fetch;
-- S3 without revision is mutable unless configured immutable;
-- File source defaults mutable without a validator and host config can make it
-  immutable;
-- HTTP source defaults mutable without a validator and host config can make it
-  immutable.
+- S3 with revision marks source bytes immutable and keeps `versionId` fetch;
+- S3 without revision is mutable unless configured source-byte-immutable;
+- File source defaults mutable without a validator and host config can mark
+  source bytes immutable;
+- HTTP source defaults mutable without a validator and host config can mark
+  source bytes immutable;
+- source validator seeds redact or digest secret identity material.
 
 Add property tests for ETag material:
 
 - raw `Accept` spelling differences that normalize to the same capability
   produce the same ETag material;
-- `If-None-Match` matching handles weak tags, comma-separated tags, whitespace,
-  and `*`;
+- `If-None-Match` matching handles weak tags, comma-separated tags, and
+  whitespace;
 - ImagePipe rejects unsupported or non-cacheable header values before response
   send;
+- ImagePipe rejects `Cache-Control` overrides containing CR or LF;
+- ImagePipe rejects invalid `Vary` values or turns off generated public caching;
+- duplicate `Vary` values merge deterministically;
+- `Vary: *` turns off generated public caching;
 - ETag material serialization is deterministic.
 
 ## Rollout

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -1,0 +1,453 @@
+# CDN HTTP Cache Design
+
+## Scope
+
+ImagePipe should act as a cacheable image origin behind a CDN or local HTTP
+cache. The CDN should cache successful transformed responses and serve fresh
+entries without contacting ImagePipe. When the source identity is immutable, the
+CDN should revalidate stale entries with a conditional request.
+
+This design covers response headers and request handling for:
+
+- `ETag`
+- `Cache-Control`
+- `Vary`
+- `Last-Modified`
+- `If-None-Match`
+
+It doesn't replace the existing internal encoded-response cache. The internal
+cache avoids recomputing inside ImagePipe. HTTP cache headers tell browsers,
+CDNs, and reverse proxies how to cache ImagePipe responses.
+
+## Current State
+
+ImagePipe already has a deterministic internal cache key in
+`ImagePipe.Cache.Key`. That key includes resolved source identity, canonical
+plan operation data, output negotiation inputs, configured key headers,
+configured key cookies, cachebuster data, schema version, and transform key data
+version.
+
+ImagePipe also preserves `Vary: Accept` for automatic output and stores
+`vary`/`cache-control` headers in internal cache entries.
+
+The missing CDN-facing behavior is:
+
+- successful responses don't get a generated `ETag`;
+- successful responses don't get a default `Cache-Control`;
+- source adapters don't expose HTTP cache semantics;
+- `Last-Modified` isn't represented;
+- `If-None-Match` can't return `304 Not Modified`;
+- internal cache hits can't preserve or check validators because cached
+  entries don't store `etag` or `last-modified`.
+
+## Design Goals
+
+Keep the cache contract path-oriented and deterministic.
+
+Prefer pre-fetch validators for immutable sources. A request with a matching
+`If-None-Match` should return `304 Not Modified` before source fetch, decode,
+transform, or encode. This path applies when the parsed plan, request headers,
+runtime options, and resolved source identity provide all validator inputs.
+
+Don't make mutable sources long-lived by default. A source adapter should mark a
+source immutable only when its resolved identity names stable bytes or when host
+configuration explicitly promises immutability.
+
+Keep HTTP validators separate from internal cache keys. The internal cache key
+identifies an ImagePipe storage entry. The `ETag` identifies a client-visible
+representation.
+
+Avoid adding a source-fetch metadata path just to support mutable revalidation.
+Mutable sources can use short cache lifetimes unless an adapter can provide
+freshness metadata during source resolution. A mutable source without freshness
+material must not emit a generated `ETag` and must not match
+`If-None-Match`.
+
+## Source Cache Semantics
+
+Add a small source-owned struct:
+
+```elixir
+defmodule ImagePipe.Source.CacheSemantics do
+  @enforce_keys [:validator, :immutable?]
+  defstruct validator: :none,
+            immutable?: false,
+            cache_control_override: nil,
+            last_modified: nil
+end
+```
+
+Add `cache_semantics` to `ImagePipe.Source.Resolved`:
+
+```elixir
+%ImagePipe.Source.Resolved{
+  adapter: :path,
+  source_kind: :path,
+  identity: [...],
+  cache: :normal,
+  fetch: [...],
+  cache_semantics: %ImagePipe.Source.CacheSemantics{...}
+}
+```
+
+`validator` is either `{:strong, seed}` or `:none`. The seed must be
+deterministic and safe to serialize. Immutable sources can use the resolved
+source identity as the seed. Mutable sources must include freshness material,
+such as an upstream validator or version identifier. If the adapter can't
+provide byte-version material during resolution, it must use
+`:none`.
+
+`last_modified` is an optional UTC `DateTime` truncated to seconds. ImagePipe
+emits it as an IMF-fixdate `Last-Modified` response header. The first
+implementation doesn't check `If-Modified-Since`.
+
+Adapter defaults:
+
+- S3 object with `revision`: immutable. The fetch URL already includes
+  `versionId`, so the resolved source names specific bytes.
+- S3 object without `revision`: mutable by default. Hosts can opt into
+  immutability if their bucket keys are content-addressed or never overwritten.
+- File path: mutable by default and has no validator by default. Hosts can opt
+  into immutability when the path space is content-addressed. Skip mutable file
+  validators from `mtime` and size in the first implementation. They would add a
+  stat/fetch race unless fetch uses the same opened file.
+- HTTP URL: mutable by default. Hosts can opt into immutability when URLs are
+  content-addressed or versioned. Mutable HTTP URLs have no generated validator
+  unless the adapter later adds explicit upstream freshness metadata during
+  resolution.
+
+Each source adapter should accept:
+
+```elixir
+immutable?: boolean()
+cache_control: String.t() | nil
+```
+
+`cache_control` is host policy copied through the resolved source. It's not a
+source identity fact. When set, ImagePipe emits it exactly after validating that
+it's a legal HTTP header value.
+
+If a source uses `cache: :skip`, ImagePipe shouldn't emit public
+cache validators or generated `Cache-Control` by default. `cache: :skip`
+currently passes request headers that normal cacheable sources strip before
+fetch. Those headers can affect source bytes. Hosts can opt back into HTTP cache
+headers only by supplying deterministic identity and `Vary` material for every
+representation-changing request input.
+
+## Response Cache Headers
+
+Add a pure module under the request boundary, tentatively
+`ImagePipe.Request.HTTPCache`.
+
+This module needs source cache semantics, plan key data, output selection
+material, request headers, and request options. Keeping it under
+`ImagePipe.Request` preserves the existing boundary direction. `ImagePipe.Response`
+should send already-prepared status codes and headers.
+
+It should compute response headers from:
+
+- source cache semantics;
+- canonical plan key data;
+- output selection material;
+- configured output/cache version material;
+- existing response headers from output policy, such as `Vary: Accept`;
+- configured representation-changing headers, when the config admits them.
+
+The result should be a normalized header list:
+
+```elixir
+[
+  {"etag", ~s("...")},
+  {"cache-control", "public, max-age=31536000, immutable"},
+  {"vary", "Accept"}
+]
+```
+
+When `last_modified` is present:
+
+```elixir
+{"last-modified", "Mon, 25 May 2026 12:00:00 GMT"}
+```
+
+Default `Cache-Control`:
+
+- immutable source: `public, max-age=31536000, immutable`
+- mutable source: `public, max-age=300, stale-while-revalidate=3600`
+
+The mutable default is intentionally conservative. Hosts that want a different
+policy can set `cache_control` on the source adapter.
+
+The `public` defaults apply only when the representation is independent of
+user-specific request state, or when the response declares all
+representation-changing request headers in `Vary` and ETag material.
+Cookie-varying responses shouldn't be public by default.
+
+## ETag Material
+
+Don't use `ImagePipe.Cache.Key.hash` as the public `ETag`.
+
+The internal key includes storage and origin concerns, such as schema version,
+selected configured headers/cookies, and cache adapter key inputs. Those fields
+are useful for safe internal reuse but too coupled for an HTTP validator.
+
+Use separate ETag material:
+
+```elixir
+[
+  etag_schema: 1,
+  source: source_validator_seed,
+  plan: canonical_plan_key_data,
+  output: output_selection_material,
+  pipeline: output_pipeline_version_material
+]
+```
+
+Only generate an ETag when source cache semantics contain `{:strong, seed}`.
+For `:none`, omit `ETag` and skip conditional `If-None-Match` handling.
+
+`output_selection_material` should describe the deterministic representation
+instructions:
+
+```elixir
+[
+  mode: :explicit,
+  selected_format: :webp,
+  quality: {:quality, 82}
+]
+```
+
+For automatic or best-format output when the policy can select the format before
+source fetch:
+
+```elixir
+[
+  mode: :best,
+  accept_capability: [:avif, :webp],
+  selection_policy: [name: :best_format, version: 1],
+  selected_format: :avif,
+  quality: :default
+]
+```
+
+For future automatic quality:
+
+```elixir
+[
+  quality: [
+    mode: :auto,
+    strategy: :dssim,
+    strategy_version: 1,
+    model_version: nil
+  ]
+]
+```
+
+If automatic quality uses ML, the model artifact version must be present. If a
+quality strategy depends on libvips or codec behavior, it may change output
+bytes across deploys. In that case, the strategy version or output pipeline
+version must change with the deploy.
+
+Automatic quality can still use a pre-fetch ETag when ImagePipe knows the
+selected output format before source fetch. The quality algorithm must be a
+deterministic function of immutable source bytes, the canonical plan, and
+versioned strategy inputs. The ETag doesn't need the resolved numeric quality in
+that case.
+
+It's acceptable for two byte-identical responses to have different ETags when
+their deterministic instruction material differs. It's not acceptable for the
+same ETag to survive a change that may change bytes.
+
+## Accept Normalization
+
+Reduce `Accept` to ImagePipe's output capability model before it enters ETag or
+internal cache material.
+
+For current automatic output:
+
+```elixir
+Accept: image/avif,image/webp
+```
+
+That header and a header that prefers WebP with quality 1 and AVIF with quality
+0.1 both normalize to the same selected format when ImagePipe's policy chooses
+AVIF.
+
+Don't store the raw `Accept` header in the ETag material. Store either the
+selected format or the normalized capability list used by the selection policy.
+
+ImagePipe must still emit `Vary: Accept` whenever response format selection
+depends on `Accept`. CDN cache keys are URL-oriented unless configured
+otherwise.
+
+Any other request header that can affect source identity, output bytes, format
+selection, or quality selection must also appear in `Vary` and ETag material.
+Cookie-varying representations should stay private or opt out of generated
+public HTTP caching unless the host explicitly accepts `Vary: Cookie` behavior
+at the CDN.
+
+## Pre-Fetch Conditional GET
+
+For cacheable immutable sources with a strong source validator, ImagePipe should
+compute the ETag before source fetch whenever these inputs define output
+selection material:
+
+- the parsed plan;
+- source cache semantics from `Source.resolve/3`;
+- normalized `Accept`;
+- runtime output options;
+- deterministic policy versions.
+
+This pre-run conditional decision belongs after `Source.resolve/3` and before
+`Runner.run/4`. A matching validator must skip internal cache lookup and
+source fetch.
+
+On matching `If-None-Match`, ImagePipe returns:
+
+```http
+304 Not Modified
+ETag: "..."
+Cache-Control: public, max-age=31536000, immutable
+Vary: Accept
+```
+
+No source fetch, decode, transform, encode, internal cache lookup, or internal
+cache write should occur after the match.
+
+`If-None-Match` parsing must handle `*` and comma-separated entity tags. For
+`GET` and `HEAD`, use weak comparison with ImagePipe's generated strong ETag:
+`W/"abc"` and `"abc"` both match `"abc"`. The first implementation only needs
+conditional behavior for methods ImagePipe already serves.
+
+A `304 Not Modified` response must have no body and must include the cache
+metadata that ImagePipe would send on the corresponding `200`: `ETag`,
+`Cache-Control`, `Vary`, and `Last-Modified` when present. Don't replay
+encoded-body headers such as `Content-Length`, `Content-Type`, or
+`Content-Disposition` on `304`.
+
+Source-dependent output decisions opt out of pre-fetch conditional handling in
+the first implementation. This includes automatic fallback paths that need the
+source format or final alpha state before choosing JPEG or PNG. Those requests
+may still use internal cache hits and normal CDN freshness, but ImagePipe should
+not claim a pre-fetch `304` path for them.
+
+## Internal Cache Interaction
+
+The internal cache should store the CDN-facing headers with successful encoded
+entries.
+
+Extend `ImagePipe.Cache.Entry.cacheable_headers/1` to accept these names:
+
+- `vary`
+- `cache-control`
+- `etag`
+- `last-modified`
+
+On internal cache hit:
+
+1. Check the cached entry and headers.
+2. If the request has `If-None-Match` matching the cached `etag`, return
+   `304 Not Modified` with the cache metadata header allowlist and no body.
+3. Otherwise return `200` with the cached body and cached response headers.
+
+This preserves header behavior between cache misses and cache hits.
+
+`ImagePipe.Cache.Entry` should only check and store cacheable headers. It
+shouldn't own conditional request behavior. The request runner or response
+sender should branch to a delivery shape that represents `304`.
+
+## Error Responses
+
+Only successful encoded responses are cacheable by default.
+
+Parser, planner, source, decode, transform, output negotiation, and encode
+errors shouldn't receive public long-lived cache headers. If an error response
+gets cache headers, it should use `Cache-Control: no-store`.
+
+The first implementation doesn't need to add error caching behavior.
+
+## Public Options
+
+Add request options:
+
+```elixir
+http_cache: [
+  immutable_cache_control: "public, max-age=31536000, immutable",
+  mutable_cache_control: "public, max-age=300, stale-while-revalidate=3600",
+  etag_version: 1,
+  output_version: 1
+]
+```
+
+Keep defaults small and explicit inside `ImagePipe.Request.Options`.
+
+Source adapter options:
+
+```elixir
+immutable?: false,
+cache_control: nil
+```
+
+For S3, if `revision` is present, the source can treat the object as immutable
+even when `immutable?` isn't set.
+
+## Test Plan
+
+Add focused tests at the request boundary:
+
+- immutable source emits `ETag` and long `Cache-Control`;
+- mutable source emits short `Cache-Control`;
+- source `cache_control` overrides defaults;
+- mutable sources without validators omit `ETag` and never return `304` from
+  generated validators;
+- `cache: :skip` omits generated public cache headers unless explicitly opted
+  back in;
+- automatic output emits `Vary: Accept`;
+- explicit output doesn't emit `Vary: Accept`;
+- matching `If-None-Match` returns `304` before source fetch for immutable
+  pre-fetch output;
+- matching `If-None-Match` returns before internal cache lookup for immutable
+  pre-fetch output;
+- non-matching `If-None-Match` proceeds normally;
+- internal cache hits preserve `etag`, `cache-control`, `vary`, and
+  `last-modified`;
+- internal cache hits can return `304` from stored `etag`;
+- transform option order variants produce the same ETag;
+- changing source revision changes ETag;
+- changing output policy version changes ETag.
+
+Add source adapter tests:
+
+- S3 with revision marks cache semantics immutable and keeps `versionId` fetch;
+- S3 without revision is mutable unless configured immutable;
+- File source defaults mutable without a validator and host config can make it
+  immutable;
+- HTTP source defaults mutable without a validator and host config can make it
+  immutable.
+
+Add property tests for ETag material:
+
+- raw `Accept` spelling differences that normalize to the same capability
+  produce the same ETag material;
+- `If-None-Match` matching handles weak tags, comma-separated tags, whitespace,
+  and `*`;
+- ImagePipe rejects unsupported or non-cacheable header values before response
+  send;
+- ETag material serialization is deterministic.
+
+## Rollout
+
+Build this in small steps:
+
+1. Add source cache semantics struct and source adapter options.
+2. Add request-owned HTTP cache header computation and unit tests.
+3. Add pre-run conditional handling after source resolution and before
+   `Runner.run/4`.
+4. Attach headers to cache misses and store the same headers in internal cache
+   entries in the same change.
+5. Replay headers and support cached `304` on internal cache hits.
+6. Document CDN behavior and source immutability configuration.
+
+The first implementation shouldn't add post-transform conditional validation.
+If deterministic instruction material can't describe a future output mode, that
+mode should opt out of pre-fetch validation until the design makes its inputs
+explicit and versioned.

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -189,6 +189,7 @@ ImagePipe reasons about, including `public`, `private`, `no-store`, `max-age`,
 `proxy-revalidate`, and `no-transform`. Unknown extension directives pass
 through after syntax validation, but they can't prove public-cache safety. A
 `public` override requires a public cache-safety proof or explicit configuration.
+`s-maxage` also requires public-cache safety because it targets shared caches.
 
 If a source uses `internal_cache: :disabled`, ImagePipe shouldn't emit public
 cache validators or generated `Cache-Control` by default. `internal_cache: :disabled`
@@ -312,8 +313,21 @@ representation_publicly_cacheable? =
 
 `allow_public_cache?` is the global option. It permits generated public defaults
 but never forces them. `public_route_or_source?` is host configuration on the
-mount, route, or source adapter. It means the host permits shared caches to store
+mount, route, or source adapter. The source adapter option is
+`public_cache_safe?: true`. It means the host permits shared caches to store
 responses for this request class.
+
+`no_disqualifying_request_state?` is true only when these are true:
+
+- the request doesn't contain `Authorization`;
+- the response doesn't set `Set-Cookie`;
+- no configured cookie changes the representation unless the host explicitly
+  opts into `Vary: Cookie`;
+- no upstream or downstream Plug state outside URL, source identity, headers,
+  cookies, and output policy can change response bytes;
+- the selected `Cache-Control` policy doesn't contain `no-store`;
+- the selected `Cache-Control` policy doesn't contain shared-cache directives,
+  such as `public` or `s-maxage`, without public-cache safety.
 
 Default generated `Cache-Control` when the representation is public-safe:
 
@@ -334,6 +348,12 @@ such as `private, max-age=300`, for browser-side reuse. Cookie-varying responses
 should stay private or opt out of generated HTTP caching unless the host
 explicitly accepts `Vary: Cookie` behavior at the CDN.
 
+V1 only generates ETags for responses eligible for generated HTTP cache headers.
+Non-public-safe responses omit generated ETags unless a host-supplied private
+cache policy explicitly enables them. If the selected `Cache-Control` policy
+contains `no-store`, ImagePipe must suppress generated ETags and
+`Last-Modified`.
+
 If the request contains `Authorization`, ImagePipe must not emit generated
 public cache headers by default. Configuration must explicitly mark the route or
 source as public-cache-safe. It must also include every authorization-derived
@@ -352,6 +372,8 @@ Header conflict behavior:
 
 Don't merge `Cache-Control` values. Directives can conflict, such as `private`
 with `public`, or two different `max-age` values. Pick one policy source.
+If an existing host `Vary` contains `*`, v1 must turn off generated public
+caching for that response instead of merging generated `Vary` values into it.
 
 ## ETag Material
 
@@ -406,8 +428,10 @@ They're correct only if the material includes every byte-changing input. That
 means source byte identity, transform instructions, output decisions, encoder
 settings, normalized request inputs, and versioned dependencies.
 
-Serialize ETag material with a deterministic encoder, such as canonical Erlang
-terms, then hash it with SHA-256. Don't expose raw material in the
+Serialize ETag material with a deterministic encoder supported by ImagePipe's
+supported Erlang/OTP versions, then hash it with SHA-256. Deterministic Erlang term
+encoding is acceptable when the runtime supports it. Otherwise use another
+canonical encoder over the same material. Don't expose raw material in the
 header. The visible tag shape should include a schema prefix:
 
 ```http
@@ -726,6 +750,7 @@ Source adapter options:
 
 ```elixir
 source_bytes_immutable?: false,
+public_cache_safe?: false,
 internal_cache: :auto,
 response_cache_control: nil
 ```
@@ -743,10 +768,15 @@ Add focused tests at the request boundary:
 - non-public-safe source omits generated public `Cache-Control`;
 - request with `Authorization` doesn't get generated public cache headers by
   default;
+- response with `Set-Cookie` doesn't get generated public cache headers in v1;
 - source `response_cache_control` overrides defaults only after header and policy
   validation;
+- `response_cache_control` containing `no-store` suppresses generated validators;
+- `response_cache_control` containing `s-maxage` requires public-cache safety;
 - mutable sources without validators omit `ETag` and never return `304` from
   generated validators;
+- non-public-safe responses omit generated ETags unless a private cache policy
+  explicitly enables them;
 - mutable public-safe sources with `Last-Modified` and no ETag return `200` for
   `If-Modified-Since` in v1;
 - `internal_cache: :auto` resolves to `:enabled` for source-byte-immutable
@@ -788,6 +818,7 @@ Add focused tests at the request boundary:
 - ImagePipe preserves existing host `Last-Modified` or conflicts
   deterministically;
 - existing `Vary` merges with generated `Accept` and configured vary headers;
+- existing `Vary: *` turns off generated public caching in v1;
 - transform option order variants produce the same ETag;
 - changing source revision changes ETag;
 - changing `etag_schema` changes ETag;
@@ -830,9 +861,12 @@ Build this in small steps:
 2. Add request-owned HTTP cache header computation and unit tests.
 3. Add pre-run conditional handling after source resolution and before
    `Runner.run/4`.
-4. Attach generated headers to cache misses while continuing to store only
-   cacheable output headers in internal cache entries.
-5. Recompute generated headers and support cached `304` on internal cache hits.
+4. Add generated-header delivery for cache misses and cache hits in one deploy.
+   Cache hits should recompute generated headers from current request inputs;
+   internal cache entries should continue to store only cacheable output headers.
+   Splitting this across rolling deploys can produce nodes with different header
+   behavior.
+5. Add cached `304` handling after generated headers are available on hits.
 6. Document CDN behavior and source immutability configuration.
 
 The first implementation shouldn't add post-transform conditional validation.

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -180,6 +180,12 @@ internal_cache: :auto | :enabled | :disabled
 stability from the resolved identity. `stable: :trusted` is the host promise
 that source bytes are stable by policy.
 
+Adapters map the config values to resolved semantics like this:
+
+- `stable: :auto` plus adapter-proven stability resolves to `stable?: true`.
+- `stable: :auto` without adapter-proven stability resolves to `stable?: false`.
+- `stable: :trusted` resolves to `stable?: true`.
+
 `http_cache` on `Source.Resolved` is the source adapter's response-cache
 override. `:inherit` uses the request option. `:disabled` and `:enabled`
 override the request option for that resolved source.
@@ -274,13 +280,21 @@ deferred.
 If `http_cache: :enabled` but `byte_identity` is `:none`, v1 emits
 `Cache-Control: no-store` and no generated `ETag`, unless a host already set
 `Cache-Control`. This avoids a half-cacheable mutable path where the CDN can
-store bytes but ImagePipe can't produce a validator.
+store bytes but ImagePipe can't produce a validator. Treat `no-store` here as a
+safety signal: the route opted into generated HTTP caching, but the source did
+not produce byte identity.
 
 Don't merge `Cache-Control` values. Directives can conflict, such as `private`
 with `public`, or two different `max-age` values. If a host already set
 `Cache-Control`, preserve it and suppress generated `Cache-Control`.
 If the selected or existing `Cache-Control` contains `no-store`, suppress the
-generated ETag.
+generated ETag. If a host sets public `Cache-Control` while ImagePipe has no
+byte identity, ImagePipe preserves the host policy and doesn't generate an
+ETag. That's a host-owned caching decision.
+
+Suppressing generated public cache headers doesn't suppress representation
+headers. Automatic output must still emit `Vary: Accept` even when ImagePipe
+suppresses generated `Cache-Control` and `ETag`.
 
 ## ETag Material
 
@@ -293,12 +307,12 @@ Use separate ETag material:
 
 ```elixir
 [
-  etag_schema: 1,
+  etag_schema: @etag_schema,
   source: source_byte_identity_seed,
   plan: canonical_plan_key_data,
   output: output_selection_material,
   accept: normalized_accept_material,
-  representation: representation_version
+  representation_version: representation_version
 ]
 ```
 
@@ -309,7 +323,6 @@ Only generate an ETag when:
 - the effective `http_cache` mode is `:enabled`;
 - `byte_identity` is `{:strong, seed}`;
 - ImagePipe can select output before source fetch;
-- automatic quality, if used later, has complete deterministic version material;
 - the response doesn't already have an `ETag`;
 - the selected cache policy isn't `no-store`.
 
@@ -481,10 +494,14 @@ On internal cache hit:
 1. Check and normalize the cached entry headers.
 2. Prepare generated HTTP cache headers from current source semantics, plan,
    request headers, and options.
-3. Merge cached output headers with generated HTTP cache headers. Generated
-   headers must not overwrite explicit host policy.
+3. Merge cached output headers with current host response headers and generated
+   HTTP cache headers. Current host headers win. Generated headers come next.
+   Cached entry headers fill gaps and contribute representation headers such as
+   `Vary`, but they shouldn't override current host policy or freshly generated
+   cache headers.
 4. If the request has `If-None-Match` matching the prepared `etag`, return
-   `304 Not Modified` with cache metadata headers and no body.
+   `304 Not Modified` with cache metadata headers and no body. V1 ignores
+   `If-None-Match: *` on cache hits too.
 5. Otherwise return `200` with the cached body and merged response headers.
 
 This preserves header behavior between cache misses and cache hits.
@@ -551,6 +568,8 @@ review without a new design note:
   automatic output.
 - Late ETags: if ETag material or selected output format is only known after
   source fetch, decode, or transform, v1 omits the generated ETag.
+- Automatic quality ETags: deferred until the quality strategy and any model
+  artifact versions are explicit ETag material.
 - Alpha-specific ETag material: source bytes already cover alpha when the chosen
   output format supports transparency.
 - Static final-alpha inference: v1 keeps source-format fallback on the existing
@@ -582,7 +601,7 @@ Add focused tests at the request boundary:
 - explicit output doesn't emit `Vary: Accept`;
 - Client Hints don't enter generated public cache headers, `Vary`, or ETag
   material in v1;
-- `Plan.expires` doesn't change generated `Cache-Control`;
+- when `Plan.expires` exists, it doesn't change generated `Cache-Control`;
 - `cachebuster` remains URL/cache-key material, not response cache policy;
 - matching `If-None-Match` returns `304` before source fetch for output with a
   strong byte identity;
@@ -593,6 +612,7 @@ Add focused tests at the request boundary:
 - weak request tags match generated strong ETags for `GET`;
 - non-cacheable methods don't use conditional response handling;
 - `If-None-Match: *` doesn't trigger `304` in v1;
+- `If-None-Match: *` doesn't trigger cached `304` on internal cache hit in v1;
 - `304` responses include only cache metadata and no body;
 - `304` responses don't include `Content-Type`, `Content-Length`, or
   `Content-Disposition`;
@@ -601,19 +621,22 @@ Add focused tests at the request boundary:
   request inputs;
 - internal cache hits can return `304` from the prepared `etag`;
 - internal cache hits recompute ETags with the current representation version;
+- internal cache hit header merging uses current host headers before generated
+  headers, and generated headers before cached entry headers;
 - existing host `ETag` suppresses generated ETag;
 - ImagePipe preserves existing host `ETag`, but it doesn't trigger generated
   `304` handling in v1;
 - existing host `Cache-Control` suppresses generated `Cache-Control`;
 - existing host `Cache-Control: no-store` suppresses generated ETags;
 - existing `Vary` merges with generated `Accept`;
+- existing `Vary: Accept` doesn't produce duplicate `Accept` values when
+  ImagePipe adds generated `Vary: Accept`;
 - existing `Vary: *` turns off generated public headers in v1;
 - transform option order variants produce the same ETag;
 - changing source revision changes ETag;
 - changing the implementation `etag_schema` constant changes ETag;
 - changing representation version changes ETag;
-- old internal cache entries don't replay stale generated ETags after
-  representation version changes.
+- internal cache hit ETags use the current representation version.
 
 Add source adapter tests:
 

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -30,10 +30,11 @@ plan operation data, output negotiation inputs, configured key headers,
 configured key cookies, cachebuster data, schema version, and transform key data
 version.
 
-`Plan.expires` doesn't exist yet. If ImagePipe adds it for signed URL
-compatibility, it should be a parser-level request validity timestamp, not HTTP
-cache freshness. A parser should reject expired URLs before source resolution,
-but generated `Cache-Control` must not derive `max-age` from `Plan.expires`.
+`Plan.expires` already exists on `ImagePipe.Plan`, but it has no runtime cache
+effect. Keep it that way for HTTP cache policy. It's a parser-level request
+validity timestamp, not HTTP cache freshness. A parser may reject expired URLs
+before source resolution, but generated `Cache-Control` must not derive
+`max-age` from `Plan.expires`.
 
 ImagePipe already emits `Vary: Accept` for automatic output and stores selected
 response headers in internal cache entries.
@@ -104,9 +105,9 @@ If the response has `Set-Cookie`, v1 suppresses generated public cache headers.
 That shouldn't occur on a normal public image route, but the rule keeps the
 failure mode conservative.
 
-Provider and parser modules don't set HTTP cache policy. Future parser-level
-fields such as `Plan.expires`, plus URL cachebuster values, affect request
-validity and cache keys, not response `Cache-Control`.
+Provider and parser modules don't set HTTP cache policy. Parser-level fields
+such as `Plan.expires`, plus URL cachebuster values, affect request validity
+and cache keys, not response `Cache-Control`.
 
 ## Source Cache Semantics
 
@@ -115,10 +116,12 @@ Add a small source-owned struct:
 ```elixir
 defmodule ImagePipe.Source.CacheSemantics do
   @enforce_keys [:byte_identity, :stable?]
-  defstruct byte_identity: :none,
-            stable?: false
+  defstruct @enforce_keys
 end
 ```
+
+Enforce the fields because each adapter must make the byte-identity
+decision explicit.
 
 Add `cache_semantics` to `ImagePipe.Source.Resolved`:
 
@@ -166,7 +169,9 @@ Adapter defaults:
   file.
 - HTTP URL: not stable by default. Hosts can set `stable: :trusted` for
   content-addressed or versioned URLs. Mutable upstream HTTP validators are
-  deferred.
+  deferred. HTTP byte identity must not reuse raw signed query parameters or
+  temporary credentials. If the stable identity needs query material, use a
+  canonical redacted value or a digest over stable components.
 
 Each source adapter should accept:
 
@@ -207,6 +212,20 @@ With both `stable: :trusted` and `http_cache: :enabled`, ImagePipe can generate 
 long `Cache-Control` and ETag. `http_cache: :enabled` alone doesn't force
 cacheable headers when `byte_identity` is `:none`, when the response has
 `Set-Cookie`, or when another v1 suppression rule applies.
+
+### Source Resolved Migration
+
+The current `ImagePipe.Source.Resolved` struct has `cache: :normal | :skip`.
+V1 should migrate that field to `internal_cache: :enabled | :disabled`.
+
+Mapping:
+
+- `cache: :normal` becomes `internal_cache: :enabled`.
+- `cache: :skip` becomes `internal_cache: :disabled`.
+
+This breaking rename touches source adapters, `ImagePipe.Request.Runner`, tests,
+and any pattern match on `%Source.Resolved{cache: ...}`. The project hasn't
+shipped, so prefer the clearer field name over a compatibility shim.
 
 ## Internal Source Cache Policy
 
@@ -250,6 +269,21 @@ material, request headers, and request options. Keeping it under
 `ImagePipe.Request` preserves the existing boundary direction.
 `ImagePipe.Response` should send already-prepared status codes and headers.
 
+The main API should return a prepared value, not only a header list:
+
+```elixir
+%ImagePipe.Request.HTTPCache.Prepared{
+  effective_mode: :enabled | :disabled,
+  representation_headers: [{"vary", "Accept"}],
+  generated_cache_headers: [{"cache-control", "..."}, {"etag", "..."}],
+  generated_etag?: boolean()
+}
+```
+
+Build this value in `ImagePipe.Plug` after `Source.resolve/3` and before
+`Runner.run/4`, then pass it through delivery. That matches the current code
+shape: cache-hit delivery doesn't carry `Source.Resolved`.
+
 An explicit mode controls generated HTTP cache headers:
 
 - `:disabled`: emit no generated `Cache-Control` or `ETag`. Preserve explicit
@@ -282,7 +316,8 @@ If `http_cache: :enabled` but `byte_identity` is `:none`, v1 emits
 `Cache-Control`. This avoids a half-cacheable mutable path where the CDN can
 store bytes but ImagePipe can't produce a validator. Treat `no-store` here as a
 safety signal: the route opted into generated HTTP caching, but the source did
-not produce byte identity.
+not produce byte identity. Emit telemetry or a low-cardinality log event for
+this fallback so operators can spot a bad route configuration.
 
 Don't merge `Cache-Control` values. Directives can conflict, such as `private`
 with `public`, or two different `max-age` values. If a host already set
@@ -295,6 +330,10 @@ ETag. That's a host-owned caching decision.
 Suppressing generated public cache headers doesn't suppress representation
 headers. Automatic output must still emit `Vary: Accept` even when ImagePipe
 suppresses generated `Cache-Control` and `ETag`.
+
+Merge `Vary` by parsing it as a comma-separated field-value list. Normalize
+field names case-insensitively and remove duplicate tokens. Don't use a raw
+string contains check. `Vary: Accept-Encoding` doesn't already contain `Accept`.
 
 ## ETag Material
 
@@ -409,8 +448,21 @@ source fetch whenever these inputs define output selection material:
 - deterministic policy versions.
 
 This pre-run conditional decision belongs after `Source.resolve/3` and before
-`Runner.run/4`. A matching ETag must skip internal cache lookup and source
-fetch.
+`Runner.run/4`. The Plug has the resolved source at that point, but the current
+cache-hit delivery shape doesn't. Compute a prepared HTTP cache value there and
+pass it into later delivery instead of asking `ImagePipe.Response.Sender` to
+recover source semantics from a cache entry.
+
+The output policy must expose whether output selection is available before
+source fetch. A shape such as `{:ok, selected_material}` or
+`{:needs_source, reason}` is enough. Accept-based automatic output and explicit
+formats can qualify. Source-format preservation can also qualify when the ETag
+material represents it as an instruction, for example `format: :source`. Stable
+source bytes imply stable source format. Choices that depend on decoded content
+properties, such as final-alpha inference, must return `:needs_source` and omit
+generated pre-fetch ETags in v1.
+
+A matching ETag must skip internal cache lookup and source fetch.
 
 On matching `If-None-Match`, ImagePipe returns:
 
@@ -435,7 +487,8 @@ path already serves HEAD.
 V1 ignores `If-None-Match: *`. Before source fetch, ImagePipe hasn't proven
 that the requested source exists, that the transform can run, or that output
 negotiation can succeed. A later version can add the wildcard path if a real
-caller needs it.
+caller needs it. If `*` appears anywhere in an `If-None-Match` field value, v1
+should treat the field as the wildcard form and ignore it.
 
 A `304 Not Modified` response must have no body and must include the cache
 metadata that ImagePipe would send on the corresponding `200`. Use a small cache
@@ -454,7 +507,8 @@ metadata allowlist:
 The server adapter normally generates `Date`. Don't replay encoded-body
 headers such as `Content-Length`, `Content-Type`, or `Content-Disposition` on
 `304`. Avoid representing `304` as a normal encoded response with an empty
-binary body. Use a delivery shape such as `{:not_modified, headers}`.
+binary body. Introduce a delivery shape such as `{:not_modified, headers}` when
+adding the pre-fetch conditional path.
 
 HTTP rules used here come from RFC 9110:
 
@@ -470,17 +524,19 @@ HTTP rules used here come from RFC 9110:
 The internal cache stores encoded response bodies. It shouldn't become the
 source of truth for generated HTTP cache headers.
 
-`ImagePipe.Request.Runner` already receives `Source.Resolved` before internal
-cache lookup, so cache-hit delivery has the same source cache semantics, plan,
-request headers, and runtime options as cache-miss delivery. Use those inputs to
-prepare generated HTTP cache headers on every request, including internal cache
-hits.
+Prepare generated HTTP cache headers before calling `ImagePipe.Request.Runner`.
+The existing runner receives `Source.Resolved`, but cache-hit delivery currently
+drops it and returns only `{:cache_entry, entry, plan.response}`. Passing a
+prepared HTTP cache value through delivery keeps cache misses and cache hits on
+the same header path without teaching the sender how to rediscover source
+semantics.
 
 That keeps old internal entries usable after header-policy changes. It also
 avoids replaying stale `ETag` or `Cache-Control` values from metadata written by
 an older version.
 
-Extend `ImagePipe.Cache.Entry.cacheable_headers/1` to accept these names:
+`ImagePipe.Cache.Entry.cacheable_headers/1` already accepts these stored header
+names:
 
 - `vary`
 - `cache-control`
@@ -488,27 +544,28 @@ Extend `ImagePipe.Cache.Entry.cacheable_headers/1` to accept these names:
 These are output-owned or host-owned headers that may already exist before
 cache storage. Generated `etag` and generated `cache-control` should come from
 `ImagePipe.Request.HTTPCache` at delivery time, not from the cached entry.
+V1 doesn't need a cache-entry allowlist change.
 
 On internal cache hit:
 
 1. Check and normalize the cached entry headers.
-2. Prepare generated HTTP cache headers from current source semantics, plan,
-   request headers, and options.
+2. Use the prepared HTTP cache value built before runner execution.
 3. Merge cached output headers with current host response headers and generated
    HTTP cache headers. Current host headers win. Generated headers come next.
    Cached entry headers fill gaps and contribute representation headers such as
    `Vary`, but they shouldn't override current host policy or freshly generated
    cache headers.
-4. If the request has `If-None-Match` matching the prepared `etag`, return
-   `304 Not Modified` with cache metadata headers and no body. V1 ignores
-   `If-None-Match: *` on cache hits too.
-5. Otherwise return `200` with the cached body and merged response headers.
+4. Return `200` with the cached body and merged response headers.
 
 This preserves header behavior between cache misses and cache hits.
 
 `ImagePipe.Cache.Entry` should only check and store cacheable headers. It should
-not own conditional request behavior. The request runner or response sender
-should branch to a delivery shape that represents `304`.
+not own conditional request behavior.
+
+V1 has no separate cached-`304` path. A generated ETag match is
+deterministic from resolved source semantics, plan, normalized `Accept`, and
+options, so the pre-fetch check catches it before runner execution. If the
+pre-fetch check can't produce an ETag, a cache hit can't produce one either.
 
 The internal cache key doesn't need to include `etag_schema` just to protect
 generated headers, because those headers come from current request inputs on
@@ -594,6 +651,8 @@ Add focused tests at the request boundary:
   `Cache-Control`;
 - `http_cache: :enabled` with `byte_identity: :none` emits
   `Cache-Control: no-store` and no generated `ETag`;
+- `http_cache: :enabled` with `byte_identity: :none` emits telemetry or a
+  low-cardinality log event for the safety fallback;
 - request `Cookie` doesn't enter generated `Vary`, ETag material, or source
   fetches;
 - response with `Set-Cookie` disables generated public cache headers in v1;
@@ -601,7 +660,7 @@ Add focused tests at the request boundary:
 - explicit output doesn't emit `Vary: Accept`;
 - Client Hints don't enter generated public cache headers, `Vary`, or ETag
   material in v1;
-- when `Plan.expires` exists, it doesn't change generated `Cache-Control`;
+- existing `Plan.expires` doesn't change generated `Cache-Control`;
 - `cachebuster` remains URL/cache-key material, not response cache policy;
 - matching `If-None-Match` returns `304` before source fetch for output with a
   strong byte identity;
@@ -612,15 +671,18 @@ Add focused tests at the request boundary:
 - weak request tags match generated strong ETags for `GET`;
 - non-cacheable methods don't use conditional response handling;
 - `If-None-Match: *` doesn't trigger `304` in v1;
-- `If-None-Match: *` doesn't trigger cached `304` on internal cache hit in v1;
+- ImagePipe treats `If-None-Match` containing `*` anywhere as the ignored wildcard
+  form in v1;
 - `304` responses include only cache metadata and no body;
 - `304` responses don't include `Content-Type`, `Content-Length`, or
   `Content-Disposition`;
 - internal cache hits preserve cached output headers such as `vary`;
-- internal cache hits prepare generated `etag` and `cache-control` from current
-  request inputs;
-- internal cache hits can return `304` from the prepared `etag`;
-- internal cache hits recompute ETags with the current representation version;
+- internal cache-hit delivery uses the prepared HTTP cache value built before
+  runner execution;
+- internal cache hits return `200` in v1 because matching generated ETags
+  already short-circuit before runner execution;
+- internal cache-hit responses use the current representation version in the
+  generated ETag;
 - internal cache hit header merging uses current host headers before generated
   headers, and generated headers before cached entry headers;
 - existing host `ETag` suppresses generated ETag;
@@ -640,6 +702,10 @@ Add focused tests at the request boundary:
 
 Add source adapter tests:
 
+- `ImagePipe.Source.CacheSemantics` requires explicit `byte_identity` and
+  `stable?`;
+- `Source.Resolved.cache: :normal | :skip` callers migrate to
+  `internal_cache: :enabled | :disabled`;
 - S3 with revision marks the source stable and keeps `versionId` fetch;
 - S3 without revision isn't stable and skips internal cache under
   `internal_cache: :auto` unless configured with `stable: :trusted`;
@@ -663,18 +729,21 @@ Add property tests for ETag material:
 
 Build this in small steps:
 
-1. Add source cache semantics struct and source adapter options.
-2. Add request-owned HTTP cache header computation and unit tests.
-3. Add pre-run conditional handling after source resolution and before
-   `Runner.run/4`.
-4. Add generated-header delivery for cache misses and cache hits in one deploy.
-   Cache hits should recompute generated headers from current request inputs;
-   internal cache entries should continue to store only cacheable output headers.
-   Splitting this across rolling deploys can produce nodes with different header
-   behavior.
-5. Add cached `304` handling after generated headers are available on hits.
+1. Add source cache semantics struct and source adapter options. Migrate
+   `Source.Resolved.cache` to `Source.Resolved.internal_cache`.
+2. Expose pre-fetch output-selection material from output policy.
+3. Add request-owned HTTP cache header preparation and unit tests. Build the
+   prepared value after source resolution and before `Runner.run/4`.
+4. Add pre-run conditional handling and introduce the `{:not_modified, headers}`
+   delivery shape.
+5. Add generated-header delivery for cache misses and cache hits in one deploy.
+   Cache hits should use the prepared value from current request inputs; internal
+   cache entries should continue to store only cacheable output headers.
+   Splitting this across rolling deploys is a user-facing consistency issue:
+   some nodes may emit generated headers while others don't.
 6. Document how to enable `http_cache: :enabled`, how to mark sources stable,
-   expected CDN cache-key settings, and stable-versus-mutable source behavior.
+   expected CDN cache-key settings, stable-versus-mutable source behavior, and
+   the operational effect of bumping the `ip1-`/`@etag_schema` pair.
 
 The first implementation shouldn't add post-transform conditional validation.
 If deterministic instruction material can't describe a future output mode, that

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -361,7 +361,7 @@ Only generate an ETag when:
 
 - the effective `http_cache` mode is `:enabled`;
 - `byte_identity` is `{:strong, seed}`;
-- ImagePipe can select output before source fetch;
+- ImagePipe can describe output deterministically before source fetch;
 - the response doesn't already have an `ETag`;
 - the selected cache policy isn't `no-store`.
 
@@ -439,7 +439,7 @@ normalized value.
 
 For requests whose effective `http_cache` mode is `:enabled` and whose source
 semantics contain strong byte identity, ImagePipe should compute the ETag before
-source fetch whenever these inputs define output selection material:
+source fetch whenever these inputs define output representation material:
 
 - parsed plan;
 - source cache semantics from `Source.resolve/3`;
@@ -453,14 +453,24 @@ cache-hit delivery shape doesn't. Compute a prepared HTTP cache value there and
 pass it into later delivery instead of asking `ImagePipe.Response.Sender` to
 recover source semantics from a cache entry.
 
-The output policy must expose whether output selection is available before
-source fetch. A shape such as `{:ok, selected_material}` or
-`{:needs_source, reason}` is enough. Accept-based automatic output and explicit
-formats can qualify. Source-format preservation can also qualify when the ETag
-material represents it as an instruction, for example `format: :source`. Stable
-source bytes imply stable source format. Choices that depend on decoded content
-properties, such as final-alpha inference, must return `:needs_source` and omit
-generated pre-fetch ETags in v1.
+The output policy must expose whether it can describe the representation before
+source fetch. It doesn't need to know the final concrete output format when a
+versioned deterministic rule can stand in for the later branch. A function that
+returns `{:ok, representation_material}` or `:omit_etag` is enough.
+
+Examples that can qualify:
+
+- explicit formats;
+- Accept-based automatic output;
+- source-format preservation represented as an instruction such as
+  `format: :source`;
+- source-compatible fallback represented as a deterministic rule, such as
+  `format: {:source_compatible, alpha: :preserve}`.
+
+Stable source bytes imply stable source format and stable decoded-content
+properties. Final alpha can affect the eventual branch, but the ETag can include
+the branch rule instead of the branch result. If the pre-fetch material can't
+describe a byte-changing input, omit the generated ETag.
 
 A matching ETag must skip internal cache lookup and source fetch.
 
@@ -623,14 +633,18 @@ review without a new design note:
   request or mount options, not parser/provider/source output.
 - Arbitrary request-header `Vary`: v1 only generates `Vary: Accept` for
   automatic output.
-- Late ETags: if ETag material or selected output format is only known after
-  source fetch, decode, or transform, v1 omits the generated ETag.
+- Non-pre-fetch generated ETags: v1 doesn't have this path. If pre-fetch
+  material can't describe a byte-changing input, v1 omits the generated ETag.
+  Needing to resolve a deterministic branch later isn't enough to opt out when
+  the ETag material includes the branch rule.
 - Automatic quality ETags: deferred until the quality strategy and any model
   artifact versions are explicit ETag material.
-- Alpha-specific ETag material: source bytes already cover alpha when the chosen
-  output format supports transparency.
-- Static final-alpha inference: v1 keeps source-format fallback on the existing
-  runtime final-alpha path instead of adding a transform effect system.
+- Alpha-specific ETag material: source bytes already cover alpha. If output
+  selection depends on final alpha, include the deterministic selection rule in
+  ETag material.
+- Static final-alpha inference: v1 doesn't need a transform effect system just
+  to generate ETags. The runtime final-alpha path can still choose the concrete
+  output branch after decode.
 - `If-None-Match: *`: v1 ignores the wildcard form.
 - HEAD response support: out of scope unless the current Plug path already
   serves HEAD.

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -37,18 +37,18 @@ The missing CDN-facing behavior is:
 - source adapters don't expose HTTP cache semantics;
 - `Last-Modified` isn't represented;
 - `If-None-Match` can't return `304 Not Modified`;
-- internal cache hits can't prepare generated validators or return
+- internal cache hits can't prepare generated ETags or return
   `304 Not Modified`.
 
 ## Design Goals
 
 Keep the cache contract path-oriented and deterministic.
 
-Prefer pre-fetch validators for source identities that name immutable bytes. A
+Prefer pre-fetch ETags for source identities that name immutable bytes. A
 request with a matching `If-None-Match` should return `304 Not Modified` before
 source fetch, decode, transform, or encode. This path applies when the parsed
 plan, request headers, runtime options, and resolved source identity provide all
-validator inputs.
+ETag inputs.
 
 Don't make mutable sources long-lived by default. A source adapter should mark a
 source's bytes immutable only when its resolved identity names stable bytes or
@@ -79,7 +79,7 @@ ImagePipe should only generate shared-cache headers when `http_cache` is
 `:enabled`. That mode is a host promise about the route. The request should
 already be suitable for a CDN cache key.
 
-The generated validator model can include:
+The generated ETag model can include:
 
 - the request path and query that parser code consumes;
 - normalized request headers configured as cache inputs;
@@ -99,10 +99,10 @@ without a decision. It should either check and preserve the host value, merge
 where HTTP permits merging, or fail configuration before sending a cacheable
 response.
 
-Downstream plugs are outside ImagePipe's validator model. If a later plug can
+Downstream plugs are outside ImagePipe's ETag model. If a later plug can
 change the response body, content encoding, `Content-Disposition`,
 `Cache-Control`, `ETag`, `Vary`, cookies, or representation metadata, ImagePipe's
-generated validators may no longer describe the bytes that reach the client.
+generated ETags may no longer describe the bytes that reach the client.
 For cacheable image responses, route the request so ImagePipe sends the terminal
 response. If the host keeps downstream response mutation, host documentation must
 state that this turns off generated HTTP cache headers.
@@ -113,8 +113,8 @@ Add a small source-owned struct:
 
 ```elixir
 defmodule ImagePipe.Source.CacheSemantics do
-  @enforce_keys [:validator, :source_bytes_immutable?]
-  defstruct validator: :none,
+  @enforce_keys [:byte_identity, :source_bytes_immutable?]
+  defstruct byte_identity: :none,
             source_bytes_immutable?: false,
             response_cache_control_override: nil,
             last_modified: nil
@@ -143,14 +143,14 @@ override the request option for that resolved source.
 HTTP caching policy. A private avatar source can be byte-immutable and still
 use `http_cache: :disabled`.
 
-`validator` is either `{:strong, seed}` or `:none`. The seed must be
+`byte_identity` is either `{:strong, seed}` or `:none`. The seed must be
 deterministic, canonical, and non-secret. Immutable sources can use a canonical
 resolved source identity as the seed. If that identity contains credentials,
 signed query parameters, temporary tokens, or filesystem details, don't log it.
 The adapter must use a stable digest or redacted identity component instead.
-Mutable sources must include freshness material, such as an upstream validator or
-version identifier. If the adapter can't provide byte-version material during
-resolution, it must use `:none`.
+Mutable sources must include byte-version material, such as an upstream strong
+ETag or version identifier. If the adapter can't provide byte-version material
+during resolution, it must use `:none`.
 
 `last_modified` is an optional UTC `DateTime` truncated to seconds. ImagePipe
 emits it as an IMF-fixdate `Last-Modified` response header. The first
@@ -160,18 +160,18 @@ Adapter defaults:
 
 - S3 object with `revision`: source bytes immutable. The fetch URL already
   includes `versionId`, so the resolved source names specific bytes. The
-  validator seed should include the adapter name and version, endpoint or bucket
+  byte identity seed should include the adapter name and version, endpoint or bucket
   identity, key, and revision. It shouldn't rely on `versionId` being globally
   unique.
 - S3 object without `revision`: mutable by default. Hosts can opt into
   immutability if their bucket keys are content-addressed or never overwritten.
-- File path: mutable by default and has no validator by default. Hosts can opt
+- File path: mutable by default and has no byte identity by default. Hosts can opt
   into immutability when the path space is content-addressed. Skip mutable file
-  validators from `mtime` and size in the first implementation. They would add a
+  byte identities from `mtime` and size in the first implementation. They would add a
   stat/fetch race unless fetch uses the same opened file. Immutable file seeds
   should use a canonical non-secret source identity, not a raw private path.
 - HTTP URL: mutable by default. Hosts can opt into immutability when URLs are
-  content-addressed or versioned. Mutable HTTP URLs have no generated validator
+  content-addressed or versioned. Mutable HTTP URLs have no source byte identity
   unless the adapter later adds explicit upstream freshness metadata during
   resolution. Immutable HTTP URL seeds must not include credentials, signed
   query parameters, or temporary tokens.
@@ -205,17 +205,17 @@ headers outside this feature. A `public` or `s-maxage` override is only valid
 when `http_cache` is `:enabled`.
 
 If a source uses `internal_cache: :disabled`, ImagePipe shouldn't emit generated
-validators or generated `Cache-Control` in v1. `internal_cache: :disabled`
+ETags or generated `Cache-Control` in v1. `internal_cache: :disabled`
 currently passes request headers that normal cacheable sources strip before
 fetch. Those headers can affect source bytes. The first implementation should
 not provide an opt-back-in path for `internal_cache: :disabled`. A future opt-in
-must require a strong source validator and an explicit complete `Vary`
+must require strong source byte identity and an explicit complete `Vary`
 declaration for every representation-changing request input.
 
 This is a v1 implementation boundary, not a permanent coupling between the
 internal cache and HTTP caching. A source can be safe for CDN caching while
 opting out of ImagePipe's internal cache. Supporting that path requires the
-source resolver to return a strong validator and complete `Vary`/ETag material
+source resolver to return strong source byte identity and complete `Vary`/ETag material
 for every request input that can change bytes.
 
 ## Internal Source Cache Policy
@@ -227,7 +227,7 @@ forever if the key still matches and the cache entry remains on disk.
 Keep that contract explicit: `Source.Resolved.internal_cache: :enabled` means the
 resolved source identity is safe for internal byte reuse. For a mutable source,
 the identity is safe only when it includes byte-version material. Examples are
-an S3 revision, content-addressed path, upstream validator, or host-provided
+an S3 revision, content-addressed path, upstream strong ETag, or host-provided
 cachebuster that changes when bytes change.
 
 Byte-stable means one of three things:
@@ -241,7 +241,7 @@ Adapt source adapters to choose internal cache policy from source semantics:
 - `internal_cache: :auto` should be the source adapter configuration default. It
   resolves to `:enabled` when the source identity is byte-stable or includes
   byte-version material. That includes future mutable sources whose resolver
-  obtains a strong upstream byte validator during source resolution. Otherwise it
+  obtains strong upstream byte identity during source resolution. Otherwise it
   resolves to `:disabled`.
 - `internal_cache: :disabled` always bypasses the internal encoded-response
   cache.
@@ -269,7 +269,7 @@ Adapter implications:
   used for the stat.
 - HTTP URL sources should resolve `internal_cache: :auto` to `:disabled` unless
   the URL is content-addressed, versioned, or the adapter resolves an upstream
-  validator before cache lookup.
+  byte identity before cache lookup.
 
 ## Response Cache Headers
 
@@ -318,7 +318,7 @@ An explicit mode controls generated HTTP cache headers:
 
 - `:disabled`: emit no generated `Cache-Control`, `ETag`, or `Last-Modified`.
   Preserve explicit host headers that already exist on the conn.
-- `:enabled`: emit public shared-cache headers and validators when validator
+- `:enabled`: emit public shared-cache headers and ETags when byte identity
   material is complete.
 
 The effective mode comes from request options, with source adapters allowed to
@@ -330,7 +330,7 @@ Default generated `Cache-Control`:
 - `:enabled` with immutable source bytes: `public, max-age=31536000, immutable`
 - `:enabled` with mutable source bytes: `public, max-age=300, stale-while-revalidate=3600`
 
-The mutable default is a freshness policy, not a validator guarantee.
+The mutable default is a freshness policy, not a byte-identity guarantee.
 These responses must omit generated ETags unless the source resolver provides
 byte-version material. A CDN may serve stale bytes within the configured
 freshness window.
@@ -347,7 +347,7 @@ V1 enabled mode has hard stops:
 
 - response `Set-Cookie` disables generated public headers;
 - existing or generated `Vary: *` disables generated public headers;
-- selected `Cache-Control: no-store` suppresses generated validators and
+- selected `Cache-Control: no-store` suppresses generated ETags and
   `Last-Modified`;
 - `public` or `s-maxage` in `response_cache_control` is only valid in
   `http_cache: :enabled`.
@@ -384,7 +384,7 @@ Use separate ETag material:
 ```elixir
 [
   etag_schema: 1,
-  source: source_validator_seed,
+  source: source_byte_identity_seed,
   plan: canonical_plan_key_data,
   output: output_selection_material,
   vary: representation_request_material,
@@ -408,17 +408,17 @@ material must match the generated `Vary` header. Every non-URL input represented
 in ETag material must appear in `Vary`. Every generated `Vary` input that can
 change bytes must appear in ETag material.
 
-Only generate an ETag when the effective `http_cache` mode is `:enabled`, source
-cache semantics contain `{:strong, seed}`, and the selected cache policy doesn't
+Only generate an ETag when the effective `http_cache` mode is `:enabled`,
+`byte_identity` is `{:strong, seed}`, and the selected cache policy doesn't
 contain `no-store`. For `:none`, omit `ETag` and skip conditional
 `If-None-Match` handling.
 
-V1 only expects strong validators from source identities that name immutable
-bytes. Future adapters may provide strong validators for mutable sources when
+V1 only expects strong byte identity from source identities that name immutable
+bytes. Future adapters may provide strong byte identity for mutable sources when
 source resolution obtains byte-version freshness material before fetch. A weak
 upstream validator, such as an HTTP `W/"..."` ETag, must not become
-`{:strong, seed}` unless the adapter has other material that proves byte
-identity. Future upstream validator support should preserve validator strength.
+`{:strong, seed}` unless the adapter has other material that proves source byte
+identity. Future upstream support should preserve validator strength.
 
 Generated ETags are instruction-derived strong validators, not body-hash ETags.
 They're correct only if the material includes every byte-changing input. That
@@ -435,7 +435,7 @@ header. The visible tag shape should include a schema prefix:
 ETag: "ip1-<base64url-sha256>"
 ```
 
-Use a strong ETag, not a weak ETag, for generated validators. A weak ETag would
+Use a strong ETag, not a weak ETag, for generated ETags. A weak ETag would
 say the response has the same meaning but not necessarily the same bytes.
 ImagePipe can treat the encoded image response as byte-identical only when the
 ETag material is complete. The representation version must change whenever an
@@ -476,7 +476,7 @@ That path is pre-fetch ETag eligible:
 
 Source alpha doesn't need separate ETag material when the selected target
 format supports transparency. AVIF and WebP do. Alpha affects the encoded bytes,
-but the source validator already represents the source bytes.
+but source byte identity already represents the source bytes.
 
 For future automatic quality:
 
@@ -495,7 +495,7 @@ If automatic quality uses ML, the model artifact version must be present. If a
 quality strategy depends on libvips or codec behavior, it may change output
 bytes across deploys. In that case, the strategy version or representation
 version must change with the deploy. For ML-based quality, `model_version: nil`
-must suppress generated ETags rather than reuse a validator across model
+must suppress generated ETags rather than reuse an ETag across model
 artifact changes.
 
 Automatic quality can still use a pre-fetch ETag when ImagePipe knows the
@@ -548,7 +548,7 @@ public headers for that representation.
 ## Pre-Fetch Conditional GET
 
 For requests whose effective `http_cache` mode is `:enabled` and whose source
-semantics contain a strong validator, ImagePipe should compute the ETag before
+semantics contain strong byte identity, ImagePipe should compute the ETag before
 source fetch whenever these inputs define output selection material:
 
 - the parsed plan;
@@ -557,14 +557,14 @@ source fetch whenever these inputs define output selection material:
 - runtime output options;
 - deterministic policy versions.
 
-The eligibility rule is: strong validator, plus deterministic representation
-selection before fetch. Source byte immutability is one way to get a strong
-validator. Future mutable sources can also qualify if source resolution obtains
-byte-version material before fetch.
+The eligibility rule is: strong source byte identity, plus deterministic
+representation selection before fetch. Source byte immutability is one way to
+get strong byte identity. Future mutable sources can also qualify if source
+resolution obtains byte-version material before fetch.
 
 This pre-run conditional decision belongs after `Source.resolve/3` and before
-`Runner.run/4`. A matching validator must skip internal cache lookup and
-source fetch.
+`Runner.run/4`. A matching ETag must skip internal cache lookup and source
+fetch.
 
 On matching `If-None-Match`, ImagePipe returns:
 
@@ -646,9 +646,9 @@ Keep v1 small. These omissions are intentional:
   only known after source fetch, decode, or transform, v1 omits the generated
   ETag for that response.
 - Source metadata probing for mutable freshness: omitted for scope. Mutable
-  sources without revisions use short cache headers, no generated validators, or an
+  sources without revisions use short cache headers, no generated ETags, or an
   explicit host promise through `internal_cache: :enabled`.
-- Alpha-specific validator material: omitted because source bytes already cover
+- Alpha-specific ETag material: omitted because source bytes already cover
   alpha. When the chosen output format supports transparency, alpha shouldn't
   add a separate ETag input.
 - Static final-alpha inference: omitted for scope. Some transform chains can
@@ -771,11 +771,11 @@ Add focused tests at the request boundary:
 - response with `Set-Cookie` disables generated public cache headers in v1;
 - source `response_cache_control` overrides defaults only after header and policy
   validation;
-- `response_cache_control` containing `no-store` suppresses generated validators;
+- `response_cache_control` containing `no-store` suppresses generated ETags;
 - `response_cache_control` containing `public` or `s-maxage` is only valid in
   `http_cache: :enabled`;
-- mutable sources without validators omit `ETag` and never return `304` from
-  generated validators;
+- mutable sources without byte identity omit `ETag` and never return `304` from
+  generated ETags;
 - mutable cache-enabled sources with `Last-Modified` and no ETag return `200` for
   `If-Modified-Since` in v1;
 - `internal_cache: :auto` resolves to `:enabled` for source-byte-immutable
@@ -794,9 +794,9 @@ Add focused tests at the request boundary:
   that header in `Vary`;
 - cookie-varying output uses `http_cache: :disabled`;
 - matching `If-None-Match` returns `304` before source fetch for output with a
-  strong source validator;
+  strong source byte identity;
 - matching `If-None-Match` returns before internal cache lookup for
-  output with a strong source validator;
+  output with a strong source byte identity;
 - non-matching `If-None-Match` proceeds normally;
 - malformed `If-None-Match` doesn't match;
 - weak request tags match generated strong ETags for `GET`;
@@ -830,11 +830,11 @@ Add source adapter tests:
 - S3 with revision marks source bytes immutable and keeps `versionId` fetch;
 - S3 without revision is mutable and skips internal cache under
   `internal_cache: :auto` unless configured source-byte-immutable;
-- File source defaults mutable without a validator and host config can mark
+- File source defaults mutable without byte identity and host config can mark
   source bytes immutable;
-- HTTP source defaults mutable without a validator and host config can mark
+- HTTP source defaults mutable without byte identity and host config can mark
   source bytes immutable;
-- source validator seeds redact or digest secret identity material.
+- byte identity seeds redact or digest secret identity material.
 
 Add property tests for ETag material:
 

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -121,7 +121,7 @@ Add `cache_semantics` to `ImagePipe.Source.Resolved`:
   adapter: :path,
   source_kind: :path,
   identity: [...],
-  cache: :normal,
+  internal_cache: :enabled,
   fetch: [...],
   cache_semantics: %ImagePipe.Source.CacheSemantics{...}
 }
@@ -188,13 +188,13 @@ ImagePipe reasons about, including `public`, `private`, `no-store`, `max-age`,
 `stale-while-revalidate`, and `immutable`. A `public` override requires a public
 cache-safety proof or explicit configuration.
 
-If a source uses `cache: :skip`, ImagePipe shouldn't emit public
-cache validators or generated `Cache-Control` by default. `cache: :skip`
+If a source uses `internal_cache: :disabled`, ImagePipe shouldn't emit public
+cache validators or generated `Cache-Control` by default. `internal_cache: :disabled`
 currently passes request headers that normal cacheable sources strip before
 fetch. Those headers can affect source bytes. The first implementation should
-not provide an opt-back-in path for `cache: :skip`. A future opt-in must require
-a strong source validator and an explicit complete `Vary` declaration for every
-representation-changing request input.
+not provide an opt-back-in path for `internal_cache: :disabled`. A future opt-in
+must require a strong source validator and an explicit complete `Vary`
+declaration for every representation-changing request input.
 
 ## Internal Source Cache Policy
 
@@ -202,7 +202,7 @@ The current internal cache assumes a cache key names stable output bytes. It has
 no freshness check on read. It can serve a cached file-path or URL response
 forever if the key still matches and the cache entry remains on disk.
 
-Keep that contract explicit: `Source.Resolved.cache: :normal` means the
+Keep that contract explicit: `Source.Resolved.internal_cache: :enabled` means the
 resolved source identity is safe for internal byte reuse. For a mutable source,
 the identity is safe only when it includes byte-version material. Examples are
 an S3 revision, content-addressed path, upstream validator, or host-provided
@@ -210,14 +210,16 @@ cachebuster that changes when bytes change.
 
 Adapt source adapters to choose internal cache policy from source semantics:
 
-- `cache: :auto` should be the default. It resolves to `:normal` only when the
-  source identity is byte-stable or includes byte-version material. Otherwise it
-  resolves to `:skip`.
-- `cache: :skip` always bypasses the internal encoded-response cache.
-- `cache: :normal` is an explicit host assertion that the resolved identity is
-  safe for byte reuse. If the source is mutable and the identity has no
-  byte-version material, configuration should fail instead of caching stale
-  bytes.
+- `internal_cache: :auto` should be the source adapter configuration default. It
+  resolves to `:enabled` only when the source identity is byte-stable or includes
+  byte-version material. Otherwise it resolves to `:disabled`.
+- `internal_cache: :disabled` always bypasses the internal encoded-response
+  cache.
+- `internal_cache: :enabled` is an explicit host assertion that the resolved
+  identity is safe for byte reuse. The source may be technically mutable, but the
+  host promises that policy prevents mutation under the same identity or accepts
+  the stale-cache risk. ImagePipe shouldn't reject this mode just because it
+  can't prove immutability.
 
 This keeps the internal cache conservative without adding a source metadata
 fetch just to make mutable paths cacheable. A later implementation can add
@@ -227,17 +229,17 @@ freshness, so it should be an explicit host policy, not the default.
 
 Adapter implications:
 
-- S3 with `revision` can use `:normal` because `versionId` is part of the fetch
+- S3 with `revision` can use `:enabled` because `versionId` is part of the fetch
   and source identity.
-- S3 without `revision` should resolve `cache: :auto` to `:skip` unless the host
-  marks keys as content-addressed or supplies a byte-version identity.
-- File sources should resolve `cache: :auto` to `:skip` unless the host marks
-  the path space as content-addressed. The first implementation shouldn't use
-  `mtime` and size as byte identity unless fetch opens the same file handle used
-  for the stat.
-- HTTP URL sources should resolve `cache: :auto` to `:skip` unless the URL is
-  content-addressed, versioned, or the adapter resolves an upstream validator
-  before cache lookup.
+- S3 without `revision` should resolve `internal_cache: :auto` to `:disabled` unless
+  the host marks keys as content-addressed or supplies a byte-version identity.
+- File sources should resolve `internal_cache: :auto` to `:disabled` unless the host
+  marks the path space as content-addressed. The first implementation shouldn't
+  use `mtime` and size as byte identity unless fetch opens the same file handle
+  used for the stat.
+- HTTP URL sources should resolve `internal_cache: :auto` to `:disabled` unless
+  the URL is content-addressed, versioned, or the adapter resolves an upstream
+  validator before cache lookup.
 
 ## Response Cache Headers
 
@@ -599,7 +601,7 @@ Source adapter options:
 
 ```elixir
 source_bytes_immutable?: false,
-cache: :auto,
+internal_cache: :auto,
 cache_control: nil
 ```
 
@@ -620,12 +622,13 @@ Add focused tests at the request boundary:
   validation;
 - mutable sources without validators omit `ETag` and never return `304` from
   generated validators;
-- `cache: :auto` resolves to `:normal` for source-byte-immutable identities;
-- `cache: :auto` resolves to `:skip` for mutable identities without byte-version
-  material;
-- `cache: :normal` fails configuration when the source is mutable and the
-  identity has no byte-version material;
-- `cache: :skip` omits generated HTTP cache headers;
+- `internal_cache: :auto` resolves to `:enabled` for source-byte-immutable
+  identities;
+- `internal_cache: :auto` resolves to `:disabled` for mutable identities without
+  byte-version material;
+- `internal_cache: :enabled` accepts mutable identities without byte-version
+  material as an explicit host policy promise;
+- `internal_cache: :disabled` omits generated HTTP cache headers;
 - automatic output emits `Vary: Accept`;
 - explicit output doesn't emit `Vary: Accept`;
 - configured header-varying output includes that header in `Vary`;
@@ -663,8 +666,8 @@ Add focused tests at the request boundary:
 Add source adapter tests:
 
 - S3 with revision marks source bytes immutable and keeps `versionId` fetch;
-- S3 without revision is mutable and skips internal cache under `cache: :auto`
-  unless configured source-byte-immutable;
+- S3 without revision is mutable and skips internal cache under
+  `internal_cache: :auto` unless configured source-byte-immutable;
 - File source defaults mutable without a validator and host config can mark
   source bytes immutable;
 - HTTP source defaults mutable without a validator and host config can mark

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -248,6 +248,13 @@ host promises that policy prevents mutation under the same identity or accepts
 the stale-cache risk. ImagePipe shouldn't reject this mode just because it
 can't prove stability.
 
+Keep `stable` and `internal_cache` separate. `stable` is about public validator
+truth: can ImagePipe generate an ETag that names response bytes for shared
+caches? `internal_cache` is about local byte reuse: is the host willing to serve
+an existing encoded body for the same internal key, including any accepted
+staleness risk? A route can use the internal cache without exposing a generated
+ETag.
+
 Adapter implications:
 
 - S3 with `revision` can use `:enabled` because `versionId` is part of the fetch
@@ -280,6 +287,11 @@ The main API should return a prepared value, not only a header list:
 }
 ```
 
+`representation_headers` are correctness headers. Always apply them. For
+example, automatic output still needs `Vary: Accept` when ImagePipe suppresses
+generated `Cache-Control` and `ETag`. `generated_cache_headers` are the optional
+CDN-facing policy and validator headers.
+
 Build this value in `ImagePipe.Plug` after `Source.resolve/3` and before
 `Runner.run/4`, then pass it through delivery. That matches the current code
 shape: cache-hit delivery doesn't carry `Source.Resolved`.
@@ -307,9 +319,9 @@ When automatic output uses `Accept`, the response also carries:
 {"vary", "Accept"}
 ```
 
-The request or mount options should configure the default `Cache-Control`.
-V1 has one generated cache-control value. Mutable short public caching stays
-deferred.
+V1 has one generated cache-control value:
+`public, max-age=31536000, immutable`. Keep it as an implementation constant.
+Mutable short public caching stays deferred.
 
 If `http_cache: :enabled` but `byte_identity` is `:none`, v1 emits
 `Cache-Control: no-store` and no generated `ETag`, unless a host already set
@@ -367,6 +379,8 @@ Only generate an ETag when:
 
 V1 conditional handling only uses ImagePipe-generated ETags. ImagePipe keeps
 existing host ETags but doesn't interpret them for `If-None-Match`.
+Don't add a custom ETag override to generated HTTP caching. Routes that need
+custom validators should use `http_cache: :disabled` and set their own headers.
 
 V1 only expects strong byte identity from source identities that name stable
 bytes. Future adapters may provide strong byte identity for mutable sources when
@@ -401,6 +415,12 @@ same ETag to survive a change that may change bytes.
 Increment `etag_schema` only when the shape or interpretation of ETag material
 changes. Increment `representation_version` when the encoded bytes may change
 while the material shape stays the same.
+
+Keep `representation_version` as an implementation constant, not a request
+option. Any byte-changing field in ETag material must also affect the internal
+cache key. `representation_version` is the catch-all for encoder and output
+policy behavior, so it must live in both places. Otherwise ImagePipe could serve
+an old cached body with a new ETag after a version bump.
 
 ## Accept Normalization
 
@@ -457,6 +477,9 @@ The output policy must expose whether it can describe the representation before
 source fetch. It doesn't need to know the final concrete output format when a
 versioned deterministic rule can stand in for the later branch. A function that
 returns `{:ok, representation_material}` or `:omit_etag` is enough.
+Name the boundary explicitly, for example
+`ImagePipe.Plan.canonical_representation_material/1`, and test it outside ETag
+hashing so it doesn't drift.
 
 Examples that can qualify:
 
@@ -579,9 +602,8 @@ pre-fetch check can't produce an ETag, a cache hit can't produce one either.
 
 The internal cache key doesn't need to include `etag_schema` just to protect
 generated headers, because those headers come from current request inputs on
-hit. It only needs `representation_version` if that version also affects encoded
-bytes. In that case the version belongs in the existing canonical key data for
-output or transform material.
+hit. It must include `representation_version`, because that version represents
+byte-changing encoder and output policy behavior.
 
 ## Error Responses
 
@@ -599,14 +621,13 @@ Add request options:
 
 ```elixir
 http_cache: [
-  mode: :disabled,
-  cache_control: "public, max-age=31536000, immutable",
-  representation_version: 1
+  mode: :disabled
 ]
 ```
 
 Keep defaults small and explicit inside `ImagePipe.Request.Options`.
-Keep `etag_schema` as an implementation constant, not a request option.
+Keep `etag_schema`, `representation_version`, and the generated
+`Cache-Control` value as implementation constants, not request options.
 
 Source adapter options:
 
@@ -709,6 +730,10 @@ Add focused tests at the request boundary:
   ImagePipe adds generated `Vary: Accept`;
 - existing `Vary: *` turns off generated public headers in v1;
 - transform option order variants produce the same ETag;
+- source-compatible output ETag material contains the rule symbolically, not a
+  post-decode branch result;
+- changing the source-compatible output rule changes ETag material through the
+  rule material or representation version;
 - changing source revision changes ETag;
 - changing the implementation `etag_schema` constant changes ETag;
 - changing representation version changes ETag;
@@ -745,7 +770,9 @@ Build this in small steps:
 
 1. Add source cache semantics struct and source adapter options. Migrate
    `Source.Resolved.cache` to `Source.Resolved.internal_cache`.
-2. Expose pre-fetch output-selection material from output policy.
+2. Expose pre-fetch representation material from the canonical plan layer. This
+   step can ship with focused unit tests; integration with HTTP cache preparation
+   comes in the next step.
 3. Add request-owned HTTP cache header preparation and unit tests. Build the
    prepared value after source resolution and before `Runner.run/4`.
 4. Add pre-run conditional handling and introduce the `{:not_modified, headers}`

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -142,10 +142,9 @@ policy by itself.
 `byte_identity` is either `{:strong, seed}` or `:none`.
 
 The source resolver sets `byte_identity`. Hosts can force ETag creation by
-configuring the source as `stable?: true`. The adapter should then derive a
-strong byte identity from the resolved source identity. Don't add a separate
-`force_etag?: true` option. The host promise is about source stability, and the
-ETag follows from that.
+configuring the source as `stable: :trusted`. The adapter should then derive a
+strong byte identity from the resolved source identity. The host promise is
+about source stability, and the ETag follows from that.
 
 The seed must be deterministic, canonical, and non-secret. A resolved source
 identity may contain credentials, signed query parameters, temporary tokens, or
@@ -160,22 +159,26 @@ Adapter defaults:
   seed should include adapter name and version, endpoint or bucket identity, key,
   and revision. Don't rely on `versionId` being globally unique.
 - S3 object without `revision`: not stable by default. Hosts can set
-  `stable?: true` for content-addressed keys or write-once buckets.
-- File path: not stable by default. Hosts can set `stable?: true` when the path
+  `stable: :trusted` for content-addressed keys or write-once buckets.
+- File path: not stable by default. Hosts can set `stable: :trusted` when the path
   space is content-addressed or write-once. V1 shouldn't use `mtime` and size as
   byte identity; that adds a stat/fetch race unless fetch uses the same opened
   file.
-- HTTP URL: not stable by default. Hosts can set `stable?: true` for
+- HTTP URL: not stable by default. Hosts can set `stable: :trusted` for
   content-addressed or versioned URLs. Mutable upstream HTTP validators are
   deferred.
 
 Each source adapter should accept:
 
 ```elixir
-stable?: boolean()
+stable: :auto | :trusted
 http_cache: :inherit | :disabled | :enabled
 internal_cache: :auto | :enabled | :disabled
 ```
+
+`stable: :auto` lets the adapter mark sources stable only when it can prove byte
+stability from the resolved identity. `stable: :trusted` is the host promise
+that source bytes are stable by policy.
 
 `http_cache` on `Source.Resolved` is the source adapter's response-cache
 override. `:inherit` uses the request option. `:disabled` and `:enabled`
@@ -192,9 +195,9 @@ end
 
 Source-level `http_cache: :enabled` is the force switch for generated HTTP cache
 headers on that source. It still requires byte identity. When the host promises
-that source bytes are stable by policy, configure `stable?: true`. The adapter
+that source bytes are stable by policy, configure `stable: :trusted`. The adapter
 then derives `byte_identity: {:strong, seed}` from the resolved source identity.
-With both `stable?: true` and `http_cache: :enabled`, ImagePipe can generate the
+With both `stable: :trusted` and `http_cache: :enabled`, ImagePipe can generate the
 long `Cache-Control` and ETag. `http_cache: :enabled` alone doesn't force
 cacheable headers when `byte_identity` is `:none`, when the response has
 `Set-Cookie`, or when another v1 suppression rule applies.
@@ -524,13 +527,13 @@ Keep `etag_schema` as an implementation constant, not a request option.
 Source adapter options:
 
 ```elixir
-stable?: false,
+stable: :auto,
 internal_cache: :auto,
 http_cache: :inherit
 ```
 
 For S3, if `revision` is present, the source can treat the object as stable even
-when `stable?` isn't set.
+when `stable` is `:auto`.
 
 ## Deferred Behaviors
 
@@ -616,9 +619,11 @@ Add source adapter tests:
 
 - S3 with revision marks the source stable and keeps `versionId` fetch;
 - S3 without revision isn't stable and skips internal cache under
-  `internal_cache: :auto` unless configured stable;
-- File source defaults to not stable and host config can mark it stable;
-- HTTP source defaults to not stable and host config can mark it stable;
+  `internal_cache: :auto` unless configured with `stable: :trusted`;
+- File source defaults to not stable and host config can mark it with
+  `stable: :trusted`;
+- HTTP source defaults to not stable and host config can mark it with
+  `stable: :trusted`;
 - byte identity seeds redact or digest secret identity material.
 
 Add property tests for ETag material:

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -2,22 +2,25 @@
 
 ## Scope
 
-ImagePipe should act as a cacheable image origin behind a CDN or local HTTP
-cache. The CDN should cache successful transformed responses and serve fresh
-entries without contacting ImagePipe. When the source identity names immutable
-bytes, the CDN should revalidate stale entries with a conditional request.
+ImagePipe should work as an image origin behind a CDN or local HTTP cache. The
+CDN caches successful transformed responses by URL and serves fresh entries
+without contacting ImagePipe.
 
-This design covers response headers and request handling for:
+V1 covers:
 
-- `ETag`
 - `Cache-Control`
-- `Vary`
-- `Last-Modified`
+- `ETag`
+- `Vary: Accept`
 - `If-None-Match`
 
-It doesn't replace the existing internal encoded-response cache. The internal
-cache avoids recomputing inside ImagePipe. HTTP cache headers tell browsers,
-CDNs, and reverse proxies how to cache ImagePipe responses.
+V1 doesn't cover source freshness probing, `Last-Modified`,
+`If-Modified-Since`, arbitrary request-header variation, Client Hints, or
+post-transform validators. "Deferred Behaviors" names these omissions so they
+stay explicit.
+
+This doesn't replace the existing internal encoded-response cache. The
+internal cache avoids recomputing inside ImagePipe. HTTP cache headers tell
+browsers, CDNs, and reverse proxies how to cache ImagePipe responses.
 
 ## Current State
 
@@ -28,19 +31,18 @@ configured key cookies, cachebuster data, schema version, and transform key data
 version.
 
 `Plan.expires` isn't HTTP cache freshness. It's a parser-level request
-validity timestamp. The imgproxy parser should keep rejecting expired URLs before
-source resolution, but generated `Cache-Control` shouldn't derive max-age from
-`Plan.expires`.
+validity timestamp. The imgproxy parser should keep rejecting expired URLs
+before source resolution, but generated `Cache-Control` must not derive
+`max-age` from `Plan.expires`.
 
-ImagePipe also preserves `Vary: Accept` for automatic output and stores
-`vary`/`cache-control` headers in internal cache entries.
+ImagePipe already emits `Vary: Accept` for automatic output and stores selected
+response headers in internal cache entries.
 
 The missing CDN-facing behavior is:
 
 - successful responses don't get a generated `ETag`;
-- successful responses don't get a default `Cache-Control`;
-- source adapters don't expose HTTP cache semantics;
-- `Last-Modified` isn't represented;
+- successful responses don't get a generated `Cache-Control`;
+- source adapters don't expose enough source byte identity for HTTP validators;
 - `If-None-Match` can't return `304 Not Modified`;
 - internal cache hits can't prepare generated ETags or return
   `304 Not Modified`.
@@ -49,29 +51,23 @@ The missing CDN-facing behavior is:
 
 Keep the cache contract path-oriented and deterministic.
 
-Prefer pre-fetch ETags for source identities that name immutable bytes. A
-request with a matching `If-None-Match` should return `304 Not Modified` before
-source fetch, decode, transform, or encode. This path applies when the parsed
-plan, request headers, runtime options, and resolved source identity provide all
-ETag inputs.
+Generated public HTTP caching is for public image routes. ImagePipe shouldn't
+try to make authenticated, per-user, per-tenant, cookie-selected, or arbitrary
+header-selected image behavior CDN-cacheable in v1. If host code outside the
+image request model changes image bytes, use `http_cache: :disabled`.
 
-Don't make mutable sources long-lived by default. A source adapter should mark a
-source's bytes immutable only when its resolved identity names stable bytes or
-when host configuration explicitly promises immutability.
-
-Generated public caching is for public image routes whose source identity and
-output bytes come from the image request model. Authenticated and
-cookie-selected representations are out of scope for generated public headers.
+Prefer pre-fetch ETags for source identities that name stable bytes. A request
+with a matching `If-None-Match` should return `304 Not Modified` before source
+fetch, decode, transform, encode, or internal cache lookup.
 
 Keep HTTP validators separate from internal cache keys. The internal cache key
 identifies an ImagePipe storage entry. The `ETag` identifies a client-visible
 representation.
 
-Avoid adding a source-fetch metadata path just to support mutable revalidation.
-Mutable sources can use short cache lifetimes unless an adapter can provide
-freshness metadata during source resolution. A mutable source without freshness
-material must not emit a generated `ETag` and must not match
-`If-None-Match`.
+Don't add a source metadata request just to support mutable revalidation.
+Mutable sources can still use the internal cache when the host explicitly
+promises stable byte reuse, but v1 generated ETags require a strong byte
+identity known during source resolution.
 
 ## Plug Chain Boundaries
 
@@ -82,35 +78,35 @@ request before ImagePipe runs.
 
 ImagePipe should only generate shared-cache headers when `http_cache` is
 `:enabled`. That mode is a host promise about the route. The request should
-already be suitable for a CDN cache key.
+already suit a CDN cache key. The URL, source resolution, output negotiation,
+and ImagePipe options should determine the image bytes.
 
-The generated ETag model can include:
+ImagePipe doesn't forward incoming `Cookie` headers to source requests and does
+not put raw cookies into generated HTTP cache material. A browser request cookie
+doesn't change generated cache behavior by itself. If earlier host code uses a
+cookie, authorization state, tenant state, assigns, or `conn.private` to choose
+source identity or output bytes, generated public caching is out of scope for
+that route.
 
-- the request path and query that parser code consumes;
-- normalized request headers configured as cache inputs;
-- source identity and source cache semantics returned by the source adapter;
-- output policy and representation versions;
-- existing response headers that ImagePipe owns or validates.
+Downstream plugs are outside ImagePipe's ETag model. If a later plug can change
+the response body, content encoding, `Content-Disposition`, `Cache-Control`,
+`ETag`, `Vary`, cookies, or other representation metadata, ImagePipe's generated
+ETags may no longer describe the bytes that reach the client. For generated
+HTTP caching, route the request so ImagePipe sends the terminal response.
 
-Plug assigns and `conn.private` are server-side state. A CDN can't vary on them
-directly. If they affect source identity or output bytes, generated public
-caching is out of scope for that route. Use `http_cache: :disabled`. ImagePipe
-shouldn't try to inspect assigns or infer whether arbitrary host state can use
-shared caches.
+Existing response cache headers are host policy. ImagePipe must not overwrite an
+existing `Cache-Control` or `ETag`. For `Vary`, ImagePipe may merge `Accept`
+into an existing value when automatic output depends on `Accept`. If an
+existing or generated `Vary` contains `*`, v1 suppresses generated public cache
+headers for that response.
 
-Existing response cache headers on the conn are host policy. ImagePipe shouldn't
-overwrite an existing `Cache-Control`, `ETag`, `Vary`, or `Last-Modified`
-without a decision. It should either check and preserve the host value, merge
-where HTTP permits merging, or fail configuration before sending a cacheable
-response.
+If the response has `Set-Cookie`, v1 suppresses generated public cache headers.
+That shouldn't occur on a normal public image route, but the rule keeps the
+failure mode conservative.
 
-Downstream plugs are outside ImagePipe's ETag model. If a later plug can
-change the response body, content encoding, `Content-Disposition`,
-`Cache-Control`, `ETag`, `Vary`, cookies, or representation metadata, ImagePipe's
-generated ETags may no longer describe the bytes that reach the client.
-For cacheable image responses, route the request so ImagePipe sends the terminal
-response. If the host keeps downstream response mutation, host documentation must
-state that this turns off generated HTTP cache headers.
+Provider and parser modules don't set HTTP cache policy. Parser-level fields
+such as `Plan.expires` and URL cachebuster values affect request validity and cache
+keys, not response `Cache-Control`.
 
 ## Source Cache Semantics
 
@@ -118,11 +114,9 @@ Add a small source-owned struct:
 
 ```elixir
 defmodule ImagePipe.Source.CacheSemantics do
-  @enforce_keys [:byte_identity, :source_bytes_immutable?]
+  @enforce_keys [:byte_identity, :stable?]
   defstruct byte_identity: :none,
-            source_bytes_immutable?: false,
-            response_cache_control_override: nil,
-            last_modified: nil
+            stable?: false
 end
 ```
 
@@ -140,88 +134,52 @@ Add `cache_semantics` to `ImagePipe.Source.Resolved`:
 }
 ```
 
-`http_cache` on `Source.Resolved` is the source adapter's response-cache
-override. `:inherit` uses the request option. `:disabled` and `:enabled`
-override the request option for that resolved source.
+`stable?` means the resolved source identity names stable bytes. This can come
+from a versioned identity, a content-addressed path space, or host configuration
+that promises bytes don't change under the same identity. It isn't an HTTP cache
+policy by itself.
 
-`source_bytes_immutable?` only describes the source bytes. It doesn't select an
-HTTP caching policy. A private avatar source can be byte-immutable and still
-use `http_cache: :disabled`.
+`byte_identity` is either `{:strong, seed}` or `:none`.
 
-`byte_identity` is either `{:strong, seed}` or `:none`. The seed must be
-deterministic, canonical, and non-secret. Immutable sources can use a canonical
-resolved source identity as the seed. If that identity contains credentials,
-signed query parameters, temporary tokens, or filesystem details, don't log it.
-The adapter must use a stable digest or redacted identity component instead.
-Mutable sources must include byte-version material, such as an upstream strong
-ETag or version identifier. If the adapter can't provide byte-version material
-during resolution, it must use `:none`.
+The source resolver sets `byte_identity`. Hosts can force ETag creation by
+configuring the source as `stable?: true`. The adapter should then derive a
+strong byte identity from the resolved source identity. Don't add a separate
+`force_etag?: true` option. The host promise is about source stability, and the
+ETag follows from that.
 
-`last_modified` is an optional UTC `DateTime` truncated to seconds. ImagePipe
-emits it as an IMF-fixdate `Last-Modified` response header. The first
-implementation doesn't check `If-Modified-Since`.
+The seed must be deterministic, canonical, and non-secret. A resolved source
+identity may contain credentials, signed query parameters, temporary tokens, or
+private filesystem details. In that case, the adapter must use a stable digest
+or redacted identity component instead of exposing raw material in logs or
+diagnostics.
 
 Adapter defaults:
 
-- S3 object with `revision`: source bytes immutable. The fetch URL already
-  includes `versionId`, so the resolved source names specific bytes. The
-  byte identity seed should include the adapter name and version, endpoint or bucket
-  identity, key, and revision. It shouldn't rely on `versionId` being globally
-  unique.
-- S3 object without `revision`: mutable by default. Hosts can opt into
-  immutability if their bucket keys are content-addressed or never overwritten.
-- File path: mutable by default and has no byte identity by default. Hosts can opt
-  into immutability when the path space is content-addressed. Skip mutable file
-  byte identities from `mtime` and size in the first implementation. They would add a
-  stat/fetch race unless fetch uses the same opened file. Immutable file seeds
-  should use a canonical non-secret source identity, not a raw private path.
-- HTTP URL: mutable by default. Hosts can opt into immutability when URLs are
-  content-addressed or versioned. Mutable HTTP URLs have no source byte identity
-  unless the adapter later adds explicit upstream freshness metadata during
-  resolution. Immutable HTTP URL seeds must not include credentials, signed
-  query parameters, or temporary tokens.
+- S3 object with `revision`: stable. The fetch URL already includes
+  `versionId`, so the resolved source names specific bytes. The byte identity
+  seed should include adapter name and version, endpoint or bucket identity, key,
+  and revision. Don't rely on `versionId` being globally unique.
+- S3 object without `revision`: not stable by default. Hosts can set
+  `stable?: true` for content-addressed keys or write-once buckets.
+- File path: not stable by default. Hosts can set `stable?: true` when the path
+  space is content-addressed or write-once. V1 shouldn't use `mtime` and size as
+  byte identity; that adds a stat/fetch race unless fetch uses the same opened
+  file.
+- HTTP URL: not stable by default. Hosts can set `stable?: true` for
+  content-addressed or versioned URLs. Mutable upstream HTTP validators are
+  deferred.
 
 Each source adapter should accept:
 
 ```elixir
-source_bytes_immutable?: boolean()
+stable?: boolean()
 http_cache: :inherit | :disabled | :enabled
 internal_cache: :auto | :enabled | :disabled
-response_cache_control: String.t() | nil
 ```
 
-`response_cache_control` is host response policy copied through the resolved
-source. It's not a source identity fact. The implementation should store it as
-`response_cache_control_override` to keep that distinction visible.
-
-When set, ImagePipe emits it only after two checks:
-
-1. The value is safe to send as an HTTP header value.
-2. ImagePipe permits the policy for this representation.
-
-Header validation rejects CR, LF, invalid binaries, and values the configured
-server adapter can't represent. Policy validation parses directives that
-ImagePipe reasons about, including `public`, `private`, `no-store`, `max-age`,
-`s-maxage`, `stale-while-revalidate`, `immutable`, `must-revalidate`,
-`proxy-revalidate`, and `no-transform`. Unknown extension directives pass
-through after syntax validation. A `private` override isn't part of generated
-HTTP caching. Hosts that need browser-private caching should set explicit
-headers outside this feature. A `public` or `s-maxage` override is only valid
-when `http_cache` is `:enabled`.
-
-If a source uses `internal_cache: :disabled`, ImagePipe shouldn't emit generated
-ETags or generated `Cache-Control` in v1. `internal_cache: :disabled`
-currently passes request headers that normal cacheable sources strip before
-fetch. Those headers can affect source bytes. The first implementation should
-not provide an opt-back-in path for `internal_cache: :disabled`. A future opt-in
-must require strong source byte identity and an explicit complete `Vary`
-declaration for every representation-changing request input.
-
-This is a v1 implementation boundary, not a permanent coupling between the
-internal cache and HTTP caching. A source can be safe for CDN caching while
-opting out of ImagePipe's internal cache. Supporting that path requires the
-source resolver to return strong source byte identity and complete `Vary`/ETag material
-for every request input that can change bytes.
+`http_cache` on `Source.Resolved` is the source adapter's response-cache
+override. `:inherit` uses the request option. `:disabled` and `:enabled`
+override the request option for that resolved source.
 
 ## Internal Source Cache Policy
 
@@ -229,52 +187,31 @@ The current internal cache assumes a cache key names stable output bytes. It has
 no freshness check on read. It can serve a cached file-path or URL response
 forever if the key still matches and the cache entry remains on disk.
 
-Keep that contract explicit: `Source.Resolved.internal_cache: :enabled` means the
-resolved source identity is safe for internal byte reuse. For a mutable source,
-the identity is safe only when it includes byte-version material. Examples are
-an S3 revision, content-addressed path, upstream strong ETag, or host-provided
-cachebuster that changes when bytes change.
+Keep that contract explicit: `Source.Resolved.internal_cache: :enabled` means
+the resolved source identity is safe for internal byte reuse.
 
-Byte-stable means one of three things:
+`internal_cache: :auto` should be the source adapter configuration default. It
+resolves to `:enabled` when the resolved source identity is stable or includes
+explicit byte-version material. Otherwise it resolves to `:disabled`.
 
-- the source identity names immutable bytes;
-- the source identity includes explicit byte-version material;
-- the host explicitly asserts stability with `internal_cache: :enabled`.
+`internal_cache: :disabled` always bypasses the internal encoded-response cache.
 
-Adapt source adapters to choose internal cache policy from source semantics:
-
-- `internal_cache: :auto` should be the source adapter configuration default. It
-  resolves to `:enabled` when the source identity is byte-stable or includes
-  byte-version material. That includes future mutable sources whose resolver
-  obtains strong upstream byte identity during source resolution. Otherwise it
-  resolves to `:disabled`.
-- `internal_cache: :disabled` always bypasses the internal encoded-response
-  cache.
-- `internal_cache: :enabled` is an explicit host assertion that the resolved
-  identity is safe for byte reuse. The source may be technically mutable, but the
-  host promises that policy prevents mutation under the same identity or accepts
-  the stale-cache risk. ImagePipe shouldn't reject this mode just because it
-  can't prove immutability.
-
-This keeps the internal cache conservative without adding a source metadata
-fetch just to make mutable paths cacheable. A later implementation can add
-bounded internal freshness, using `Entry.created_at` and a configured TTL to
-treat old entries as misses. That would limit staleness but still wouldn't prove
-freshness, so it should be an explicit host policy, not the default.
+`internal_cache: :enabled` is an explicit host assertion that the resolved
+identity is safe for byte reuse. The source may be technically mutable, but the
+host promises that policy prevents mutation under the same identity or accepts
+the stale-cache risk. ImagePipe shouldn't reject this mode just because it
+can't prove stability.
 
 Adapter implications:
 
 - S3 with `revision` can use `:enabled` because `versionId` is part of the fetch
   and source identity.
-- S3 without `revision` should resolve `internal_cache: :auto` to `:disabled` unless
-  the host marks keys as content-addressed or supplies a byte-version identity.
-- File sources should resolve `internal_cache: :auto` to `:disabled` unless the host
-  marks the path space as content-addressed. The first implementation shouldn't
-  use `mtime` and size as byte identity unless fetch opens the same file handle
-  used for the stat.
+- S3 without `revision` should resolve `internal_cache: :auto` to `:disabled`
+  unless the host marks keys as stable.
+- File sources should resolve `internal_cache: :auto` to `:disabled` unless the
+  host marks the path space as stable.
 - HTTP URL sources should resolve `internal_cache: :auto` to `:disabled` unless
-  the URL is content-addressed, versioned, or the adapter resolves an upstream
-  byte identity before cache lookup.
+  the URL is content-addressed, versioned, or marked stable by the host.
 
 ## Response Cache Headers
 
@@ -283,106 +220,49 @@ Add a pure module under the request boundary, tentatively
 
 This module needs source cache semantics, plan key data, output selection
 material, request headers, and request options. Keeping it under
-`ImagePipe.Request` preserves the existing boundary direction. `ImagePipe.Response`
-should send already-prepared status codes and headers.
-
-It should compute response headers from:
-
-- source cache semantics;
-- canonical plan key data;
-- output selection material;
-- configured output/cache version material;
-- existing response headers from output policy, such as `Vary: Accept`;
-- configured representation-changing headers, when the config admits them.
-
-The result should be a normalized header list:
-
-```elixir
-[
-  {"etag", ~s("...")},
-  {"cache-control", "public, max-age=31536000, immutable"},
-  {"vary", "Accept"}
-]
-```
-
-When `last_modified` is present:
-
-```elixir
-{"last-modified", "Mon, 25 May 2026 12:00:00 GMT"}
-```
-
-ImagePipe emits `Last-Modified` as response metadata and for downstream cache
-visibility. It describes the source byte version used to generate the
-representation, not the time ImagePipe encoded the response. The first
-implementation doesn't use it as a validator. If a CDN or client sends
-`If-Modified-Since`, ImagePipe returns the normal `200` path until explicit
-`If-Modified-Since` support lands. After that, `If-None-Match` takes precedence
-when a request sends both validators.
+`ImagePipe.Request` preserves the existing boundary direction.
+`ImagePipe.Response` should send already-prepared status codes and headers.
 
 An explicit mode controls generated HTTP cache headers:
 
-- `:disabled`: emit no generated `Cache-Control`, `ETag`, or `Last-Modified`.
-  Preserve explicit host headers that already exist on the conn.
-- `:enabled`: emit public shared-cache headers and ETags when byte identity
+- `:disabled`: emit no generated `Cache-Control` or `ETag`. Preserve explicit
+  host headers that already exist on the conn.
+- `:enabled`: emit generated public shared-cache headers when byte identity
   material is complete.
 
-The effective mode comes from request options, with source adapters allowed to
-override it with `http_cache: :disabled | :enabled`. The adapter default is
-`:inherit`.
+For v1, `:enabled` with `byte_identity: {:strong, seed}` emits:
 
-Default generated `Cache-Control`:
+```elixir
+[
+  {"cache-control", "public, max-age=31536000, immutable"},
+  {"etag", ~s("ip1-...")}
+]
+```
 
-- `:enabled` with immutable source bytes: `public, max-age=31536000, immutable`
-- `:enabled` with mutable source bytes: `public, max-age=300, stale-while-revalidate=3600`
+When automatic output uses `Accept`, the response also carries:
 
-The mutable default is a freshness policy, not a byte-identity guarantee.
-These responses must omit generated ETags unless the source resolver provides
-byte-version material. A CDN may serve stale bytes within the configured
-freshness window.
+```elixir
+{"vary", "Accept"}
+```
 
-ImagePipe doesn't forward incoming `Cookie` to source requests and doesn't place
-raw cookies in generated HTTP cache material. A cookie on the browser request
-doesn't change public cache behavior by itself.
+The request or mount options should configure the default `Cache-Control`.
+V1 has one generated cache-control value. Mutable short public caching stays
+deferred.
 
-If a host or earlier plug uses a cookie to choose source identity, grant access,
-or change output bytes, generated public caching is out of scope for that route.
-Use `http_cache: :disabled`.
-
-V1 enabled mode has hard stops:
-
-- response `Set-Cookie` disables generated public headers;
-- existing or generated `Vary: *` disables generated public headers;
-- selected `Cache-Control: no-store` suppresses generated ETags and
-  `Last-Modified`;
-- `public` or `s-maxage` in `response_cache_control` is only valid in
-  `http_cache: :enabled`.
-
-Per-user and per-tenant image behavior is out of scope for generated public
-headers.
-
-Header conflict behavior:
-
-| Existing or source header | Generated header | Behavior |
-| --- | --- | --- |
-| no existing `Cache-Control` | generated default | emit generated value |
-| existing host `Cache-Control` | generated default | preserve host value after validation |
-| source `response_cache_control` | generated default | source value wins after header and policy validation |
-| existing host `ETag` | generated ETag | preserve host value and suppress generated ETag, or fail configuration |
-| existing host `Last-Modified` | generated `Last-Modified` | preserve host value and suppress generated value, or fail configuration |
-| existing `Vary` | generated `Vary` | merge deterministically after validating values |
+If `http_cache: :enabled` but `byte_identity` is `:none`, v1 emits no generated
+`Cache-Control` and no generated `ETag`. This avoids a half-cacheable mutable
+path where the CDN can store bytes but ImagePipe can't produce a validator.
 
 Don't merge `Cache-Control` values. Directives can conflict, such as `private`
-with `public`, or two different `max-age` values. Pick one policy source.
-If an existing host `Vary` contains `*`, v1 must turn off generated public
-headers for that response instead of merging generated `Vary` values into it.
+with `public`, or two different `max-age` values. If a host already set
+`Cache-Control`, preserve it and suppress generated `Cache-Control`.
 
 ## ETag Material
 
 Don't use `ImagePipe.Cache.Key.hash` as the public `ETag`.
 
-The internal key includes storage and origin concerns, such as schema version,
-selected configured headers/cookies, and cache adapter key inputs. Those fields
-are useful for safe internal reuse but too coupled for an HTTP validator.
+The internal key includes storage and origin concerns. Those fields are useful
+for safe internal reuse but too coupled for an HTTP validator.
 
 Use separate ETag material:
 
@@ -392,125 +272,50 @@ Use separate ETag material:
   source: source_byte_identity_seed,
   plan: canonical_plan_key_data,
   output: output_selection_material,
-  vary: representation_request_material,
-  pipeline: representation_version_material
+  accept: normalized_accept_material,
+  representation: representation_version
 ]
 ```
 
-`representation_request_material` contains normalized request inputs that affect
-the response but aren't encoded in the URL. It should use lower-case field names
-and canonical values. Examples:
+For explicit output with no `Accept` dependency, use `accept: []`.
 
-```elixir
-[
-  accept: [selected_format: :avif, capability: [:avif, :webp]],
-  headers: [{"x-image-profile", ["catalog"]}]
-]
-```
+Only generate an ETag when:
 
-For explicit output with no request-varying inputs, use an empty list. The
-material must match the generated `Vary` header. Every non-URL input represented
-in ETag material must appear in `Vary`. Every generated `Vary` input that can
-change bytes must appear in ETag material.
+- the effective `http_cache` mode is `:enabled`;
+- `byte_identity` is `{:strong, seed}`;
+- ImagePipe can select output before source fetch;
+- automatic quality, if used later, has complete deterministic version material;
+- the response doesn't already have an `ETag`;
+- the selected cache policy isn't `no-store`.
 
-Only generate an ETag when the effective `http_cache` mode is `:enabled`,
-`byte_identity` is `{:strong, seed}`, and the selected cache policy doesn't
-contain `no-store`. For `:none`, omit `ETag` and skip conditional
-`If-None-Match` handling.
-
-V1 only expects strong byte identity from source identities that name immutable
+V1 only expects strong byte identity from source identities that name stable
 bytes. Future adapters may provide strong byte identity for mutable sources when
 source resolution obtains byte-version freshness material before fetch. A weak
 upstream validator, such as an HTTP `W/"..."` ETag, must not become
 `{:strong, seed}` unless the adapter has other material that proves source byte
-identity. Future upstream support should preserve validator strength.
+identity.
 
 Generated ETags are instruction-derived strong validators, not body-hash ETags.
-They're correct only if the material includes every byte-changing input. That
-means source byte identity, transform instructions, output decisions, encoder
-settings, normalized request inputs, and versioned dependencies.
+They're correct only if the material includes every byte-changing input:
+source byte identity, transform instructions, output decisions, encoder
+settings, normalized `Accept`, and versioned dependencies.
 
 Serialize ETag material with a deterministic encoder supported by ImagePipe's
-supported Erlang/OTP versions, then hash it with SHA-256. Deterministic Erlang term
-encoding is acceptable when the runtime supports it. Otherwise use another
-canonical encoder over the same material. Don't expose raw material in the
-header. The visible tag shape should include a schema prefix:
+supported Erlang/OTP versions, then hash it with SHA-256. Don't expose raw
+material in the header. The visible tag shape should include a schema prefix:
 
 ```http
 ETag: "ip1-<base64url-sha256>"
 ```
 
-Use a strong ETag, not a weak ETag, for generated ETags. A weak ETag would
-say the response has the same meaning but not necessarily the same bytes.
-ImagePipe can treat the encoded image response as byte-identical only when the
-ETag material is complete. The representation version must change whenever an
-encoder, codec, libvips behavior, metadata policy, default quality, orientation
-handling, color-profile behavior, animation handling, or output timestamp
-behavior can change bytes.
-
-`output_selection_material` should describe the deterministic representation
-instructions:
-
-```elixir
-[
-  mode: :explicit,
-  selected_format: :webp,
-  quality: {:quality, 82}
-]
-```
-
-For automatic or best-format output, the policy should select the output format
-from normalized `Accept` and configured format preference when possible. Browser
-headers such as this are enough to choose AVIF or WebP before source fetch:
-
-```http
-Accept: image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
-```
-
-That path is pre-fetch ETag eligible:
-
-```elixir
-[
-  mode: :best,
-  accept_capability: [:avif, :webp],
-  selection_policy: [name: :best_format, version: 1],
-  selected_format: :avif,
-  quality: :default
-]
-```
-
-Source alpha doesn't need separate ETag material when the selected target
-format supports transparency. AVIF and WebP do. Alpha affects the encoded bytes,
-but source byte identity already represents the source bytes.
-
-For future automatic quality:
-
-```elixir
-[
-  quality: [
-    mode: :auto,
-    strategy: :dssim,
-    strategy_version: 1,
-    model_version: nil
-  ]
-]
-```
-
-If automatic quality uses ML, the model artifact version must be present. If a
-quality strategy depends on libvips or codec behavior, it may change output
-bytes across deploys. In that case, the strategy version or representation
-version must change with the deploy. For ML-based quality, `model_version: nil`
-must suppress generated ETags rather than reuse an ETag across model
-artifact changes.
-
-Automatic quality can still use a pre-fetch ETag when ImagePipe knows the
-selected output format before source fetch. The quality algorithm must be a
-deterministic function of immutable source bytes, the canonical plan, and
-versioned strategy inputs. The ETag doesn't need the resolved numeric quality in
-that case.
+Use a strong ETag, not a weak ETag, for generated ETags. A weak ETag would say
+the response has the same meaning but not necessarily the same bytes. The
+representation version must change whenever an encoder, codec, libvips behavior,
+metadata policy, default quality, orientation handling, color-profile behavior,
+animation handling, or output timestamp behavior can change bytes.
 
 It's acceptable for two byte-identical responses to have different ETags when
-their deterministic instruction material differs. It's not acceptable for the
+their deterministic instruction material differs. It isn't acceptable for the
 same ETag to survive a change that may change bytes.
 
 Increment `etag_schema` only when the shape or interpretation of ETag material
@@ -524,37 +329,31 @@ internal cache material.
 
 For current automatic output:
 
-```elixir
+```http
 Accept: image/avif,image/webp
 ```
 
-That header and a header that prefers WebP with quality 1 and AVIF with quality
-0.1 both normalize to the same selected format when ImagePipe's policy chooses
-AVIF.
+That header and a header that prefers WebP with quality `1` and AVIF with
+quality `0.1` both normalize to the same selected format when ImagePipe's policy
+chooses AVIF.
 
-Don't store the raw `Accept` header in the ETag material. Store either the
-selected format or the normalized capability list used by the selection policy.
+Don't store the raw `Accept` header in ETag material. Store either the selected
+format or the normalized capability list used by the selection policy.
 
-ImagePipe must still emit `Vary: Accept` whenever response format selection
-depends on `Accept`. CDN cache keys are URL-oriented unless configured
-otherwise.
+ImagePipe must emit `Vary: Accept` whenever response format selection depends
+on `Accept`. CDN cache keys are URL-oriented unless configured otherwise.
 
-Any non-URL request input that can affect source identity, output bytes, format
-selection, or quality selection must appear in `Vary` and ETag material when
-`http_cache` is `:enabled`. ImagePipe doesn't infer those inputs from Plug state.
-If the host can't declare them, use `http_cache: :disabled` for that route. This
-includes image profile headers, locale, device class, and custom source-routing
-headers.
+V1 doesn't support generated public caching for arbitrary request headers that
+change source identity or output bytes. This includes image profile headers,
+locale, device class, tenant headers, and custom source-routing headers. Use
+`http_cache: :disabled` for those routes.
 
 Client Hints such as `DPR`, `Width`, `Viewport-Width`, `Sec-CH-DPR`, and
 `Sec-CH-Width` are out of scope for v1 generated public caching. They're
 client-controlled headers. Supporting them later requires a bounded model:
-explicit opt-in, accepted header names, normalization or clamping, `Vary` emission,
-CDN cache-key documentation, and ETag material that uses the normalized value.
-
-`Vary: *` means a cache can't reuse the response for later requests. ImagePipe
-should reject it for generated public-header responses or turn off generated
-public headers for that representation.
+explicit opt-in, accepted header names, normalization or clamping,
+`Vary` emission, CDN cache-key documentation, and ETag material that uses the
+normalized value.
 
 ## Pre-Fetch Conditional GET
 
@@ -562,16 +361,11 @@ For requests whose effective `http_cache` mode is `:enabled` and whose source
 semantics contain strong byte identity, ImagePipe should compute the ETag before
 source fetch whenever these inputs define output selection material:
 
-- the parsed plan;
+- parsed plan;
 - source cache semantics from `Source.resolve/3`;
 - normalized `Accept`;
 - runtime output options;
 - deterministic policy versions.
-
-The eligibility rule is: strong source byte identity, plus deterministic
-representation selection before fetch. Source byte immutability is one way to
-get strong byte identity. Future mutable sources can also qualify if source
-resolution obtains byte-version material before fetch.
 
 This pre-run conditional decision belongs after `Source.resolve/3` and before
 `Runner.run/4`. A matching ETag must skip internal cache lookup and source
@@ -581,7 +375,7 @@ On matching `If-None-Match`, ImagePipe returns:
 
 ```http
 304 Not Modified
-ETag: "..."
+ETag: "ip1-..."
 Cache-Control: public, max-age=31536000, immutable
 Vary: Accept
 ```
@@ -589,47 +383,35 @@ Vary: Accept
 No source fetch, decode, transform, encode, internal cache lookup, or internal
 cache write should occur after the match.
 
-`If-None-Match` parsing must handle `*` and comma-separated entity tags. For
-`GET` and `HEAD`, use weak comparison with ImagePipe's generated strong ETag:
-`W/"abc"` and `"abc"` both match `"abc"`. ImagePipe must gate conditional
-behavior to `GET` and `HEAD`.
+`If-None-Match` parsing must handle comma-separated entity tags. For `GET`, use
+weak comparison with ImagePipe's generated strong ETag: `W/"abc"` and `"abc"`
+both match `"abc"`. ImagePipe must gate conditional behavior to methods it
+serves as cacheable image reads. V1 defers HEAD support unless the current Plug
+path already serves HEAD.
 
-The pre-fetch path must not treat `If-None-Match: *` as a match in the first
-implementation. For `GET` and `HEAD`, `*` means any current representation
-exists. Before source fetch, ImagePipe hasn't proven that the requested source
-exists, that the transform can run, or that output negotiation can succeed. `*`
-can return `304` on an internal cache hit because the cached successful entry
-proves that a current representation exists for the internal cache key.
+V1 ignores `If-None-Match: *`. Before source fetch, ImagePipe hasn't proven
+that the requested source exists, that the transform can run, or that output
+negotiation can succeed. A later version can add the wildcard path if a real
+caller needs it.
 
 A `304 Not Modified` response must have no body and must include the cache
-metadata that ImagePipe would send on the corresponding `200`. Use a cache
+metadata that ImagePipe would send on the corresponding `200`. Use a small cache
 metadata allowlist:
 
 ```elixir
 [
   "cache-control",
-  "content-location",
   "date",
   "etag",
   "expires",
-  "last-modified",
-  "surrogate-control",
   "vary"
 ]
 ```
 
-The first implementation only emits the subset ImagePipe can produce. The server
-adapter normally generates `Date`. Don't replay encoded-body headers such as
-`Content-Length`, `Content-Type`, or `Content-Disposition` on `304`. Avoid
-representing `304` as a normal encoded response with an empty binary body. Use a
-delivery shape such as `{:not_modified, headers}`. `Surrogate-Control` is
-CDN-specific. Include it only when a host or earlier layer set it.
-
-HEAD response support isn't a v1 deliverable unless the current Plug path
-already serves HEAD. If ImagePipe adds or already supports HEAD, a non-matching
-`HEAD` response should send the headers that the corresponding `GET` would send,
-without a body. A matching conditional `HEAD` should return `304` without a
-body.
+The server adapter normally generates `Date`. Don't replay encoded-body
+headers such as `Content-Length`, `Content-Type`, or `Content-Disposition` on
+`304`. Avoid representing `304` as a normal encoded response with an empty
+binary body. Use a delivery shape such as `{:not_modified, headers}`.
 
 HTTP rules used here come from RFC 9110:
 
@@ -639,49 +421,6 @@ HTTP rules used here come from RFC 9110:
 - [`304 Not Modified`](https://www.rfc-editor.org/rfc/rfc9110.html#name-304-not-modified)
   carries cache metadata for the matching `200` response and no response
   content.
-
-Source-dependent output-format decisions opt out of pre-fetch conditional
-handling in the first implementation. This applies to modes where the selected
-output format depends on source metadata, such as source-format preservation or
-source-compatible fallback. Those requests may still use internal cache hits and
-normal CDN freshness, but ImagePipe shouldn't claim a pre-fetch `304` path for
-them.
-
-## Deferred Behaviors
-
-Keep v1 small. These omissions are intentional:
-
-- `If-Modified-Since`: omitted for scope. ImagePipe may emit `Last-Modified` as
-  metadata, but `If-None-Match` is the only conditional validator v1 acts on.
-- Late ETags: omitted for scope. If ETag material or selected output format is
-  only known after source fetch, decode, or transform, v1 omits the generated
-  ETag for that response.
-- Source metadata probing for mutable freshness: omitted for scope. Mutable
-  sources without revisions use short cache headers, no generated ETags, or an
-  explicit host promise through `internal_cache: :enabled`.
-- Alpha-specific ETag material: omitted because source bytes already cover
-  alpha. When the chosen output format supports transparency, alpha shouldn't
-  add a separate ETag input.
-- Static final-alpha inference: omitted for scope. Some transform chains can
-  prove final opacity before source fetch, such as an opaque background after
-  canvas-changing operations. v1 keeps source-format fallback on the existing
-  runtime final-alpha path instead of adding a transform effect system.
-- Stored generated ETags in the internal cache: omitted for correctness.
-  ImagePipe prepares generated HTTP cache headers from current source, request,
-  and policy inputs on each request.
-- Pre-fetch `If-None-Match: *`: omitted for correctness. `*` can match on an
-  internal cache hit, where a cached successful representation proves existence.
-- HEAD response support: out of scope unless the current Plug path already
-  serves HEAD. The conditional matcher still needs explicit method gates.
-- Cookie-varying public output: out of scope. ImagePipe ignores incoming request
-  cookies for generated HTTP caching and source fetches. Hosts that use cookies
-  to choose image bytes should use `http_cache: :disabled`.
-- Client Hints for generated public caching: out of scope. Unsigned headers such
-  as `DPR`, `Width`, and `Sec-CH-Width` can fragment a CDN cache if clients vary
-  them. Add a normalization design before using them in public cache
-  keys.
-- Surrogate keys and CDN tag purge headers: out of scope for v1. Hosts can set
-  those headers outside ImagePipe if they need them.
 
 ## Internal Cache Interaction
 
@@ -703,10 +442,9 @@ Extend `ImagePipe.Cache.Entry.cacheable_headers/1` to accept these names:
 - `vary`
 - `cache-control`
 
-These are output-owned headers that already exist today or that host policy may
-set before cache storage. Generated `etag`, generated `last-modified`, and
-generated `cache-control` should come from `ImagePipe.Request.HTTPCache` at
-delivery time, not from the cached entry.
+These are output-owned or host-owned headers that may already exist before
+cache storage. Generated `etag` and generated `cache-control` should come from
+`ImagePipe.Request.HTTPCache` at delivery time, not from the cached entry.
 
 On internal cache hit:
 
@@ -714,25 +452,22 @@ On internal cache hit:
 2. Prepare generated HTTP cache headers from current source semantics, plan,
    request headers, and options.
 3. Merge cached output headers with generated HTTP cache headers. Generated
-   headers must not overwrite explicit host policy without the conflict rules
-   described in "Plug Chain Boundaries."
+   headers must not overwrite explicit host policy.
 4. If the request has `If-None-Match` matching the prepared `etag`, return
-   `304 Not Modified` with the cache metadata header allowlist and no body.
-   `If-None-Match: *` can match here because the cache entry proves the current
-   representation exists.
+   `304 Not Modified` with cache metadata headers and no body.
 5. Otherwise return `200` with the cached body and merged response headers.
 
 This preserves header behavior between cache misses and cache hits.
 
-`ImagePipe.Cache.Entry` should only check and store cacheable headers. It
-shouldn't own conditional request behavior. The request runner or response
-sender should branch to a delivery shape that represents `304`.
+`ImagePipe.Cache.Entry` should only check and store cacheable headers. It should
+not own conditional request behavior. The request runner or response sender
+should branch to a delivery shape that represents `304`.
 
-The internal cache key doesn't need to include `etag_schema` or
-`representation_version` just to protect generated headers, because those
-headers come from current request inputs on hit. It only needs those versions if
-they also affect encoded bytes. In that case they belong in the existing
-canonical key data for output or transform material.
+The internal cache key doesn't need to include `etag_schema` just to protect
+generated headers, because those headers come from current request inputs on
+hit. It only needs `representation_version` if that version also affects encoded
+bytes. In that case the version belongs in the existing canonical key data for
+output or transform material.
 
 ## Error Responses
 
@@ -751,9 +486,8 @@ Add request options:
 ```elixir
 http_cache: [
   mode: :disabled,
-  immutable_cache_control: "public, max-age=31536000, immutable",
-  mutable_cache_control: "public, max-age=300, stale-while-revalidate=3600",
-  etag_version: 1,
+  cache_control: "public, max-age=31536000, immutable",
+  etag_schema: 1,
   representation_version: 1
 ]
 ```
@@ -763,79 +497,83 @@ Keep defaults small and explicit inside `ImagePipe.Request.Options`.
 Source adapter options:
 
 ```elixir
-source_bytes_immutable?: false,
+stable?: false,
 internal_cache: :auto,
-http_cache: :inherit,
-response_cache_control: nil
+http_cache: :inherit
 ```
 
-For S3, if `revision` is present, the source can treat the object as immutable
-even when `source_bytes_immutable?` isn't set.
+For S3, if `revision` is present, the source can treat the object as stable even
+when `stable?` isn't set.
+
+## Deferred Behaviors
+
+These omissions are intentional. Don't reintroduce them during implementation
+review without a new design note:
+
+- `Last-Modified` and `If-Modified-Since`: v1 acts only on `If-None-Match`.
+- Mutable short public caching: v1 generated public cache headers require strong
+  byte identity.
+- Source metadata probing for mutable freshness: v1 doesn't issue `HEAD`,
+  `stat`, or upstream metadata requests just to build validators.
+- Source-provided response `Cache-Control`: v1 policy comes from ImagePipe
+  request or mount options, not parser/provider/source output.
+- Arbitrary request-header `Vary`: v1 only generates `Vary: Accept` for
+  automatic output.
+- Late ETags: if ETag material or selected output format is only known after
+  source fetch, decode, or transform, v1 omits the generated ETag.
+- Alpha-specific ETag material: source bytes already cover alpha when the chosen
+  output format supports transparency.
+- Static final-alpha inference: v1 keeps source-format fallback on the existing
+  runtime final-alpha path instead of adding a transform effect system.
+- `If-None-Match: *`: v1 ignores the wildcard form.
+- HEAD response support: out of scope unless the current Plug path already
+  serves HEAD.
+- Cookie-varying public output: ImagePipe ignores incoming request cookies for
+  generated HTTP caching and source fetches. Hosts that use cookies to choose
+  image bytes should use `http_cache: :disabled`.
+- Client Hints for generated public caching: unsigned headers such as `DPR`,
+  `Width`, and `Sec-CH-Width` can fragment a CDN cache if clients vary them.
+- Surrogate keys and CDN tag purge headers: hosts can set those headers outside
+  ImagePipe if they need them.
 
 ## Test Plan
 
 Add focused tests at the request boundary:
 
-- `http_cache: :disabled` emits no generated `Cache-Control`, `ETag`, or
-  `Last-Modified`;
-- source-byte-immutable `http_cache: :enabled` response emits `ETag` and long
-  public `Cache-Control`;
-- mutable `http_cache: :enabled` response emits short public `Cache-Control`;
+- `http_cache: :disabled` emits no generated `Cache-Control` or `ETag`;
+- stable `http_cache: :enabled` response emits `ETag` and configured
+  `Cache-Control`;
+- `http_cache: :enabled` with `byte_identity: :none` emits no generated
+  `Cache-Control` or `ETag`;
 - request `Cookie` doesn't enter generated `Vary`, ETag material, or source
   fetches;
 - response with `Set-Cookie` disables generated public cache headers in v1;
-- source `response_cache_control` overrides defaults only after header and policy
-  validation;
-- `response_cache_control` containing `no-store` suppresses generated ETags;
-- `response_cache_control` containing `public` or `s-maxage` is only valid in
-  `http_cache: :enabled`;
-- mutable sources without byte identity omit `ETag` and never return `304` from
-  generated ETags;
-- mutable cache-enabled sources with `Last-Modified` and no ETag return `200` for
-  `If-Modified-Since` in v1;
-- `internal_cache: :auto` resolves to `:enabled` for source-byte-immutable
-  identities;
-- `internal_cache: :auto` resolves to `:enabled` for mutable identities that
-  include byte-version material;
-- `internal_cache: :auto` resolves to `:disabled` for mutable identities without
-  byte-version material;
-- `internal_cache: :enabled` accepts mutable identities without byte-version
-  material as an explicit host policy promise;
-- `internal_cache: :disabled` omits generated HTTP cache headers in v1;
 - automatic output emits `Vary: Accept`;
 - explicit output doesn't emit `Vary: Accept`;
-- configured header-varying output includes that header in `Vary`;
-- `http_cache: :enabled` requires configured header-varying output to include
-  that header in `Vary`;
-- Client Hints don't enter generated public cache headers, `Vary`, ETag
-  material, or CDN documentation in v1;
+- Client Hints don't enter generated public cache headers, `Vary`, or ETag
+  material in v1;
 - `Plan.expires` doesn't change generated `Cache-Control`;
 - `cachebuster` remains URL/cache-key material, not response cache policy;
-- cookie-varying output uses `http_cache: :disabled`;
 - matching `If-None-Match` returns `304` before source fetch for output with a
-  strong source byte identity;
-- matching `If-None-Match` returns before internal cache lookup for
-  output with a strong source byte identity;
+  strong byte identity;
+- matching `If-None-Match` returns before internal cache lookup for output with a
+  strong byte identity;
 - non-matching `If-None-Match` proceeds normally;
 - malformed `If-None-Match` doesn't match;
 - weak request tags match generated strong ETags for `GET`;
-- non-`GET` and non-`HEAD` requests don't use conditional response handling;
-- `If-None-Match: *` doesn't trigger pre-fetch `304`;
-- `If-None-Match: *` can trigger cached `304` on internal cache hit;
-- `304` responses include only the cache metadata allowlist and no body;
+- non-cacheable methods don't use conditional response handling;
+- `If-None-Match: *` doesn't trigger `304` in v1;
+- `304` responses include only cache metadata and no body;
 - `304` responses don't include `Content-Type`, `Content-Length`, or
   `Content-Disposition`;
 - internal cache hits preserve cached output headers such as `vary`;
-- internal cache hits prepare generated `etag`, `cache-control`, and
-  `last-modified` from current request inputs;
+- internal cache hits prepare generated `etag` and `cache-control` from current
+  request inputs;
 - internal cache hits can return `304` from the prepared `etag`;
 - internal cache hits recompute ETags with the current representation version;
-- existing host `ETag` suppresses generated ETag or fails configuration;
-- ImagePipe preserves existing host `Cache-Control` instead of merging it with
-  generated defaults;
-- ImagePipe preserves existing host `Last-Modified` or conflicts
-  deterministically;
-- existing `Vary` merges with generated `Accept` and configured vary headers;
+- existing host `ETag` suppresses generated ETag;
+- existing host `Cache-Control` suppresses generated `Cache-Control`;
+- existing `Vary` merges with generated `Accept`;
 - existing `Vary: *` turns off generated public headers in v1;
 - transform option order variants produce the same ETag;
 - changing source revision changes ETag;
@@ -846,13 +584,11 @@ Add focused tests at the request boundary:
 
 Add source adapter tests:
 
-- S3 with revision marks source bytes immutable and keeps `versionId` fetch;
-- S3 without revision is mutable and skips internal cache under
-  `internal_cache: :auto` unless configured source-byte-immutable;
-- File source defaults mutable without byte identity and host config can mark
-  source bytes immutable;
-- HTTP source defaults mutable without byte identity and host config can mark
-  source bytes immutable;
+- S3 with revision marks the source stable and keeps `versionId` fetch;
+- S3 without revision isn't stable and skips internal cache under
+  `internal_cache: :auto` unless configured stable;
+- File source defaults to not stable and host config can mark it stable;
+- HTTP source defaults to not stable and host config can mark it stable;
 - byte identity seeds redact or digest secret identity material.
 
 Add property tests for ETag material:
@@ -863,12 +599,6 @@ Add property tests for ETag material:
   produce the same internal cache output material;
 - `If-None-Match` matching handles weak tags, comma-separated tags, and
   whitespace;
-- ImagePipe rejects unsupported or non-cacheable header values before response
-  send;
-- ImagePipe rejects `Cache-Control` overrides containing CR or LF;
-- ImagePipe rejects invalid `Vary` values or turns off generated public headers;
-- duplicate `Vary` values merge deterministically;
-- `Vary: *` turns off generated public headers;
 - ETag material serialization is deterministic.
 
 ## Rollout
@@ -885,7 +615,7 @@ Build this in small steps:
    Splitting this across rolling deploys can produce nodes with different header
    behavior.
 5. Add cached `304` handling after generated headers are available on hits.
-6. Document CDN behavior and source immutability configuration.
+6. Document CDN behavior and source stability configuration.
 
 The first implementation shouldn't add post-transform conditional validation.
 If deterministic instruction material can't describe a future output mode, that

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -196,6 +196,49 @@ not provide an opt-back-in path for `cache: :skip`. A future opt-in must require
 a strong source validator and an explicit complete `Vary` declaration for every
 representation-changing request input.
 
+## Internal Source Cache Policy
+
+The current internal cache assumes a cache key names stable output bytes. It has
+no freshness check on read. It can serve a cached file-path or URL response
+forever if the key still matches and the cache entry remains on disk.
+
+Keep that contract explicit: `Source.Resolved.cache: :normal` means the
+resolved source identity is safe for internal byte reuse. For a mutable source,
+the identity is safe only when it includes byte-version material. Examples are
+an S3 revision, content-addressed path, upstream validator, or host-provided
+cachebuster that changes when bytes change.
+
+Adapt source adapters to choose internal cache policy from source semantics:
+
+- `cache: :auto` should be the default. It resolves to `:normal` only when the
+  source identity is byte-stable or includes byte-version material. Otherwise it
+  resolves to `:skip`.
+- `cache: :skip` always bypasses the internal encoded-response cache.
+- `cache: :normal` is an explicit host assertion that the resolved identity is
+  safe for byte reuse. If the source is mutable and the identity has no
+  byte-version material, configuration should fail instead of caching stale
+  bytes.
+
+This keeps the internal cache conservative without adding a source metadata
+fetch just to make mutable paths cacheable. A later implementation can add
+bounded internal freshness, using `Entry.created_at` and a configured TTL to
+treat old entries as misses. That would limit staleness but still wouldn't prove
+freshness, so it should be an explicit host policy, not the default.
+
+Adapter implications:
+
+- S3 with `revision` can use `:normal` because `versionId` is part of the fetch
+  and source identity.
+- S3 without `revision` should resolve `cache: :auto` to `:skip` unless the host
+  marks keys as content-addressed or supplies a byte-version identity.
+- File sources should resolve `cache: :auto` to `:skip` unless the host marks
+  the path space as content-addressed. The first implementation shouldn't use
+  `mtime` and size as byte identity unless fetch opens the same file handle used
+  for the stat.
+- HTTP URL sources should resolve `cache: :auto` to `:skip` unless the URL is
+  content-addressed, versioned, or the adapter resolves an upstream validator
+  before cache lookup.
+
 ## Response Cache Headers
 
 Add a pure module under the request boundary, tentatively
@@ -556,6 +599,7 @@ Source adapter options:
 
 ```elixir
 source_bytes_immutable?: false,
+cache: :auto,
 cache_control: nil
 ```
 
@@ -576,6 +620,11 @@ Add focused tests at the request boundary:
   validation;
 - mutable sources without validators omit `ETag` and never return `304` from
   generated validators;
+- `cache: :auto` resolves to `:normal` for source-byte-immutable identities;
+- `cache: :auto` resolves to `:skip` for mutable identities without byte-version
+  material;
+- `cache: :normal` fails configuration when the source is mutable and the
+  identity has no byte-version material;
 - `cache: :skip` omits generated HTTP cache headers;
 - automatic output emits `Vary: Accept`;
 - explicit output doesn't emit `Vary: Accept`;
@@ -614,7 +663,8 @@ Add focused tests at the request boundary:
 Add source adapter tests:
 
 - S3 with revision marks source bytes immutable and keeps `versionId` fetch;
-- S3 without revision is mutable unless configured source-byte-immutable;
+- S3 without revision is mutable and skips internal cache under `cache: :auto`
+  unless configured source-byte-immutable;
 - File source defaults mutable without a validator and host config can mark
   source bytes immutable;
 - HTTP source defaults mutable without a validator and host config can mark

--- a/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
+++ b/docs/superpowers/specs/2026-05-25-cdn-http-cache-design.md
@@ -137,6 +137,9 @@ Add `cache_semantics` to `ImagePipe.Source.Resolved`:
 }
 ```
 
+Add `cache_semantics` to `Source.Resolved.@enforce_keys` so adapters can't omit
+it.
+
 `stable?` means the resolved source identity names stable bytes. This can come
 from a versioned identity, a content-addressed path space, or host configuration
 that promises bytes don't change under the same identity. It isn't an HTTP cache
@@ -280,21 +283,22 @@ The main API should return a prepared value, not only a header list:
 
 ```elixir
 %ImagePipe.Request.HTTPCache.Prepared{
-  effective_mode: :enabled | :disabled,
   representation_headers: [{"vary", "Accept"}],
-  generated_cache_headers: [{"cache-control", "..."}, {"etag", "..."}],
-  generated_etag?: boolean()
+  headers: [{"cache-control", "..."}, {"etag", "..."}],
+  etag: ~s("ip1-...") | nil
 }
 ```
 
 `representation_headers` are correctness headers. Always apply them. For
 example, automatic output still needs `Vary: Accept` when ImagePipe suppresses
-generated `Cache-Control` and `ETag`. `generated_cache_headers` are the optional
-CDN-facing policy and validator headers.
+generated `Cache-Control` and `ETag`. `headers` are the optional CDN-facing
+policy and validator headers. `etag` is non-nil only when ImagePipe generated
+the ETag and can interpret `If-None-Match`.
 
 Build this value in `ImagePipe.Plug` after `Source.resolve/3` and before
-`Runner.run/4`, then pass it through delivery. That matches the current code
-shape: cache-hit delivery doesn't carry `Source.Resolved`.
+`Runner.run/4`, then pass it through delivery for normal `200` responses. That
+matches the current code shape: cache-hit delivery doesn't carry
+`Source.Resolved`.
 
 An explicit mode controls generated HTTP cache headers:
 
@@ -330,6 +334,13 @@ store bytes but ImagePipe can't produce a validator. Treat `no-store` here as a
 safety signal: the route opted into generated HTTP caching, but the source did
 not produce byte identity. Emit telemetry or a low-cardinality log event for
 this fallback so operators can spot a bad route configuration.
+
+Emit low-cardinality HTTP cache telemetry for:
+
+- effective mode, byte identity kind, and whether ImagePipe emitted an ETag;
+- conditional request matches;
+- the `no-store` fallback;
+- cache-hit delivery using freshly prepared HTTP cache headers.
 
 Don't merge `Cache-Control` values. Directives can conflict, such as `private`
 with `public`, or two different `max-age` values. If a host already set
@@ -401,6 +412,9 @@ material in the header. The visible tag shape should include a schema prefix:
 ```http
 ETag: "ip1-<base64url-sha256>"
 ```
+
+Build the visible prefix from `@etag_schema`, for example
+`"ip#{@etag_schema}-..."`, so the prefix and hashed material can't disagree.
 
 Use a strong ETag, not a weak ETag, for generated ETags. A weak ETag would say
 the response has the same meaning but not necessarily the same bytes. The
@@ -540,8 +554,8 @@ metadata allowlist:
 The server adapter normally generates `Date`. Don't replay encoded-body
 headers such as `Content-Length`, `Content-Type`, or `Content-Disposition` on
 `304`. Avoid representing `304` as a normal encoded response with an empty
-binary body. Introduce a delivery shape such as `{:not_modified, headers}` when
-adding the pre-fetch conditional path.
+binary body. The Plug should send the `304` directly before calling
+`Runner.run/4`. Don't add a runner delivery shape for this path.
 
 HTTP rules used here come from RFC 9110:
 
@@ -734,6 +748,9 @@ Add focused tests at the request boundary:
   post-decode branch result;
 - changing the source-compatible output rule changes ETag material through the
   rule material or representation version;
+- different source byte identities with the same source-compatible rule can
+  resolve to different concrete output formats while still using pre-fetch ETag
+  material based on the symbolic rule;
 - changing source revision changes ETag;
 - changing the implementation `etag_schema` constant changes ETag;
 - changing representation version changes ETag;
@@ -743,6 +760,7 @@ Add source adapter tests:
 
 - `ImagePipe.Source.CacheSemantics` requires explicit `byte_identity` and
   `stable?`;
+- `Source.Resolved` enforces `cache_semantics`;
 - `Source.Resolved.cache: :normal | :skip` callers migrate to
   `internal_cache: :enabled | :disabled`;
 - S3 with revision marks the source stable and keeps `versionId` fetch;
@@ -775,8 +793,8 @@ Build this in small steps:
    comes in the next step.
 3. Add request-owned HTTP cache header preparation and unit tests. Build the
    prepared value after source resolution and before `Runner.run/4`.
-4. Add pre-run conditional handling and introduce the `{:not_modified, headers}`
-   delivery shape.
+4. Add pre-run conditional handling. The Plug sends matching `304` responses
+   before calling `Runner.run/4`.
 5. Add generated-header delivery for cache misses and cache hits in one deploy.
    Cache hits should use the prepared value from current request inputs; internal
    cache entries should continue to store only cacheable output headers.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -59,6 +59,10 @@ transform execution, output negotiation, encoding, and send streaming spans.
 [:image_pipe, :cache, :stage, ...]
 [:image_pipe, :cache, :write, ...]
 [:image_pipe, :send, ...]
+[:image_pipe, :http_cache, :prepare]
+[:image_pipe, :http_cache, :conditional, :match]
+[:image_pipe, :http_cache, :fallback, :no_store]
+[:image_pipe, :http_cache, :cache_hit, :headers]
 ```
 
 For example, the cache lookup stop event with the default prefix is:
@@ -151,6 +155,19 @@ successful commit stop event includes `cache: :write`. A commit error after
 successful streamed delivery includes `cache: :write_error` and
 `result: :cache_error`, but the response still fails open because the body was
 already delivered.
+
+Generated CDN HTTP cache handling emits non-span events:
+
+- `[:image_pipe, :http_cache, :prepare]` with `:effective_mode`,
+  `:byte_identity`, and `:etag`.
+- `[:image_pipe, :http_cache, :conditional, :match]` with `method: :get`.
+- `[:image_pipe, :http_cache, :fallback, :no_store]` with `:adapter`,
+  `:source_kind`, and `:reason`.
+- `[:image_pipe, :http_cache, :cache_hit, :headers]` with booleans for `:etag`,
+  `:generated_cache_headers`, and `:representation_headers`.
+
+These events don't include request paths, source identities, cache keys, or ETag
+values.
 
 ## Attaching handlers
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -59,10 +59,6 @@ transform execution, output negotiation, encoding, and send streaming spans.
 [:image_pipe, :cache, :stage, ...]
 [:image_pipe, :cache, :write, ...]
 [:image_pipe, :send, ...]
-[:image_pipe, :http_cache, :prepare]
-[:image_pipe, :http_cache, :conditional, :match]
-[:image_pipe, :http_cache, :fallback, :no_store]
-[:image_pipe, :http_cache, :cache_hit, :headers]
 ```
 
 For example, the cache lookup stop event with the default prefix is:
@@ -81,6 +77,16 @@ ImagePipe uses the measurements provided by `:telemetry.span/3`:
 
 Durations use the native time unit from `System.monotonic_time/0`. Handlers can
 convert them with `System.convert_time_unit/3` for a specific display unit.
+
+HTTP cache decision events aren't spans. ImagePipe emits them with
+`Telemetry.execute/4`, and they're sent with empty measurements:
+
+```text
+[:image_pipe, :http_cache, :prepare]
+[:image_pipe, :http_cache, :conditional, :match]
+[:image_pipe, :http_cache, :fallback, :no_store]
+[:image_pipe, :http_cache, :cache_hit, :headers]
+```
 
 ## Metadata
 

--- a/lib/image_pipe/cache/key.ex
+++ b/lib/image_pipe/cache/key.ex
@@ -14,6 +14,7 @@ defmodule ImagePipe.Cache.Key do
 
   @schema_version 2
   @transform_key_data_version 1
+  @representation_version 1
   @enforce_keys [:hash, :data, :serialized_data]
 
   defstruct @enforce_keys
@@ -37,6 +38,7 @@ defmodule ImagePipe.Cache.Key do
         pipelines: pipelines,
         transform: transform_data(),
         output: output,
+        representation: representation_data(),
         cache: cache,
         selected_headers: selected_headers(conn, opts),
         selected_cookies: selected_cookies(conn, opts)
@@ -60,6 +62,10 @@ defmodule ImagePipe.Cache.Key do
     |> :erlang.term_to_binary([:deterministic])
   end
 
+  @doc false
+  @spec representation_version() :: pos_integer()
+  def representation_version, do: @representation_version
+
   defp validate_source_identity(identity) do
     if Identity.valid?(identity),
       do: :ok,
@@ -74,6 +80,8 @@ defmodule ImagePipe.Cache.Key do
   end
 
   defp transform_data, do: [key_data_version: @transform_key_data_version]
+
+  defp representation_data, do: [version: @representation_version]
 
   defp output_data(conn, %Output{mode: :automatic} = output, opts) do
     accept_header = conn |> get_req_header("accept") |> Enum.join(",")

--- a/lib/image_pipe/cache/key.ex
+++ b/lib/image_pipe/cache/key.ex
@@ -29,20 +29,18 @@ defmodule ImagePipe.Cache.Key do
           {:ok, t()} | {:error, term()}
   def build(conn, %Plan{} = plan, source_identity, opts \\ []) when is_list(opts) do
     with :ok <- validate_source_identity(source_identity),
-         {:ok, pipelines} <- pipelines_data(plan.pipelines),
-         {:ok, output} <- output_data(conn, plan.output, opts),
-         {:ok, cache} <- cache_data(plan.cachebuster) do
-      data = [
-        schema_version: @schema_version,
-        source_identity: source_identity,
-        pipelines: pipelines,
-        transform: transform_data(),
-        output: output,
-        representation: representation_data(),
-        cache: cache,
-        selected_headers: selected_headers(conn, opts),
-        selected_cookies: selected_cookies(conn, opts)
-      ]
+         {:ok, plan_material} <- plan_material(plan, opts),
+         {:ok, output} <- output_data(conn, plan.output, opts) do
+      data =
+        [
+          schema_version: @schema_version,
+          source_identity: source_identity
+        ] ++
+          replace_keyword_value(plan_material, :output, output) ++
+          [
+            selected_headers: selected_headers(conn, opts),
+            selected_cookies: selected_cookies(conn, opts)
+          ]
 
       serialized_data = serialize_key_data(data)
 
@@ -60,6 +58,23 @@ defmodule ImagePipe.Cache.Key do
     key_data
     |> canonicalize()
     |> :erlang.term_to_binary([:deterministic])
+  end
+
+  @doc false
+  @spec plan_material(Plan.t(), keyword()) :: {:ok, keyword()} | {:error, term()}
+  def plan_material(%Plan{} = plan, opts) do
+    with {:ok, pipelines} <- pipelines_data(plan.pipelines),
+         {:ok, output} <- output_plan_data(plan.output, opts),
+         {:ok, cache} <- cache_data(plan.cachebuster) do
+      {:ok,
+       [
+         pipelines: pipelines,
+         transform: transform_data(),
+         output: output,
+         representation: representation_data(),
+         cache: cache
+       ]}
+    end
   end
 
   @doc false
@@ -83,6 +98,31 @@ defmodule ImagePipe.Cache.Key do
 
   defp representation_data, do: [version: @representation_version]
 
+  defp output_plan_data(%Output{mode: :automatic} = output, opts) do
+    {:ok,
+     [
+       mode: :automatic,
+       auto: [
+         avif: Keyword.get(opts, :auto_avif, true),
+         webp: Keyword.get(opts, :auto_webp, true)
+       ],
+       quality: output.quality,
+       format_qualities: output.format_qualities
+     ]}
+  end
+
+  defp output_plan_data(%Output{mode: {:explicit, format}} = output, _opts) do
+    {:ok,
+     [
+       mode: :explicit,
+       format: format,
+       quality: output.quality,
+       format_qualities: output.format_qualities
+     ]}
+  end
+
+  defp output_plan_data(output, _opts), do: {:error, {:invalid_output_plan, output}}
+
   defp output_data(conn, %Output{mode: :automatic} = output, opts) do
     accept_header = conn |> get_req_header("accept") |> Enum.join(",")
 
@@ -99,18 +139,13 @@ defmodule ImagePipe.Cache.Key do
      ]}
   end
 
-  defp output_data(_conn, %Output{mode: {:explicit, format}} = output, _opts) do
-    {:ok,
-     [
-       mode: :explicit,
-       format: format,
-       quality: output.quality,
-       format_qualities: output.format_qualities
-     ]}
-  end
+  defp output_data(_conn, %Output{} = output, opts), do: output_plan_data(output, opts)
 
-  defp output_data(_conn, output, _opts) do
-    {:error, {:invalid_output_plan, output}}
+  defp replace_keyword_value(keyword, key, value) do
+    Enum.map(keyword, fn
+      {^key, _old_value} -> {key, value}
+      entry -> entry
+    end)
   end
 
   defp cache_data(cachebuster) when is_binary(cachebuster) or is_nil(cachebuster) do

--- a/lib/image_pipe/plan.ex
+++ b/lib/image_pipe/plan.ex
@@ -88,9 +88,17 @@ defmodule ImagePipe.Plan do
     do: {:error, {:invalid_pipeline_plan, pipelines}}
 
   @spec canonical_representation_material(t()) :: {:ok, keyword()} | :omit_etag
-  def canonical_representation_material(%__MODULE__{output: %Output{} = output}) do
+  def canonical_representation_material(%__MODULE__{
+        output: %Output{mode: {:explicit, _format}} = output
+      }) do
     {:ok, [output: output_material(output)]}
   end
+
+  def canonical_representation_material(%__MODULE__{output: %Output{mode: :automatic} = output}) do
+    {:ok, [output: output_material(output)]}
+  end
+
+  def canonical_representation_material(%__MODULE__{}), do: :omit_etag
 
   defp do_validate_pipelines(pipelines) do
     Enum.reduce_while(pipelines, {:ok, []}, fn

--- a/lib/image_pipe/plan.ex
+++ b/lib/image_pipe/plan.ex
@@ -87,19 +87,6 @@ defmodule ImagePipe.Plan do
   def validated_pipelines(%__MODULE__{pipelines: pipelines}),
     do: {:error, {:invalid_pipeline_plan, pipelines}}
 
-  @spec canonical_representation_material(t()) :: {:ok, keyword()} | :omit_etag
-  def canonical_representation_material(%__MODULE__{
-        output: %Output{mode: {:explicit, _format}} = output
-      }) do
-    {:ok, [output: output_material(output)]}
-  end
-
-  def canonical_representation_material(%__MODULE__{output: %Output{mode: :automatic} = output}) do
-    {:ok, [output: output_material(output)]}
-  end
-
-  def canonical_representation_material(%__MODULE__{}), do: :omit_etag
-
   defp do_validate_pipelines(pipelines) do
     Enum.reduce_while(pipelines, {:ok, []}, fn
       %Pipeline{operations: operations} = pipeline, {:ok, valid_pipelines}
@@ -112,37 +99,6 @@ defmodule ImagePipe.Plan do
       _pipeline, _acc ->
         {:halt, {:error, {:invalid_pipeline_plan, pipelines}}}
     end)
-  end
-
-  defp output_material(%Output{
-         mode: {:explicit, format},
-         quality: quality,
-         format_qualities: format_qualities
-       }) do
-    [
-      mode: :explicit,
-      format: format,
-      quality: quality,
-      format_qualities: sorted_format_qualities(format_qualities)
-    ]
-  end
-
-  defp output_material(%Output{
-         mode: :automatic,
-         quality: quality,
-         format_qualities: format_qualities
-       }) do
-    [
-      mode: :automatic,
-      quality: quality,
-      format_qualities: sorted_format_qualities(format_qualities)
-    ]
-  end
-
-  defp sorted_format_qualities(format_qualities) when is_map(format_qualities) do
-    format_qualities
-    |> Map.to_list()
-    |> Enum.sort_by(fn {format, _quality} -> format end)
   end
 
   defp invalid_operation?(%_{} = operation), do: not Operation.semantic?(operation)

--- a/lib/image_pipe/plan.ex
+++ b/lib/image_pipe/plan.ex
@@ -87,6 +87,11 @@ defmodule ImagePipe.Plan do
   def validated_pipelines(%__MODULE__{pipelines: pipelines}),
     do: {:error, {:invalid_pipeline_plan, pipelines}}
 
+  @spec canonical_representation_material(t()) :: {:ok, keyword()} | :omit_etag
+  def canonical_representation_material(%__MODULE__{output: %Output{} = output}) do
+    {:ok, [output: output_material(output)]}
+  end
+
   defp do_validate_pipelines(pipelines) do
     Enum.reduce_while(pipelines, {:ok, []}, fn
       %Pipeline{operations: operations} = pipeline, {:ok, valid_pipelines}
@@ -99,6 +104,37 @@ defmodule ImagePipe.Plan do
       _pipeline, _acc ->
         {:halt, {:error, {:invalid_pipeline_plan, pipelines}}}
     end)
+  end
+
+  defp output_material(%Output{
+         mode: {:explicit, format},
+         quality: quality,
+         format_qualities: format_qualities
+       }) do
+    [
+      mode: :explicit,
+      format: format,
+      quality: quality,
+      format_qualities: sorted_format_qualities(format_qualities)
+    ]
+  end
+
+  defp output_material(%Output{
+         mode: :automatic,
+         quality: quality,
+         format_qualities: format_qualities
+       }) do
+    [
+      mode: :automatic,
+      quality: quality,
+      format_qualities: sorted_format_qualities(format_qualities)
+    ]
+  end
+
+  defp sorted_format_qualities(format_qualities) when is_map(format_qualities) do
+    format_qualities
+    |> Map.to_list()
+    |> Enum.sort_by(fn {format, _quality} -> format end)
   end
 
   defp invalid_operation?(%_{} = operation), do: not Operation.semantic?(operation)

--- a/lib/image_pipe/plug.ex
+++ b/lib/image_pipe/plug.ex
@@ -21,6 +21,7 @@ defmodule ImagePipe.Plug do
   alias ImagePipe.Error
   alias ImagePipe.Parser.Imgproxy
   alias ImagePipe.Plan
+  alias ImagePipe.Request.HTTPCache
   alias ImagePipe.Request.Options
   alias ImagePipe.Request.Runner
   alias ImagePipe.Response.Sender
@@ -52,14 +53,29 @@ defmodule ImagePipe.Plug do
          {:ok, %Plan{} = plan} <- validate_client_plan(plan),
          {:ok, %Source.Resolved{} = resolved_source} <-
            Source.resolve(plan.source, opts, Options.source_runtime_opts(opts)) do
-      result = Runner.run(conn, plan, resolved_source, opts)
+      prepared_http_cache = HTTPCache.prepare(conn, plan, resolved_source, opts)
 
-      {conn, send_metadata} =
-        send_response(conn, opts, request_result(result), fn ->
-          Sender.send_result(conn, result, opts)
-        end)
+      case HTTPCache.evaluate_conditional(conn, prepared_http_cache, opts) do
+        {:not_modified, headers} ->
+          result = :not_modified
 
-      {conn, request_stop_metadata(result, send_metadata)}
+          {conn, send_metadata} =
+            send_response(conn, opts, result, fn ->
+              HTTPCache.send_not_modified(conn, headers)
+            end)
+
+          {conn, request_stop_metadata(result, send_metadata)}
+
+        :proceed ->
+          result = Runner.run(conn, plan, resolved_source, prepared_http_cache, opts)
+
+          {conn, send_metadata} =
+            send_response(conn, opts, request_result(result), fn ->
+              Sender.send_result(conn, result, opts)
+            end)
+
+          {conn, request_stop_metadata(result, send_metadata)}
+      end
     else
       {:error, {:parser, error}} ->
         {conn, _send_metadata} =
@@ -137,6 +153,7 @@ defmodule ImagePipe.Plug do
   defp request_result({:error, {:cache, _error}}), do: :cache_error
   defp request_result({:error, {:processing, reason, _headers}}), do: processing_result(reason)
 
+  defp request_result_metadata(:not_modified), do: %{result: :not_modified}
   defp request_result_metadata({:ok, _delivery}), do: %{result: :ok}
 
   defp request_result_metadata({:error, {:cache, error}}),

--- a/lib/image_pipe/plug.ex
+++ b/lib/image_pipe/plug.ex
@@ -56,12 +56,12 @@ defmodule ImagePipe.Plug do
       prepared_http_cache = HTTPCache.prepare(conn, plan, resolved_source, opts)
 
       case HTTPCache.evaluate_conditional(conn, prepared_http_cache, opts) do
-        {:not_modified, headers} ->
+        {:not_modified, prepared} ->
           result = :not_modified
 
           {conn, send_metadata} =
             send_response(conn, opts, result, fn ->
-              HTTPCache.send_not_modified(conn, headers)
+              Sender.send_not_modified(conn, prepared)
             end)
 
           {conn, request_stop_metadata(result, send_metadata)}

--- a/lib/image_pipe/request.ex
+++ b/lib/image_pipe/request.ex
@@ -15,6 +15,7 @@ defmodule ImagePipe.Request do
       ImagePipe.Transform
     ],
     exports: [
+      HTTPCache,
       Options,
       Runner,
       SourceSessionSupervisor

--- a/lib/image_pipe/request/http_cache.ex
+++ b/lib/image_pipe/request/http_cache.ex
@@ -2,7 +2,7 @@ defmodule ImagePipe.Request.HTTPCache do
   @moduledoc false
 
   import Plug.Conn,
-    only: [get_req_header: 2, get_resp_header: 2, put_resp_header: 3, send_resp: 3]
+    only: [get_req_header: 2, get_resp_header: 2]
 
   alias ImagePipe.Cache.Key
   alias ImagePipe.Output.Negotiation
@@ -16,8 +16,6 @@ defmodule ImagePipe.Request.HTTPCache do
   @etag_schema 1
   @generated_cache_control "public, max-age=31536000, immutable"
   @no_store "no-store"
-  @plug_default_cache_control "max-age=0, private, must-revalidate"
-  @not_modified_header_allowlist ~w(cache-control date etag expires vary)
 
   @spec prepare(Plug.Conn.t(), Plan.t(), Resolved.t(), keyword()) :: CacheHeaders.t()
   def prepare(%Plug.Conn{} = conn, %Plan{} = plan, %Resolved{} = resolved, opts) do
@@ -56,28 +54,21 @@ defmodule ImagePipe.Request.HTTPCache do
   def generated_cache_control, do: @generated_cache_control
 
   @doc false
-  @spec etag_material(Plug.Conn.t(), Plan.t(), term(), keyword()) :: {:ok, keyword()} | :omit_etag
+  @spec etag_material(Plug.Conn.t(), Plan.t(), term(), keyword()) :: {:ok, keyword()}
   def etag_material(conn, %Plan{} = plan, source_seed, opts) do
-    case Plan.canonical_representation_material(plan) do
-      {:ok, _representation_material} ->
-        with {:ok, plan_material} <- Key.plan_material(plan, opts) do
-          {:ok,
-           [
-             etag_schema: @etag_schema,
-             source: source_seed,
-             plan: Keyword.drop(plan_material, [:cache]),
-             accept: accept_material(conn, plan.output, opts),
-             representation_version: Key.representation_version()
-           ]}
-        end
-
-      :omit_etag ->
-        :omit_etag
+    with {:ok, plan_material} <- Key.plan_material(plan, opts) do
+      {:ok,
+       [
+         etag_schema: @etag_schema,
+         source: source_seed,
+         plan: Keyword.drop(plan_material, [:cache]),
+         accept: accept_material(conn, plan.output, opts)
+       ]}
     end
   end
 
   @spec evaluate_conditional(Plug.Conn.t(), CacheHeaders.t(), keyword()) ::
-          :proceed | {:not_modified, [{String.t(), String.t()}]}
+          :proceed | {:not_modified, CacheHeaders.t()}
   def evaluate_conditional(
         %Plug.Conn{method: "GET"} = conn,
         %CacheHeaders{etag: etag} = prepared,
@@ -85,8 +76,6 @@ defmodule ImagePipe.Request.HTTPCache do
       )
       when is_binary(etag) do
     if if_none_match?(conn, etag) do
-      headers = not_modified_headers(prepared)
-
       Telemetry.execute(
         Telemetry.telemetry_opts(opts),
         [:http_cache, :conditional, :match],
@@ -94,23 +83,13 @@ defmodule ImagePipe.Request.HTTPCache do
         %{method: :get}
       )
 
-      {:not_modified, headers}
+      {:not_modified, prepared}
     else
       :proceed
     end
   end
 
   def evaluate_conditional(%Plug.Conn{}, %CacheHeaders{}, _opts), do: :proceed
-
-  @spec send_not_modified(Plug.Conn.t(), [{String.t(), String.t()}]) :: Plug.Conn.t()
-  def send_not_modified(conn, headers) do
-    conn =
-      Enum.reduce(headers, conn, fn {name, value}, conn ->
-        put_resp_header(conn, name, value)
-      end)
-
-    send_resp(conn, 304, "")
-  end
 
   defp effective_mode(%Resolved{http_cache: :inherit}, opts),
     do: opts |> Keyword.fetch!(:http_cache) |> Keyword.fetch!(:mode)
@@ -128,15 +107,26 @@ defmodule ImagePipe.Request.HTTPCache do
        ),
        do: {[], nil, nil}
 
+  defp generated_cache_headers(
+         %Plug.Conn{method: method},
+         _plan,
+         _resolved,
+         _opts,
+         :enabled,
+         _representation_headers
+       )
+       when method != "GET",
+       do: {[], nil, nil}
+
   defp generated_cache_headers(conn, plan, resolved, opts, :enabled, representation_headers) do
     cond do
-      has_resp_header?(conn, "set-cookie") ->
+      has_set_cookie?(conn) ->
         {[], nil, nil}
 
-      vary_star?(representation_headers) ->
+      vary_star?(conn) or vary_star?(representation_headers) ->
         {[], nil, nil}
 
-      selected_cache_control(conn) == @no_store ->
+      host_has_no_store?(conn) ->
         {[], nil, nil}
 
       has_host_cache_control?(conn) ->
@@ -152,15 +142,12 @@ defmodule ImagePipe.Request.HTTPCache do
       {:etag, etag} ->
         {[{"cache-control", @generated_cache_control}, {"etag", etag}], etag, nil}
 
-      :omit_etag ->
-        {[{"cache-control", @no_store}], nil, :missing_representation_material}
-
       :not_generated ->
         case resolved.cache_semantics do
           %CacheSemantics{byte_identity: :none} ->
             {[{"cache-control", @no_store}], nil, :missing_byte_identity}
 
-          %CacheSemantics{byte_identity: {:strong, _seed}} ->
+          %CacheSemantics{byte_identity: {:strong, _seed}, stable?: true} ->
             if has_resp_header?(conn, "etag"),
               do: {[{"cache-control", @generated_cache_control}], nil, nil},
               else: {[], nil, nil}
@@ -171,7 +158,6 @@ defmodule ImagePipe.Request.HTTPCache do
   defp generated_etag_only(conn, plan, resolved, opts) do
     case generated_etag(conn, plan, resolved, opts) do
       {:etag, etag} -> {[{"etag", etag}], etag, nil}
-      :omit_etag -> {[], nil, nil}
       :not_generated -> {[], nil, nil}
     end
   end
@@ -181,7 +167,7 @@ defmodule ImagePipe.Request.HTTPCache do
       has_resp_header?(conn, "etag") ->
         :not_generated
 
-      selected_cache_control(conn) == @no_store ->
+      host_has_no_store?(conn) ->
         :not_generated
 
       true ->
@@ -190,17 +176,13 @@ defmodule ImagePipe.Request.HTTPCache do
   end
 
   defp do_generated_etag(conn, plan, %CacheSemantics{byte_identity: {:strong, seed}}, opts) do
-    case etag_material(conn, plan, seed, opts) do
-      {:ok, material} ->
-        material
-        |> serialize_material()
-        |> then(&:crypto.hash(:sha256, &1))
-        |> Base.url_encode64(padding: false)
-        |> then(&{:etag, ~s("ip#{@etag_schema}-#{&1}")})
+    {:ok, material} = etag_material(conn, plan, seed, opts)
 
-      :omit_etag ->
-        :omit_etag
-    end
+    material
+    |> serialize_material()
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.url_encode64(padding: false)
+    |> then(&{:etag, ~s("ip#{@etag_schema}-#{&1}")})
   end
 
   defp do_generated_etag(_conn, _plan, %CacheSemantics{byte_identity: :none}, _opts),
@@ -251,6 +233,12 @@ defmodule ImagePipe.Request.HTTPCache do
     end)
   end
 
+  defp vary_star?(%Plug.Conn{} = conn) do
+    conn
+    |> get_resp_header("vary")
+    |> Enum.any?(fn value -> "*" in split_vary(value) end)
+  end
+
   defp vary_star?(headers) do
     Enum.any?(headers, fn
       {"vary", value} -> "*" in split_vary(value)
@@ -258,24 +246,24 @@ defmodule ImagePipe.Request.HTTPCache do
     end)
   end
 
-  defp selected_cache_control(conn) do
+  defp host_has_no_store?(conn) do
     conn
     |> get_resp_header("cache-control")
     |> Enum.join(",")
     |> String.downcase()
     |> String.split(",")
     |> Enum.map(&String.trim/1)
-    |> Enum.find(&(&1 == "no-store"))
+    |> Enum.any?(&(&1 == @no_store))
   end
 
   defp has_resp_header?(conn, name), do: get_resp_header(conn, name) != []
 
+  defp has_set_cookie?(%Plug.Conn{} = conn) do
+    has_resp_header?(conn, "set-cookie") or conn.resp_cookies != %{}
+  end
+
   defp has_host_cache_control?(conn) do
-    case get_resp_header(conn, "cache-control") do
-      [] -> false
-      [@plug_default_cache_control] -> false
-      _headers -> true
-    end
+    CacheHeaders.host_cache_control?(get_resp_header(conn, "cache-control"))
   end
 
   defp byte_identity_kind(%CacheSemantics{byte_identity: {:strong, _seed}}), do: :strong
@@ -331,14 +319,6 @@ defmodule ImagePipe.Request.HTTPCache do
 
   defp strip_weak("W/" <> rest), do: rest
   defp strip_weak(value), do: value
-
-  defp not_modified_headers(%CacheHeaders{} = prepared) do
-    prepared.headers
-    |> Kernel.++(prepared.representation_headers)
-    |> Enum.filter(fn {name, _value} ->
-      String.downcase(name) in @not_modified_header_allowlist
-    end)
-  end
 
   defp serialize_material(material) do
     material

--- a/lib/image_pipe/request/http_cache.ex
+++ b/lib/image_pipe/request/http_cache.ex
@@ -54,7 +54,8 @@ defmodule ImagePipe.Request.HTTPCache do
   def generated_cache_control, do: @generated_cache_control
 
   @doc false
-  @spec etag_material(Plug.Conn.t(), Plan.t(), term(), keyword()) :: {:ok, keyword()}
+  @spec etag_material(Plug.Conn.t(), Plan.t(), term(), keyword()) ::
+          {:ok, keyword()} | {:error, term()}
   def etag_material(conn, %Plan{} = plan, source_seed, opts) do
     with {:ok, plan_material} <- Key.plan_material(plan, opts) do
       {:ok,
@@ -176,13 +177,17 @@ defmodule ImagePipe.Request.HTTPCache do
   end
 
   defp do_generated_etag(conn, plan, %CacheSemantics{byte_identity: {:strong, seed}}, opts) do
-    {:ok, material} = etag_material(conn, plan, seed, opts)
+    case etag_material(conn, plan, seed, opts) do
+      {:ok, material} ->
+        material
+        |> serialize_material()
+        |> then(&:crypto.hash(:sha256, &1))
+        |> Base.url_encode64(padding: false)
+        |> then(&{:etag, ~s("ip#{@etag_schema}-#{&1}")})
 
-    material
-    |> serialize_material()
-    |> then(&:crypto.hash(:sha256, &1))
-    |> Base.url_encode64(padding: false)
-    |> then(&{:etag, ~s("ip#{@etag_schema}-#{&1}")})
+      {:error, _reason} ->
+        :not_generated
+    end
   end
 
   defp do_generated_etag(_conn, _plan, %CacheSemantics{byte_identity: :none}, _opts),

--- a/lib/image_pipe/request/http_cache.ex
+++ b/lib/image_pipe/request/http_cache.ex
@@ -78,7 +78,11 @@ defmodule ImagePipe.Request.HTTPCache do
 
   @spec evaluate_conditional(Plug.Conn.t(), CacheHeaders.t(), keyword()) ::
           :proceed | {:not_modified, [{String.t(), String.t()}]}
-  def evaluate_conditional(%Plug.Conn{method: "GET"} = conn, %CacheHeaders{etag: etag} = prepared, opts)
+  def evaluate_conditional(
+        %Plug.Conn{method: "GET"} = conn,
+        %CacheHeaders{etag: etag} = prepared,
+        opts
+      )
       when is_binary(etag) do
     if if_none_match?(conn, etag) do
       headers = not_modified_headers(prepared)
@@ -114,8 +118,15 @@ defmodule ImagePipe.Request.HTTPCache do
   defp effective_mode(%Resolved{http_cache: mode}, _opts) when mode in [:enabled, :disabled],
     do: mode
 
-  defp generated_cache_headers(_conn, _plan, _resolved, _opts, :disabled, _representation_headers),
-    do: {[], nil, nil}
+  defp generated_cache_headers(
+         _conn,
+         _plan,
+         _resolved,
+         _opts,
+         :disabled,
+         _representation_headers
+       ),
+       do: {[], nil, nil}
 
   defp generated_cache_headers(conn, plan, resolved, opts, :enabled, representation_headers) do
     cond do
@@ -324,7 +335,9 @@ defmodule ImagePipe.Request.HTTPCache do
   defp not_modified_headers(%CacheHeaders{} = prepared) do
     prepared.headers
     |> Kernel.++(prepared.representation_headers)
-    |> Enum.filter(fn {name, _value} -> String.downcase(name) in @not_modified_header_allowlist end)
+    |> Enum.filter(fn {name, _value} ->
+      String.downcase(name) in @not_modified_header_allowlist
+    end)
   end
 
   defp serialize_material(material) do

--- a/lib/image_pipe/request/http_cache.ex
+++ b/lib/image_pipe/request/http_cache.ex
@@ -1,0 +1,360 @@
+defmodule ImagePipe.Request.HTTPCache do
+  @moduledoc false
+
+  import Plug.Conn,
+    only: [get_req_header: 2, get_resp_header: 2, put_resp_header: 3, send_resp: 3]
+
+  alias ImagePipe.Cache.Key
+  alias ImagePipe.Output.Negotiation
+  alias ImagePipe.Plan
+  alias ImagePipe.Plan.Output
+  alias ImagePipe.Response.CacheHeaders
+  alias ImagePipe.Source.CacheSemantics
+  alias ImagePipe.Source.Resolved
+  alias ImagePipe.Telemetry
+
+  @etag_schema 1
+  @generated_cache_control "public, max-age=31536000, immutable"
+  @no_store "no-store"
+  @plug_default_cache_control "max-age=0, private, must-revalidate"
+  @not_modified_header_allowlist ~w(cache-control date etag expires vary)
+
+  @spec prepare(Plug.Conn.t(), Plan.t(), Resolved.t(), keyword()) :: CacheHeaders.t()
+  def prepare(%Plug.Conn{} = conn, %Plan{} = plan, %Resolved{} = resolved, opts) do
+    effective_mode = effective_mode(resolved, opts)
+    representation_headers = representation_headers(conn, plan)
+
+    {headers, etag, fallback_reason} =
+      generated_cache_headers(conn, plan, resolved, opts, effective_mode, representation_headers)
+
+    Telemetry.execute(
+      Telemetry.telemetry_opts(opts),
+      [:http_cache, :prepare],
+      %{},
+      %{
+        effective_mode: effective_mode,
+        byte_identity: byte_identity_kind(resolved.cache_semantics),
+        etag: etag_emitted?(etag)
+      }
+    )
+
+    emit_fallback_telemetry(fallback_reason, resolved, opts)
+
+    %CacheHeaders{
+      representation_headers: representation_headers,
+      headers: headers,
+      etag: etag
+    }
+  end
+
+  @doc false
+  @spec etag_schema() :: pos_integer()
+  def etag_schema, do: @etag_schema
+
+  @doc false
+  @spec generated_cache_control() :: String.t()
+  def generated_cache_control, do: @generated_cache_control
+
+  @doc false
+  @spec etag_material(Plug.Conn.t(), Plan.t(), term(), keyword()) :: {:ok, keyword()} | :omit_etag
+  def etag_material(conn, %Plan{} = plan, source_seed, opts) do
+    case Plan.canonical_representation_material(plan) do
+      {:ok, _representation_material} ->
+        with {:ok, plan_material} <- Key.plan_material(plan, opts) do
+          {:ok,
+           [
+             etag_schema: @etag_schema,
+             source: source_seed,
+             plan: Keyword.drop(plan_material, [:cache]),
+             accept: accept_material(conn, plan.output, opts),
+             representation_version: Key.representation_version()
+           ]}
+        end
+
+      :omit_etag ->
+        :omit_etag
+    end
+  end
+
+  @spec evaluate_conditional(Plug.Conn.t(), CacheHeaders.t(), keyword()) ::
+          :proceed | {:not_modified, [{String.t(), String.t()}]}
+  def evaluate_conditional(%Plug.Conn{method: "GET"} = conn, %CacheHeaders{etag: etag} = prepared, opts)
+      when is_binary(etag) do
+    if if_none_match?(conn, etag) do
+      headers = not_modified_headers(prepared)
+
+      Telemetry.execute(
+        Telemetry.telemetry_opts(opts),
+        [:http_cache, :conditional, :match],
+        %{},
+        %{method: :get}
+      )
+
+      {:not_modified, headers}
+    else
+      :proceed
+    end
+  end
+
+  def evaluate_conditional(%Plug.Conn{}, %CacheHeaders{}, _opts), do: :proceed
+
+  @spec send_not_modified(Plug.Conn.t(), [{String.t(), String.t()}]) :: Plug.Conn.t()
+  def send_not_modified(conn, headers) do
+    conn =
+      Enum.reduce(headers, conn, fn {name, value}, conn ->
+        put_resp_header(conn, name, value)
+      end)
+
+    send_resp(conn, 304, "")
+  end
+
+  defp effective_mode(%Resolved{http_cache: :inherit}, opts),
+    do: opts |> Keyword.fetch!(:http_cache) |> Keyword.fetch!(:mode)
+
+  defp effective_mode(%Resolved{http_cache: mode}, _opts) when mode in [:enabled, :disabled],
+    do: mode
+
+  defp generated_cache_headers(_conn, _plan, _resolved, _opts, :disabled, _representation_headers),
+    do: {[], nil, nil}
+
+  defp generated_cache_headers(conn, plan, resolved, opts, :enabled, representation_headers) do
+    cond do
+      has_resp_header?(conn, "set-cookie") ->
+        {[], nil, nil}
+
+      vary_star?(representation_headers) ->
+        {[], nil, nil}
+
+      selected_cache_control(conn) == @no_store ->
+        {[], nil, nil}
+
+      has_host_cache_control?(conn) ->
+        generated_etag_only(conn, plan, resolved, opts)
+
+      true ->
+        generated_cache_control_and_etag(conn, plan, resolved, opts)
+    end
+  end
+
+  defp generated_cache_control_and_etag(conn, plan, resolved, opts) do
+    case generated_etag(conn, plan, resolved, opts) do
+      {:etag, etag} ->
+        {[{"cache-control", @generated_cache_control}, {"etag", etag}], etag, nil}
+
+      :omit_etag ->
+        {[{"cache-control", @no_store}], nil, :missing_representation_material}
+
+      :not_generated ->
+        case resolved.cache_semantics do
+          %CacheSemantics{byte_identity: :none} ->
+            {[{"cache-control", @no_store}], nil, :missing_byte_identity}
+
+          %CacheSemantics{byte_identity: {:strong, _seed}} ->
+            if has_resp_header?(conn, "etag"),
+              do: {[{"cache-control", @generated_cache_control}], nil, nil},
+              else: {[], nil, nil}
+        end
+    end
+  end
+
+  defp generated_etag_only(conn, plan, resolved, opts) do
+    case generated_etag(conn, plan, resolved, opts) do
+      {:etag, etag} -> {[{"etag", etag}], etag, nil}
+      :omit_etag -> {[], nil, nil}
+      :not_generated -> {[], nil, nil}
+    end
+  end
+
+  defp generated_etag(conn, plan, %Resolved{cache_semantics: cache_semantics}, opts) do
+    cond do
+      has_resp_header?(conn, "etag") ->
+        :not_generated
+
+      selected_cache_control(conn) == @no_store ->
+        :not_generated
+
+      true ->
+        do_generated_etag(conn, plan, cache_semantics, opts)
+    end
+  end
+
+  defp do_generated_etag(conn, plan, %CacheSemantics{byte_identity: {:strong, seed}}, opts) do
+    case etag_material(conn, plan, seed, opts) do
+      {:ok, material} ->
+        material
+        |> serialize_material()
+        |> then(&:crypto.hash(:sha256, &1))
+        |> Base.url_encode64(padding: false)
+        |> then(&{:etag, ~s("ip#{@etag_schema}-#{&1}")})
+
+      :omit_etag ->
+        :omit_etag
+    end
+  end
+
+  defp do_generated_etag(_conn, _plan, %CacheSemantics{byte_identity: :none}, _opts),
+    do: :not_generated
+
+  defp accept_material(conn, %Output{mode: :automatic}, opts) do
+    conn
+    |> get_req_header("accept")
+    |> Enum.join(",")
+    |> Negotiation.modern_candidates(opts)
+  end
+
+  defp accept_material(_conn, %Output{}, _opts), do: []
+
+  defp representation_headers(conn, %Plan{output: %Output{mode: :automatic}}),
+    do: merge_vary(conn, "Accept")
+
+  defp representation_headers(_conn, %Plan{}), do: []
+
+  defp merge_vary(conn, added_name) do
+    existing =
+      conn
+      |> get_resp_header("vary")
+      |> Enum.flat_map(&split_vary/1)
+
+    values =
+      existing
+      |> Kernel.++([added_name])
+      |> dedupe_tokens()
+
+    if Enum.any?(existing, &(String.downcase(&1) == "*")),
+      do: [{"vary", "*"}],
+      else: [{"vary", Enum.join(values, ", ")}]
+  end
+
+  defp split_vary(value) do
+    value
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp dedupe_tokens(tokens) do
+    Enum.reduce(tokens, [], fn token, acc ->
+      if Enum.any?(acc, &(String.downcase(&1) == String.downcase(token))),
+        do: acc,
+        else: acc ++ [token]
+    end)
+  end
+
+  defp vary_star?(headers) do
+    Enum.any?(headers, fn
+      {"vary", value} -> "*" in split_vary(value)
+      _header -> false
+    end)
+  end
+
+  defp selected_cache_control(conn) do
+    conn
+    |> get_resp_header("cache-control")
+    |> Enum.join(",")
+    |> String.downcase()
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.find(&(&1 == "no-store"))
+  end
+
+  defp has_resp_header?(conn, name), do: get_resp_header(conn, name) != []
+
+  defp has_host_cache_control?(conn) do
+    case get_resp_header(conn, "cache-control") do
+      [] -> false
+      [@plug_default_cache_control] -> false
+      _headers -> true
+    end
+  end
+
+  defp byte_identity_kind(%CacheSemantics{byte_identity: {:strong, _seed}}), do: :strong
+  defp byte_identity_kind(%CacheSemantics{byte_identity: :none}), do: :none
+
+  defp etag_emitted?(nil), do: false
+  defp etag_emitted?(_etag), do: true
+
+  defp emit_fallback_telemetry(nil, _resolved, _opts), do: :ok
+
+  defp emit_fallback_telemetry(reason, resolved, opts) do
+    Telemetry.execute(
+      Telemetry.telemetry_opts(opts),
+      [:http_cache, :fallback, :no_store],
+      %{},
+      %{
+        adapter: resolved.adapter,
+        source_kind: resolved.source_kind,
+        reason: reason
+      }
+    )
+  end
+
+  defp if_none_match?(conn, etag) do
+    conn
+    |> get_req_header("if-none-match")
+    |> Enum.join(",")
+    |> parse_if_none_match()
+    |> tags_match?(etag)
+  end
+
+  defp parse_if_none_match(""), do: []
+
+  defp parse_if_none_match(value) do
+    tags =
+      value
+      |> String.split(",")
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+
+    if "*" in tags, do: :wildcard, else: tags
+  end
+
+  defp tags_match?(:wildcard, _etag), do: false
+  defp tags_match?(tags, etag), do: Enum.any?(tags, &weak_entity_match?(&1, etag))
+
+  defp weak_entity_match?(candidate, etag),
+    do: quoted_entity_tag?(candidate) and strip_weak(candidate) == strip_weak(etag)
+
+  defp quoted_entity_tag?("W/\"" <> rest), do: String.ends_with?(rest, "\"")
+  defp quoted_entity_tag?("\"" <> rest), do: String.ends_with?(rest, "\"")
+  defp quoted_entity_tag?(_value), do: false
+
+  defp strip_weak("W/" <> rest), do: rest
+  defp strip_weak(value), do: value
+
+  defp not_modified_headers(%CacheHeaders{} = prepared) do
+    prepared.headers
+    |> Kernel.++(prepared.representation_headers)
+    |> Enum.filter(fn {name, _value} -> String.downcase(name) in @not_modified_header_allowlist end)
+  end
+
+  defp serialize_material(material) do
+    material
+    |> canonicalize()
+    |> :erlang.term_to_binary([:deterministic])
+  end
+
+  defp canonicalize(value) when is_list(value) do
+    if Keyword.keyword?(value) do
+      value
+      |> Enum.map(fn {key, item} -> {canonicalize(key), canonicalize(item)} end)
+      |> Enum.sort_by(fn {key, _item} -> key end)
+    else
+      Enum.map(value, &canonicalize/1)
+    end
+  end
+
+  defp canonicalize(value) when is_map(value) do
+    value
+    |> Enum.map(fn {key, item} -> {canonicalize(key), canonicalize(item)} end)
+    |> Enum.sort()
+  end
+
+  defp canonicalize(value) when is_tuple(value) do
+    value
+    |> Tuple.to_list()
+    |> Enum.map(&canonicalize/1)
+    |> List.to_tuple()
+  end
+
+  defp canonicalize(value), do: value
+end

--- a/lib/image_pipe/request/options.ex
+++ b/lib/image_pipe/request/options.ex
@@ -5,7 +5,7 @@ defmodule ImagePipe.Request.Options do
   alias ImagePipe.Source
   alias ImagePipe.Telemetry
 
-  @parser_visible_option_keys [:parser, :clock, :telemetry_prefix]
+  @validated_option_keys [:parser, :clock, :telemetry_prefix, :http_cache]
   @stale_origin_option_keys [
     :root_url,
     :origin_req_options,
@@ -26,6 +26,13 @@ defmodule ImagePipe.Request.Options do
                     telemetry_prefix: [
                       type: {:custom, __MODULE__, :validate_telemetry_prefix, []},
                       default: Telemetry.default_prefix()
+                    ],
+                    http_cache: [
+                      type: :keyword_list,
+                      default: [mode: :disabled],
+                      keys: [
+                        mode: [type: {:in, [:disabled, :enabled]}, default: :disabled]
+                      ]
                     ]
                   )
 
@@ -60,7 +67,7 @@ defmodule ImagePipe.Request.Options do
     do: {:error, "expected a non-empty list of atoms"}
 
   defp validate_known_opts!(opts) do
-    known_opts = Keyword.take(opts, @parser_visible_option_keys)
+    known_opts = Keyword.take(opts, @validated_option_keys)
 
     case NimbleOptions.validate(known_opts, @options_schema) do
       {:ok, validated_opts} ->

--- a/lib/image_pipe/request/runner.ex
+++ b/lib/image_pipe/request/runner.ex
@@ -35,10 +35,20 @@ defmodule ImagePipe.Request.Runner do
     run_with_cache_config(conn, plan, resolved_source, opts)
   end
 
-  defp run_with_cache_config(conn, plan, %Source.Resolved{cache: :skip} = resolved_source, opts),
+  defp run_with_cache_config(
+         conn,
+         plan,
+         %Source.Resolved{internal_cache: :disabled} = resolved_source,
+         opts
+       ),
     do: process_prepared_stream(conn, plan, resolved_source, nil, opts)
 
-  defp run_with_cache_config(conn, plan, %Source.Resolved{cache: :normal} = resolved_source, opts) do
+  defp run_with_cache_config(
+         conn,
+         plan,
+         %Source.Resolved{internal_cache: :enabled} = resolved_source,
+         opts
+       ) do
     telemetry_opts = Telemetry.telemetry_opts(opts)
 
     result =

--- a/lib/image_pipe/request/runner.ex
+++ b/lib/image_pipe/request/runner.ex
@@ -43,22 +43,6 @@ defmodule ImagePipe.Request.Runner do
     run_with_cache_config(conn, plan, resolved_source, prepared_http_cache, opts)
   end
 
-  def run(conn, %Plan{} = plan, %Source.Resolved{} = resolved_source, opts) do
-    conn
-    |> run(plan, resolved_source, empty_cache_headers(), opts)
-    |> drop_prepared_http_cache()
-  end
-
-  defp drop_prepared_http_cache({:ok, {:cache_entry, entry, response, %CacheHeaders{}}}),
-    do: {:ok, {:cache_entry, entry, response}}
-
-  defp drop_prepared_http_cache(
-         {:ok, {:prepared_stream, prepared_stream, response, %CacheHeaders{}}}
-       ),
-       do: {:ok, {:prepared_stream, prepared_stream, response}}
-
-  defp drop_prepared_http_cache(result), do: result
-
   defp run_with_cache_config(
          conn,
          plan,
@@ -227,8 +211,4 @@ defmodule ImagePipe.Request.Runner do
 
   defp cache_lookup_stop_metadata({:error, {:cache_read, error}}),
     do: %{result: :cache_error, cache: :read_error, error: Error.tag(error)}
-
-  defp empty_cache_headers do
-    %CacheHeaders{representation_headers: [], headers: [], etag: nil}
-  end
 end

--- a/lib/image_pipe/request/runner.ex
+++ b/lib/image_pipe/request/runner.ex
@@ -12,13 +12,14 @@ defmodule ImagePipe.Request.Runner do
   alias ImagePipe.Request.SourceSession.Prepared, as: SessionPrepared
   alias ImagePipe.Request.SourceSession.Request, as: SessionRequest
   alias ImagePipe.Request.SourceSessionSupervisor
+  alias ImagePipe.Response.CacheHeaders
   alias ImagePipe.Response.PreparedStream
   alias ImagePipe.Source
   alias ImagePipe.Telemetry
 
   @type delivery() ::
-          {:cache_entry, Entry.t(), Response.t()}
-          | {:prepared_stream, PreparedStream.t(), Response.t()}
+          {:cache_entry, Entry.t(), Response.t(), CacheHeaders.t()}
+          | {:prepared_stream, PreparedStream.t(), Response.t(), CacheHeaders.t()}
 
   @type error() ::
           {:cache, term()}
@@ -28,25 +29,50 @@ defmodule ImagePipe.Request.Runner do
           Plug.Conn.t(),
           Plan.t(),
           Source.Resolved.t(),
+          CacheHeaders.t(),
           keyword()
         ) ::
           {:ok, delivery()} | {:error, error()}
-  def run(conn, %Plan{} = plan, %Source.Resolved{} = resolved_source, opts) do
-    run_with_cache_config(conn, plan, resolved_source, opts)
+  def run(
+        conn,
+        %Plan{} = plan,
+        %Source.Resolved{} = resolved_source,
+        %CacheHeaders{} = prepared_http_cache,
+        opts
+      ) do
+    run_with_cache_config(conn, plan, resolved_source, prepared_http_cache, opts)
   end
+
+  def run(conn, %Plan{} = plan, %Source.Resolved{} = resolved_source, opts) do
+    conn
+    |> run(plan, resolved_source, empty_cache_headers(), opts)
+    |> drop_prepared_http_cache()
+  end
+
+  defp drop_prepared_http_cache({:ok, {:cache_entry, entry, response, %CacheHeaders{}}}),
+    do: {:ok, {:cache_entry, entry, response}}
+
+  defp drop_prepared_http_cache(
+         {:ok, {:prepared_stream, prepared_stream, response, %CacheHeaders{}}}
+       ),
+       do: {:ok, {:prepared_stream, prepared_stream, response}}
+
+  defp drop_prepared_http_cache(result), do: result
 
   defp run_with_cache_config(
          conn,
          plan,
          %Source.Resolved{internal_cache: :disabled} = resolved_source,
+         prepared_http_cache,
          opts
        ),
-    do: process_prepared_stream(conn, plan, resolved_source, nil, opts)
+       do: process_prepared_stream(conn, plan, resolved_source, nil, prepared_http_cache, opts)
 
   defp run_with_cache_config(
          conn,
          plan,
          %Source.Resolved{internal_cache: :enabled} = resolved_source,
+         prepared_http_cache,
          opts
        ) do
     telemetry_opts = Telemetry.telemetry_opts(opts)
@@ -64,27 +90,34 @@ defmodule ImagePipe.Request.Runner do
 
     case result do
       :disabled ->
-        process_prepared_stream(conn, plan, resolved_source, nil, opts)
+        process_prepared_stream(conn, plan, resolved_source, nil, prepared_http_cache, opts)
 
       {:hit, %Key{}, %Entry{} = entry} ->
-        {:ok, {:cache_entry, entry, plan.response}}
+        {:ok, {:cache_entry, entry, plan.response, prepared_http_cache}}
 
       {:miss, %Key{} = key} ->
-        process_cacheable_miss(conn, plan, resolved_source, key, opts)
+        process_cacheable_miss(conn, plan, resolved_source, key, prepared_http_cache, opts)
 
       {:miss, %Key{} = key, {:cache_read, _error}} ->
-        process_cacheable_miss(conn, plan, resolved_source, key, opts)
+        process_cacheable_miss(conn, plan, resolved_source, key, prepared_http_cache, opts)
 
       {:error, {:cache_read, error}} ->
         {:error, {:cache, error}}
     end
   end
 
-  defp process_cacheable_miss(conn, plan, resolved_source, %Key{} = key, opts) do
-    process_prepared_stream(conn, plan, resolved_source, key, opts)
+  defp process_cacheable_miss(
+         conn,
+         plan,
+         resolved_source,
+         %Key{} = key,
+         prepared_http_cache,
+         opts
+       ) do
+    process_prepared_stream(conn, plan, resolved_source, key, prepared_http_cache, opts)
   end
 
-  defp process_prepared_stream(conn, plan, resolved_source, cache_key, opts) do
+  defp process_prepared_stream(conn, plan, resolved_source, cache_key, prepared_http_cache, opts) do
     policy = Policy.from_output_plan(conn, plan.output, opts)
 
     request = %SessionRequest{
@@ -99,19 +132,31 @@ defmodule ImagePipe.Request.Runner do
 
     case SourceSessionSupervisor.start_session(supervisor, request) do
       {:ok, session} ->
-        prepare_supervised_session(session, supervisor, plan.response, policy)
+        prepare_supervised_session(
+          session,
+          supervisor,
+          plan.response,
+          policy,
+          prepared_http_cache
+        )
 
       {:error, reason} ->
         {:error, {:processing, normalize_session_prepare_error(reason), policy.headers}}
     end
   end
 
-  defp prepare_supervised_session(session, supervisor, %Response{} = response, %Policy{} = policy) do
+  defp prepare_supervised_session(
+         session,
+         supervisor,
+         %Response{} = response,
+         %Policy{} = policy,
+         %CacheHeaders{} = prepared_http_cache
+       ) do
     case SourceSession.prepare(session) do
       {:ok, %SessionPrepared{} = prepared} ->
         case prepared_stream(session, supervisor, prepared, response) do
           {:ok, %PreparedStream{} = prepared_stream} ->
-            {:ok, {:prepared_stream, prepared_stream, response}}
+            {:ok, {:prepared_stream, prepared_stream, response, prepared_http_cache}}
 
           {:error, reason} ->
             _stop_result = SourceSessionSupervisor.stop_session(supervisor, session)
@@ -182,4 +227,8 @@ defmodule ImagePipe.Request.Runner do
 
   defp cache_lookup_stop_metadata({:error, {:cache_read, error}}),
     do: %{result: :cache_error, cache: :read_error, error: Error.tag(error)}
+
+  defp empty_cache_headers do
+    %CacheHeaders{representation_headers: [], headers: [], etag: nil}
+  end
 end

--- a/lib/image_pipe/request/source_session.ex
+++ b/lib/image_pipe/request/source_session.ex
@@ -8,7 +8,7 @@ defmodule ImagePipe.Request.SourceSession do
   alias ImagePipe.Request.SourceSession.Producer
   alias ImagePipe.Request.SourceSession.Request
 
-  @call_timeout 30_000
+  @call_timeout 15_000
   @cancel_timeout 2_000
   @shutdown_timeout 2_000
 

--- a/lib/image_pipe/request/source_session.ex
+++ b/lib/image_pipe/request/source_session.ex
@@ -8,7 +8,7 @@ defmodule ImagePipe.Request.SourceSession do
   alias ImagePipe.Request.SourceSession.Producer
   alias ImagePipe.Request.SourceSession.Request
 
-  @call_timeout 15_000
+  @call_timeout 30_000
   @cancel_timeout 2_000
   @shutdown_timeout 2_000
 

--- a/lib/image_pipe/request/source_session/producer.ex
+++ b/lib/image_pipe/request/source_session/producer.ex
@@ -11,7 +11,7 @@ defmodule ImagePipe.Request.SourceSession.Producer do
   alias ImagePipe.Telemetry
   alias ImagePipe.Transform.State
 
-  @call_timeout 30_000
+  @call_timeout 15_000
   @halt_timeout 2_000
 
   defstruct [

--- a/lib/image_pipe/request/source_session/producer.ex
+++ b/lib/image_pipe/request/source_session/producer.ex
@@ -11,7 +11,7 @@ defmodule ImagePipe.Request.SourceSession.Producer do
   alias ImagePipe.Telemetry
   alias ImagePipe.Transform.State
 
-  @call_timeout 15_000
+  @call_timeout 30_000
   @halt_timeout 2_000
 
   defstruct [

--- a/lib/image_pipe/response.ex
+++ b/lib/image_pipe/response.ex
@@ -11,6 +11,7 @@ defmodule ImagePipe.Response do
       ImagePipe.Telemetry
     ],
     exports: [
+      CacheHeaders,
       PreparedStream,
       Sender
     ]

--- a/lib/image_pipe/response/cache_headers.ex
+++ b/lib/image_pipe/response/cache_headers.ex
@@ -1,0 +1,13 @@
+defmodule ImagePipe.Response.CacheHeaders do
+  @moduledoc false
+
+  @enforce_keys [:representation_headers, :headers, :etag]
+  defstruct @enforce_keys
+
+  @type header :: {String.t(), String.t()}
+  @type t :: %__MODULE__{
+          representation_headers: [header()],
+          headers: [header()],
+          etag: String.t() | nil
+        }
+end

--- a/lib/image_pipe/response/cache_headers.ex
+++ b/lib/image_pipe/response/cache_headers.ex
@@ -4,10 +4,18 @@ defmodule ImagePipe.Response.CacheHeaders do
   @enforce_keys [:representation_headers, :headers, :etag]
   defstruct @enforce_keys
 
+  @plug_default_cache_control "max-age=0, private, must-revalidate"
+
   @type header :: {String.t(), String.t()}
   @type t :: %__MODULE__{
           representation_headers: [header()],
           headers: [header()],
           etag: String.t() | nil
         }
+
+  @doc false
+  @spec host_cache_control?([String.t()]) :: boolean()
+  def host_cache_control?([]), do: false
+  def host_cache_control?([@plug_default_cache_control]), do: false
+  def host_cache_control?(_headers), do: true
 end

--- a/lib/image_pipe/response/sender.ex
+++ b/lib/image_pipe/response/sender.ex
@@ -21,7 +21,7 @@ defmodule ImagePipe.Response.Sender do
   alias ImagePipe.Response.PreparedStream
   alias ImagePipe.Telemetry
 
-  @plug_default_cache_control "max-age=0, private, must-revalidate"
+  @not_modified_header_allowlist ~w(cache-control date etag expires vary)
 
   @type delivery() ::
           {:cache_entry, Entry.t(), Response.t(), CacheHeaders.t()}
@@ -59,28 +59,12 @@ defmodule ImagePipe.Response.Sender do
 
   def send_result(
         %Plug.Conn{} = conn,
-        {:ok, {:cache_entry, %Entry{} = entry, %Response{} = response}},
-        opts
-      ) do
-    send_cache_entry(conn, entry, response, empty_cache_headers(), opts)
-  end
-
-  def send_result(
-        %Plug.Conn{} = conn,
         {:ok,
          {:prepared_stream, %PreparedStream{} = prepared_stream, %Response{} = response,
           %CacheHeaders{} = prepared}},
         opts
       ) do
     send_prepared_stream(conn, prepared_stream, response, prepared, opts)
-  end
-
-  def send_result(
-        %Plug.Conn{} = conn,
-        {:ok, {:prepared_stream, %PreparedStream{} = prepared_stream, %Response{} = response}},
-        opts
-      ) do
-    send_prepared_stream(conn, prepared_stream, response, empty_cache_headers(), opts)
   end
 
   def send_result(conn, {:error, {:cache, error}}, _opts) do
@@ -105,6 +89,16 @@ defmodule ImagePipe.Response.Sender do
     |> put_resp_headers(response_headers)
     |> put_resp_content_type("text/plain")
     |> send_resp(422, "invalid image source")
+  end
+
+  @spec send_not_modified(Plug.Conn.t(), CacheHeaders.t()) :: Plug.Conn.t()
+  def send_not_modified(%Plug.Conn{} = conn, %CacheHeaders{} = prepared) do
+    prepared
+    |> not_modified_headers()
+    |> Enum.reduce(conn, fn {name, value}, conn ->
+      put_resp_header(conn, name, value)
+    end)
+    |> send_resp(304, "")
   end
 
   defp handle_processing_error(
@@ -439,11 +433,9 @@ defmodule ImagePipe.Response.Sender do
   end
 
   defp host_resp_header?(conn, "cache-control") do
-    case Plug.Conn.get_resp_header(conn, "cache-control") do
-      [] -> false
-      [@plug_default_cache_control] -> false
-      _headers -> true
-    end
+    conn
+    |> Plug.Conn.get_resp_header("cache-control")
+    |> CacheHeaders.host_cache_control?()
   end
 
   defp host_resp_header?(conn, name), do: Plug.Conn.get_resp_header(conn, name) != []
@@ -461,8 +453,12 @@ defmodule ImagePipe.Response.Sender do
     |> send_resp(500, "error encoding image")
   end
 
-  defp empty_cache_headers do
-    %CacheHeaders{representation_headers: [], headers: [], etag: nil}
+  defp not_modified_headers(%CacheHeaders{} = prepared) do
+    prepared.headers
+    |> Kernel.++(prepared.representation_headers)
+    |> Enum.filter(fn {name, _value} ->
+      String.downcase(name) in @not_modified_header_allowlist
+    end)
   end
 
   defp output_metadata(%Resolved{format: format}), do: %{output_format: format}

--- a/lib/image_pipe/response/sender.ex
+++ b/lib/image_pipe/response/sender.ex
@@ -17,12 +17,15 @@ defmodule ImagePipe.Response.Sender do
   alias ImagePipe.Error
   alias ImagePipe.Output.Resolved
   alias ImagePipe.Plan.Response
+  alias ImagePipe.Response.CacheHeaders
   alias ImagePipe.Response.PreparedStream
   alias ImagePipe.Telemetry
 
+  @plug_default_cache_control "max-age=0, private, must-revalidate"
+
   @type delivery() ::
-          {:cache_entry, Entry.t(), Response.t()}
-          | {:prepared_stream, PreparedStream.t(), Response.t()}
+          {:cache_entry, Entry.t(), Response.t(), CacheHeaders.t()}
+          | {:prepared_stream, PreparedStream.t(), Response.t(), CacheHeaders.t()}
 
   @type error() ::
           {:cache, term()}
@@ -47,10 +50,29 @@ defmodule ImagePipe.Response.Sender do
         ) :: Plug.Conn.t()
   def send_result(
         %Plug.Conn{} = conn,
-        {:ok, {:cache_entry, %Entry{} = entry, %Response{} = response}},
-        _opts
+        {:ok,
+         {:cache_entry, %Entry{} = entry, %Response{} = response, %CacheHeaders{} = prepared}},
+        opts
       ) do
-    send_cache_entry(conn, entry, response)
+    send_cache_entry(conn, entry, response, prepared, opts)
+  end
+
+  def send_result(
+        %Plug.Conn{} = conn,
+        {:ok, {:cache_entry, %Entry{} = entry, %Response{} = response}},
+        opts
+      ) do
+    send_cache_entry(conn, entry, response, empty_cache_headers(), opts)
+  end
+
+  def send_result(
+        %Plug.Conn{} = conn,
+        {:ok,
+         {:prepared_stream, %PreparedStream{} = prepared_stream, %Response{} = response,
+          %CacheHeaders{} = prepared}},
+        opts
+      ) do
+    send_prepared_stream(conn, prepared_stream, response, prepared, opts)
   end
 
   def send_result(
@@ -58,7 +80,7 @@ defmodule ImagePipe.Response.Sender do
         {:ok, {:prepared_stream, %PreparedStream{} = prepared_stream, %Response{} = response}},
         opts
       ) do
-    send_prepared_stream(conn, prepared_stream, response, opts)
+    send_prepared_stream(conn, prepared_stream, response, empty_cache_headers(), opts)
   end
 
   def send_result(conn, {:error, {:cache, error}}, _opts) do
@@ -164,9 +186,27 @@ defmodule ImagePipe.Response.Sender do
     |> send_resp(422, "invalid image transform")
   end
 
-  defp send_cache_entry(%Plug.Conn{} = conn, %Entry{} = entry, %Response{} = response) do
+  defp send_cache_entry(
+         %Plug.Conn{} = conn,
+         %Entry{} = entry,
+         %Response{} = response,
+         %CacheHeaders{} = prepared,
+         opts
+       ) do
     with {:ok, headers} <- Entry.cacheable_headers(entry.headers),
-         {:ok, headers} <- delivery_headers(headers, response, entry.content_type) do
+         merged_headers <- merge_delivery_headers(conn, headers, prepared),
+         {:ok, headers} <- delivery_headers(merged_headers, response, entry.content_type) do
+      Telemetry.execute(
+        Telemetry.telemetry_opts(opts),
+        [:http_cache, :cache_hit, :headers],
+        %{},
+        %{
+          etag: prepared.etag != nil,
+          generated_cache_headers: prepared.headers != [],
+          representation_headers: prepared.representation_headers != []
+        }
+      )
+
       send_normalized_cache_entry(conn, entry, headers)
     else
       {:error, error} -> send_cache_error(conn, error)
@@ -188,6 +228,7 @@ defmodule ImagePipe.Response.Sender do
          %Plug.Conn{} = conn,
          %PreparedStream{} = prepared_stream,
          %Response{},
+         %CacheHeaders{} = prepared,
          opts
        ) do
     telemetry_opts = Telemetry.telemetry_opts(opts)
@@ -197,6 +238,7 @@ defmodule ImagePipe.Response.Sender do
       [:encode],
       output_metadata(prepared_stream.resolved_output),
       fn ->
+        prepared_stream = merge_prepared_stream_headers(conn, prepared_stream, prepared)
         {conn, outcome} = do_send_prepared_stream(conn, prepared_stream)
 
         {conn, prepared_encode_stop_metadata(outcome, conn, prepared_stream.resolved_output)}
@@ -340,6 +382,72 @@ defmodule ImagePipe.Response.Sender do
     end
   end
 
+  defp merge_prepared_stream_headers(
+         %Plug.Conn{} = conn,
+         %PreparedStream{} = prepared_stream,
+         %CacheHeaders{} = prepared
+       ) do
+    headers = merge_delivery_headers(conn, prepared_stream.headers, prepared)
+    %{prepared_stream | headers: headers}
+  end
+
+  defp merge_delivery_headers(%Plug.Conn{} = conn, delivery_headers, %CacheHeaders{} = prepared) do
+    authoritative_names = authoritative_header_names(prepared.representation_headers)
+
+    []
+    |> merge_header_list(prepared.headers)
+    |> merge_authoritative_header_list(prepared.representation_headers)
+    |> merge_header_list(delivery_headers)
+    |> reject_existing_conn_headers(conn, authoritative_names)
+  end
+
+  defp merge_header_list(headers, new_headers) do
+    Enum.reduce(new_headers, headers, fn {name, value}, headers ->
+      name = String.downcase(name)
+
+      if Enum.any?(headers, fn {existing_name, _value} ->
+           String.downcase(existing_name) == name
+         end) do
+        headers
+      else
+        headers ++ [{name, value}]
+      end
+    end)
+  end
+
+  defp merge_authoritative_header_list(headers, new_headers) do
+    Enum.reduce(new_headers, headers, fn {name, value}, headers ->
+      name = String.downcase(name)
+
+      headers
+      |> Enum.reject(fn {existing_name, _value} -> String.downcase(existing_name) == name end)
+      |> Kernel.++([{name, value}])
+    end)
+  end
+
+  defp reject_existing_conn_headers(headers, %Plug.Conn{} = conn, authoritative_names) do
+    Enum.reject(headers, fn {name, _value} ->
+      name = String.downcase(name)
+      name not in authoritative_names and host_resp_header?(conn, name)
+    end)
+  end
+
+  defp authoritative_header_names(headers) do
+    headers
+    |> Enum.map(fn {name, _value} -> String.downcase(name) end)
+    |> Enum.uniq()
+  end
+
+  defp host_resp_header?(conn, "cache-control") do
+    case Plug.Conn.get_resp_header(conn, "cache-control") do
+      [] -> false
+      [@plug_default_cache_control] -> false
+      _headers -> true
+    end
+  end
+
+  defp host_resp_header?(conn, name), do: Plug.Conn.get_resp_header(conn, name) != []
+
   defp put_resp_headers(%Plug.Conn{} = conn, response_headers) do
     Enum.reduce(response_headers, conn, fn {name, value}, conn ->
       put_resp_header(conn, name, value)
@@ -351,6 +459,10 @@ defmodule ImagePipe.Response.Sender do
     |> put_resp_headers(response_headers)
     |> put_resp_content_type("text/plain")
     |> send_resp(500, "error encoding image")
+  end
+
+  defp empty_cache_headers do
+    %CacheHeaders{representation_headers: [], headers: [], etag: nil}
   end
 
   defp output_metadata(%Resolved{format: format}), do: %{output_format: format}

--- a/lib/image_pipe/source.ex
+++ b/lib/image_pipe/source.ex
@@ -201,11 +201,13 @@ defmodule ImagePipe.Source do
       Identity.valid?(resolved.identity)
   end
 
-  defp valid_cache_semantics?(%CacheSemantics{byte_identity: :none, stable?: stable?}),
-    do: is_boolean(stable?)
+  defp valid_cache_semantics?(%CacheSemantics{byte_identity: :none, stable?: false}), do: true
 
-  defp valid_cache_semantics?(%CacheSemantics{byte_identity: {:strong, _seed}, stable?: stable?}),
-    do: is_boolean(stable?)
+  defp valid_cache_semantics?(%CacheSemantics{
+         byte_identity: {:strong, _seed},
+         stable?: true
+       }),
+       do: true
 
   defp valid_cache_semantics?(_cache_semantics), do: false
 

--- a/lib/image_pipe/source.ex
+++ b/lib/image_pipe/source.ex
@@ -5,6 +5,7 @@ defmodule ImagePipe.Source do
     top_level?: true,
     deps: [ImagePipe.Error, ImagePipe.Plan, ImagePipe.Telemetry],
     exports: [
+      CacheSemantics,
       Resolved,
       Response,
       StreamError,
@@ -16,6 +17,7 @@ defmodule ImagePipe.Source do
   alias ImagePipe.Plan.Source, as: PlanSource
   alias ImagePipe.Plan.Source.Identity
   alias ImagePipe.Error
+  alias ImagePipe.Source.CacheSemantics
   alias ImagePipe.Source.Resolved
   alias ImagePipe.Source.Response
   alias ImagePipe.Source.WrappedStream
@@ -29,7 +31,8 @@ defmodule ImagePipe.Source do
   @callback fetch(Resolved.t(), keyword(), keyword()) :: {:ok, Response.t()} | {:error, error()}
 
   @source_kinds [:path, :url, :object, :reference]
-  @cache_policies [:normal, :skip]
+  @internal_cache_policies [:enabled, :disabled]
+  @http_cache_policies [:inherit, :enabled, :disabled]
 
   @spec validate_config(keyword()) :: {:ok, keyword()} | {:error, error()}
   def validate_config(opts) when is_list(opts) do
@@ -190,13 +193,21 @@ defmodule ImagePipe.Source do
 
   defp validate_resolved(%Resolved{}, _adapter), do: {:error, {:source, :invalid_adapter_result}}
 
-  defp valid_resolved?(%Resolved{
-         source_kind: source_kind,
-         identity: identity,
-         cache: cache
-       }) do
-    source_kind in @source_kinds and cache in @cache_policies and Identity.valid?(identity)
+  defp valid_resolved?(%Resolved{} = resolved) do
+    resolved.source_kind in @source_kinds and
+      resolved.internal_cache in @internal_cache_policies and
+      resolved.http_cache in @http_cache_policies and
+      valid_cache_semantics?(resolved.cache_semantics) and
+      Identity.valid?(resolved.identity)
   end
+
+  defp valid_cache_semantics?(%CacheSemantics{byte_identity: :none, stable?: stable?}),
+    do: is_boolean(stable?)
+
+  defp valid_cache_semantics?(%CacheSemantics{byte_identity: {:strong, _seed}, stable?: stable?}),
+    do: is_boolean(stable?)
+
+  defp valid_cache_semantics?(_cache_semantics), do: false
 
   defp source_metadata(source_kind, adapter_opts) do
     %{

--- a/lib/image_pipe/source/cache_semantics.ex
+++ b/lib/image_pipe/source/cache_semantics.ex
@@ -1,0 +1,19 @@
+defmodule ImagePipe.Source.CacheSemantics do
+  @moduledoc """
+  Source-owned cache facts used by internal and HTTP cache decisions.
+
+  `byte_identity` seeds must be deterministic, non-secret, and stable across
+  nodes for the same source bytes. The core validates the tagged shape but does
+  not validate seed contents structurally.
+  """
+
+  @enforce_keys [:byte_identity, :stable?]
+  defstruct @enforce_keys
+
+  @type byte_identity :: {:strong, term()} | :none
+
+  @type t :: %__MODULE__{
+          byte_identity: byte_identity(),
+          stable?: boolean()
+        }
+end

--- a/lib/image_pipe/source/cache_semantics.ex
+++ b/lib/image_pipe/source/cache_semantics.ex
@@ -5,6 +5,10 @@ defmodule ImagePipe.Source.CacheSemantics do
   `byte_identity` seeds must be deterministic, non-secret, and stable across
   nodes for the same source bytes. The core validates the tagged shape but does
   not validate seed contents structurally.
+
+  A strong byte identity is only valid when `stable?` is `true`. Sources that
+  cannot provide a stable byte identity must use `byte_identity: :none` and
+  `stable?: false`.
   """
 
   @enforce_keys [:byte_identity, :stable?]

--- a/lib/image_pipe/source/file.ex
+++ b/lib/image_pipe/source/file.ex
@@ -5,13 +5,16 @@ defmodule ImagePipe.Source.File do
 
   alias ImagePipe.Plan.Source.Path, as: SourcePath
   alias ImagePipe.Source
+  alias ImagePipe.Source.CacheSemantics
   alias ImagePipe.Source.Resolved
   alias ImagePipe.Source.Response
 
   @options_schema NimbleOptions.new!(
                     root: [type: :string, required: true],
                     root_id: [type: :string, required: true],
-                    cache: [type: {:in, [:normal, :skip]}, default: :normal]
+                    stable: [type: {:in, [:auto, :trusted]}, default: :auto],
+                    internal_cache: [type: {:in, [:auto, :enabled, :disabled]}, default: :auto],
+                    http_cache: [type: {:in, [:inherit, :disabled, :enabled]}, default: :inherit]
                   )
 
   @impl Source
@@ -34,17 +37,23 @@ defmodule ImagePipe.Source.File do
   def resolve(%SourcePath{segments: segments}, opts, _runtime_opts) do
     with :ok <- validate_segments(segments),
          {:ok, path} <- safe_path(opts, segments) do
+      identity = [
+        kind: :path,
+        adapter: :path,
+        root: Keyword.fetch!(opts, :root_id),
+        path: segments
+      ]
+
+      stable? = Keyword.fetch!(opts, :stable) == :trusted
+
       {:ok,
        %Resolved{
          adapter: :path,
          source_kind: :path,
-         identity: [
-           kind: :path,
-           adapter: :path,
-           root: Keyword.fetch!(opts, :root_id),
-           path: segments
-         ],
-         cache: Keyword.fetch!(opts, :cache),
+         identity: identity,
+         internal_cache: internal_cache_mode(opts, stable?),
+         http_cache: Keyword.fetch!(opts, :http_cache),
+         cache_semantics: cache_semantics(opts, stable?, identity),
          fetch: [path: path, root: Keyword.fetch!(opts, :root), segments: segments]
        }}
     end
@@ -96,5 +105,24 @@ defmodule ImagePipe.Source.File do
       {:error, :eacces} -> {:error, {:source, :unreadable}}
       {:error, _reason} -> {:error, {:source, :unreadable}}
     end
+  end
+
+  defp internal_cache_mode(opts, stable?) do
+    case Keyword.fetch!(opts, :internal_cache) do
+      :enabled -> :enabled
+      :disabled -> :disabled
+      :auto -> if stable?, do: :enabled, else: :disabled
+    end
+  end
+
+  defp cache_semantics(opts, stable?, identity) do
+    byte_identity =
+      if Keyword.fetch!(opts, :stable) == :trusted do
+        {:strong, identity}
+      else
+        :none
+      end
+
+    %CacheSemantics{byte_identity: byte_identity, stable?: stable?}
   end
 end

--- a/lib/image_pipe/source/file.ex
+++ b/lib/image_pipe/source/file.ex
@@ -115,9 +115,9 @@ defmodule ImagePipe.Source.File do
     end
   end
 
-  defp cache_semantics(opts, stable?, identity) do
+  defp cache_semantics(_opts, stable?, identity) do
     byte_identity =
-      if Keyword.fetch!(opts, :stable) == :trusted do
+      if stable? do
         {:strong, identity}
       else
         :none

--- a/lib/image_pipe/source/http.ex
+++ b/lib/image_pipe/source/http.ex
@@ -76,7 +76,7 @@ defmodule ImagePipe.Source.HTTP do
          cache_semantics: cache_semantics(opts, stable?, identity),
          fetch: [
            url: build_url(%{source | host: host, port: port}),
-           internal_cache: internal_cache
+           strip_byte_headers: stable? or internal_cache == :enabled
          ]
        }}
     else
@@ -89,7 +89,7 @@ defmodule ImagePipe.Source.HTTP do
     req_options =
       opts
       |> Keyword.fetch!(:req_options)
-      |> sanitize_req_options(fetch[:internal_cache])
+      |> sanitize_req_options(fetch[:strip_byte_headers])
       |> Keyword.merge(
         url: fetch[:url],
         method: :get,
@@ -105,22 +105,22 @@ defmodule ImagePipe.Source.HTTP do
     {:ok, %Response{stream: ReqStream.stream(req_options, stream_options)}}
   end
 
-  defp sanitize_req_options(req_options, cache) do
+  defp sanitize_req_options(req_options, strip_byte_headers?) do
     req_options
     |> Keyword.drop(@internal_option_keys)
-    |> Keyword.update(:headers, [], &sanitize_headers(&1, cache))
+    |> Keyword.update(:headers, [], &sanitize_headers(&1, strip_byte_headers?))
   end
 
-  defp sanitize_headers(headers, cache) do
-    denied = denied_header_names(cache)
+  defp sanitize_headers(headers, strip_byte_headers?) do
+    denied = denied_header_names(strip_byte_headers?)
 
     Enum.reject(headers, fn {name, _value} ->
       String.downcase(to_string(name)) in denied
     end)
   end
 
-  defp denied_header_names(:enabled), do: @host_header_names ++ @cacheable_byte_header_names
-  defp denied_header_names(:disabled), do: @host_header_names
+  defp denied_header_names(true), do: @host_header_names ++ @cacheable_byte_header_names
+  defp denied_header_names(false), do: @host_header_names
 
   defp internal_cache_mode(opts, stable?) do
     case Keyword.fetch!(opts, :internal_cache) do
@@ -130,9 +130,9 @@ defmodule ImagePipe.Source.HTTP do
     end
   end
 
-  defp cache_semantics(opts, stable?, identity) do
+  defp cache_semantics(_opts, stable?, identity) do
     byte_identity =
-      if Keyword.fetch!(opts, :stable) == :trusted do
+      if stable? do
         {:strong, redacted_http_identity(identity)}
       else
         :none

--- a/lib/image_pipe/source/http.ex
+++ b/lib/image_pipe/source/http.ex
@@ -5,6 +5,7 @@ defmodule ImagePipe.Source.HTTP do
 
   alias ImagePipe.Plan.Source.URL
   alias ImagePipe.Source
+  alias ImagePipe.Source.CacheSemantics
   alias ImagePipe.Source.ReqStream
   alias ImagePipe.Source.Resolved
   alias ImagePipe.Source.Response
@@ -31,7 +32,9 @@ defmodule ImagePipe.Source.HTTP do
                     connect_timeout: [type: :non_neg_integer],
                     pool_timeout: [type: :non_neg_integer],
                     max_redirects: [type: :non_neg_integer, default: 0],
-                    cache: [type: {:in, [:normal, :skip]}, default: :normal]
+                    stable: [type: {:in, [:auto, :trusted]}, default: :auto],
+                    internal_cache: [type: {:in, [:auto, :enabled, :disabled]}, default: :auto],
+                    http_cache: [type: {:in, [:inherit, :disabled, :enabled]}, default: :inherit]
                   )
 
   @impl Source
@@ -49,24 +52,30 @@ defmodule ImagePipe.Source.HTTP do
 
     if host in Keyword.fetch!(opts, :allowed_hosts) do
       port = source.port || Map.fetch!(@default_ports, scheme)
+      identity = [
+        kind: :url,
+        adapter: scheme,
+        scheme: scheme,
+        host: host,
+        port: port,
+        path: source.path,
+        query: source.query
+      ]
+
+      stable? = Keyword.fetch!(opts, :stable) == :trusted
+      internal_cache = internal_cache_mode(opts, stable?)
 
       {:ok,
        %Resolved{
          adapter: scheme,
          source_kind: :url,
-         identity: [
-           kind: :url,
-           adapter: scheme,
-           scheme: scheme,
-           host: host,
-           port: port,
-           path: source.path,
-           query: source.query
-         ],
-         cache: Keyword.fetch!(opts, :cache),
+         identity: identity,
+         internal_cache: internal_cache,
+         http_cache: Keyword.fetch!(opts, :http_cache),
+         cache_semantics: cache_semantics(opts, stable?, identity),
          fetch: [
            url: build_url(%{source | host: host, port: port}),
-           cache: Keyword.fetch!(opts, :cache)
+           internal_cache: internal_cache
          ]
        }}
     else
@@ -79,7 +88,7 @@ defmodule ImagePipe.Source.HTTP do
     req_options =
       opts
       |> Keyword.fetch!(:req_options)
-      |> sanitize_req_options(fetch[:cache])
+      |> sanitize_req_options(fetch[:internal_cache])
       |> Keyword.merge(
         url: fetch[:url],
         method: :get,
@@ -109,8 +118,39 @@ defmodule ImagePipe.Source.HTTP do
     end)
   end
 
-  defp denied_header_names(:normal), do: @host_header_names ++ @cacheable_byte_header_names
-  defp denied_header_names(:skip), do: @host_header_names
+  defp denied_header_names(:enabled), do: @host_header_names ++ @cacheable_byte_header_names
+  defp denied_header_names(:disabled), do: @host_header_names
+
+  defp internal_cache_mode(opts, stable?) do
+    case Keyword.fetch!(opts, :internal_cache) do
+      :enabled -> :enabled
+      :disabled -> :disabled
+      :auto -> if stable?, do: :enabled, else: :disabled
+    end
+  end
+
+  defp cache_semantics(opts, stable?, identity) do
+    byte_identity =
+      if Keyword.fetch!(opts, :stable) == :trusted do
+        {:strong, redacted_http_identity(identity)}
+      else
+        :none
+      end
+
+    %CacheSemantics{byte_identity: byte_identity, stable?: stable?}
+  end
+
+  defp redacted_http_identity(identity) do
+    case Keyword.fetch!(identity, :query) do
+      nil ->
+        Keyword.delete(identity, :query)
+
+      query ->
+        identity
+        |> Keyword.delete(:query)
+        |> Keyword.put(:query_sha256, :crypto.hash(:sha256, query) |> Base.encode16(case: :lower))
+    end
+  end
 
   defp build_url(%URL{} = source) do
     path =

--- a/lib/image_pipe/source/http.ex
+++ b/lib/image_pipe/source/http.ex
@@ -52,6 +52,7 @@ defmodule ImagePipe.Source.HTTP do
 
     if host in Keyword.fetch!(opts, :allowed_hosts) do
       port = source.port || Map.fetch!(@default_ports, scheme)
+
       identity = [
         kind: :url,
         adapter: scheme,

--- a/lib/image_pipe/source/resolved.ex
+++ b/lib/image_pipe/source/resolved.ex
@@ -1,16 +1,29 @@
 defmodule ImagePipe.Source.Resolved do
   @moduledoc false
 
-  @enforce_keys [:adapter, :source_kind, :identity, :cache, :fetch]
+  alias ImagePipe.Source.CacheSemantics
+
+  @enforce_keys [
+    :adapter,
+    :source_kind,
+    :identity,
+    :internal_cache,
+    :http_cache,
+    :cache_semantics,
+    :fetch
+  ]
   defstruct @enforce_keys
 
-  @type cache_policy :: :normal | :skip
+  @type internal_cache :: :enabled | :disabled
+  @type http_cache :: :inherit | :disabled | :enabled
 
   @type t :: %__MODULE__{
           adapter: atom(),
           source_kind: :path | :url | :object | :reference,
           identity: term(),
-          cache: cache_policy(),
+          internal_cache: internal_cache(),
+          http_cache: http_cache(),
+          cache_semantics: CacheSemantics.t(),
           fetch: term()
         }
 end

--- a/lib/image_pipe/source/s3.ex
+++ b/lib/image_pipe/source/s3.ex
@@ -5,6 +5,7 @@ defmodule ImagePipe.Source.S3 do
 
   alias ImagePipe.Plan.Source.Object
   alias ImagePipe.Source
+  alias ImagePipe.Source.CacheSemantics
   alias ImagePipe.Source.ReqStream
   alias ImagePipe.Source.Resolved
   alias ImagePipe.Source.Response
@@ -39,7 +40,9 @@ defmodule ImagePipe.Source.S3 do
                      type: {:custom, __MODULE__, :validate_credentials_option, []}
                    ],
                    req_options: [type: :keyword_list, default: []],
-                   cache: [type: {:in, [:normal, :skip]}, default: :normal],
+                   stable: [type: {:in, [:auto, :trusted]}, default: :auto],
+                   internal_cache: [type: {:in, [:auto, :enabled, :disabled]}, default: :auto],
+                   http_cache: [type: {:in, [:inherit, :disabled, :enabled]}, default: :inherit],
                    receive_timeout: [type: :non_neg_integer],
                    connect_timeout: [type: :non_neg_integer],
                    pool_timeout: [type: :non_neg_integer]
@@ -73,20 +76,26 @@ defmodule ImagePipe.Source.S3 do
              (is_binary(revision) or is_nil(revision)) do
     with {:ok, config} <- bucket_config(bucket, opts) do
       endpoint = Keyword.fetch!(config, :endpoint)
+      identity = [
+        kind: :object,
+        adapter: :s3,
+        endpoint: endpoint,
+        bucket: bucket,
+        key: key,
+        revision: revision
+      ]
+
+      stable? = s3_stable?(config, revision)
+      internal_cache = internal_cache_mode(config, stable?)
 
       {:ok,
        %Resolved{
          adapter: :s3,
          source_kind: :object,
-         identity: [
-           kind: :object,
-           adapter: :s3,
-           endpoint: endpoint,
-           bucket: bucket,
-           key: key,
-           revision: revision
-         ],
-         cache: Keyword.fetch!(config, :cache),
+         identity: identity,
+         internal_cache: internal_cache,
+         http_cache: Keyword.fetch!(config, :http_cache),
+         cache_semantics: cache_semantics(stable?, identity),
          fetch:
            [
              endpoint: endpoint,
@@ -96,7 +105,7 @@ defmodule ImagePipe.Source.S3 do
              region: Keyword.fetch!(config, :region),
              credentials: Keyword.get(config, :credentials),
              req_options: Keyword.fetch!(config, :req_options),
-             cache: Keyword.fetch!(config, :cache)
+             internal_cache: internal_cache
            ]
            |> Keyword.merge(Keyword.take(config, @timeout_keys))
        }}
@@ -113,7 +122,7 @@ defmodule ImagePipe.Source.S3 do
       req_options =
         fetch
         |> Keyword.fetch!(:req_options)
-        |> sanitize_req_options(fetch[:cache])
+        |> sanitize_req_options(fetch[:internal_cache])
         |> Keyword.merge(
           url: build_url(fetch),
           method: :get,
@@ -298,8 +307,26 @@ defmodule ImagePipe.Source.S3 do
     end)
   end
 
-  defp denied_header_names(:normal), do: @signed_header_names ++ @cacheable_byte_header_names
-  defp denied_header_names(:skip), do: @signed_header_names
+  defp denied_header_names(:enabled), do: @signed_header_names ++ @cacheable_byte_header_names
+  defp denied_header_names(:disabled), do: @signed_header_names
+
+  defp s3_stable?(config, revision) do
+    Keyword.fetch!(config, :stable) == :trusted or is_binary(revision)
+  end
+
+  defp internal_cache_mode(config, stable?) do
+    case Keyword.fetch!(config, :internal_cache) do
+      :enabled -> :enabled
+      :disabled -> :disabled
+      :auto -> if stable?, do: :enabled, else: :disabled
+    end
+  end
+
+  defp cache_semantics(true, identity),
+    do: %CacheSemantics{byte_identity: {:strong, identity}, stable?: true}
+
+  defp cache_semantics(false, _identity),
+    do: %CacheSemantics{byte_identity: :none, stable?: false}
 
   defp aws_sigv4_options(region, credentials) do
     credentials

--- a/lib/image_pipe/source/s3.ex
+++ b/lib/image_pipe/source/s3.ex
@@ -106,7 +106,7 @@ defmodule ImagePipe.Source.S3 do
              region: Keyword.fetch!(config, :region),
              credentials: Keyword.get(config, :credentials),
              req_options: Keyword.fetch!(config, :req_options),
-             internal_cache: internal_cache
+             strip_byte_headers: stable? or internal_cache == :enabled
            ]
            |> Keyword.merge(Keyword.take(config, @timeout_keys))
        }}
@@ -123,7 +123,7 @@ defmodule ImagePipe.Source.S3 do
       req_options =
         fetch
         |> Keyword.fetch!(:req_options)
-        |> sanitize_req_options(fetch[:internal_cache])
+        |> sanitize_req_options(fetch[:strip_byte_headers])
         |> Keyword.merge(
           url: build_url(fetch),
           method: :get,
@@ -294,22 +294,22 @@ defmodule ImagePipe.Source.S3 do
     end
   end
 
-  defp sanitize_req_options(req_options, cache) do
+  defp sanitize_req_options(req_options, strip_byte_headers?) do
     req_options
     |> Keyword.drop(@internal_option_keys)
-    |> Keyword.update(:headers, [], &sanitize_headers(&1, cache))
+    |> Keyword.update(:headers, [], &sanitize_headers(&1, strip_byte_headers?))
   end
 
-  defp sanitize_headers(headers, cache) do
-    denied = denied_header_names(cache)
+  defp sanitize_headers(headers, strip_byte_headers?) do
+    denied = denied_header_names(strip_byte_headers?)
 
     Enum.reject(headers, fn {name, _value} ->
       String.downcase(to_string(name)) in denied
     end)
   end
 
-  defp denied_header_names(:enabled), do: @signed_header_names ++ @cacheable_byte_header_names
-  defp denied_header_names(:disabled), do: @signed_header_names
+  defp denied_header_names(true), do: @signed_header_names ++ @cacheable_byte_header_names
+  defp denied_header_names(false), do: @signed_header_names
 
   defp s3_stable?(config, revision) do
     Keyword.fetch!(config, :stable) == :trusted or is_binary(revision)

--- a/lib/image_pipe/source/s3.ex
+++ b/lib/image_pipe/source/s3.ex
@@ -312,7 +312,8 @@ defmodule ImagePipe.Source.S3 do
   defp denied_header_names(false), do: @signed_header_names
 
   defp s3_stable?(config, revision) do
-    Keyword.fetch!(config, :stable) == :trusted or is_binary(revision)
+    Keyword.fetch!(config, :stable) == :trusted or
+      (is_binary(revision) and revision != "")
   end
 
   defp internal_cache_mode(config, stable?) do

--- a/lib/image_pipe/source/s3.ex
+++ b/lib/image_pipe/source/s3.ex
@@ -76,6 +76,7 @@ defmodule ImagePipe.Source.S3 do
              (is_binary(revision) or is_nil(revision)) do
     with {:ok, config} <- bucket_config(bucket, opts) do
       endpoint = Keyword.fetch!(config, :endpoint)
+
       identity = [
         kind: :object,
         adapter: :s3,

--- a/test/image_pipe/architecture_boundary_test.exs
+++ b/test/image_pipe/architecture_boundary_test.exs
@@ -124,6 +124,7 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
     refute_boundary_deps(request, [ImagePipe.Parser | concrete_transform_modules()])
 
     assert_boundary_exports(request, [
+      ImagePipe.Request.HTTPCache,
       ImagePipe.Request.Options,
       ImagePipe.Request.Runner,
       ImagePipe.Request.SourceSessionSupervisor
@@ -152,6 +153,7 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
     ])
 
     assert_boundary_exports(source, [
+      ImagePipe.Source.CacheSemantics,
       ImagePipe.Source.Resolved,
       ImagePipe.Source.Response,
       ImagePipe.Source.StreamError,
@@ -175,6 +177,7 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
     refute_boundary_deps(response, [ImagePipe.Request, ImagePipe.Source, ImagePipe.Transform])
 
     assert_boundary_exports(response, [
+      ImagePipe.Response.CacheHeaders,
       ImagePipe.Response.PreparedStream,
       ImagePipe.Response.Sender
     ])

--- a/test/image_pipe/cache/key_test.exs
+++ b/test/image_pipe/cache/key_test.exs
@@ -179,6 +179,7 @@ defmodule ImagePipe.Cache.KeyTest do
                quality: :default,
                format_qualities: %{}
              ],
+             representation: [version: 1],
              cache: [cachebuster: nil],
              selected_headers: [],
              selected_cookies: []
@@ -189,6 +190,15 @@ defmodule ImagePipe.Cache.KeyTest do
     refute inspect(key.data) =~ "sig-one"
     refute inspect(key.data) =~ "ignored=true"
     refute key.hash == different_source.hash
+  end
+
+  test "cache key contains representation version" do
+    plan = plan(output: %Output{mode: {:explicit, :webp}})
+    conn = conn(:get, "/image")
+
+    assert {:ok, key} = Key.build(conn, plan, source_identity())
+
+    assert key.data[:representation] == [version: Key.representation_version()]
   end
 
   test "source identity key data is product-neutral and independent of request URL" do

--- a/test/image_pipe/cdn_http_cache_wire_test.exs
+++ b/test/image_pipe/cdn_http_cache_wire_test.exs
@@ -150,8 +150,21 @@ defmodule ImagePipe.CDNHTTPCacheWireTest do
       |> ImagePipe.Plug.call(opts)
 
     assert get_resp_header(with_cookie, "etag") == [etag]
-    assert get_resp_header(with_cookie, "vary") != ["Cookie"]
+    refute "cookie" in vary_tokens(with_cookie)
     assert_received :source_fetch_called
+  end
+
+  test "response cookies suppress generated public cache headers", %{opts: opts} do
+    conn =
+      :get
+      |> conn("/_/plain/beach.jpg")
+      |> put_resp_cookie("session", "abc")
+      |> ImagePipe.Plug.call(opts)
+
+    assert conn.status == 200
+    refute get_resp_header(conn, "cache-control") == ["public, max-age=31536000, immutable"]
+    assert get_resp_header(conn, "etag") == []
+    assert get_resp_header(conn, "set-cookie") != []
   end
 
   test "internal cache hit returns 200 with current prepared etag" do
@@ -202,5 +215,13 @@ defmodule ImagePipe.CDNHTTPCacheWireTest do
     after
       0 -> :ok
     end
+  end
+
+  defp vary_tokens(conn) do
+    conn
+    |> get_resp_header("vary")
+    |> Enum.flat_map(&String.split(&1, ","))
+    |> Enum.map(&String.trim/1)
+    |> Enum.map(&String.downcase/1)
   end
 end

--- a/test/image_pipe/cdn_http_cache_wire_test.exs
+++ b/test/image_pipe/cdn_http_cache_wire_test.exs
@@ -1,0 +1,206 @@
+defmodule ImagePipe.CDNHTTPCacheWireTest do
+  use ExUnit.Case, async: true
+
+  import Plug.Conn
+  import Plug.Test
+
+  alias ImagePipe.Cache.Entry
+  alias ImagePipe.Cache.Key
+  alias ImagePipe.Source.CacheSemantics
+  alias ImagePipe.Source.Resolved
+  alias ImagePipe.Source.Response
+
+  defmodule StableSource do
+    @behaviour ImagePipe.Source
+
+    def validate_options(opts), do: {:ok, Keyword.put_new(opts, :telemetry_kind, :stable_test)}
+
+    def resolve(source, _opts, _runtime_opts) do
+      path = source.segments
+
+      {:ok,
+       %Resolved{
+         adapter: :path,
+         source_kind: :path,
+         identity: [kind: :path, adapter: :path, root: "wire", path: path],
+         internal_cache: :enabled,
+         http_cache: :enabled,
+         cache_semantics: %CacheSemantics{
+           byte_identity: {:strong, [kind: :path, root: "wire", path: path]},
+           stable?: true
+         },
+         fetch: [path: path]
+       }}
+    end
+
+    def fetch(_resolved, opts, _runtime_opts) do
+      send(Keyword.fetch!(opts, :test_pid), :source_fetch_called)
+      {:ok, %Response{stream: [File.read!("priv/static/images/beach.jpg")]}}
+    end
+  end
+
+  defmodule CacheProbe do
+    @behaviour ImagePipe.Cache
+
+    def get(%Key{} = key, opts) do
+      send(Keyword.fetch!(opts, :test_pid), {:cache_get, key})
+      :miss
+    end
+
+    def open_sink(%Key{}, metadata, opts),
+      do: {:ok, %{metadata: metadata, chunks: [], opts: opts}}
+
+    def write_chunk(state, chunk, _opts), do: {:ok, %{state | chunks: [chunk | state.chunks]}}
+
+    def commit_sink(state, _opts) do
+      entry = %Entry{
+        body: state.chunks |> Enum.reverse() |> IO.iodata_to_binary(),
+        content_type: state.metadata.content_type,
+        headers: state.metadata.headers,
+        created_at: state.metadata.created_at
+      }
+
+      send(Keyword.fetch!(state.opts, :test_pid), {:cache_put, entry})
+      :ok
+    end
+
+    def abort_sink(_state, _opts), do: :ok
+  end
+
+  defmodule CacheHitProbe do
+    @behaviour ImagePipe.Cache
+
+    def get(%Key{} = key, opts) do
+      send(Keyword.fetch!(opts, :test_pid), {:cache_get, key})
+      {:hit, Keyword.fetch!(opts, :entry)}
+    end
+
+    def open_sink(_key, _metadata, _opts), do: raise("cache hit should not write")
+    def write_chunk(_state, _chunk, _opts), do: raise("cache hit should not write")
+    def commit_sink(_state, _opts), do: raise("cache hit should not write")
+    def abort_sink(_state, _opts), do: :ok
+  end
+
+  setup do
+    opts =
+      ImagePipe.Plug.init(
+        parser: ImagePipe.Parser.Imgproxy,
+        sources: [path: {StableSource, test_pid: self()}],
+        cache: {CacheProbe, test_pid: self()},
+        test_pid: self(),
+        http_cache: [mode: :enabled]
+      )
+
+    [opts: opts]
+  end
+
+  test "stable public route emits cache-control and etag", %{opts: opts} do
+    conn = ImagePipe.Plug.call(conn(:get, "/_/plain/beach.jpg"), opts)
+
+    assert conn.status == 200
+    assert get_resp_header(conn, "cache-control") == ["public, max-age=31536000, immutable"]
+
+    assert [etag] = get_resp_header(conn, "etag")
+    assert etag =~ ~r/^"ip1-[A-Za-z0-9_-]+"$/
+  end
+
+  test "matching if-none-match returns before cache lookup and source fetch", %{opts: opts} do
+    first = ImagePipe.Plug.call(conn(:get, "/_/plain/beach.jpg"), opts)
+    [etag] = get_resp_header(first, "etag")
+
+    assert_received :source_fetch_called
+    flush_messages()
+
+    conn =
+      :get
+      |> conn("/_/plain/beach.jpg")
+      |> put_req_header("if-none-match", etag)
+      |> ImagePipe.Plug.call(opts)
+
+    assert conn.status == 304
+    assert conn.resp_body == ""
+    assert get_resp_header(conn, "etag") == [etag]
+    assert get_resp_header(conn, "content-type") == []
+    refute_received {:cache_get, %Key{}}
+    refute_received :source_fetch_called
+  end
+
+  test "existing vary is merged in the final response", %{opts: opts} do
+    conn =
+      :get
+      |> conn("/_/plain/beach.jpg")
+      |> put_req_header("accept", "image/avif,image/webp")
+      |> put_resp_header("vary", "Accept-Encoding")
+      |> ImagePipe.Plug.call(opts)
+
+    assert conn.status == 200
+    assert get_resp_header(conn, "vary") == ["Accept-Encoding, Accept"]
+  end
+
+  test "request cookie does not change generated headers or source fetch", %{opts: opts} do
+    without_cookie = ImagePipe.Plug.call(conn(:get, "/_/plain/beach.jpg"), opts)
+    [etag] = get_resp_header(without_cookie, "etag")
+
+    flush_messages()
+
+    with_cookie =
+      :get
+      |> conn("/_/plain/beach.jpg")
+      |> put_req_header("cookie", "session=private")
+      |> ImagePipe.Plug.call(opts)
+
+    assert get_resp_header(with_cookie, "etag") == [etag]
+    assert get_resp_header(with_cookie, "vary") != ["Cookie"]
+    assert_received :source_fetch_called
+  end
+
+  test "internal cache hit returns 200 with current prepared etag" do
+    entry = %Entry{
+      body: "cached body",
+      content_type: "image/jpeg",
+      headers: [{"cache-control", "public, max-age=60"}],
+      created_at: DateTime.utc_now()
+    }
+
+    opts =
+      ImagePipe.Plug.init(
+        parser: ImagePipe.Parser.Imgproxy,
+        sources: [path: {StableSource, test_pid: self()}],
+        cache: {CacheHitProbe, test_pid: self(), entry: entry},
+        http_cache: [mode: :enabled]
+      )
+
+    conn = ImagePipe.Plug.call(conn(:get, "/_/plain/beach.jpg"), opts)
+
+    assert conn.status == 200
+    assert conn.resp_body == "cached body"
+    assert [etag] = get_resp_header(conn, "etag")
+    assert String.starts_with?(etag, "\"ip1-")
+    assert get_resp_header(conn, "cache-control") == ["public, max-age=31536000, immutable"]
+    refute_received :source_fetch_called
+  end
+
+  test "transform option order variants produce the same etag", %{opts: opts} do
+    left =
+      ImagePipe.Plug.call(
+        conn(:get, "/_/rs:fill:0:400:0/c:0.5:0.5/plain/beach.jpg"),
+        opts
+      )
+
+    right =
+      ImagePipe.Plug.call(
+        conn(:get, "/_/c:0.5:0.5/rs:fill:0:400:0/plain/beach.jpg"),
+        opts
+      )
+
+    assert get_resp_header(left, "etag") == get_resp_header(right, "etag")
+  end
+
+  defp flush_messages do
+    receive do
+      _message -> flush_messages()
+    after
+      0 -> :ok
+    end
+  end
+end

--- a/test/image_pipe/cdn_http_cache_wire_test.exs
+++ b/test/image_pipe/cdn_http_cache_wire_test.exs
@@ -162,7 +162,7 @@ defmodule ImagePipe.CDNHTTPCacheWireTest do
       |> ImagePipe.Plug.call(opts)
 
     assert conn.status == 200
-    refute get_resp_header(conn, "cache-control") == ["public, max-age=31536000, immutable"]
+    assert get_resp_header(conn, "cache-control") == ["max-age=0, private, must-revalidate"]
     assert get_resp_header(conn, "etag") == []
     assert get_resp_header(conn, "set-cookie") != []
   end

--- a/test/image_pipe/cdn_http_cache_wire_test.exs
+++ b/test/image_pipe/cdn_http_cache_wire_test.exs
@@ -129,7 +129,7 @@ defmodule ImagePipe.CDNHTTPCacheWireTest do
     conn =
       :get
       |> conn("/_/plain/beach.jpg")
-      |> put_req_header("accept", "image/avif,image/webp")
+      |> put_req_header("accept", "image/webp")
       |> put_resp_header("vary", "Accept-Encoding")
       |> ImagePipe.Plug.call(opts)
 

--- a/test/image_pipe/imgproxy_resize_auto_test.exs
+++ b/test/image_pipe/imgproxy_resize_auto_test.exs
@@ -83,7 +83,9 @@ defmodule ImagePipe.ImgproxyResizeAutoTest do
       adapter: :path,
       source_kind: :path,
       identity: source_identity(source),
-      cache: :normal,
+      internal_cache: :enabled,
+      http_cache: :inherit,
+      cache_semantics: %ImagePipe.Source.CacheSemantics{byte_identity: :none, stable?: false},
       fetch: source
     }
   end

--- a/test/image_pipe/imgproxy_resize_auto_test.exs
+++ b/test/image_pipe/imgproxy_resize_auto_test.exs
@@ -5,6 +5,7 @@ defmodule ImagePipe.ImgproxyResizeAutoTest do
 
   alias ImagePipe.Parser.Imgproxy
   alias ImagePipe.Request.Runner
+  alias ImagePipe.Response.CacheHeaders
   alias ImagePipe.Response.PreparedStream
   alias ImagePipe.Source.Resolved
 
@@ -38,8 +39,8 @@ defmodule ImagePipe.ImgproxyResizeAutoTest do
     {conn, plan} = parse_plan!(path)
     resolved_source = resolved_source(source)
 
-    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, _response}} =
-             Runner.run(
+    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, _response, %CacheHeaders{}}} =
+             run(
                conn,
                plan,
                resolved_source,
@@ -88,6 +89,14 @@ defmodule ImagePipe.ImgproxyResizeAutoTest do
       cache_semantics: %ImagePipe.Source.CacheSemantics{byte_identity: :none, stable?: false},
       fetch: source
     }
+  end
+
+  defp run(conn, plan, resolved_source, opts) do
+    Runner.run(conn, plan, resolved_source, empty_cache_headers(), opts)
+  end
+
+  defp empty_cache_headers do
+    %CacheHeaders{representation_headers: [], headers: [], etag: nil}
   end
 
   test "1. request-level resize:auto from 300x200 to 100x50 returns 100x50" do

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -697,7 +697,7 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
           source_schemes: %{"foobar" => {FoobarTranslator, []}}
         ],
         sources: [
-          foobar: {PlugCustomAdapter, adapter: :foobar, cache: :skip}
+          foobar: {PlugCustomAdapter, adapter: :foobar, internal_cache: :disabled}
         ],
         cache: {CacheProbe, result: :miss}
       )

--- a/test/image_pipe/output_policy_test.exs
+++ b/test/image_pipe/output_policy_test.exs
@@ -9,6 +9,18 @@ defmodule ImagePipe.Output.PolicyTest do
   alias ImagePipe.Plan.Output
 
   describe "from_output_plan/3" do
+    test "automatic output policy exposes Vary Accept and selected candidates from Accept" do
+      conn =
+        :get
+        |> conn("/image")
+        |> put_req_header("accept", "image/webp,image/avif;q=0.1")
+
+      policy = Policy.from_output_plan(conn, %Output{mode: :automatic}, [])
+
+      assert policy.headers == [{"vary", "Accept"}]
+      assert policy.modern_candidates != []
+    end
+
     test "represents explicit output independently of Accept" do
       conn =
         :get

--- a/test/image_pipe/output_policy_test.exs
+++ b/test/image_pipe/output_policy_test.exs
@@ -18,7 +18,7 @@ defmodule ImagePipe.Output.PolicyTest do
       policy = Policy.from_output_plan(conn, %Output{mode: :automatic}, [])
 
       assert policy.headers == [{"vary", "Accept"}]
-      assert policy.modern_candidates != []
+      assert policy.modern_candidates == [:avif, :webp]
     end
 
     test "represents explicit output independently of Accept" do

--- a/test/image_pipe/plan_test.exs
+++ b/test/image_pipe/plan_test.exs
@@ -135,6 +135,18 @@ defmodule ImagePipe.PlanTest do
                 ]
               ]} = Plan.canonical_representation_material(plan)
     end
+
+    test "automatic output material contains the symbolic rule instead of a resolved branch" do
+      plan = %Plan{
+        source: %Source.Path{segments: ["alpha.png"]},
+        pipelines: [%Pipeline{operations: []}],
+        output: %Output{mode: :automatic}
+      }
+
+      assert {:ok, [output: output]} = Plan.canonical_representation_material(plan)
+      assert output[:mode] == :automatic
+      refute Keyword.has_key?(output, :resolved_format)
+    end
   end
 
   defp plan(overrides \\ []) do

--- a/test/image_pipe/plan_test.exs
+++ b/test/image_pipe/plan_test.exs
@@ -96,59 +96,6 @@ defmodule ImagePipe.PlanTest do
     end
   end
 
-  describe "canonical_representation_material/1" do
-    test "explicit output contains output rule and quality material" do
-      plan = %Plan{
-        source: %Source.Path{segments: ["cat.jpg"]},
-        pipelines: [%Pipeline{operations: []}],
-        output: %Output{
-          mode: {:explicit, :webp},
-          quality: {:quality, 82},
-          format_qualities: %{webp: {:quality, 80}}
-        }
-      }
-
-      assert {:ok,
-              [
-                output: [
-                  mode: :explicit,
-                  format: :webp,
-                  quality: {:quality, 82},
-                  format_qualities: [webp: {:quality, 80}]
-                ]
-              ]} = Plan.canonical_representation_material(plan)
-    end
-
-    test "automatic output contains symbolic automatic rule" do
-      plan = %Plan{
-        source: %Source.Path{segments: ["cat.jpg"]},
-        pipelines: [%Pipeline{operations: []}],
-        output: %Output{mode: :automatic}
-      }
-
-      assert {:ok,
-              [
-                output: [
-                  mode: :automatic,
-                  quality: :default,
-                  format_qualities: []
-                ]
-              ]} = Plan.canonical_representation_material(plan)
-    end
-
-    test "automatic output material contains the symbolic rule instead of a resolved branch" do
-      plan = %Plan{
-        source: %Source.Path{segments: ["alpha.png"]},
-        pipelines: [%Pipeline{operations: []}],
-        output: %Output{mode: :automatic}
-      }
-
-      assert {:ok, [output: output]} = Plan.canonical_representation_material(plan)
-      assert output[:mode] == :automatic
-      refute Keyword.has_key?(output, :resolved_format)
-    end
-  end
-
   defp plan(overrides \\ []) do
     struct!(
       Plan,

--- a/test/image_pipe/plan_test.exs
+++ b/test/image_pipe/plan_test.exs
@@ -96,6 +96,47 @@ defmodule ImagePipe.PlanTest do
     end
   end
 
+  describe "canonical_representation_material/1" do
+    test "explicit output contains output rule and quality material" do
+      plan = %Plan{
+        source: %Source.Path{segments: ["cat.jpg"]},
+        pipelines: [%Pipeline{operations: []}],
+        output: %Output{
+          mode: {:explicit, :webp},
+          quality: {:quality, 82},
+          format_qualities: %{webp: {:quality, 80}}
+        }
+      }
+
+      assert {:ok,
+              [
+                output: [
+                  mode: :explicit,
+                  format: :webp,
+                  quality: {:quality, 82},
+                  format_qualities: [webp: {:quality, 80}]
+                ]
+              ]} = Plan.canonical_representation_material(plan)
+    end
+
+    test "automatic output contains symbolic automatic rule" do
+      plan = %Plan{
+        source: %Source.Path{segments: ["cat.jpg"]},
+        pipelines: [%Pipeline{operations: []}],
+        output: %Output{mode: :automatic}
+      }
+
+      assert {:ok,
+              [
+                output: [
+                  mode: :automatic,
+                  quality: :default,
+                  format_qualities: []
+                ]
+              ]} = Plan.canonical_representation_material(plan)
+    end
+  end
+
   defp plan(overrides \\ []) do
     struct!(
       Plan,

--- a/test/image_pipe/processor_test.exs
+++ b/test/image_pipe/processor_test.exs
@@ -10,6 +10,7 @@ defmodule ImagePipe.Request.ProcessorTest do
   alias ImagePipe.Request.ProcessorTest.DecodeErrorImageOpen
   alias ImagePipe.Request.ProcessorTest.Materializer
   alias ImagePipe.Source
+  alias ImagePipe.Source.CacheSemantics
   alias ImagePipe.Source.Resolved
   alias ImagePipe.Source.Response
   alias ImagePipe.SourceTest.ValidAdapter
@@ -32,7 +33,9 @@ defmodule ImagePipe.Request.ProcessorTest do
       adapter: :path,
       source_kind: :path,
       identity: [kind: :path, root: "test", path: ["images", "beach.jpg"]],
-      cache: :normal,
+      internal_cache: :enabled,
+      http_cache: :inherit,
+      cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false},
       fetch: :fixture
     }
   end

--- a/test/image_pipe/request/http_cache_test.exs
+++ b/test/image_pipe/request/http_cache_test.exs
@@ -72,6 +72,13 @@ defmodule ImagePipe.Request.HTTPCacheTest do
     assert prepared.etag == nil
   end
 
+  test "non-GET requests emit no generated cache headers" do
+    prepared = HTTPCache.prepare(conn(:post, "/image"), plan(), resolved(), opts())
+
+    assert prepared.headers == []
+    assert prepared.etag == nil
+  end
+
   test "missing byte identity emits no-store fallback without generated etag" do
     prepared =
       HTTPCache.prepare(
@@ -156,8 +163,29 @@ defmodule ImagePipe.Request.HTTPCacheTest do
     assert prepared.etag == nil
   end
 
+  test "existing vary star suppresses generated public cache headers for explicit output" do
+    conn =
+      conn(:get, "/image")
+      |> put_resp_header("vary", "*")
+
+    prepared = HTTPCache.prepare(conn, plan(), resolved(), opts())
+
+    assert prepared.representation_headers == []
+    assert prepared.headers == []
+    assert prepared.etag == nil
+  end
+
   test "set-cookie suppresses generated public cache headers" do
     conn = put_resp_header(conn(:get, "/image"), "set-cookie", "a=b")
+
+    prepared = HTTPCache.prepare(conn, plan(), resolved(), opts())
+
+    assert prepared.headers == []
+    assert prepared.etag == nil
+  end
+
+  test "response cookies suppress generated public cache headers" do
+    conn = put_resp_cookie(conn(:get, "/image"), "session", "abc")
 
     prepared = HTTPCache.prepare(conn, plan(), resolved(), opts())
 
@@ -276,7 +304,10 @@ defmodule ImagePipe.Request.HTTPCacheTest do
     assert {:strong, seed} = resolved().cache_semantics.byte_identity
 
     assert {:ok, material} = HTTPCache.etag_material(conn(:get, "/image"), plan(), seed, opts())
-    assert material[:representation_version] == ImagePipe.Cache.Key.representation_version()
+
+    assert material[:plan][:representation] == [
+             version: ImagePipe.Cache.Key.representation_version()
+           ]
   end
 
   test "cookie request header does not enter generated vary or etag" do
@@ -290,9 +321,7 @@ defmodule ImagePipe.Request.HTTPCacheTest do
 
     assert with_cookie.etag == without_cookie.etag
 
-    refute Enum.any?(with_cookie.representation_headers, fn {_name, value} ->
-             String.downcase(value) == "cookie"
-           end)
+    refute "cookie" in vary_tokens(with_cookie.representation_headers)
   end
 
   describe "evaluate_conditional/3" do
@@ -308,8 +337,7 @@ defmodule ImagePipe.Request.HTTPCacheTest do
         |> conn("/image")
         |> put_req_header("if-none-match", ~s(W/"ip1-abc"))
 
-      assert {:not_modified, headers} = HTTPCache.evaluate_conditional(conn, prepared, [])
-      assert {"etag", ~s("ip1-abc")} in headers
+      assert {:not_modified, ^prepared} = HTTPCache.evaluate_conditional(conn, prepared, [])
     end
 
     property "whitespace around if-none-match tags doesn't change matching" do
@@ -326,7 +354,7 @@ defmodule ImagePipe.Request.HTTPCacheTest do
           |> conn("/image")
           |> put_req_header("if-none-match", left <> ~s(W/"ip1-token") <> right)
 
-        assert {:not_modified, _headers} = HTTPCache.evaluate_conditional(conn, prepared, [])
+        assert {:not_modified, ^prepared} = HTTPCache.evaluate_conditional(conn, prepared, [])
       end
     end
 
@@ -342,7 +370,7 @@ defmodule ImagePipe.Request.HTTPCacheTest do
         |> conn("/image")
         |> put_req_header("if-none-match", ~s("other", W/"ip1-token"))
 
-      assert {:not_modified, _headers} = HTTPCache.evaluate_conditional(conn, prepared, [])
+      assert {:not_modified, ^prepared} = HTTPCache.evaluate_conditional(conn, prepared, [])
     end
 
     test "wildcard form is ignored in v1" do
@@ -468,12 +496,8 @@ defmodule ImagePipe.Request.HTTPCacheTest do
 
     _prepared = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
 
-    assert_receive {:telemetry_event, [:image_pipe, :http_cache, :prepare], %{},
-                    %{effective_mode: :enabled, byte_identity: :strong, etag: true} = metadata}
-
-    refute Map.has_key?(metadata, :path)
-    refute Map.has_key?(metadata, :etag_value)
-    refute Map.has_key?(metadata, :source_identity)
+    assert_receive {:telemetry_event, [:image_pipe, :http_cache, :prepare], %{}, metadata}
+    assert metadata == %{effective_mode: :enabled, byte_identity: :strong, etag: true}
   end
 
   test "no-store fallback telemetry is required and low-cardinality" do
@@ -488,12 +512,9 @@ defmodule ImagePipe.Request.HTTPCacheTest do
       )
 
     assert_receive {:telemetry_event, [:image_pipe, :http_cache, :fallback, :no_store], %{},
-                    %{adapter: :path, source_kind: :path, reason: :missing_byte_identity} =
-                      metadata}
+                    metadata}
 
-    refute Map.has_key?(metadata, :path)
-    refute Map.has_key?(metadata, :url)
-    refute Map.has_key?(metadata, :etag)
+    assert metadata == %{adapter: :path, source_kind: :path, reason: :missing_byte_identity}
   end
 
   test "conditional match telemetry omits etag and path" do
@@ -510,19 +531,26 @@ defmodule ImagePipe.Request.HTTPCacheTest do
       |> conn("/image")
       |> put_req_header("if-none-match", ~s("ip1-token"))
 
-    assert {:not_modified, _headers} = HTTPCache.evaluate_conditional(conn, prepared, opts())
+    assert {:not_modified, ^prepared} = HTTPCache.evaluate_conditional(conn, prepared, opts())
 
     assert_receive {:telemetry_event, [:image_pipe, :http_cache, :conditional, :match], %{},
-                    %{method: :get} = metadata}
+                    metadata}
 
-    refute Map.has_key?(metadata, :etag)
-    refute Map.has_key?(metadata, :path)
+    assert metadata == %{method: :get}
   end
 
   defp header(headers, name) do
     headers
     |> Enum.find(fn {header_name, _value} -> header_name == name end)
     |> elem(1)
+  end
+
+  defp vary_tokens(headers) do
+    headers
+    |> Enum.filter(fn {name, _value} -> name == "vary" end)
+    |> Enum.flat_map(fn {_name, value} -> String.split(value, ",") end)
+    |> Enum.map(&String.trim/1)
+    |> Enum.map(&String.downcase/1)
   end
 
   def handle_telemetry_event(event, measurements, metadata, test_pid) do

--- a/test/image_pipe/request/http_cache_test.exs
+++ b/test/image_pipe/request/http_cache_test.exs
@@ -1,8 +1,10 @@
 defmodule ImagePipe.Request.HTTPCacheTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   import Plug.Conn
   import Plug.Test
+  import StreamData
 
   alias ImagePipe.Plan
   alias ImagePipe.Plan.Output
@@ -75,9 +77,7 @@ defmodule ImagePipe.Request.HTTPCacheTest do
       HTTPCache.prepare(
         conn(:get, "/image"),
         plan(),
-        resolved(
-          cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false}
-        ),
+        resolved(cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false}),
         opts()
       )
 
@@ -92,9 +92,7 @@ defmodule ImagePipe.Request.HTTPCacheTest do
       HTTPCache.prepare(
         conn,
         plan(),
-        resolved(
-          cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false}
-        ),
+        resolved(cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false}),
         opts()
       )
 
@@ -158,6 +156,145 @@ defmodule ImagePipe.Request.HTTPCacheTest do
     assert prepared.etag == nil
   end
 
+  test "set-cookie suppresses generated public cache headers" do
+    conn = put_resp_header(conn(:get, "/image"), "set-cookie", "a=b")
+
+    prepared = HTTPCache.prepare(conn, plan(), resolved(), opts())
+
+    assert prepared.headers == []
+    assert prepared.etag == nil
+  end
+
+  test "cache-control no-store suppresses generated etag" do
+    conn = put_resp_header(conn(:get, "/image"), "cache-control", "no-store")
+
+    prepared = HTTPCache.prepare(conn, plan(), resolved(), opts())
+
+    assert prepared.headers == []
+    assert prepared.etag == nil
+  end
+
+  test "explicit output doesn't emit Vary Accept" do
+    prepared =
+      HTTPCache.prepare(
+        conn(:get, "/image"),
+        plan(%Output{mode: {:explicit, :jpeg}}),
+        resolved(),
+        opts()
+      )
+
+    assert prepared.representation_headers == []
+  end
+
+  test "client hints don't enter generated vary" do
+    conn =
+      conn(:get, "/image")
+      |> put_req_header("width", "600")
+      |> put_req_header("dpr", "2")
+      |> put_req_header("sec-ch-width", "600")
+
+    prepared = HTTPCache.prepare(conn, plan(), resolved(), opts())
+
+    refute Enum.any?(prepared.representation_headers, fn {_name, value} ->
+             String.contains?(String.downcase(value), "width")
+           end)
+  end
+
+  test "plan expires does not change generated cache-control" do
+    base = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
+
+    expiring =
+      HTTPCache.prepare(
+        conn(:get, "/image"),
+        %{plan() | expires: 1_899_345_600},
+        resolved(),
+        opts()
+      )
+
+    assert header(base.headers, "cache-control") == header(expiring.headers, "cache-control")
+  end
+
+  test "cachebuster changes internal key data but not generated etag" do
+    base_plan = plan()
+    busted_plan = %{plan() | cachebuster: "v2"}
+    plug_conn = conn(:get, "/image")
+
+    assert {:ok, base_key} = ImagePipe.Cache.Key.build(plug_conn, base_plan, resolved().identity)
+
+    assert {:ok, busted_key} =
+             ImagePipe.Cache.Key.build(plug_conn, busted_plan, resolved().identity)
+
+    assert base_key.data[:cache] != busted_key.data[:cache]
+
+    base = HTTPCache.prepare(conn(:get, "/image"), base_plan, resolved(), opts())
+    busted = HTTPCache.prepare(conn(:get, "/image"), busted_plan, resolved(), opts())
+
+    assert base.etag == busted.etag
+  end
+
+  test "source revision changes generated etag" do
+    left =
+      HTTPCache.prepare(
+        conn(:get, "/image"),
+        plan(),
+        resolved(
+          cache_semantics: %CacheSemantics{
+            byte_identity:
+              {:strong,
+               [kind: :object, adapter: :s3, bucket: "b", key: "cat.jpg", revision: "v1"]},
+            stable?: true
+          }
+        ),
+        opts()
+      )
+
+    right =
+      HTTPCache.prepare(
+        conn(:get, "/image"),
+        plan(),
+        resolved(
+          cache_semantics: %CacheSemantics{
+            byte_identity:
+              {:strong,
+               [kind: :object, adapter: :s3, bucket: "b", key: "cat.jpg", revision: "v2"]},
+            stable?: true
+          }
+        ),
+        opts()
+      )
+
+    assert left.etag != right.etag
+  end
+
+  test "visible etag prefix comes from etag schema" do
+    prepared = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
+
+    assert String.starts_with?(prepared.etag, ~s("ip#{HTTPCache.etag_schema()}-))
+  end
+
+  test "etag material uses the internal cache representation version" do
+    assert {:strong, seed} = resolved().cache_semantics.byte_identity
+
+    assert {:ok, material} = HTTPCache.etag_material(conn(:get, "/image"), plan(), seed, opts())
+    assert material[:representation_version] == ImagePipe.Cache.Key.representation_version()
+  end
+
+  test "cookie request header does not enter generated vary or etag" do
+    without_cookie = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
+
+    with_cookie =
+      :get
+      |> conn("/image")
+      |> put_req_header("cookie", "session=private")
+      |> HTTPCache.prepare(plan(), resolved(), opts())
+
+    assert with_cookie.etag == without_cookie.etag
+
+    refute Enum.any?(with_cookie.representation_headers, fn {_name, value} ->
+             String.downcase(value) == "cookie"
+           end)
+  end
+
   describe "evaluate_conditional/3" do
     test "weak request tag matches generated strong etag for GET" do
       prepared = %ImagePipe.Response.CacheHeaders{
@@ -173,6 +310,39 @@ defmodule ImagePipe.Request.HTTPCacheTest do
 
       assert {:not_modified, headers} = HTTPCache.evaluate_conditional(conn, prepared, [])
       assert {"etag", ~s("ip1-abc")} in headers
+    end
+
+    property "whitespace around if-none-match tags doesn't change matching" do
+      check all left <- member_of(["", " ", "  ", "\t"]),
+                right <- member_of(["", " ", "  ", "\t"]) do
+        prepared = %ImagePipe.Response.CacheHeaders{
+          representation_headers: [],
+          headers: [{"etag", ~s("ip1-token")}],
+          etag: ~s("ip1-token")
+        }
+
+        conn =
+          :get
+          |> conn("/image")
+          |> put_req_header("if-none-match", left <> ~s(W/"ip1-token") <> right)
+
+        assert {:not_modified, _headers} = HTTPCache.evaluate_conditional(conn, prepared, [])
+      end
+    end
+
+    test "comma-separated weak and strong tags can match generated etag" do
+      prepared = %ImagePipe.Response.CacheHeaders{
+        representation_headers: [],
+        headers: [{"etag", ~s("ip1-token")}],
+        etag: ~s("ip1-token")
+      }
+
+      conn =
+        :get
+        |> conn("/image")
+        |> put_req_header("if-none-match", ~s("other", W/"ip1-token"))
+
+      assert {:not_modified, _headers} = HTTPCache.evaluate_conditional(conn, prepared, [])
     end
 
     test "wildcard form is ignored in v1" do
@@ -249,5 +419,53 @@ defmodule ImagePipe.Request.HTTPCacheTest do
 
       assert :proceed = HTTPCache.evaluate_conditional(conn, prepared, [])
     end
+  end
+
+  test "equivalent Accept capability material produces the same generated etag" do
+    left =
+      :get
+      |> conn("/image")
+      |> put_req_header("accept", "image/avif,image/webp")
+      |> HTTPCache.prepare(plan(%Output{mode: :automatic}), resolved(), opts())
+
+    right =
+      :get
+      |> conn("/image")
+      |> put_req_header("accept", "image/avif;q=1.0,image/webp;q=0.8")
+      |> HTTPCache.prepare(plan(%Output{mode: :automatic}), resolved(), opts())
+
+    assert left.etag == right.etag
+  end
+
+  test "different source byte identities produce different generated etags" do
+    left = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
+
+    right =
+      HTTPCache.prepare(
+        conn(:get, "/image"),
+        plan(),
+        resolved(
+          cache_semantics: %CacheSemantics{
+            byte_identity: {:strong, [kind: :path, root: "test", path: ["other.jpg"]]},
+            stable?: true
+          }
+        ),
+        opts()
+      )
+
+    assert left.etag != right.etag
+  end
+
+  test "etag serialization is deterministic for the same prepared inputs" do
+    first = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
+    second = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
+
+    assert first.etag == second.etag
+  end
+
+  defp header(headers, name) do
+    headers
+    |> Enum.find(fn {header_name, _value} -> header_name == name end)
+    |> elem(1)
   end
 end

--- a/test/image_pipe/request/http_cache_test.exs
+++ b/test/image_pipe/request/http_cache_test.exs
@@ -463,9 +463,84 @@ defmodule ImagePipe.Request.HTTPCacheTest do
     assert first.etag == second.etag
   end
 
+  test "prepare telemetry is low-cardinality" do
+    attach_telemetry([[:image_pipe, :http_cache, :prepare]])
+
+    _prepared = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
+
+    assert_receive {:telemetry_event, [:image_pipe, :http_cache, :prepare], %{},
+                    %{effective_mode: :enabled, byte_identity: :strong, etag: true} = metadata}
+
+    refute Map.has_key?(metadata, :path)
+    refute Map.has_key?(metadata, :etag_value)
+    refute Map.has_key?(metadata, :source_identity)
+  end
+
+  test "no-store fallback telemetry is required and low-cardinality" do
+    attach_telemetry([[:image_pipe, :http_cache, :fallback, :no_store]])
+
+    _prepared =
+      HTTPCache.prepare(
+        conn(:get, "/image"),
+        plan(),
+        resolved(cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false}),
+        opts()
+      )
+
+    assert_receive {:telemetry_event, [:image_pipe, :http_cache, :fallback, :no_store], %{},
+                    %{adapter: :path, source_kind: :path, reason: :missing_byte_identity} =
+                      metadata}
+
+    refute Map.has_key?(metadata, :path)
+    refute Map.has_key?(metadata, :url)
+    refute Map.has_key?(metadata, :etag)
+  end
+
+  test "conditional match telemetry omits etag and path" do
+    attach_telemetry([[:image_pipe, :http_cache, :conditional, :match]])
+
+    prepared = %ImagePipe.Response.CacheHeaders{
+      representation_headers: [],
+      headers: [{"etag", ~s("ip1-token")}],
+      etag: ~s("ip1-token")
+    }
+
+    conn =
+      :get
+      |> conn("/image")
+      |> put_req_header("if-none-match", ~s("ip1-token"))
+
+    assert {:not_modified, _headers} = HTTPCache.evaluate_conditional(conn, prepared, opts())
+
+    assert_receive {:telemetry_event, [:image_pipe, :http_cache, :conditional, :match], %{},
+                    %{method: :get} = metadata}
+
+    refute Map.has_key?(metadata, :etag)
+    refute Map.has_key?(metadata, :path)
+  end
+
   defp header(headers, name) do
     headers
     |> Enum.find(fn {header_name, _value} -> header_name == name end)
     |> elem(1)
+  end
+
+  def handle_telemetry_event(event, measurements, metadata, test_pid) do
+    send(test_pid, {:telemetry_event, event, measurements, metadata})
+  end
+
+  defp attach_telemetry(events) do
+    test_pid = self()
+    handler_id = {__MODULE__, make_ref()}
+
+    :ok =
+      :telemetry.attach_many(
+        handler_id,
+        events,
+        &__MODULE__.handle_telemetry_event/4,
+        test_pid
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
   end
 end

--- a/test/image_pipe/request/http_cache_test.exs
+++ b/test/image_pipe/request/http_cache_test.exs
@@ -1,0 +1,253 @@
+defmodule ImagePipe.Request.HTTPCacheTest do
+  use ExUnit.Case, async: true
+
+  import Plug.Conn
+  import Plug.Test
+
+  alias ImagePipe.Plan
+  alias ImagePipe.Plan.Output
+  alias ImagePipe.Plan.Pipeline
+  alias ImagePipe.Plan.Source.Path, as: SourcePath
+  alias ImagePipe.Request.HTTPCache
+  alias ImagePipe.Source.CacheSemantics
+  alias ImagePipe.Source.Resolved
+
+  defp plan(output \\ %Output{mode: {:explicit, :webp}}) do
+    %Plan{
+      source: %SourcePath{segments: ["cat.jpg"]},
+      pipelines: [%Pipeline{operations: []}],
+      output: output
+    }
+  end
+
+  defp resolved(overrides \\ []) do
+    struct!(
+      %Resolved{
+        adapter: :path,
+        source_kind: :path,
+        identity: [kind: :path, adapter: :path, root: "test", path: ["cat.jpg"]],
+        internal_cache: :enabled,
+        http_cache: :inherit,
+        cache_semantics: %CacheSemantics{
+          byte_identity: {:strong, [kind: :path, root: "test", path: ["cat.jpg"]]},
+          stable?: true
+        },
+        fetch: [path: "/tmp/cat.jpg"]
+      },
+      overrides
+    )
+  end
+
+  defp opts(overrides \\ []) do
+    Keyword.merge(
+      [
+        http_cache: [mode: :enabled],
+        telemetry_prefix: [:image_pipe]
+      ],
+      overrides
+    )
+  end
+
+  test "enabled mode with strong byte identity emits cache-control and strong etag" do
+    prepared = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
+
+    assert %ImagePipe.Response.CacheHeaders{
+             representation_headers: [],
+             headers: headers,
+             etag: etag
+           } = prepared
+
+    assert {"cache-control", "public, max-age=31536000, immutable"} in headers
+    assert {"etag", etag} in headers
+    assert etag =~ ~r/^"ip1-[A-Za-z0-9_-]+"$/
+  end
+
+  test "disabled mode emits no generated cache headers" do
+    prepared =
+      HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), http_cache: [mode: :disabled])
+
+    assert prepared.headers == []
+    assert prepared.etag == nil
+  end
+
+  test "missing byte identity emits no-store fallback without generated etag" do
+    prepared =
+      HTTPCache.prepare(
+        conn(:get, "/image"),
+        plan(),
+        resolved(
+          cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false}
+        ),
+        opts()
+      )
+
+    assert prepared.headers == [{"cache-control", "no-store"}]
+    assert prepared.etag == nil
+  end
+
+  test "host cache-control suppresses generated cache-control and no-store fallback" do
+    conn = put_resp_header(conn(:get, "/image"), "cache-control", "public, max-age=60")
+
+    prepared =
+      HTTPCache.prepare(
+        conn,
+        plan(),
+        resolved(
+          cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false}
+        ),
+        opts()
+      )
+
+    assert prepared.headers == []
+    assert prepared.etag == nil
+  end
+
+  test "host etag suppresses generated etag" do
+    conn = put_resp_header(conn(:get, "/image"), "etag", ~s("host"))
+
+    prepared = HTTPCache.prepare(conn, plan(), resolved(), opts())
+
+    refute Enum.any?(prepared.headers, fn {name, _value} -> name == "etag" end)
+    assert {"cache-control", "public, max-age=31536000, immutable"} in prepared.headers
+    assert prepared.etag == nil
+  end
+
+  test "automatic output emits representation Vary Accept" do
+    prepared =
+      HTTPCache.prepare(
+        conn(:get, "/image") |> put_req_header("accept", "image/avif,image/webp"),
+        plan(%Output{mode: :automatic}),
+        resolved(),
+        opts()
+      )
+
+    assert prepared.representation_headers == [{"vary", "Accept"}]
+  end
+
+  test "existing vary merges accept without duplicates" do
+    conn =
+      conn(:get, "/image")
+      |> put_resp_header("vary", "Accept-Encoding, Accept")
+
+    prepared =
+      HTTPCache.prepare(
+        conn,
+        plan(%Output{mode: :automatic}),
+        resolved(),
+        opts()
+      )
+
+    assert prepared.representation_headers == [{"vary", "Accept-Encoding, Accept"}]
+  end
+
+  test "existing vary star suppresses generated public cache headers but keeps representation headers" do
+    conn =
+      conn(:get, "/image")
+      |> put_resp_header("vary", "*")
+
+    prepared =
+      HTTPCache.prepare(
+        conn,
+        plan(%Output{mode: :automatic}),
+        resolved(),
+        opts()
+      )
+
+    assert prepared.representation_headers == [{"vary", "*"}]
+    assert prepared.headers == []
+    assert prepared.etag == nil
+  end
+
+  describe "evaluate_conditional/3" do
+    test "weak request tag matches generated strong etag for GET" do
+      prepared = %ImagePipe.Response.CacheHeaders{
+        representation_headers: [],
+        headers: [{"etag", ~s("ip1-abc")}],
+        etag: ~s("ip1-abc")
+      }
+
+      conn =
+        :get
+        |> conn("/image")
+        |> put_req_header("if-none-match", ~s(W/"ip1-abc"))
+
+      assert {:not_modified, headers} = HTTPCache.evaluate_conditional(conn, prepared, [])
+      assert {"etag", ~s("ip1-abc")} in headers
+    end
+
+    test "wildcard form is ignored in v1" do
+      prepared = %ImagePipe.Response.CacheHeaders{
+        representation_headers: [],
+        headers: [{"etag", ~s("ip1-abc")}],
+        etag: ~s("ip1-abc")
+      }
+
+      conn =
+        :get
+        |> conn("/image")
+        |> put_req_header("if-none-match", ~s("ip1-abc", *))
+
+      assert :proceed = HTTPCache.evaluate_conditional(conn, prepared, [])
+    end
+
+    test "host etag isn't interpreted when prepared etag is nil" do
+      prepared = %ImagePipe.Response.CacheHeaders{
+        representation_headers: [],
+        headers: [],
+        etag: nil
+      }
+
+      conn =
+        :get
+        |> conn("/image")
+        |> put_req_header("if-none-match", ~s("host"))
+
+      assert :proceed = HTTPCache.evaluate_conditional(conn, prepared, [])
+    end
+
+    test "non-matching if-none-match proceeds" do
+      prepared = %ImagePipe.Response.CacheHeaders{
+        representation_headers: [],
+        headers: [{"etag", ~s("ip1-abc")}],
+        etag: ~s("ip1-abc")
+      }
+
+      conn =
+        :get
+        |> conn("/image")
+        |> put_req_header("if-none-match", ~s("ip1-other"))
+
+      assert :proceed = HTTPCache.evaluate_conditional(conn, prepared, [])
+    end
+
+    test "malformed if-none-match proceeds" do
+      prepared = %ImagePipe.Response.CacheHeaders{
+        representation_headers: [],
+        headers: [{"etag", ~s("ip1-abc")}],
+        etag: ~s("ip1-abc")
+      }
+
+      conn =
+        :get
+        |> conn("/image")
+        |> put_req_header("if-none-match", "not-a-quoted-tag")
+
+      assert :proceed = HTTPCache.evaluate_conditional(conn, prepared, [])
+    end
+
+    test "non-cacheable methods do not use conditional response handling" do
+      prepared = %ImagePipe.Response.CacheHeaders{
+        representation_headers: [],
+        headers: [{"etag", ~s("ip1-abc")}],
+        etag: ~s("ip1-abc")
+      }
+
+      conn =
+        :post
+        |> conn("/image")
+        |> put_req_header("if-none-match", ~s("ip1-abc"))
+
+      assert :proceed = HTTPCache.evaluate_conditional(conn, prepared, [])
+    end
+  end
+end

--- a/test/image_pipe/request/source_session/producer_test.exs
+++ b/test/image_pipe/request/source_session/producer_test.exs
@@ -217,7 +217,9 @@ defmodule ImagePipe.Request.SourceSession.ProducerTest do
       source_kind: :path,
       identity: [kind: :path, root: "test", path: ["images", "beach.jpg"]],
       fetch: fetch,
-      cache: :normal
+      internal_cache: :enabled,
+      http_cache: :inherit,
+      cache_semantics: %ImagePipe.Source.CacheSemantics{byte_identity: :none, stable?: false}
     }
   end
 

--- a/test/image_pipe/request/source_session_supervisor_test.exs
+++ b/test/image_pipe/request/source_session_supervisor_test.exs
@@ -355,7 +355,9 @@ defmodule ImagePipe.Request.SourceSessionSupervisorTest do
       adapter: :path,
       source_kind: :path,
       identity: [kind: :path, root: "test", path: ["images", "beach.jpg"]],
-      cache: :normal,
+      internal_cache: :enabled,
+      http_cache: :inherit,
+      cache_semantics: %ImagePipe.Source.CacheSemantics{byte_identity: :none, stable?: false},
       fetch: fetch
     }
   end

--- a/test/image_pipe/request/source_session_test.exs
+++ b/test/image_pipe/request/source_session_test.exs
@@ -966,7 +966,9 @@ defmodule ImagePipe.Request.SourceSessionTest do
       adapter: :path,
       source_kind: :path,
       identity: [kind: :path, root: "test", path: ["images", "beach.jpg"]],
-      cache: :normal,
+      internal_cache: :enabled,
+      http_cache: :inherit,
+      cache_semantics: %ImagePipe.Source.CacheSemantics{byte_identity: :none, stable?: false},
       fetch: fetch
     }
   end

--- a/test/image_pipe/request/vix_stream_continuation_test.exs
+++ b/test/image_pipe/request/vix_stream_continuation_test.exs
@@ -494,7 +494,9 @@ defmodule ImagePipe.Request.VixStreamContinuationTest do
       source_kind: :path,
       identity: [kind: :path, root: "test", path: ["images", "beach.jpg"]],
       fetch: :fixture,
-      cache: :normal
+      internal_cache: :enabled,
+      http_cache: :inherit,
+      cache_semantics: %ImagePipe.Source.CacheSemantics{byte_identity: :none, stable?: false}
     }
   end
 

--- a/test/image_pipe/request_options_test.exs
+++ b/test/image_pipe/request_options_test.exs
@@ -17,6 +17,24 @@ defmodule ImagePipe.RequestOptionsTest do
     assert Options.validate!(Keyword.put(@base_opts, :clock, clock))[:clock] == clock
   end
 
+  test "http_cache defaults to disabled" do
+    opts = Options.validate!(@base_opts)
+
+    assert Keyword.fetch!(opts, :http_cache) == [mode: :disabled]
+  end
+
+  test "http_cache accepts enabled mode" do
+    opts = Options.validate!(Keyword.put(@base_opts, :http_cache, mode: :enabled))
+
+    assert Keyword.fetch!(opts, :http_cache) == [mode: :enabled]
+  end
+
+  test "http_cache rejects unknown mode" do
+    assert_raise ArgumentError, ~r/invalid ImagePipe options/, fn ->
+      Options.validate!(Keyword.put(@base_opts, :http_cache, mode: :public))
+    end
+  end
+
   test "validate! rejects malformed clock values before call opts are used" do
     for clock <- [:bad, ~U[2026-05-05 12:00:00Z], 100, fn value -> value end] do
       assert_raise ArgumentError,

--- a/test/image_pipe/request_runner_test.exs
+++ b/test/image_pipe/request_runner_test.exs
@@ -488,6 +488,24 @@ defmodule ImagePipe.Request.RunnerTest do
     send(test_pid, {:telemetry_event, event, measurements, metadata})
   end
 
+  defp run(conn, %Plan{} = plan, %SourceResolved{} = resolved_source, opts) do
+    Runner.run(conn, plan, resolved_source, empty_cache_headers(), opts)
+  end
+
+  defp run(
+         conn,
+         %Plan{} = plan,
+         %SourceResolved{} = resolved_source,
+         %CacheHeaders{} = prepared_http_cache,
+         opts
+       ) do
+    Runner.run(conn, plan, resolved_source, prepared_http_cache, opts)
+  end
+
+  defp empty_cache_headers do
+    %CacheHeaders{representation_headers: [], headers: [], etag: nil}
+  end
+
   defp attach_telemetry(events) do
     handler_id = {__MODULE__, self(), make_ref()}
 
@@ -506,8 +524,8 @@ defmodule ImagePipe.Request.RunnerTest do
     require_tiff_support!()
     supervisor = start_source_session_supervisor()
 
-    assert {:ok, {:prepared_stream, prepared, %Response{}}} =
-             Runner.run(
+    assert {:ok, {:prepared_stream, prepared, %Response{}, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/plain/images/source.tiff"),
                plan(output: %Output{mode: :automatic}),
                resolved_source(),
@@ -526,8 +544,8 @@ defmodule ImagePipe.Request.RunnerTest do
     require_tiff_support!()
     supervisor = start_source_session_supervisor()
 
-    assert {:ok, {:prepared_stream, prepared, %Response{}}} =
-             Runner.run(
+    assert {:ok, {:prepared_stream, prepared, %Response{}, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/plain/images/source.tiff"),
                plan(output: %Output{mode: :automatic}),
                resolved_source(),
@@ -552,8 +570,8 @@ defmodule ImagePipe.Request.RunnerTest do
         output: %Output{mode: :automatic}
       )
 
-    assert {:ok, {:prepared_stream, prepared, %Response{}}} =
-             Runner.run(
+    assert {:ok, {:prepared_stream, prepared, %Response{}, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/bg:fff/plain/images/source.tiff"),
                plan,
                resolved_source(),
@@ -577,8 +595,8 @@ defmodule ImagePipe.Request.RunnerTest do
       |> conn("/_/plain/images/source.tiff")
       |> Plug.Conn.put_req_header("accept", "image/webp")
 
-    assert {:ok, {:prepared_stream, prepared, %Response{}}} =
-             Runner.run(
+    assert {:ok, {:prepared_stream, prepared, %Response{}, %CacheHeaders{}}} =
+             run(
                conn,
                plan(output: %Output{mode: :automatic}),
                resolved_source(),
@@ -599,8 +617,8 @@ defmodule ImagePipe.Request.RunnerTest do
     supervisor = start_source_session_supervisor()
     ref = make_ref()
 
-    assert {:ok, {:prepared_stream, prepared, %Response{}}} =
-             Runner.run(
+    assert {:ok, {:prepared_stream, prepared, %Response{}, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/plain/images/source.tiff"),
                plan(output: %Output{mode: :automatic}),
                resolved_source(),
@@ -637,8 +655,8 @@ defmodule ImagePipe.Request.RunnerTest do
     supervisor = start_source_session_supervisor()
     ref = make_ref()
 
-    assert {:ok, {:prepared_stream, prepared, %Response{}}} =
-             Runner.run(
+    assert {:ok, {:prepared_stream, prepared, %Response{}, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/plain/images/source.tiff"),
                plan(output: %Output{mode: :automatic}),
                resolved_source(),
@@ -679,8 +697,8 @@ defmodule ImagePipe.Request.RunnerTest do
       created_at: DateTime.utc_now()
     }
 
-    assert {:ok, {:cache_entry, ^entry, %ImagePipe.Plan.Response{}}} =
-             Runner.run(
+    assert {:ok, {:cache_entry, ^entry, %ImagePipe.Plan.Response{}, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/plain/images/source.tiff"),
                plan(output: %Output{mode: :automatic}),
                resolved_source(),
@@ -707,8 +725,8 @@ defmodule ImagePipe.Request.RunnerTest do
       |> conn("/_/plain/images/source.tiff")
       |> Plug.Conn.put_req_header("accept", "image/jpeg;q=0")
 
-    assert {:ok, {:cache_entry, ^entry, %ImagePipe.Plan.Response{}}} =
-             Runner.run(
+    assert {:ok, {:cache_entry, ^entry, %ImagePipe.Plan.Response{}, %CacheHeaders{}}} =
+             run(
                png_conn,
                plan(output: %Output{mode: :automatic}),
                resolved_source(),
@@ -718,8 +736,8 @@ defmodule ImagePipe.Request.RunnerTest do
 
     assert_received {:cache_lookup, png_key}
 
-    assert {:ok, {:cache_entry, ^entry, %ImagePipe.Plan.Response{}}} =
-             Runner.run(
+    assert {:ok, {:cache_entry, ^entry, %ImagePipe.Plan.Response{}, %CacheHeaders{}}} =
+             run(
                jpeg_q0_conn,
                plan(output: %Output{mode: :automatic}),
                resolved_source(),
@@ -740,8 +758,8 @@ defmodule ImagePipe.Request.RunnerTest do
       created_at: DateTime.utc_now()
     }
 
-    assert {:ok, {:cache_entry, ^entry, %Response{}}} =
-             Runner.run(
+    assert {:ok, {:cache_entry, ^entry, %Response{}, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/f:jpeg/plain/images/beach.jpg"),
                plan(),
                resolved_source(),
@@ -764,7 +782,7 @@ defmodule ImagePipe.Request.RunnerTest do
     }
 
     assert {:ok, {:cache_entry, ^entry, %Response{}, ^prepared_http_cache}} =
-             Runner.run(
+             run(
                conn(:get, "/image"),
                plan(),
                resolved_source(),
@@ -786,8 +804,8 @@ defmodule ImagePipe.Request.RunnerTest do
       |> conn("/_/plain/images/beach.jpg")
       |> Plug.Conn.put_req_header("accept", "image/jpeg")
 
-    assert {:ok, {:cache_entry, ^entry, %ImagePipe.Plan.Response{}}} =
-             Runner.run(
+    assert {:ok, {:cache_entry, ^entry, %ImagePipe.Plan.Response{}, %CacheHeaders{}}} =
+             run(
                conn,
                plan(output: %Output{mode: :automatic}),
                resolved_source(),
@@ -809,8 +827,8 @@ defmodule ImagePipe.Request.RunnerTest do
                enlargement: :deny
              )
 
-    assert {:ok, {:cache_entry, ^entry, %ImagePipe.Plan.Response{}}} =
-             Runner.run(
+    assert {:ok, {:cache_entry, ^entry, %ImagePipe.Plan.Response{}, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/rt:auto/w:100/h:100/f:jpeg/plain/images/beach.jpg"),
                plan(pipelines: [%Pipeline{operations: [operation]}]),
                resolved_source(
@@ -853,8 +871,8 @@ defmodule ImagePipe.Request.RunnerTest do
                enlargement: :deny
              )
 
-    assert {:ok, {:prepared_stream, prepared, %Response{}}} =
-             Runner.run(
+    assert {:ok, {:prepared_stream, prepared, %Response{}, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/rt:auto/w:100/h:100/f:jpeg/plain/images/beach.jpg"),
                plan(pipelines: [%Pipeline{operations: [operation]}]),
                resolved_source(),
@@ -881,8 +899,8 @@ defmodule ImagePipe.Request.RunnerTest do
   test "no-cache explicit output returns a prepared stream delivery" do
     supervisor = start_source_session_supervisor()
 
-    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, %Response{}}} =
-             Runner.run(
+    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, %Response{}, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/plain/images/beach.jpg"),
                plan(),
                resolved_source(internal_cache: :enabled),
@@ -903,8 +921,8 @@ defmodule ImagePipe.Request.RunnerTest do
   test "cache-skip explicit output returns a prepared stream delivery even when cache is configured" do
     supervisor = start_source_session_supervisor()
 
-    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, %Response{}}} =
-             Runner.run(
+    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, %Response{}, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/plain/images/beach.jpg"),
                plan(),
                resolved_source(internal_cache: :disabled),
@@ -924,8 +942,8 @@ defmodule ImagePipe.Request.RunnerTest do
     supervisor = start_source_session_supervisor()
     ref = make_ref()
 
-    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, response}} =
-             Runner.run(
+    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, response, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/plain/images/beach.jpg"),
                plan(),
                resolved_source(internal_cache: :enabled),
@@ -941,7 +959,7 @@ defmodule ImagePipe.Request.RunnerTest do
     conn =
       ImagePipe.Response.Sender.send_result(
         conn(:get, "/image"),
-        {:ok, {:prepared_stream, prepared, response}},
+        {:ok, {:prepared_stream, prepared, response, empty_cache_headers()}},
         []
       )
 
@@ -961,8 +979,8 @@ defmodule ImagePipe.Request.RunnerTest do
     supervisor = start_source_session_supervisor()
     ref = make_ref()
 
-    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, %Response{}}} =
-             Runner.run(
+    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, %Response{}, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/plain/images/beach.jpg"),
                plan(),
                resolved_source(internal_cache: :enabled),
@@ -985,8 +1003,8 @@ defmodule ImagePipe.Request.RunnerTest do
     supervisor = start_source_session_supervisor()
     ref = make_ref()
 
-    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, response}} =
-             Runner.run(
+    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, response, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/plain/images/beach.jpg"),
                plan(),
                resolved_source(internal_cache: :enabled),
@@ -999,7 +1017,10 @@ defmodule ImagePipe.Request.RunnerTest do
       :get
       |> conn("/image")
       |> Map.put(:adapter, {ClosingAfterFirstChunkAdapter, %{chunks: nil}})
-      |> ImagePipe.Response.Sender.send_result({:ok, {:prepared_stream, prepared, response}}, [])
+      |> ImagePipe.Response.Sender.send_result(
+        {:ok, {:prepared_stream, prepared, response, empty_cache_headers()}},
+        []
+      )
 
     refute Map.has_key?(conn.private, :image_pipe_send_result)
     assert_received {:cache_lookup, _key}
@@ -1013,8 +1034,8 @@ defmodule ImagePipe.Request.RunnerTest do
     supervisor = start_source_session_supervisor()
     ref = make_ref()
 
-    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, response}} =
-             Runner.run(
+    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, response, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/plain/images/beach.jpg"),
                plan(),
                resolved_source(internal_cache: :enabled),
@@ -1027,7 +1048,10 @@ defmodule ImagePipe.Request.RunnerTest do
       :get
       |> conn("/image")
       |> Map.put(:adapter, {FailingChunkedAdapter, %{}})
-      |> ImagePipe.Response.Sender.send_result({:ok, {:prepared_stream, prepared, response}}, [])
+      |> ImagePipe.Response.Sender.send_result(
+        {:ok, {:prepared_stream, prepared, response, empty_cache_headers()}},
+        []
+      )
 
     assert conn.private.image_pipe_send_result == :processing_error
     assert_received {:cache_lookup, _key}
@@ -1041,8 +1065,8 @@ defmodule ImagePipe.Request.RunnerTest do
     supervisor = start_source_session_supervisor()
     ref = make_ref()
 
-    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, response}} =
-             Runner.run(
+    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, response, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/plain/images/beach.jpg"),
                plan(),
                resolved_source(internal_cache: :enabled),
@@ -1055,7 +1079,10 @@ defmodule ImagePipe.Request.RunnerTest do
       :get
       |> conn("/image")
       |> Map.put(:adapter, {FirstChunkClosedAdapter, %{}})
-      |> ImagePipe.Response.Sender.send_result({:ok, {:prepared_stream, prepared, response}}, [])
+      |> ImagePipe.Response.Sender.send_result(
+        {:ok, {:prepared_stream, prepared, response, empty_cache_headers()}},
+        []
+      )
 
     refute Map.has_key?(conn.private, :image_pipe_send_result)
     assert_received {:cache_lookup, _key}
@@ -1071,8 +1098,8 @@ defmodule ImagePipe.Request.RunnerTest do
     supervisor = start_source_session_supervisor()
     ref = make_ref()
 
-    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, response}} =
-             Runner.run(
+    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, response, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/plain/images/beach.jpg"),
                plan(),
                resolved_source(internal_cache: :enabled),
@@ -1084,7 +1111,7 @@ defmodule ImagePipe.Request.RunnerTest do
     conn =
       ImagePipe.Response.Sender.send_result(
         conn(:get, "/image"),
-        {:ok, {:prepared_stream, prepared, response}},
+        {:ok, {:prepared_stream, prepared, response, empty_cache_headers()}},
         []
       )
 
@@ -1102,8 +1129,8 @@ defmodule ImagePipe.Request.RunnerTest do
     supervisor = start_source_session_supervisor()
     ref = make_ref()
 
-    assert {:ok, {:prepared_stream, prepared, %Response{}}} =
-             Runner.run(
+    assert {:ok, {:prepared_stream, prepared, %Response{}, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/f:auto/plain/images/beach.jpg", "")
                |> Plug.Conn.put_req_header("accept", "image/webp,image/jpeg;q=0.8"),
                plan(output: %Output{mode: :automatic}),
@@ -1135,7 +1162,7 @@ defmodule ImagePipe.Request.RunnerTest do
     supervisor = start_source_session_supervisor()
 
     assert {:error, {:processing, {:decode, _reason}, _headers}} =
-             Runner.run(
+             run(
                conn(:get, "/_/plain/images/not-image.jpg"),
                plan(),
                resolved_source(internal_cache: :enabled),
@@ -1167,8 +1194,8 @@ defmodule ImagePipe.Request.RunnerTest do
       test_ref: ref
     ]
 
-    assert {:ok, {:prepared_stream, prepared, %Response{}}} =
-             Runner.run(
+    assert {:ok, {:prepared_stream, prepared, %Response{}, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/f:jpeg/plain/images/beach.jpg"),
                plan,
                resolved_source(),
@@ -1195,8 +1222,8 @@ defmodule ImagePipe.Request.RunnerTest do
         }
       )
 
-    assert {:ok, {:prepared_stream, prepared, %Response{}}} =
-             Runner.run(
+    assert {:ok, {:prepared_stream, prepared, %Response{}, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/f:webp/fq:webp:70/plain/images/beach.jpg"),
                plan,
                resolved_source(),
@@ -1227,8 +1254,8 @@ defmodule ImagePipe.Request.RunnerTest do
 
     plan = plan(pipelines: [%Pipeline{operations: operations}])
 
-    assert {:ok, {:cache_entry, ^entry, %ImagePipe.Plan.Response{}}} =
-             Runner.run(
+    assert {:ok, {:cache_entry, ^entry, %ImagePipe.Plan.Response{}, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/f:jpeg/plain/images/beach.jpg"),
                plan,
                resolved_source(),
@@ -1266,8 +1293,8 @@ defmodule ImagePipe.Request.RunnerTest do
       filename: "carried"
     }
 
-    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, ^response}} =
-             Runner.run(
+    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, ^response, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/f:jpeg/plain/images/beach.jpg"),
                plan(response: response),
                resolved_source(),
@@ -1284,8 +1311,8 @@ defmodule ImagePipe.Request.RunnerTest do
       created_at: DateTime.utc_now()
     }
 
-    assert {:ok, {:cache_entry, ^entry, ^response}} =
-             Runner.run(
+    assert {:ok, {:cache_entry, ^entry, ^response, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/f:jpeg/plain/images/beach.jpg"),
                plan(response: response),
                resolved_source(),
@@ -1308,8 +1335,8 @@ defmodule ImagePipe.Request.RunnerTest do
 
     supervisor = start_source_session_supervisor()
 
-    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, ^response}} =
-             Runner.run(
+    assert {:ok, {:prepared_stream, %PreparedStream{} = prepared, ^response, %CacheHeaders{}}} =
+             run(
                conn(:get, "/_/f:jpeg/plain/images/beach.jpg"),
                plan(response: response),
                resolved_source(),

--- a/test/image_pipe/request_runner_test.exs
+++ b/test/image_pipe/request_runner_test.exs
@@ -15,6 +15,7 @@ defmodule ImagePipe.Request.RunnerTest do
   alias ImagePipe.Request.Runner
   alias ImagePipe.Request.SourceSessionSupervisor
   alias ImagePipe.Response.PreparedStream
+  alias ImagePipe.Source.CacheSemantics
   alias ImagePipe.Source.Resolved, as: SourceResolved
   alias ImagePipe.Source.Response, as: SourceResponse
   alias ImagePipe.Transform.State
@@ -434,7 +435,9 @@ defmodule ImagePipe.Request.RunnerTest do
           adapter: :path,
           source_kind: :path,
           identity: [kind: :path, root: "test", path: ["images", "beach.jpg"]],
-          cache: :normal,
+          internal_cache: :enabled,
+          http_cache: :inherit,
+          cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false},
           fetch: :fixture
         ],
         overrides
@@ -857,7 +860,7 @@ defmodule ImagePipe.Request.RunnerTest do
              Runner.run(
                conn(:get, "/_/plain/images/beach.jpg"),
                plan(),
-               resolved_source(cache: :normal),
+               resolved_source(internal_cache: :enabled),
                source_session_supervisor: supervisor,
                sources: %{path: {SourceImage, []}}
              )
@@ -879,7 +882,7 @@ defmodule ImagePipe.Request.RunnerTest do
              Runner.run(
                conn(:get, "/_/plain/images/beach.jpg"),
                plan(),
-               resolved_source(cache: :skip),
+               resolved_source(internal_cache: :disabled),
                cache: {CacheMissWriteProbe, test_pid: self(), test_ref: make_ref()},
                source_session_supervisor: supervisor,
                sources: %{path: {SourceImage, []}}
@@ -900,7 +903,7 @@ defmodule ImagePipe.Request.RunnerTest do
              Runner.run(
                conn(:get, "/_/plain/images/beach.jpg"),
                plan(),
-               resolved_source(cache: :normal),
+               resolved_source(internal_cache: :enabled),
                cache: {CacheMissWriteProbe, test_pid: self(), test_ref: ref},
                source_session_supervisor: supervisor,
                sources: %{path: {SourceImage, []}}
@@ -937,7 +940,7 @@ defmodule ImagePipe.Request.RunnerTest do
              Runner.run(
                conn(:get, "/_/plain/images/beach.jpg"),
                plan(),
-               resolved_source(cache: :normal),
+               resolved_source(internal_cache: :enabled),
                cache: {CacheReadErrorWriteProbe, test_pid: self(), test_ref: ref},
                source_session_supervisor: supervisor,
                sources: %{path: {SourceImage, []}}
@@ -961,7 +964,7 @@ defmodule ImagePipe.Request.RunnerTest do
              Runner.run(
                conn(:get, "/_/plain/images/beach.jpg"),
                plan(),
-               resolved_source(cache: :normal),
+               resolved_source(internal_cache: :enabled),
                cache: {CacheMissWriteProbe, test_pid: self(), test_ref: ref},
                source_session_supervisor: supervisor,
                sources: %{path: {SourceImage, []}}
@@ -989,7 +992,7 @@ defmodule ImagePipe.Request.RunnerTest do
              Runner.run(
                conn(:get, "/_/plain/images/beach.jpg"),
                plan(),
-               resolved_source(cache: :normal),
+               resolved_source(internal_cache: :enabled),
                cache: {CacheMissWriteProbe, test_pid: self(), test_ref: ref},
                source_session_supervisor: supervisor,
                sources: %{path: {SourceImage, []}}
@@ -1017,7 +1020,7 @@ defmodule ImagePipe.Request.RunnerTest do
              Runner.run(
                conn(:get, "/_/plain/images/beach.jpg"),
                plan(),
-               resolved_source(cache: :normal),
+               resolved_source(internal_cache: :enabled),
                cache: {CacheMissWriteProbe, test_pid: self(), test_ref: ref},
                source_session_supervisor: supervisor,
                sources: %{path: {SourceImage, []}}
@@ -1047,7 +1050,7 @@ defmodule ImagePipe.Request.RunnerTest do
              Runner.run(
                conn(:get, "/_/plain/images/beach.jpg"),
                plan(),
-               resolved_source(cache: :normal),
+               resolved_source(internal_cache: :enabled),
                cache: {CacheWriteErrorProbe, test_pid: self(), test_ref: ref},
                source_session_supervisor: supervisor,
                sources: %{path: {SourceImage, []}}
@@ -1079,7 +1082,7 @@ defmodule ImagePipe.Request.RunnerTest do
                conn(:get, "/_/f:auto/plain/images/beach.jpg", "")
                |> Plug.Conn.put_req_header("accept", "image/webp,image/jpeg;q=0.8"),
                plan(output: %Output{mode: :automatic}),
-               resolved_source(cache: :normal),
+               resolved_source(internal_cache: :enabled),
                cache: {CacheMissWriteProbe, test_pid: self(), test_ref: ref},
                source_session_supervisor: supervisor,
                sources: %{path: {SourceImage, []}}
@@ -1110,7 +1113,7 @@ defmodule ImagePipe.Request.RunnerTest do
              Runner.run(
                conn(:get, "/_/plain/images/not-image.jpg"),
                plan(),
-               resolved_source(cache: :normal),
+               resolved_source(internal_cache: :enabled),
                body: "not an image",
                source_session_supervisor: supervisor,
                sources: %{path: {SourceBytes, body: "not an image"}}

--- a/test/image_pipe/request_runner_test.exs
+++ b/test/image_pipe/request_runner_test.exs
@@ -14,6 +14,7 @@ defmodule ImagePipe.Request.RunnerTest do
   alias ImagePipe.Plan.Source.Path, as: SourcePath
   alias ImagePipe.Request.Runner
   alias ImagePipe.Request.SourceSessionSupervisor
+  alias ImagePipe.Response.CacheHeaders
   alias ImagePipe.Response.PreparedStream
   alias ImagePipe.Source.CacheSemantics
   alias ImagePipe.Source.Resolved, as: SourceResolved
@@ -744,6 +745,30 @@ defmodule ImagePipe.Request.RunnerTest do
                conn(:get, "/_/f:jpeg/plain/images/beach.jpg"),
                plan(),
                resolved_source(),
+               cache: {CacheHit, entry: entry}
+             )
+  end
+
+  test "cache hit delivery carries prepared HTTP cache value" do
+    prepared_http_cache = %CacheHeaders{
+      representation_headers: [],
+      headers: [{"cache-control", "public, max-age=31536000, immutable"}],
+      etag: nil
+    }
+
+    entry = %Entry{
+      body: "cached",
+      content_type: "image/jpeg",
+      headers: [],
+      created_at: DateTime.utc_now()
+    }
+
+    assert {:ok, {:cache_entry, ^entry, %Response{}, ^prepared_http_cache}} =
+             Runner.run(
+               conn(:get, "/image"),
+               plan(),
+               resolved_source(),
+               prepared_http_cache,
                cache: {CacheHit, entry: entry}
              )
   end

--- a/test/image_pipe/request_safety_test.exs
+++ b/test/image_pipe/request_safety_test.exs
@@ -38,7 +38,9 @@ defmodule ImagePipe.RequestSafetyTest do
          adapter: :path,
          source_kind: :path,
          identity: [kind: :path, root: "test", path: ["missing.jpg"]],
-         cache: :normal,
+         internal_cache: :enabled,
+         http_cache: :inherit,
+         cache_semantics: %ImagePipe.Source.CacheSemantics{byte_identity: :none, stable?: false},
          fetch: :missing
        }}
     end
@@ -60,7 +62,9 @@ defmodule ImagePipe.RequestSafetyTest do
          adapter: :path,
          source_kind: :path,
          identity: [kind: :path, root: "test", path: ["stream-fails.jpg"]],
-         cache: :skip,
+         internal_cache: :disabled,
+         http_cache: :inherit,
+         cache_semantics: %ImagePipe.Source.CacheSemantics{byte_identity: :none, stable?: false},
          fetch: :stream_fails
        }}
     end
@@ -85,7 +89,9 @@ defmodule ImagePipe.RequestSafetyTest do
          adapter: :path,
          source_kind: :path,
          identity: [kind: :path, root: "test", path: ["cacheable-stream-fails.jpg"]],
-         cache: :normal,
+         internal_cache: :enabled,
+         http_cache: :inherit,
+         cache_semantics: %ImagePipe.Source.CacheSemantics{byte_identity: :none, stable?: false},
          fetch: :stream_fails
        }}
     end

--- a/test/image_pipe/response_sender_test.exs
+++ b/test/image_pipe/response_sender_test.exs
@@ -6,6 +6,7 @@ defmodule ImagePipe.Response.SenderTest do
   alias ImagePipe.Cache.Entry
   alias ImagePipe.Output.Resolved
   alias ImagePipe.Plan.Response
+  alias ImagePipe.Response.CacheHeaders
   alias ImagePipe.Response.PreparedStream
   alias ImagePipe.Response.Sender
 
@@ -132,6 +133,84 @@ defmodule ImagePipe.Response.SenderTest do
 
     assert Plug.Conn.get_resp_header(conn, "content-disposition") ==
              [~s(attachment; filename="report.webp")]
+  end
+
+  test "cache hits merge generated headers before cached entry headers" do
+    entry = %Entry{
+      body: "body",
+      content_type: "image/webp",
+      headers: [{"cache-control", "public, max-age=60"}, {"vary", "Accept"}],
+      created_at: DateTime.utc_now()
+    }
+
+    prepared = %CacheHeaders{
+      representation_headers: [{"vary", "Accept"}],
+      headers: [
+        {"cache-control", "public, max-age=31536000, immutable"},
+        {"etag", ~s("ip1-test")}
+      ],
+      etag: ~s("ip1-test")
+    }
+
+    conn =
+      Sender.send_result(
+        conn(:get, "/image"),
+        {:ok, {:cache_entry, entry, %Response{}, prepared}},
+        []
+      )
+
+    assert Plug.Conn.get_resp_header(conn, "cache-control") == [
+             "public, max-age=31536000, immutable"
+           ]
+
+    assert Plug.Conn.get_resp_header(conn, "etag") == [~s("ip1-test")]
+    assert Plug.Conn.get_resp_header(conn, "vary") == ["Accept"]
+    assert conn.status == 200
+  end
+
+  test "current host cache-control wins over generated and cached headers" do
+    entry = %Entry{
+      body: "body",
+      content_type: "image/webp",
+      headers: [{"cache-control", "public, max-age=60"}],
+      created_at: DateTime.utc_now()
+    }
+
+    prepared = %CacheHeaders{
+      representation_headers: [],
+      headers: [{"cache-control", "public, max-age=31536000, immutable"}],
+      etag: nil
+    }
+
+    conn =
+      :get
+      |> conn("/image")
+      |> Plug.Conn.put_resp_header("cache-control", "private, max-age=30")
+      |> Sender.send_result({:ok, {:cache_entry, entry, %Response{}, prepared}}, [])
+
+    assert Plug.Conn.get_resp_header(conn, "cache-control") == ["private, max-age=30"]
+  end
+
+  test "prepared streams merge generated headers before stream headers" do
+    prepared_stream =
+      prepared_stream(headers: [{"cache-control", "public, max-age=60"}])
+
+    prepared = %CacheHeaders{
+      representation_headers: [],
+      headers: [{"cache-control", "public, max-age=31536000, immutable"}],
+      etag: nil
+    }
+
+    conn =
+      Sender.send_result(
+        conn(:get, "/image"),
+        {:ok, {:prepared_stream, prepared_stream, %Response{}, prepared}},
+        []
+      )
+
+    assert Plug.Conn.get_resp_header(conn, "cache-control") == [
+             "public, max-age=31536000, immutable"
+           ]
   end
 
   test "prepared streams send first chunk and pull later chunks" do

--- a/test/image_pipe/response_sender_test.exs
+++ b/test/image_pipe/response_sender_test.exs
@@ -127,7 +127,11 @@ defmodule ImagePipe.Response.SenderTest do
     response = %Response{disposition: :attachment, filename: "report"}
 
     conn =
-      Sender.send_result(conn(:get, "/image"), {:ok, {:cache_entry, entry, response}}, [])
+      Sender.send_result(
+        conn(:get, "/image"),
+        {:ok, {:cache_entry, entry, response, empty_cache_headers()}},
+        []
+      )
 
     assert conn.status == 200
 
@@ -237,10 +241,13 @@ defmodule ImagePipe.Response.SenderTest do
       )
 
     assert_receive {:telemetry_event, [:image_pipe, :http_cache, :cache_hit, :headers], %{},
-                    %{etag: true} = metadata}
+                    metadata}
 
-    refute Map.has_key?(metadata, :path)
-    refute Map.has_key?(metadata, :etag_value)
+    assert metadata == %{
+             etag: true,
+             generated_cache_headers: true,
+             representation_headers: false
+           }
   end
 
   test "prepared streams send first chunk and pull later chunks" do
@@ -263,7 +270,11 @@ defmodule ImagePipe.Response.SenderTest do
       )
 
     conn =
-      Sender.send_result(conn(:get, "/image"), {:ok, {:prepared_stream, prepared, response}}, [])
+      Sender.send_result(
+        conn(:get, "/image"),
+        {:ok, {:prepared_stream, prepared, response, empty_cache_headers()}},
+        []
+      )
 
     assert conn.status == 200
     assert conn.resp_body == "firstsecond"
@@ -292,7 +303,11 @@ defmodule ImagePipe.Response.SenderTest do
       )
 
     conn =
-      Sender.send_result(conn(:get, "/image"), {:ok, {:prepared_stream, prepared, response}}, [])
+      Sender.send_result(
+        conn(:get, "/image"),
+        {:ok, {:prepared_stream, prepared, response, empty_cache_headers()}},
+        []
+      )
 
     assert conn.status == 200
     refute_received ^cancel_ref
@@ -315,7 +330,11 @@ defmodule ImagePipe.Response.SenderTest do
       )
 
     conn =
-      Sender.send_result(conn(:get, "/image"), {:ok, {:prepared_stream, prepared, response}}, [])
+      Sender.send_result(
+        conn(:get, "/image"),
+        {:ok, {:prepared_stream, prepared, response, empty_cache_headers()}},
+        []
+      )
 
     assert conn.status == 200
     assert conn.private.image_pipe_send_result == :processing_error
@@ -350,7 +369,10 @@ defmodule ImagePipe.Response.SenderTest do
       :get
       |> conn("/image")
       |> Map.put(:adapter, {ClosingChunkAdapter, %{chunks: nil}})
-      |> Sender.send_result({:ok, {:prepared_stream, prepared, %Response{}}}, [])
+      |> Sender.send_result(
+        {:ok, {:prepared_stream, prepared, %Response{}, empty_cache_headers()}},
+        []
+      )
 
     refute Map.has_key?(conn.private, :image_pipe_send_result)
     assert conn.resp_body == "first"
@@ -384,7 +406,10 @@ defmodule ImagePipe.Response.SenderTest do
       :get
       |> conn("/image")
       |> Map.put(:adapter, {FailingChunkedAdapter, %{}})
-      |> Sender.send_result({:ok, {:prepared_stream, prepared, %Response{}}}, [])
+      |> Sender.send_result(
+        {:ok, {:prepared_stream, prepared, %Response{}, empty_cache_headers()}},
+        []
+      )
 
     assert conn.private.image_pipe_send_result == :processing_error
     assert_receive ^cancel_ref
@@ -415,7 +440,10 @@ defmodule ImagePipe.Response.SenderTest do
       :get
       |> conn("/image")
       |> Map.put(:adapter, {FirstChunkClosedAdapter, %{}})
-      |> Sender.send_result({:ok, {:prepared_stream, prepared, %Response{}}}, [])
+      |> Sender.send_result(
+        {:ok, {:prepared_stream, prepared, %Response{}, empty_cache_headers()}},
+        []
+      )
 
     refute Map.has_key?(conn.private, :image_pipe_send_result)
     assert_receive ^cancel_ref
@@ -437,7 +465,7 @@ defmodule ImagePipe.Response.SenderTest do
     conn =
       Sender.send_result(
         conn(:get, "/image"),
-        {:ok, {:prepared_stream, prepared, %Response{}}},
+        {:ok, {:prepared_stream, prepared, %Response{}, empty_cache_headers()}},
         []
       )
 
@@ -464,6 +492,10 @@ defmodule ImagePipe.Response.SenderTest do
         overrides
       )
     )
+  end
+
+  defp empty_cache_headers do
+    %CacheHeaders{representation_headers: [], headers: [], etag: nil}
   end
 
   defp attach_telemetry(events) do

--- a/test/image_pipe/response_sender_test.exs
+++ b/test/image_pipe/response_sender_test.exs
@@ -213,6 +213,36 @@ defmodule ImagePipe.Response.SenderTest do
            ]
   end
 
+  test "cache hit header telemetry is low-cardinality" do
+    attach_telemetry([[:image_pipe, :http_cache, :cache_hit, :headers]])
+
+    entry = %Entry{
+      body: "body",
+      content_type: "image/webp",
+      headers: [],
+      created_at: DateTime.utc_now()
+    }
+
+    prepared = %CacheHeaders{
+      representation_headers: [],
+      headers: [{"etag", ~s("ip1-token")}],
+      etag: ~s("ip1-token")
+    }
+
+    _conn =
+      Sender.send_result(
+        conn(:get, "/image"),
+        {:ok, {:cache_entry, entry, %Response{}, prepared}},
+        []
+      )
+
+    assert_receive {:telemetry_event, [:image_pipe, :http_cache, :cache_hit, :headers], %{},
+                    %{etag: true} = metadata}
+
+    refute Map.has_key?(metadata, :path)
+    refute Map.has_key?(metadata, :etag_value)
+  end
+
   test "prepared streams send first chunk and pull later chunks" do
     parent = self()
     response = %Response{disposition: :inline, filename: "prepared"}

--- a/test/image_pipe/source/file_test.exs
+++ b/test/image_pipe/source/file_test.exs
@@ -97,4 +97,31 @@ defmodule ImagePipe.Source.FileTest do
 
     assert SourceFile.fetch(resolved, opts, []) == {:error, {:source, :not_found}}
   end
+
+  test "file source defaults to not stable and disables internal cache in auto mode", %{root: root} do
+    assert {:ok, opts} = SourceFile.validate_options(root: root, root_id: "fixture-root")
+    source = %SourcePath{segments: ["images", "cat.jpg"]}
+
+    assert {:ok, resolved} = SourceFile.resolve(source, opts, [])
+
+    assert resolved.internal_cache == :disabled
+    assert resolved.http_cache == :inherit
+    assert resolved.cache_semantics.stable? == false
+    assert resolved.cache_semantics.byte_identity == :none
+  end
+
+  test "file source trusted stability derives strong byte identity", %{root: root} do
+    assert {:ok, opts} =
+             SourceFile.validate_options(root: root, root_id: "fixture-root", stable: :trusted)
+
+    source = %SourcePath{segments: ["images", "cat.jpg"]}
+
+    assert {:ok, resolved} = SourceFile.resolve(source, opts, [])
+
+    assert resolved.internal_cache == :enabled
+    assert resolved.cache_semantics.stable? == true
+    assert {:strong, seed} = resolved.cache_semantics.byte_identity
+    assert seed[:root] == "fixture-root"
+    assert seed[:path] == ["images", "cat.jpg"]
+  end
 end

--- a/test/image_pipe/source/file_test.exs
+++ b/test/image_pipe/source/file_test.exs
@@ -98,7 +98,9 @@ defmodule ImagePipe.Source.FileTest do
     assert SourceFile.fetch(resolved, opts, []) == {:error, {:source, :not_found}}
   end
 
-  test "file source defaults to not stable and disables internal cache in auto mode", %{root: root} do
+  test "file source defaults to not stable and disables internal cache in auto mode", %{
+    root: root
+  } do
     assert {:ok, opts} = SourceFile.validate_options(root: root, root_id: "fixture-root")
     source = %SourcePath{segments: ["images", "cat.jpg"]}
 

--- a/test/image_pipe/source/http_test.exs
+++ b/test/image_pipe/source/http_test.exs
@@ -181,6 +181,52 @@ defmodule ImagePipe.Source.HTTPTest do
            end)
   end
 
+  test "trusted byte identity strips byte-changing headers even when internal cache is disabled" do
+    plug = fn conn ->
+      send(self(), {:http_request, conn.req_headers})
+      Plug.Conn.send_resp(conn, 200, "image bytes")
+    end
+
+    source = %URL{
+      scheme: :https,
+      host: "assets.example.com",
+      port: nil,
+      path: ["cat.jpg"],
+      query: nil
+    }
+
+    assert {:ok, opts} =
+             HTTP.validate_options(
+               allowed_hosts: ["assets.example.com"],
+               stable: :trusted,
+               internal_cache: :disabled,
+               req_options: [
+                 plug: plug,
+                 headers: [
+                   {"Range", "bytes=0-1"},
+                   {"Accept", "application/json"},
+                   {"Accept-Encoding", "gzip"},
+                   {"x-extra", "kept"}
+                 ]
+               ]
+             )
+
+    assert {:ok, resolved} = HTTP.resolve(source, opts, [])
+
+    assert {:ok, %Response{} = response} =
+             Source.fetch(resolved, [sources: %{https: {HTTP, opts}}], [])
+
+    assert Enum.join(response.stream) == "image bytes"
+    assert_receive {:http_request, headers}
+
+    assert {_name, "kept"} =
+             Enum.find(headers, fn {name, _value} -> String.downcase(name) == "x-extra" end)
+
+    refute Enum.any?(headers, fn {name, _value} ->
+             String.downcase(name) in ["range", "accept", "accept-encoding"]
+           end)
+  end
+
   test "configured max redirects allows bounded redirects" do
     plug = fn
       %{request_path: "/redirect.jpg"} = conn ->

--- a/test/image_pipe/source/http_test.exs
+++ b/test/image_pipe/source/http_test.exs
@@ -7,6 +7,32 @@ defmodule ImagePipe.Source.HTTPTest do
   alias ImagePipe.Source.Resolved
   alias ImagePipe.Source.Response
 
+  test "http source defaults to not stable and disables internal cache in auto mode" do
+    assert {:ok, opts} = HTTP.validate_options(allowed_hosts: ["example.com"])
+    source = %URL{scheme: :https, host: "example.com", path: ["cat.jpg"]}
+
+    assert {:ok, resolved} = HTTP.resolve(source, opts, [])
+
+    assert resolved.internal_cache == :disabled
+    assert resolved.cache_semantics.byte_identity == :none
+  end
+
+  test "http trusted byte identity doesn't expose raw query" do
+    assert {:ok, opts} = HTTP.validate_options(allowed_hosts: ["example.com"], stable: :trusted)
+
+    source = %URL{
+      scheme: :https,
+      host: "example.com",
+      path: ["cat.jpg"],
+      query: "X-Amz-Signature=secret"
+    }
+
+    assert {:ok, resolved} = HTTP.resolve(source, opts, [])
+    assert {:strong, seed} = resolved.cache_semantics.byte_identity
+    refute inspect(seed) =~ "X-Amz-Signature=secret"
+    assert is_binary(seed[:query_sha256])
+  end
+
   test "resolve normalizes URL identity and enforces allowed hosts" do
     assert {:ok, opts} = HTTP.validate_options(allowed_hosts: ["assets.example.com"])
 
@@ -51,9 +77,12 @@ defmodule ImagePipe.Source.HTTPTest do
     assert resolved.identity[:host] == "assets.example.com"
   end
 
-  test "resolve honors HTTP cache skip option" do
+  test "resolve honors HTTP internal cache disabled option" do
     assert {:ok, opts} =
-             HTTP.validate_options(allowed_hosts: ["assets.example.com"], cache: :skip)
+             HTTP.validate_options(
+               allowed_hosts: ["assets.example.com"],
+               internal_cache: :disabled
+             )
 
     source = %URL{
       scheme: :https,
@@ -64,7 +93,7 @@ defmodule ImagePipe.Source.HTTPTest do
     }
 
     assert {:ok, %Resolved{} = resolved} = HTTP.resolve(source, opts, [])
-    assert resolved.cache == :skip
+    assert resolved.internal_cache == :disabled
   end
 
   test "fetch creates a Req-backed lazy stream and preserves safe request options" do
@@ -115,6 +144,7 @@ defmodule ImagePipe.Source.HTTPTest do
     assert {:ok, opts} =
              HTTP.validate_options(
                allowed_hosts: ["assets.example.com"],
+               internal_cache: :enabled,
                req_options: [
                  plug: plug,
                  url: "https://evil.example/other.jpg",

--- a/test/image_pipe/source/s3_test.exs
+++ b/test/image_pipe/source/s3_test.exs
@@ -359,6 +359,49 @@ defmodule ImagePipe.Source.S3Test do
     refute authorization =~ "Bearer evil"
   end
 
+  test "stable S3 byte identity strips byte-changing headers even when internal cache is disabled" do
+    plug = fn conn ->
+      send(self(), {:s3_request, conn.req_headers})
+      Plug.Conn.send_resp(conn, 200, "image bytes")
+    end
+
+    assert {:ok, opts} =
+             S3.validate_options(
+               default: [
+                 region: "us-east-1",
+                 endpoint: "https://minio.test",
+                 stable: :trusted,
+                 internal_cache: :disabled,
+                 credentials: {:static, access_key_id: "A", secret_access_key: "S"},
+                 req_options: [
+                   plug: plug,
+                   headers: [
+                     {"Range", "bytes=0-1"},
+                     {"Accept", "application/json"},
+                     {"Accept-Encoding", "gzip"},
+                     {"x-extra", "kept"}
+                   ]
+                 ]
+               ]
+             )
+
+    source = %Object{adapter: :s3, scope: "tenant-a", key: "images/cat.jpg"}
+    assert {:ok, resolved} = S3.resolve(source, opts, [])
+
+    assert {:ok, %Response{} = response} =
+             Source.fetch(resolved, [sources: %{s3: {S3, opts}}], [])
+
+    assert Enum.join(response.stream) == "image bytes"
+    assert_receive {:s3_request, headers}
+
+    assert {_name, "kept"} =
+             Enum.find(headers, fn {name, _value} -> String.downcase(name) == "x-extra" end)
+
+    refute Enum.any?(headers, fn {name, _value} ->
+             String.downcase(name) in ["range", "accept", "accept-encoding"]
+           end)
+  end
+
   test "credential failures are safe source errors" do
     defmodule FailingProvider do
       def fetch_credentials(_scope, _provider_opts, _runtime_opts),

--- a/test/image_pipe/source/s3_test.exs
+++ b/test/image_pipe/source/s3_test.exs
@@ -48,6 +48,25 @@ defmodule ImagePipe.Source.S3Test do
     assert resolved.cache_semantics.byte_identity == :none
   end
 
+  test "empty s3 revision isn't stable under auto mode" do
+    assert {:ok, opts} =
+             S3.validate_options(
+               default: [
+                 region: "us-east-1",
+                 endpoint: "https://s3.amazonaws.com",
+                 credentials: {:static, access_key_id: "A", secret_access_key: "S"}
+               ]
+             )
+
+    source = %Object{adapter: :s3, scope: "bucket", key: "cat.jpg", revision: ""}
+
+    assert {:ok, resolved} = S3.resolve(source, opts, [])
+
+    assert resolved.internal_cache == :disabled
+    assert resolved.cache_semantics.byte_identity == :none
+    assert resolved.cache_semantics.stable? == false
+  end
+
   test "per-bucket config overrides defaults and identity includes endpoint bucket key revision" do
     assert {:ok, opts} =
              S3.validate_options(

--- a/test/image_pipe/source/s3_test.exs
+++ b/test/image_pipe/source/s3_test.exs
@@ -8,6 +8,46 @@ defmodule ImagePipe.Source.S3Test do
   alias ImagePipe.Source.S3
   alias ImagePipe.SourceTest.CredentialProvider
 
+  test "s3 revision is stable under auto mode" do
+    assert {:ok, opts} =
+             S3.validate_options(
+               default: [
+                 region: "us-east-1",
+                 endpoint: "https://s3.amazonaws.com",
+                 credentials: {:static, access_key_id: "A", secret_access_key: "S"}
+               ]
+             )
+
+    source = %Object{adapter: :s3, scope: "bucket", key: "cat.jpg", revision: "v1"}
+
+    assert {:ok, resolved} = S3.resolve(source, opts, [])
+
+    assert resolved.internal_cache == :enabled
+    assert resolved.cache_semantics.stable? == true
+    assert {:strong, seed} = resolved.cache_semantics.byte_identity
+    assert seed[:bucket] == "bucket"
+    assert seed[:key] == "cat.jpg"
+    assert seed[:revision] == "v1"
+  end
+
+  test "s3 without revision isn't stable unless trusted" do
+    assert {:ok, opts} =
+             S3.validate_options(
+               default: [
+                 region: "us-east-1",
+                 endpoint: "https://s3.amazonaws.com",
+                 credentials: {:static, access_key_id: "A", secret_access_key: "S"}
+               ]
+             )
+
+    source = %Object{adapter: :s3, scope: "bucket", key: "cat.jpg", revision: nil}
+
+    assert {:ok, resolved} = S3.resolve(source, opts, [])
+
+    assert resolved.internal_cache == :disabled
+    assert resolved.cache_semantics.byte_identity == :none
+  end
+
   test "per-bucket config overrides defaults and identity includes endpoint bucket key revision" do
     assert {:ok, opts} =
              S3.validate_options(

--- a/test/image_pipe/source_test.exs
+++ b/test/image_pipe/source_test.exs
@@ -86,6 +86,42 @@ defmodule ImagePipe.SourceTest do
     assert {:error, {:source, :invalid_adapter_result}} = Source.resolve(source, opts, [])
   end
 
+  test "source validation rejects contradictory cache semantics" do
+    defmodule ContradictorySemanticsSource do
+      @behaviour ImagePipe.Source
+
+      def validate_options(opts), do: {:ok, opts}
+
+      def resolve(%SourcePath{}, _opts, _runtime_opts) do
+        {:ok,
+         %Resolved{
+           adapter: :path,
+           source_kind: :path,
+           identity: [kind: :path, adapter: :path, root: "test", path: ["cat.jpg"]],
+           internal_cache: :disabled,
+           http_cache: :inherit,
+           cache_semantics: %CacheSemantics{
+             byte_identity: {:strong, [kind: :path, root: "test", path: ["cat.jpg"]]},
+             stable?: false
+           },
+           fetch: [path: "/tmp/cat.jpg"]
+         }}
+      end
+
+      def fetch(_resolved, _opts, _runtime_opts), do: raise("not used")
+    end
+
+    assert {:ok, opts} =
+             Source.validate_config(
+               parser: ImagePipe.Parser.Imgproxy,
+               sources: [path: {ContradictorySemanticsSource, []}]
+             )
+
+    source = %SourcePath{segments: ["cat.jpg"]}
+
+    assert {:error, {:source, :invalid_adapter_result}} = Source.resolve(source, opts, [])
+  end
+
   test "validate_config calls adapter validation during init-time option normalization" do
     assert {:ok, opts} =
              Source.validate_config(

--- a/test/image_pipe/source_test.exs
+++ b/test/image_pipe/source_test.exs
@@ -2,8 +2,10 @@ defmodule ImagePipe.SourceTest do
   use ExUnit.Case, async: true
 
   alias ImagePipe.Plan.Source.Path
+  alias ImagePipe.Plan.Source.Path, as: SourcePath
   alias ImagePipe.Plan.Source.URL
   alias ImagePipe.Source
+  alias ImagePipe.Source.CacheSemantics
   alias ImagePipe.Source.HTTP
   alias ImagePipe.Source.Resolved
   alias ImagePipe.Source.Response
@@ -14,6 +16,75 @@ defmodule ImagePipe.SourceTest do
   alias ImagePipe.SourceTest.InvalidIdentityAdapter
   alias ImagePipe.SourceTest.RaisingAdapter
   alias ImagePipe.SourceTest.StreamWithCleanup
+
+  test "cache semantics requires explicit byte identity and stability" do
+    assert_raise ArgumentError, fn ->
+      struct!(CacheSemantics, byte_identity: :none)
+    end
+
+    assert %CacheSemantics{byte_identity: :none, stable?: false} =
+             struct!(CacheSemantics, byte_identity: :none, stable?: false)
+  end
+
+  test "resolved source requires internal cache mode, http cache mode, and cache semantics" do
+    assert_raise ArgumentError, fn ->
+      struct!(Resolved,
+        adapter: :path,
+        source_kind: :path,
+        identity: [kind: :path, adapter: :path, root: "test", path: ["cat.jpg"]],
+        internal_cache: :disabled,
+        fetch: [path: "/tmp/cat.jpg"]
+      )
+    end
+
+    assert %Resolved{
+             internal_cache: :disabled,
+             http_cache: :inherit,
+             cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false}
+           } =
+             struct!(Resolved,
+               adapter: :path,
+               source_kind: :path,
+               identity: [kind: :path, adapter: :path, root: "test", path: ["cat.jpg"]],
+               internal_cache: :disabled,
+               http_cache: :inherit,
+               cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false},
+               fetch: [path: "/tmp/cat.jpg"]
+             )
+  end
+
+  test "source validation rejects resolved values without cache semantics" do
+    defmodule MissingSemanticsSource do
+      @behaviour ImagePipe.Source
+
+      def validate_options(opts), do: {:ok, opts}
+
+      def resolve(%SourcePath{}, _opts, _runtime_opts) do
+        {:ok,
+         %Resolved{
+           adapter: :path,
+           source_kind: :path,
+           identity: [kind: :path, adapter: :path, root: "test", path: ["cat.jpg"]],
+           internal_cache: :disabled,
+           http_cache: :inherit,
+           cache_semantics: nil,
+           fetch: [path: "/tmp/cat.jpg"]
+         }}
+      end
+
+      def fetch(_resolved, _opts, _runtime_opts), do: raise("not used")
+    end
+
+    assert {:ok, opts} =
+             Source.validate_config(
+               parser: ImagePipe.Parser.Imgproxy,
+               sources: [path: {MissingSemanticsSource, []}]
+             )
+
+    source = %SourcePath{segments: ["cat.jpg"]}
+
+    assert {:error, {:source, :invalid_adapter_result}} = Source.resolve(source, opts, [])
+  end
 
   test "validate_config calls adapter validation during init-time option normalization" do
     assert {:ok, opts} =
@@ -48,7 +119,7 @@ defmodule ImagePipe.SourceTest do
     assert resolved.adapter == :path
     assert resolved.source_kind == :path
     assert resolved.identity == [kind: :path, root: "test", path: ["images", "cat.jpg"]]
-    assert resolved.cache == :normal
+    assert resolved.internal_cache == :enabled
 
     assert_receive {:resolve, ^source, adapter_opts, [request_id: "r1"]}
     assert adapter_opts[:validated]
@@ -96,7 +167,7 @@ defmodule ImagePipe.SourceTest do
              Source.validate_config(
                sources: [
                  url: {HTTP, allowed_hosts: ["assets.example.com"]},
-                 https: {HTTP, allowed_hosts: ["assets.example.com"], cache: :skip}
+                 https: {HTTP, allowed_hosts: ["assets.example.com"], internal_cache: :disabled}
                ]
              )
 
@@ -109,7 +180,7 @@ defmodule ImagePipe.SourceTest do
     }
 
     assert {:ok, %Resolved{} = resolved} = Source.resolve(source, opts, [])
-    assert resolved.cache == :skip
+    assert resolved.internal_cache == :disabled
   end
 
   test "malformed adapter callback results become source errors" do
@@ -126,7 +197,9 @@ defmodule ImagePipe.SourceTest do
       adapter: :path,
       source_kind: :path,
       identity: [kind: :path, root: "test", path: ["images", "cat.jpg"]],
-      cache: :normal,
+      internal_cache: :enabled,
+      http_cache: :inherit,
+      cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false},
       fetch: :invalid_fetch
     }
 
@@ -282,7 +355,9 @@ defmodule ImagePipe.SourceTest do
       adapter: :path,
       source_kind: :path,
       identity: [kind: :path, root: "test", path: ["images", "cat.jpg"]],
-      cache: :normal,
+      internal_cache: :enabled,
+      http_cache: :inherit,
+      cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false},
       fetch: :raise
     }
 

--- a/test/image_pipe/source_test.exs
+++ b/test/image_pipe/source_test.exs
@@ -17,42 +17,6 @@ defmodule ImagePipe.SourceTest do
   alias ImagePipe.SourceTest.RaisingAdapter
   alias ImagePipe.SourceTest.StreamWithCleanup
 
-  test "cache semantics requires explicit byte identity and stability" do
-    assert_raise ArgumentError, fn ->
-      struct!(CacheSemantics, byte_identity: :none)
-    end
-
-    assert %CacheSemantics{byte_identity: :none, stable?: false} =
-             struct!(CacheSemantics, byte_identity: :none, stable?: false)
-  end
-
-  test "resolved source requires internal cache mode, http cache mode, and cache semantics" do
-    assert_raise ArgumentError, fn ->
-      struct!(Resolved,
-        adapter: :path,
-        source_kind: :path,
-        identity: [kind: :path, adapter: :path, root: "test", path: ["cat.jpg"]],
-        internal_cache: :disabled,
-        fetch: [path: "/tmp/cat.jpg"]
-      )
-    end
-
-    assert %Resolved{
-             internal_cache: :disabled,
-             http_cache: :inherit,
-             cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false}
-           } =
-             struct!(Resolved,
-               adapter: :path,
-               source_kind: :path,
-               identity: [kind: :path, adapter: :path, root: "test", path: ["cat.jpg"]],
-               internal_cache: :disabled,
-               http_cache: :inherit,
-               cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false},
-               fetch: [path: "/tmp/cat.jpg"]
-             )
-  end
-
   test "source validation rejects resolved values without cache semantics" do
     defmodule MissingSemanticsSource do
       @behaviour ImagePipe.Source

--- a/test/image_pipe/telemetry_test.exs
+++ b/test/image_pipe/telemetry_test.exs
@@ -583,7 +583,7 @@ defmodule ImagePipe.TelemetryTest do
       [
         parser: ImagePipe.Parser.Imgproxy,
         sources: [
-          path: {ImagePipe.Source.File, root: "priv/static", root_id: "static"}
+          path: {ImagePipe.Source.File, root: "priv/static", root_id: "static", stable: :trusted}
         ]
       ],
       overrides

--- a/test/image_pipe/telemetry_test.exs
+++ b/test/image_pipe/telemetry_test.exs
@@ -25,7 +25,9 @@ defmodule ImagePipe.TelemetryTest do
          adapter: :path,
          source_kind: :path,
          identity: [kind: :path, root: "invalid", path: ["images", "beach.jpg"]],
-         cache: :normal,
+         internal_cache: :enabled,
+         http_cache: :inherit,
+         cache_semantics: %ImagePipe.Source.CacheSemantics{byte_identity: :none, stable?: false},
          fetch: :invalid
        }}
     end
@@ -128,7 +130,9 @@ defmodule ImagePipe.TelemetryTest do
          adapter: :path,
          source_kind: :path,
          identity: [kind: :path, root: "test", path: ["images", "source.tiff"]],
-         cache: :normal,
+         internal_cache: :enabled,
+         http_cache: :inherit,
+         cache_semantics: %ImagePipe.Source.CacheSemantics{byte_identity: :none, stable?: false},
          fetch: Keyword.fetch!(opts, :body)
        }}
     end

--- a/test/support/image_pipe/source_test/adapter_mismatch_adapter.ex
+++ b/test/support/image_pipe/source_test/adapter_mismatch_adapter.ex
@@ -4,6 +4,7 @@ defmodule ImagePipe.SourceTest.AdapterMismatchAdapter do
   use Boundary, top_level?: true, deps: [ImagePipe.Source]
 
   alias ImagePipe.Source
+  alias ImagePipe.Source.CacheSemantics
   alias ImagePipe.Source.Resolved
 
   @behaviour Source
@@ -18,7 +19,9 @@ defmodule ImagePipe.SourceTest.AdapterMismatchAdapter do
        adapter: :path,
        source_kind: :object,
        identity: [kind: :object, adapter: :foobar, scope: "custom", key: "cat.jpg"],
-       cache: :normal,
+       internal_cache: :enabled,
+       http_cache: :inherit,
+       cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false},
        fetch: :wrong_adapter
      }}
   end

--- a/test/support/image_pipe/source_test/custom_adapter.ex
+++ b/test/support/image_pipe/source_test/custom_adapter.ex
@@ -4,6 +4,7 @@ defmodule ImagePipe.SourceTest.CustomAdapter do
   use Boundary, top_level?: true, deps: [ImagePipe.Source]
 
   alias ImagePipe.Source
+  alias ImagePipe.Source.CacheSemantics
   alias ImagePipe.Source.Resolved
   alias ImagePipe.Source.Response
 
@@ -24,7 +25,9 @@ defmodule ImagePipe.SourceTest.CustomAdapter do
        adapter: Keyword.fetch!(opts, :adapter),
        source_kind: :path,
        identity: [kind: :path, root: "test", path: ["images", "cat.jpg"]],
-       cache: Keyword.get(opts, :cache, :normal),
+       internal_cache: Keyword.get(opts, :internal_cache, :enabled),
+       http_cache: Keyword.get(opts, :http_cache, :inherit),
+       cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false},
        fetch: {:source, source}
      }}
   end

--- a/test/support/image_pipe/source_test/invalid_identity_adapter.ex
+++ b/test/support/image_pipe/source_test/invalid_identity_adapter.ex
@@ -4,6 +4,7 @@ defmodule ImagePipe.SourceTest.InvalidIdentityAdapter do
   use Boundary, top_level?: true, deps: [ImagePipe.Source]
 
   alias ImagePipe.Source
+  alias ImagePipe.Source.CacheSemantics
   alias ImagePipe.Source.Resolved
 
   @behaviour Source
@@ -18,7 +19,9 @@ defmodule ImagePipe.SourceTest.InvalidIdentityAdapter do
        adapter: :path,
        source_kind: :path,
        identity: Keyword.get(opts, :identity, kind: :path, client: self()),
-       cache: :skip,
+       internal_cache: :disabled,
+       http_cache: :inherit,
+       cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false},
        fetch: :bad_identity
      }}
   end

--- a/test/support/image_pipe/source_test/plug_custom_adapter.ex
+++ b/test/support/image_pipe/source_test/plug_custom_adapter.ex
@@ -4,6 +4,7 @@ defmodule ImagePipe.SourceTest.PlugCustomAdapter do
   use Boundary, top_level?: true, deps: [ImagePipe.Source]
 
   alias ImagePipe.Source
+  alias ImagePipe.Source.CacheSemantics
   alias ImagePipe.Source.Resolved
   alias ImagePipe.Source.Response
 
@@ -27,7 +28,9 @@ defmodule ImagePipe.SourceTest.PlugCustomAdapter do
          scope: "custom",
          key: "cat.jpg"
        ],
-       cache: Keyword.get(opts, :cache, :normal),
+       internal_cache: Keyword.get(opts, :internal_cache, :enabled),
+       http_cache: Keyword.get(opts, :http_cache, :inherit),
+       cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false},
        fetch: :cat
      }}
   end

--- a/test/support/image_pipe/source_test/root_http_adapter.ex
+++ b/test/support/image_pipe/source_test/root_http_adapter.ex
@@ -5,6 +5,7 @@ defmodule ImagePipe.SourceTest.RootHTTPAdapter do
 
   alias ImagePipe.Plan.Source.Path, as: SourcePath
   alias ImagePipe.Source
+  alias ImagePipe.Source.CacheSemantics
   alias ImagePipe.Source.Resolved
   alias ImagePipe.Source.Response
   alias ImagePipe.Source.StreamError
@@ -13,9 +14,9 @@ defmodule ImagePipe.SourceTest.RootHTTPAdapter do
   def validate_options(opts) when is_list(opts) do
     root_url = Keyword.fetch!(opts, :root_url)
     req_options = Keyword.get(opts, :req_options, [])
-    cache = Keyword.get(opts, :cache, :normal)
+    internal_cache = Keyword.get(opts, :internal_cache, :enabled)
 
-    {:ok, [root_url: root_url, req_options: req_options, cache: cache]}
+    {:ok, [root_url: root_url, req_options: req_options, internal_cache: internal_cache]}
   end
 
   @impl Source
@@ -32,7 +33,9 @@ defmodule ImagePipe.SourceTest.RootHTTPAdapter do
          root: root_url,
          path: segments
        ],
-       cache: Keyword.fetch!(opts, :cache),
+       internal_cache: Keyword.fetch!(opts, :internal_cache),
+       http_cache: :inherit,
+       cache_semantics: %CacheSemantics{byte_identity: :none, stable?: false},
        fetch: [
          url: build_url(root_url, segments),
          req_options: Keyword.fetch!(opts, :req_options)

--- a/test/support/image_pipe/source_test/valid_adapter.ex
+++ b/test/support/image_pipe/source_test/valid_adapter.ex
@@ -16,7 +16,9 @@ defmodule ImagePipe.SourceTest.ValidAdapter do
        adapter: Keyword.get(opts, :adapter, :path),
        source_kind: :path,
        identity: [kind: :path, root: "test", path: ["images", "cat.jpg"]],
-       cache: Keyword.get(opts, :cache, :normal),
+       internal_cache: Keyword.get(opts, :internal_cache, :enabled),
+       http_cache: Keyword.get(opts, :http_cache, :inherit),
+       cache_semantics: %ImagePipe.Source.CacheSemantics{byte_identity: :none, stable?: false},
        fetch: {:fixture, self()}
      }}
   end

--- a/vale/config/vocabularies/ImagePipe/accept.txt
+++ b/vale/config/vocabularies/ImagePipe/accept.txt
@@ -1,5 +1,9 @@
+CDNs
+ETag
+ETags
 EXIF
 Imgproxy
+Rollout
 Vite
 Vix
 agentic
@@ -10,6 +14,7 @@ booleans
 cacheable
 cachebuster
 ciphertext
+codec
 config
 downscales
 imgproxy
@@ -23,3 +28,5 @@ uncached
 unconfigured
 unreferenced
 upscales
+validator
+validators


### PR DESCRIPTION
## Summary
- Add opt-in CDN-facing HTTP cache headers with strong generated ETags, `Vary: Accept`, and pre-run `If-None-Match` handling.
- Add source byte identity semantics, cache/header merge plumbing, and low-cardinality telemetry for HTTP cache decisions.
- Document CDN behavior, source stability configuration, versioning, and v1 deferred boundaries.

## Test Plan
- `mise exec -- mix format`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix test`
- `mise exec -- vale docs/cdn-http-cache.md README.md docs/telemetry.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CDN HTTP caching with automatic ETag generation and conditional request support (304 Not Modified responses)
  * Implemented configurable HTTP cache headers (Cache-Control, Vary, ETag) for improved CDN efficiency
  * Added per-source cache semantics configuration for granular stability and caching control

* **Documentation**
  * Added comprehensive guide for CDN HTTP caching behavior and configuration
  * Added design specification for HTTP caching features and rollout strategy
  * Updated telemetry documentation with new cache-related events

* **Tests**
  * Added comprehensive HTTP caching integration and unit tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hlindset/image_plug/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->