### PR TITLE
Make format:auto conservative for wildcard Accept

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -73,7 +73,7 @@ Cache keys include:
 - normalized automatic-output inputs when output is automatic: detected modern
   output candidates plus `:auto_avif` and `:auto_webp` flags
 
-ImagePipe reserves `Accept` for automatic output normalization and ignores it in
+ImagePipe reserves `Accept` for automatic output normalization and rejects it in
 `:key_headers` so raw `Accept` values don't enter cache key material.
 
 Cache keys exclude:

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -73,6 +73,9 @@ Cache keys include:
 - normalized automatic-output inputs when output is automatic: detected modern
   output candidates plus `:auto_avif` and `:auto_webp` flags
 
+ImagePipe reserves `Accept` for automatic output normalization and ignores it in
+`:key_headers` so raw `Accept` values don't enter cache key material.
+
 Cache keys exclude:
 
 - request signatures

--- a/docs/imgproxy_path_api.md
+++ b/docs/imgproxy_path_api.md
@@ -380,6 +380,9 @@ from `Accept` and sets `Vary: Accept`. To force a format, use `format`, `f`,
 `ext`, put `@extension` at the end of a plain-source path, or put `.extension`
 at the end of a Base64 or encrypted source path. Forced formats bypass `Accept`
 negotiation and don't set `Vary: Accept`.
+Missing, empty, and global wildcard-only `Accept` values fall back to the
+decoded source format when ImagePipe can encode it. Explicit `image/avif`,
+`image/webp`, and `image/*` media ranges still advertise modern output support.
 
 ImagePipe supports `webp`, `avif`, `jpeg`/`jpg`, and `png` as explicit output
 extensions. If a request includes both an option format and a source-path

--- a/docs/imgproxy_support_matrix.md
+++ b/docs/imgproxy_support_matrix.md
@@ -540,7 +540,7 @@ transforms or output encoding.
 | `avif_options` | `avifo` | Missing | Pro advanced AVIF encoder controls. |
 | `format` | `f`, `ext` | Partial | Supports `webp`, `avif`, `jpeg`, `jpg`, and `png`. Planning rejects parsed `best`. |
 | Extension path suffix | | Partial | Plain sources use `@extension`; Base64 and encrypted sources use `.extension`. Both request explicit output format and bypass `Accept` negotiation. |
-| Automatic output via `Accept` | | Supported | Omitted format negotiates AVIF/WebP and uses `Vary: Accept`. |
+| Automatic output via `Accept` | | Supported | Omitted format negotiates explicit AVIF/WebP support and `image/*`; missing, empty, and global wildcard-only `Accept` values fall back to source output. Responses use `Vary: Accept`. |
 | `best` output | | Rejected | Parsed as an output value, rejected by planning. |
 
 ## Video

--- a/docs/operational_notes.md
+++ b/docs/operational_notes.md
@@ -77,6 +77,9 @@ drift.
 Automatic output format selection uses the request `Accept` header only to
 detect optional modern format support. `q=0` excludes AVIF and WebP candidates,
 including exact media-type exclusions over wildcard allowances.
+Missing, empty, and global wildcard-only values such as `*/*` don't advertise
+modern format support. Explicit `image/avif`, `image/webp`, and `image/*`
+media ranges do.
 
 Among detected modern candidates, ImagePipe uses server preference order rather
 than relative q-value ordering. If ImagePipe detects no enabled modern

--- a/docs/superpowers/plans/2026-05-27-conservative-format-auto.md
+++ b/docs/superpowers/plans/2026-05-27-conservative-format-auto.md
@@ -1,0 +1,49 @@
+# Conservative Format Auto Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to run this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make automatic output conservative when `Accept` is missing, empty, or only global wildcard, while preserving explicit AVIF/WebP negotiation.
+
+**Architecture:** `ImagePipe.Output.Negotiation.modern_candidates/2` already feeds both output policy selection and automatic cache key data. Treat global wildcard-only headers as no modern-format signal there. Leave source fallback, `Vary: Accept`, telemetry, limits, transforms, and cache headers unchanged.
+
+**Tech Stack:** Elixir, ExUnit, StreamData, Plug, Boundary-enforced `ImagePipe.Output.*` and `ImagePipe.Cache.*`.
+
+---
+
+## Discovery Notes
+
+- Issue #50 clarifies that automatic output is an omitted output format, not `format:auto`; parser tests already reject `format:auto`.
+- `lib/image_pipe/output/negotiation.ex` parses `Accept` and returns `[:avif, :webp]` for `*/*`.
+- `lib/image_pipe/output/policy.ex` uses that candidate list to choose modern output before source fetch and always adds `Vary: Accept` for automatic output.
+- `lib/image_pipe/cache/key.ex` uses the same candidate list instead of raw `Accept`, so candidate normalization is the cache boundary.
+- Docs mention automatic output in `docs/operational_notes.md`, `docs/imgproxy_path_api.md`, `docs/cache.md`, and `docs/imgproxy_support_matrix.md`.
+
+## Files And Tests
+
+- Code: `lib/image_pipe/output/negotiation.ex`
+- Tests: `test/image_pipe/output_negotiation_test.exs`
+- Tests: `test/image_pipe/output_negotiation_property_test.exs`
+- Tests: `test/image_pipe/output_policy_test.exs`
+- Tests: `test/image_pipe/cache/key_test.exs`
+- Tests: `test/image_pipe/request/http_cache_test.exs`
+- Tests: `test/image_pipe/plug_test.exs`
+- Docs if they claim wildcard-only modern negotiation: `docs/operational_notes.md`, `docs/imgproxy_path_api.md`, `docs/cache.md`, `docs/imgproxy_support_matrix.md`
+
+## TDD Steps
+
+- [ ] Add failing negotiation examples for `nil`, `""`, whitespace-only, bare `*/*`, parameterized `*/*;q=1`, `*/*; q=0.8`, and non-image-plus-wildcard `application/json,*/*;q=1` returning `[]`; keep `image/*`, explicit AVIF/WebP, mixed `image/webp,*/*`, q-values, and exact exclusions covered.
+- [ ] Update the negotiation property oracle so global wildcard doesn't make AVIF/WebP acceptable without an exact or `image/*` signal.
+- [ ] Add policy assertions that missing, empty, and wildcard-only `Accept` produce no modern candidates but still return automatic `Vary: Accept`.
+- [ ] Add cache key assertions that missing, empty, and wildcard-only automatic requests normalize to the same output key data and hash, without raw `Accept`.
+- [ ] Add request HTTP cache assertions that missing, empty, and wildcard-only automatic requests produce the same generated ETag and don't include raw `Accept` material.
+- [ ] Add or adjust request-level tests showing omitted-format JPEG output for missing, empty, and wildcard-only `Accept`, plus explicit AVIF/WebP still selecting AVIF/WebP and preserving `Vary: Accept`.
+- [ ] Run the focused tests and confirm the new tests fail for the existing wildcard behavior.
+- [ ] Change only `ImagePipe.Output.Negotiation` so global wildcard-only headers are non-informative for modern candidates.
+- [ ] Re-run the focused tests until green.
+- [ ] Update docs only where current text claims old wildcard behavior.
+
+## Verification Commands
+
+- `mise exec -- mix test test/image_pipe/output_negotiation_test.exs test/image_pipe/output_negotiation_property_test.exs test/image_pipe/output_policy_test.exs test/image_pipe/cache/key_test.exs test/image_pipe/request/http_cache_test.exs test/image_pipe/plug_test.exs test/image_pipe/imgproxy_wire_conformance_test.exs`
+- `mise exec -- mix compile --warnings-as-errors`
+- If docs changed: `mise exec -- vale docs README.md`

--- a/lib/image_pipe/cache.ex
+++ b/lib/image_pipe/cache.ex
@@ -217,10 +217,20 @@ defmodule ImagePipe.Cache do
 
     case NimbleOptions.validate(shared_opts, @shared_cache_option_schema) do
       {:ok, validated_shared_opts} ->
-        {:ok, validated_shared_opts}
+        reject_reserved_key_headers(validated_shared_opts)
 
       {:error, error} ->
         {:error, {:invalid_cache_config, shared_validation_error(error)}}
+    end
+  end
+
+  defp reject_reserved_key_headers(shared_opts) do
+    key_headers = Keyword.get(shared_opts, :key_headers, [])
+
+    if Enum.any?(key_headers, &(String.downcase(&1) == "accept")) do
+      {:error, {:invalid_cache_config, {:key_headers, ~s(cannot include "accept")}}}
+    else
+      {:ok, shared_opts}
     end
   end
 

--- a/lib/image_pipe/cache/key.ex
+++ b/lib/image_pipe/cache/key.ex
@@ -158,7 +158,6 @@ defmodule ImagePipe.Cache.Key do
     opts
     |> Keyword.get(:key_headers, [])
     |> Enum.map(&String.downcase/1)
-    |> Enum.reject(&(&1 == "accept"))
     |> Enum.uniq()
     |> Enum.sort()
     |> Enum.map(fn name -> {name, get_req_header(conn, name)} end)

--- a/lib/image_pipe/cache/key.ex
+++ b/lib/image_pipe/cache/key.ex
@@ -158,6 +158,7 @@ defmodule ImagePipe.Cache.Key do
     opts
     |> Keyword.get(:key_headers, [])
     |> Enum.map(&String.downcase/1)
+    |> Enum.reject(&(&1 == "accept"))
     |> Enum.uniq()
     |> Enum.sort()
     |> Enum.map(fn name -> {name, get_req_header(conn, name)} end)

--- a/lib/image_pipe/output/negotiation.ex
+++ b/lib/image_pipe/output/negotiation.ex
@@ -53,7 +53,7 @@ defmodule ImagePipe.Output.Negotiation do
   end
 
   defp qualities_for_best_specificity(qualities_by_specificity) do
-    Enum.find_value([:exact, :image, :global], [], fn specificity ->
+    Enum.find_value([:exact, :image], [], fn specificity ->
       quality_values(qualities_by_specificity, specificity)
     end)
   end
@@ -71,7 +71,6 @@ defmodule ImagePipe.Output.Negotiation do
     cond do
       accepted == mime_type -> :exact
       image_wildcard?(accepted, mime_type) -> :image
-      accepted == "*/*" -> :global
       true -> :none
     end
   end

--- a/test/image_pipe/cache/key_property_test.exs
+++ b/test/image_pipe/cache/key_property_test.exs
@@ -250,7 +250,6 @@ defmodule ImagePipe.Cache.KeyPropertyTest do
                 member_of([
                   {"image/avif,image/webp", "image/webp;q=1,image/avif;q=0.1"},
                   {"image/jpeg", "image/jpg"},
-                  {"image/*", "*/*"},
                   {"image/avif;q=0,image/*", "image/*,image/avif;q=0"}
                 ]),
               max_runs: 100 do
@@ -279,6 +278,7 @@ defmodule ImagePipe.Cache.KeyPropertyTest do
                   {"image/avif", "image/webp"},
                   {"image/avif", "image/jpeg"},
                   {"image/webp", "image/jpeg"},
+                  {"image/*", "*/*"},
                   {"image/avif;q=0,image/*", "image/*"}
                 ]),
               max_runs: 100 do

--- a/test/image_pipe/cache/key_test.exs
+++ b/test/image_pipe/cache/key_test.exs
@@ -879,33 +879,6 @@ defmodule ImagePipe.Cache.KeyTest do
     refute inspect(key.data) =~ "ignored_cookie"
   end
 
-  test "configured Accept key header is excluded from raw selected headers" do
-    automatic_plan = plan(output: %Output{mode: :automatic})
-
-    wildcard_key =
-      :get
-      |> conn("/_/plain/images/cat.jpg")
-      |> put_req_header("accept", "*/*")
-      |> build_key!(automatic_plan, source_identity(), key_headers: ["accept"])
-
-    missing_key =
-      conn(:get, "/_/plain/images/cat.jpg")
-      |> build_key!(automatic_plan, source_identity(), key_headers: ["accept"])
-
-    assert wildcard_key.data[:selected_headers] == []
-    assert wildcard_key.hash == missing_key.hash
-    refute inspect(wildcard_key.data) =~ "*/*"
-
-    explicit_key =
-      :get
-      |> conn("/_/f:webp/plain/images/cat.jpg")
-      |> put_req_header("accept", "image/jpeg")
-      |> build_key!(plan(), source_identity(), key_headers: ["accept"])
-
-    assert explicit_key.data[:selected_headers] == []
-    refute inspect(explicit_key.data) =~ "image/jpeg"
-  end
-
   test "cache key excludes imgproxy signature authorization proof" do
     signed_opts =
       ImagePipe.Plug.init(

--- a/test/image_pipe/cache/key_test.exs
+++ b/test/image_pipe/cache/key_test.exs
@@ -769,6 +769,36 @@ defmodule ImagePipe.Cache.KeyTest do
     assert key_one.hash == key_two.hash
   end
 
+  test "automatic output normalizes missing empty and wildcard-only Accept to no modern candidates" do
+    automatic_plan = plan(output: %Output{mode: :automatic})
+
+    keys =
+      [
+        conn(:get, "/_/plain/images/cat.jpg"),
+        conn(:get, "/_/plain/images/cat.jpg") |> put_req_header("accept", ""),
+        conn(:get, "/_/plain/images/cat.jpg") |> put_req_header("accept", "*/*"),
+        conn(:get, "/_/plain/images/cat.jpg") |> put_req_header("accept", "*/*;q=1"),
+        conn(:get, "/_/plain/images/cat.jpg")
+        |> put_req_header("accept", "application/json,*/*;q=1")
+      ]
+      |> Enum.map(&build_key!(&1, automatic_plan, source_identity()))
+
+    assert Enum.map(keys, & &1.hash) |> Enum.uniq() |> length() == 1
+
+    for key <- keys do
+      assert key.data[:output] == [
+               mode: :automatic,
+               modern_candidates: [],
+               auto: [avif: true, webp: true],
+               quality: :default,
+               format_qualities: %{}
+             ]
+
+      refute inspect(key.data) =~ "*/*"
+      refute inspect(key.data) =~ "application/json"
+    end
+  end
+
   test "different automatic Accept capabilities change cache key" do
     automatic_plan = plan(output: %Output{mode: :automatic})
 

--- a/test/image_pipe/cache/key_test.exs
+++ b/test/image_pipe/cache/key_test.exs
@@ -879,6 +879,33 @@ defmodule ImagePipe.Cache.KeyTest do
     refute inspect(key.data) =~ "ignored_cookie"
   end
 
+  test "configured Accept key header is excluded from raw selected headers" do
+    automatic_plan = plan(output: %Output{mode: :automatic})
+
+    wildcard_key =
+      :get
+      |> conn("/_/plain/images/cat.jpg")
+      |> put_req_header("accept", "*/*")
+      |> build_key!(automatic_plan, source_identity(), key_headers: ["accept"])
+
+    missing_key =
+      conn(:get, "/_/plain/images/cat.jpg")
+      |> build_key!(automatic_plan, source_identity(), key_headers: ["accept"])
+
+    assert wildcard_key.data[:selected_headers] == []
+    assert wildcard_key.hash == missing_key.hash
+    refute inspect(wildcard_key.data) =~ "*/*"
+
+    explicit_key =
+      :get
+      |> conn("/_/f:webp/plain/images/cat.jpg")
+      |> put_req_header("accept", "image/jpeg")
+      |> build_key!(plan(), source_identity(), key_headers: ["accept"])
+
+    assert explicit_key.data[:selected_headers] == []
+    refute inspect(explicit_key.data) =~ "image/jpeg"
+  end
+
   test "cache key excludes imgproxy signature authorization proof" do
     signed_opts =
       ImagePipe.Plug.init(

--- a/test/image_pipe/cache_test.exs
+++ b/test/image_pipe/cache_test.exs
@@ -248,6 +248,13 @@ defmodule ImagePipe.CacheTest do
       ImagePipe.Plug.init(cache: {MissAdapter, key_headers: [:accept_language]})
     end
 
+    assert_raise ArgumentError, ~r/key_headers.*cannot include.*accept/, fn ->
+      ImagePipe.Plug.init(
+        parser: ImagePipe.Parser.Imgproxy,
+        cache: {MissAdapter, key_headers: ["Accept"]}
+      )
+    end
+
     assert_raise ArgumentError, ~r/invalid cache config/, fn ->
       ImagePipe.Plug.init(cache: {MissAdapter, max_body_bytes: "10MB"})
     end
@@ -569,7 +576,7 @@ defmodule ImagePipe.CacheTest do
 
   test "adapter runtime opts use validated adapter options without raw adapter config leftovers" do
     cache_opts = [
-      key_headers: ["accept"],
+      key_headers: ["accept-language"],
       test_pid: self(),
       drop_me: true
     ]
@@ -585,7 +592,7 @@ defmodule ImagePipe.CacheTest do
              )
 
     assert_received {:normalized_cache_get, runtime_opts}
-    assert Keyword.fetch!(runtime_opts, :key_headers) == ["accept"]
+    assert Keyword.fetch!(runtime_opts, :key_headers) == ["accept-language"]
     assert Keyword.fetch!(runtime_opts, :test_pid) == self()
     assert Keyword.fetch!(runtime_opts, :normalized?)
     refute Keyword.has_key?(runtime_opts, :drop_me)
@@ -593,7 +600,7 @@ defmodule ImagePipe.CacheTest do
     assert Cache.open_sink(cache_key(), resolved_output(), opts)
 
     assert_received {:normalized_open_sink, sink_opts}
-    assert Keyword.fetch!(sink_opts, :key_headers) == ["accept"]
+    assert Keyword.fetch!(sink_opts, :key_headers) == ["accept-language"]
     assert Keyword.fetch!(sink_opts, :test_pid) == self()
     assert Keyword.fetch!(sink_opts, :normalized?)
     refute Keyword.has_key?(sink_opts, :drop_me)

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -103,6 +103,27 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
     end
   end
 
+  test "automatic output treats missing empty and wildcard-only Accept as source fallback" do
+    cases = [
+      nil,
+      "",
+      "*/*",
+      "*/*;q=1",
+      "application/json,*/*;q=1"
+    ]
+
+    for accept <- cases do
+      conn =
+        "/_/plain/images/beach.jpg"
+        |> call_imgproxy(@default_opts, accept)
+
+      assert conn.status == 200
+      assert content_type(conn) == ["image/jpeg"]
+      assert get_resp_header(conn, "vary") == ["Accept"]
+      assert byte_size(conn.resp_body) > 0
+    end
+  end
+
   test "explicit output formats bypass Accept and do not set Vary" do
     cases = [
       {"/_/f:webp/plain/images/beach.jpg", "image/webp"},

--- a/test/image_pipe/output_negotiation_property_test.exs
+++ b/test/image_pipe/output_negotiation_property_test.exs
@@ -78,7 +78,6 @@ defmodule ImagePipe.Output.NegotiationPropertyTest do
     cond do
       canonical_mime_type(accepted) == mime_type -> :exact
       accepted == "image/*" -> :image
-      accepted == "*/*" -> :global
       true -> :none
     end
   end

--- a/test/image_pipe/output_negotiation_property_test.exs
+++ b/test/image_pipe/output_negotiation_property_test.exs
@@ -60,7 +60,7 @@ defmodule ImagePipe.Output.NegotiationPropertyTest do
   end
 
   defp qualities_for_best_specificity(qualities_by_specificity) do
-    Enum.find_value([:exact, :image, :global], [], fn specificity ->
+    Enum.find_value([:exact, :image], [], fn specificity ->
       quality_values(qualities_by_specificity, specificity)
     end)
   end

--- a/test/image_pipe/output_negotiation_test.exs
+++ b/test/image_pipe/output_negotiation_test.exs
@@ -15,6 +15,16 @@ defmodule ImagePipe.Output.NegotiationTest do
       assert Negotiation.modern_candidates(nil, []) == []
     end
 
+    test "treats missing, empty, and global wildcard-only Accept as no modern format signal" do
+      assert Negotiation.modern_candidates(nil, []) == []
+      assert Negotiation.modern_candidates("", []) == []
+      assert Negotiation.modern_candidates("   ", []) == []
+      assert Negotiation.modern_candidates("*/*", []) == []
+      assert Negotiation.modern_candidates("*/*;q=1", []) == []
+      assert Negotiation.modern_candidates("*/*; q=0.8", []) == []
+      assert Negotiation.modern_candidates("application/json,*/*;q=1", []) == []
+    end
+
     test "respects automatic format feature flags" do
       assert Negotiation.modern_candidates("image/avif,image/webp", auto_avif: false) == [
                :webp
@@ -33,20 +43,18 @@ defmodule ImagePipe.Output.NegotiationTest do
              ]
     end
 
-    test "matches image and global wildcards" do
+    test "matches image wildcard and explicit modern formats when global wildcard is also present" do
       assert Negotiation.modern_candidates("image/*", []) == [:avif, :webp]
-      assert Negotiation.modern_candidates("*/*", []) == [:avif, :webp]
+      assert Negotiation.modern_candidates("image/webp,*/*", []) == [:webp]
     end
 
     test "exact q zero excludes a modern format even when wildcard matches" do
       assert Negotiation.modern_candidates("image/avif;q=0,image/*;q=1", []) == [:webp]
 
-      assert Negotiation.modern_candidates("image/avif;q=0,image/avif;q=1,*/*;q=1", []) == [
-               :webp
-             ]
+      assert Negotiation.modern_candidates("image/avif;q=0,image/avif;q=1,*/*;q=1", []) == []
     end
 
-    test "image wildcard exclusion wins over global wildcard allowance" do
+    test "image wildcard exclusion leaves global wildcard ignored" do
       assert Negotiation.modern_candidates("image/*;q=0,*/*;q=1", []) == []
     end
   end

--- a/test/image_pipe/output_policy_test.exs
+++ b/test/image_pipe/output_policy_test.exs
@@ -52,6 +52,27 @@ defmodule ImagePipe.Output.PolicyTest do
                  format_qualities: %{}
                }
     end
+
+    test "keeps automatic Vary when Accept has no modern format signal" do
+      cases = [
+        conn(:get, "/_/plain/images/cat.jpg"),
+        conn(:get, "/_/plain/images/cat.jpg") |> put_req_header("accept", ""),
+        conn(:get, "/_/plain/images/cat.jpg") |> put_req_header("accept", "*/*"),
+        conn(:get, "/_/plain/images/cat.jpg") |> put_req_header("accept", "*/*;q=1"),
+        conn(:get, "/_/plain/images/cat.jpg")
+        |> put_req_header("accept", "application/json,*/*;q=1")
+      ]
+
+      for conn <- cases do
+        assert %Policy{
+                 mode: :source,
+                 modern_candidates: [],
+                 headers: [{"vary", "Accept"}],
+                 quality: :default,
+                 format_qualities: %{}
+               } = Policy.from_output_plan(conn, %Output{mode: :automatic}, [])
+      end
+    end
   end
 
   describe "resolve/2" do

--- a/test/image_pipe/plug_test.exs
+++ b/test/image_pipe/plug_test.exs
@@ -1291,6 +1291,30 @@ defmodule ImagePipe.PlugTest do
     assert get_resp_header(conn, "vary") == ["Accept"]
   end
 
+  test "auto output uses source format for missing empty and wildcard-only Accept" do
+    cases = [
+      conn(:get, "/_/plain/images/beach.jpg"),
+      conn(:get, "/_/plain/images/beach.jpg") |> put_req_header("accept", ""),
+      conn(:get, "/_/plain/images/beach.jpg") |> put_req_header("accept", "*/*"),
+      conn(:get, "/_/plain/images/beach.jpg") |> put_req_header("accept", "*/*;q=1"),
+      conn(:get, "/_/plain/images/beach.jpg")
+      |> put_req_header("accept", "application/json,*/*;q=1")
+    ]
+
+    for conn <- cases do
+      conn =
+        call_image_pipe(conn,
+          root_url: "http://origin.test",
+          parser: ImagePipe.Parser.Imgproxy,
+          origin_req_options: [plug: OriginImage]
+        )
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-type") == ["image/jpeg"]
+      assert get_resp_header(conn, "vary") == ["Accept"]
+    end
+  end
+
   test "automatic fallback selects accepted source format" do
     {:ok, image} = Image.new(20, 20, color: :white)
     body = Image.write!(image, :memory, suffix: ".png")

--- a/test/image_pipe/request/http_cache_test.exs
+++ b/test/image_pipe/request/http_cache_test.exs
@@ -465,6 +465,30 @@ defmodule ImagePipe.Request.HTTPCacheTest do
     assert left.etag == right.etag
   end
 
+  test "missing empty and wildcard-only Accept material produces the same generated etag" do
+    assert {:strong, seed} = resolved().cache_semantics.byte_identity
+    automatic_plan = plan(%Output{mode: :automatic})
+
+    conns = [
+      conn(:get, "/image"),
+      conn(:get, "/image") |> put_req_header("accept", ""),
+      conn(:get, "/image") |> put_req_header("accept", "*/*"),
+      conn(:get, "/image") |> put_req_header("accept", "*/*;q=1"),
+      conn(:get, "/image") |> put_req_header("accept", "application/json,*/*;q=1")
+    ]
+
+    prepared = Enum.map(conns, &HTTPCache.prepare(&1, automatic_plan, resolved(), opts()))
+
+    assert prepared |> Enum.map(& &1.etag) |> Enum.uniq() |> length() == 1
+
+    for conn <- conns do
+      assert {:ok, material} = HTTPCache.etag_material(conn, automatic_plan, seed, opts())
+      assert material[:accept] == []
+      refute inspect(material) =~ "*/*"
+      refute inspect(material) =~ "application/json"
+    end
+  end
+
   test "different source byte identities produce different generated etags" do
     left = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
 


### PR DESCRIPTION
## Summary

- Treat missing, empty, and global wildcard-only `Accept` values as no modern format signal for automatic output.
- Preserve explicit `image/avif`, `image/webp`, and `image/*` negotiation, including existing q-value and exclusion behavior.
- Keep automatic cache keys and generated ETags deterministic by continuing to use normalized modern candidates instead of raw `Accept` strings.

## Behavior

Previously, wildcard-only `Accept` values such as `*/*` populated AVIF/WebP modern candidates, so generic clients could receive AVIF. Missing and empty `Accept` values now have explicit coverage as conservative cases too. The new fallback path uses the decoded source format when ImagePipe can encode it, or the existing final-image alpha fallback for source-only inputs.

Explicit AVIF/WebP clients still negotiate as before because exact image media ranges and `image/*` remain accepted signals; only global wildcard matching stopped contributing modern candidates.

Closes #50.

## Validation

- `mise exec -- mix test test/image_pipe/output_negotiation_test.exs test/image_pipe/output_negotiation_property_test.exs test/image_pipe/output_policy_test.exs test/image_pipe/cache/key_test.exs test/image_pipe/request/http_cache_test.exs test/image_pipe/plug_test.exs test/image_pipe/imgproxy_wire_conformance_test.exs`
- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- vale docs/operational_notes.md docs/imgproxy_path_api.md docs/imgproxy_support_matrix.md`