### PR TITLE
Add EXIF autorotation default support

### DIFF
--- a/docs/imgproxy_path_api.md
+++ b/docs/imgproxy_path_api.md
@@ -313,6 +313,10 @@ Orientation options are `auto_rotate`/`ar`, `rotate`/`rot`, and `flip`/`fl`.
 
 - `ar:true` applies embedded orientation metadata, such as EXIF orientation.
   `ar:false` disables it.
+- `imgproxy: [auto_rotate: true]` applies EXIF autorotation when the URL doesn't
+  specify `auto_rotate`/`ar`. The default config value is `false`.
+- URL `ar:true` and `ar:false` override the configured default for the request.
+  `rotate` and `flip` don't suppress the default.
 - `rot` accepts integer degrees in multiples of 90 and stores them as `0`,
   `90`, `180`, or `270`.
 - `fl:true:true` flips both axes.

--- a/docs/imgproxy_path_api.md
+++ b/docs/imgproxy_path_api.md
@@ -314,9 +314,12 @@ Orientation options are `auto_rotate`/`ar`, `rotate`/`rot`, and `flip`/`fl`.
 - `ar:true` applies embedded orientation metadata, such as EXIF orientation.
   `ar:false` disables it.
 - `imgproxy: [auto_rotate: true]` applies EXIF autorotation when the URL doesn't
-  specify `auto_rotate`/`ar`. The default config value is `false`.
+  specify `auto_rotate`/`ar`. The default config value is `true`, matching
+  Imgproxy's `IMGPROXY_AUTO_ROTATE` default.
 - URL `ar:true` and `ar:false` override the configured default for the request.
-  `rotate` and `flip` don't suppress the default.
+  In chained paths, the parser puts the effective request value before pipeline
+  processing starts so later geometry uses dimensions after EXIF
+  normalization. `rotate` and `flip` don't suppress the default.
 - `rot` accepts integer degrees in multiples of 90 and stores them as `0`,
   `90`, `180`, or `270`.
 - `fl:true:true` flips both axes.

--- a/docs/imgproxy_path_api.md
+++ b/docs/imgproxy_path_api.md
@@ -316,10 +316,15 @@ Orientation options are `auto_rotate`/`ar`, `rotate`/`rot`, and `flip`/`fl`.
 - `imgproxy: [auto_rotate: true]` applies EXIF autorotation when the URL doesn't
   specify `auto_rotate`/`ar`. The default config value is `true`, matching
   Imgproxy's `IMGPROXY_AUTO_ROTATE` default.
-- URL `ar:true` and `ar:false` override the configured default for the request.
-  In chained paths, the parser puts the effective request value before pipeline
-  processing starts so later geometry uses dimensions after EXIF
-  normalization. `rotate` and `flip` don't suppress the default.
+- URL `ar:true` and `ar:false` resolve as request-scoped EXIF decode policy,
+  not as pipeline-local pixel operations. If more than one URL group contains
+  `ar`, the last `ar` in path order wins.
+- When the resolved request policy is `true`, ImagePipe represents it as one
+  `AutoOrient` operation at the start of the first produced pipeline. That keeps
+  cache keys, ETags, and transform execution on the same canonical plan
+  machinery while making later geometry use dimensions after EXIF normalization.
+- `rotate` and `flip` stay pipeline-scoped. They don't suppress the configured
+  `auto_rotate` default and don't move across pipeline separators.
 - `rot` accepts integer degrees in multiples of 90 and stores them as `0`,
   `90`, `180`, or `270`.
 - `fl:true:true` flips both axes.

--- a/docs/imgproxy_support_matrix.md
+++ b/docs/imgproxy_support_matrix.md
@@ -277,6 +277,12 @@ ImagePipe supports URL `auto_rotate` and the matching parser config default:
 stripping, profile handling, HDR preservation, and thumbnail-source selection
 aren't configurable.
 
+URL `auto_rotate`/`ar` resolves as request-scoped EXIF decode policy. If the URL
+contains more than one `ar`, the last value in path order wins. When the
+resolved policy is `true`, ImagePipe represents it as one `AutoOrient` operation
+at the start of the first produced pipeline. Cache keys, ETags, and transform
+execution then use the normal canonical plan machinery.
+
 - ⭕ `IMGPROXY_STRIP_METADATA`
 - ⭕ `IMGPROXY_KEEP_COPYRIGHT`
 - ⭕ `IMGPROXY_STRIP_METADATA_DPI`
@@ -479,7 +485,7 @@ transforms or output encoding.
 | `crop_aspect_ratio` | `crop_ar`, `car` | Missing | Documented as unsupported in current ImagePipe docs. |
 | `trim` | `t` | Missing | Requires full-image memory behavior and trim operation. |
 | `padding` | `pd` | Supported | CSS-style shorthand, sparse repeated options, effective DPR scaling, and `padding:` no-op compatibility. |
-| `auto_rotate` | `ar` | Supported | Omitted argument enables auto-orient; boolean form supported. URL `ar` overrides `imgproxy: [auto_rotate: ...]`. |
+| `auto_rotate` | `ar` | Supported | Omitted argument enables auto-orient; boolean form supported. URL `ar` overrides `imgproxy: [auto_rotate: ...]` request-wide, with last value in path order winning. |
 | `rotate` | `rot` | Supported | Right-angle multiples normalize to `0`, `90`, `180`, or `270`. |
 | `flip` | `fl` | Supported | No arguments means both axes. Supports one or two booleans. |
 

--- a/docs/imgproxy_support_matrix.md
+++ b/docs/imgproxy_support_matrix.md
@@ -273,8 +273,9 @@ XL output.
 ### Metadata, color profile, HDR, and default autorotation policy
 
 ImagePipe supports URL `auto_rotate` and the matching parser config default:
-`imgproxy: [auto_rotate: true]`. Global metadata stripping, profile handling,
-HDR preservation, and thumbnail-source selection aren't configurable.
+`imgproxy: [auto_rotate: true]`, which is also the default. Global metadata
+stripping, profile handling, HDR preservation, and thumbnail-source selection
+aren't configurable.
 
 - ⭕ `IMGPROXY_STRIP_METADATA`
 - ⭕ `IMGPROXY_KEEP_COPYRIGHT`

--- a/docs/imgproxy_support_matrix.md
+++ b/docs/imgproxy_support_matrix.md
@@ -272,8 +272,9 @@ XL output.
 
 ### Metadata, color profile, HDR, and default autorotation policy
 
-ImagePipe supports URL `auto_rotate`. Global metadata stripping, profile
-handling, HDR preservation, and thumbnail-source selection aren't configurable.
+ImagePipe supports URL `auto_rotate` and the matching parser config default:
+`imgproxy: [auto_rotate: true]`. Global metadata stripping, profile handling,
+HDR preservation, and thumbnail-source selection aren't configurable.
 
 - ⭕ `IMGPROXY_STRIP_METADATA`
 - ⭕ `IMGPROXY_KEEP_COPYRIGHT`
@@ -281,7 +282,7 @@ handling, HDR preservation, and thumbnail-source selection aren't configurable.
 - ⭕ `IMGPROXY_STRIP_COLOR_PROFILE`
 - ⭕ `IMGPROXY_COLOR_PROFILES_DIR`
 - ⭕ `IMGPROXY_PRESERVE_HDR`
-- 🔗 `IMGPROXY_AUTO_ROTATE`
+- ✅ `IMGPROXY_AUTO_ROTATE`
 - ⭕ `IMGPROXY_ENFORCE_THUMBNAIL`
 
 ### Input and output safety limits
@@ -477,7 +478,7 @@ transforms or output encoding.
 | `crop_aspect_ratio` | `crop_ar`, `car` | Missing | Documented as unsupported in current ImagePipe docs. |
 | `trim` | `t` | Missing | Requires full-image memory behavior and trim operation. |
 | `padding` | `pd` | Supported | CSS-style shorthand, sparse repeated options, effective DPR scaling, and `padding:` no-op compatibility. |
-| `auto_rotate` | `ar` | Supported | Omitted argument enables auto-orient; boolean form supported. |
+| `auto_rotate` | `ar` | Supported | Omitted argument enables auto-orient; boolean form supported. URL `ar` overrides `imgproxy: [auto_rotate: ...]`. |
 | `rotate` | `rot` | Supported | Right-angle multiples normalize to `0`, `90`, `180`, or `270`. |
 | `flip` | `fl` | Supported | No arguments means both axes. Supports one or two booleans. |
 

--- a/docs/superpowers/plans/2026-05-27-exif-autorotate-default.md
+++ b/docs/superpowers/plans/2026-05-27-exif-autorotate-default.md
@@ -1,0 +1,150 @@
+# EXIF Autorotation Default Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to apply this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add imgproxy-compatible default autorotation config while preserving URL-level `auto_rotate` behavior.
+
+**Architecture:** Keep autorotation as `ImagePipe.Plan.Orientation.auto_orient`, which `ImagePipe.Parser.Imgproxy.PlanBuilder` already translates into `ImagePipe.Transform.Operation.AutoOrient` before crop and resize. Add the default in imgproxy parser/options config so request/source/response code continues to see only `ImagePipe.Plan`.
+
+**Tech Stack:** Elixir, ExUnit, Plug test requests, NimbleOptions, Vale.
+
+---
+
+### Task 1: Parser config and precedence
+
+**Files:**
+- Change: `lib/image_pipe/parser/imgproxy.ex`
+- Change: `lib/image_pipe/parser/imgproxy/options.ex`
+- Test: `test/parser/imgproxy_test.exs`
+
+- [ ] **Step 1: Write failing parser tests**
+
+Add tests near the existing orientation parser assertions:
+
+```elixir
+test "imgproxy auto_rotate default applies when URL omits orientation" do
+  opts = [imgproxy: [auto_rotate: true]]
+
+  assert {:ok, %Plan{pipelines: [%Pipeline{operations: [%AutoOrient{}]}]}} =
+           Imgproxy.parse(conn(:get, "/_/plain/images/cat.jpg"), opts)
+end
+
+test "URL auto_rotate overrides the imgproxy default" do
+  opts = [imgproxy: [auto_rotate: true]]
+
+  assert {:ok, %Plan{pipelines: [%Pipeline{operations: []}]}} =
+           Imgproxy.parse(conn(:get, "/_/ar:false/plain/images/cat.jpg"), opts)
+
+  assert {:ok, %Plan{pipelines: [%Pipeline{operations: [%AutoOrient{}]}]}} =
+           Imgproxy.parse(conn(:get, "/_/ar:true/plain/images/cat.jpg"), opts)
+end
+```
+
+- [ ] **Step 2: Run parser tests and confirm failure**
+
+Run: `mise exec -- mix test test/parser/imgproxy_test.exs`
+
+Expected: tests fail because `:auto_rotate` isn't accepted or applied.
+
+- [ ] **Step 3: Add config/default handling**
+
+Add `auto_rotate: [type: :boolean, default: false]` to the imgproxy NimbleOptions schema and add validation coverage for accepted booleans and a rejected non-boolean value.
+
+Change `Options.parse/2` to `Options.parse/3`, with a default keyword list for callers that only pass presets. Add `auto_rotate_requested: false` to `PipelineRequest` and set it only when parsed URL assignments contain `auto_orient`.
+
+After parsing and finalizing pipelines, apply `auto_rotate: true` to the first pipeline only when no URL pipeline explicitly requested `auto_rotate`/`ar`. This models the config as a request default applied once before processing. URL `ar:false` anywhere in the request suppresses the default. `rotate` and `flip` don't suppress it.
+
+In `ImagePipe.Parser.Imgproxy.parse_request/2`, pass `[auto_rotate: Keyword.get(imgproxy_opts, :auto_rotate, false)]` into `Options.parse/3`.
+
+Keep URL precedence in `update_current_pipeline/2`: parsed `orientation` assignments update the existing orientation struct and set `orientation_requested: true`. Parsed `auto_rotate` also sets `auto_rotate_requested: true`.
+
+- [ ] **Step 4: Run parser tests**
+
+Run: `mise exec -- mix test test/parser/imgproxy_test.exs`
+
+Expected: pass.
+
+- [ ] **Step 5: Run focused validation tests**
+
+Run: `mise exec -- mix test test/image_pipe/request_options_test.exs test/parser/imgproxy_test.exs`
+
+Expected: pass.
+
+### Task 2: Wire-Level Orientation Behavior
+
+**Files:**
+- Change: `test/image_pipe/imgproxy_wire_conformance_test.exs`
+
+- [ ] **Step 1: Write failing wire tests**
+
+Add a small test-only origin plug in the test module that returns an in-memory JPEG with EXIF orientation `6`. Assert a real `ImagePipe.Plug.call/2` request rotates by default config, URL `ar:true` still rotates without config, and URL `ar:false` disables the configured default.
+
+Use generated image bytes instead of adding a fixture file:
+
+```elixir
+defmodule ExifOrientationOriginImage do
+  @moduledoc false
+
+  def call(conn, _opts) do
+    body =
+      40
+      |> Image.new!(80, color: :white)
+      |> Image.Draw.rect!(0, 0, 40, 40, color: :red)
+      |> Image.set_orientation!(6)
+      |> Image.write!(:memory, suffix: ".jpg")
+
+    conn
+    |> Plug.Conn.put_resp_content_type("image/jpeg")
+    |> Plug.Conn.send_resp(200, body)
+  end
+end
+```
+
+Expected decoded dimensions:
+- configured `imgproxy: [auto_rotate: true]` and no URL `ar`: `{80, 40}`
+- no config and URL `ar:true`: `{80, 40}`
+- configured default plus URL `ar:false`: `{40, 80}`
+
+- [ ] **Step 2: Run wire tests and confirm failure**
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs`
+
+Expected: configured-default case fails before implementation; URL-level case should already pass.
+
+- [ ] **Step 3: Make implementation adjustments if the parser-level change was incomplete**
+
+Keep all behavior in parser/options/plan translation. Don't change source limits, result limits, output negotiation, metadata stripping, filters, cache headers, or request/source/response transform dispatch.
+
+- [ ] **Step 4: Run wire tests**
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs`
+
+Expected: pass.
+
+### Task 3: Docs And Verification
+
+**Files:**
+- Change: `docs/imgproxy_path_api.md`
+- Change: `docs/imgproxy_support_matrix.md`
+
+- [ ] **Step 1: Update public docs**
+
+Document `imgproxy: [auto_rotate: true | false]`, state the default is `false`, and state URL `ar:true`/`ar:false` overrides the configured default.
+
+- [ ] **Step 2: Run focused tests**
+
+Run: `mise exec -- mix test test/parser/imgproxy_test.exs test/image_pipe/imgproxy_wire_conformance_test.exs`
+
+Expected: pass.
+
+- [ ] **Step 3: Run compile verification**
+
+Run: `mise exec -- mix compile --warnings-as-errors`
+
+Expected: pass.
+
+- [ ] **Step 4: Run Vale**
+
+Run: `mise exec -- vale docs/imgproxy_path_api.md docs/imgproxy_support_matrix.md`
+
+Expected: pass.

--- a/lib/image_pipe/parser/imgproxy.ex
+++ b/lib/image_pipe/parser/imgproxy.ex
@@ -44,7 +44,7 @@ defmodule ImagePipe.Parser.Imgproxy do
                      ],
                      auto_rotate: [
                        type: :boolean,
-                       default: false
+                       default: true
                      ]
                    )
 
@@ -173,7 +173,7 @@ defmodule ImagePipe.Parser.Imgproxy do
   end
 
   defp request_defaults(imgproxy_opts) do
-    [auto_rotate: Keyword.get(imgproxy_opts, :auto_rotate, false)]
+    [auto_rotate: Keyword.get(imgproxy_opts, :auto_rotate, true)]
   end
 
   defp source_parsing_config(opts) do

--- a/lib/image_pipe/parser/imgproxy.ex
+++ b/lib/image_pipe/parser/imgproxy.ex
@@ -41,6 +41,10 @@ defmodule ImagePipe.Parser.Imgproxy do
                      presets: [
                        type: {:custom, Presets, :validate_config, []},
                        default: %{}
+                     ],
+                     auto_rotate: [
+                       type: :boolean,
+                       default: false
                      ]
                    )
 
@@ -104,10 +108,17 @@ defmodule ImagePipe.Parser.Imgproxy do
   end
 
   defp parse_request(%Plug.Conn{} = conn, opts) do
+    imgproxy_opts = Keyword.get(opts, :imgproxy, [])
+
     with {:ok, signature, signed_path, path_info} <- Path.extract(conn),
          :ok <- verify_signature(signature, signed_path, opts),
          {:ok, option_segments, source_kind, raw_source_path} <- Path.split_source(path_info),
-         {:ok, request_options} <- Options.parse(option_segments, preset_config(opts)),
+         {:ok, request_options} <-
+           Options.parse(
+             option_segments,
+             preset_config(imgproxy_opts),
+             request_defaults(imgproxy_opts)
+           ),
          {:ok, source_path, source_format} <-
            Path.parse_source(source_kind, raw_source_path, source_parsing_config(opts)) do
       parsed_request(
@@ -157,10 +168,12 @@ defmodule ImagePipe.Parser.Imgproxy do
     |> Keyword.get(:signature, Signature.disabled())
   end
 
-  defp preset_config(opts) do
-    opts
-    |> Keyword.get(:imgproxy, [])
-    |> Keyword.get(:presets, Presets.empty())
+  defp preset_config(imgproxy_opts) do
+    Keyword.get(imgproxy_opts, :presets, Presets.empty())
+  end
+
+  defp request_defaults(imgproxy_opts) do
+    [auto_rotate: Keyword.get(imgproxy_opts, :auto_rotate, false)]
   end
 
   defp source_parsing_config(opts) do

--- a/lib/image_pipe/parser/imgproxy/options.ex
+++ b/lib/image_pipe/parser/imgproxy/options.ex
@@ -16,14 +16,15 @@ defmodule ImagePipe.Parser.Imgproxy.Options do
           response: ParsedRequest.response_request()
         }
 
-  @spec parse([String.t()], Presets.t()) :: {:ok, request_options()} | {:error, term()}
-  def parse(option_segments, %Presets{} = presets) do
+  @spec parse([String.t()], Presets.t(), keyword()) :: {:ok, request_options()} | {:error, term()}
+  def parse(option_segments, %Presets{} = presets, defaults \\ []) when is_list(defaults) do
     with {:ok, options} <- initial_request_options() |> apply_default_preset(presets),
          {:ok, options} <- apply_segments(option_segments, options, presets, []),
          {:ok, options} <- drain_queued_preset_groups(options, presets) do
       request =
         options
         |> finalize_request_options()
+        |> apply_request_defaults(defaults)
         |> Map.take([:pipelines, :output, :policy, :cache, :response])
 
       {:ok, request}
@@ -197,7 +198,10 @@ defmodule ImagePipe.Parser.Imgproxy.Options do
           %{
             pipeline
             | orientation: struct!(pipeline.orientation, orientation_assignments),
-              orientation_requested: true
+              orientation_requested: true,
+              auto_rotate_requested:
+                pipeline.auto_rotate_requested or
+                  Keyword.has_key?(orientation_assignments, :auto_orient)
           }
 
         {:padding, padding_args}, pipeline ->
@@ -281,6 +285,7 @@ defmodule ImagePipe.Parser.Imgproxy.Options do
          gravity_y_offset: gravity_y_offset,
          crop: nil,
          orientation_requested: false,
+         auto_rotate_requested: false,
          orientation: %Orientation{} = orientation
        })
        when gravity_x_offset in [{:pixels, 0.0}, 0.0] and
@@ -289,6 +294,33 @@ defmodule ImagePipe.Parser.Imgproxy.Options do
   end
 
   defp pipeline_empty?(%PipelineRequest{}), do: false
+
+  defp apply_request_defaults(options, defaults) do
+    case Keyword.get(defaults, :auto_rotate, false) do
+      true -> apply_auto_rotate_default(options)
+      false -> options
+    end
+  end
+
+  defp apply_auto_rotate_default(%{pipelines: pipelines} = options) do
+    if Enum.any?(pipelines, & &1.auto_rotate_requested) do
+      options
+    else
+      %{options | pipelines: apply_auto_rotate_to_first_pipeline(pipelines)}
+    end
+  end
+
+  defp apply_auto_rotate_to_first_pipeline([
+         %PipelineRequest{orientation: %Orientation{} = orientation} = pipeline | pipelines
+       ]) do
+    pipeline = %{
+      pipeline
+      | orientation: %Orientation{orientation | auto_orient: true},
+        orientation_requested: true
+    }
+
+    [pipeline | pipelines]
+  end
 
   defp apply_padding(%PipelineRequest{} = pipeline, values) do
     top = padding_value(Enum.at(values, 0), pipeline.padding_top)

--- a/lib/image_pipe/parser/imgproxy/options.ex
+++ b/lib/image_pipe/parser/imgproxy/options.ex
@@ -285,7 +285,6 @@ defmodule ImagePipe.Parser.Imgproxy.Options do
          gravity_y_offset: gravity_y_offset,
          crop: nil,
          orientation_requested: false,
-         auto_rotate_requested: false,
          orientation: %Orientation{} = orientation
        })
        when gravity_x_offset in [{:pixels, 0.0}, 0.0] and
@@ -295,24 +294,51 @@ defmodule ImagePipe.Parser.Imgproxy.Options do
 
   defp pipeline_empty?(%PipelineRequest{}), do: false
 
-  defp apply_request_defaults(options, defaults) do
-    case Keyword.get(defaults, :auto_rotate, false) do
-      true -> apply_auto_rotate_default(options)
-      false -> options
-    end
+  defp apply_request_defaults(%{pipelines: pipelines} = options, defaults) do
+    auto_rotate? = effective_auto_rotate(pipelines, Keyword.get(defaults, :auto_rotate, false))
+
+    pipelines =
+      pipelines
+      |> Enum.map(&consume_auto_rotate_request/1)
+      |> apply_auto_rotate_to_first_pipeline(auto_rotate?)
+      |> reject_empty_pipelines()
+
+    %{options | pipelines: pipelines}
   end
 
-  defp apply_auto_rotate_default(%{pipelines: pipelines} = options) do
-    if Enum.any?(pipelines, & &1.auto_rotate_requested) do
-      options
-    else
-      %{options | pipelines: apply_auto_rotate_to_first_pipeline(pipelines)}
-    end
+  defp effective_auto_rotate(pipelines, default) do
+    Enum.reduce(pipelines, default, fn
+      %PipelineRequest{
+        auto_rotate_requested: true,
+        orientation: %Orientation{auto_orient: auto_rotate?}
+      },
+      _auto_rotate? ->
+        auto_rotate?
+
+      %PipelineRequest{}, auto_rotate? ->
+        auto_rotate?
+    end)
   end
 
-  defp apply_auto_rotate_to_first_pipeline([
-         %PipelineRequest{orientation: %Orientation{} = orientation} = pipeline | pipelines
-       ]) do
+  defp consume_auto_rotate_request(
+         %PipelineRequest{orientation: %Orientation{} = orientation} = pipeline
+       ) do
+    orientation = %Orientation{orientation | auto_orient: false}
+
+    %{
+      pipeline
+      | orientation: orientation,
+        orientation_requested: orientation_requested?(orientation),
+        auto_rotate_requested: false
+    }
+  end
+
+  defp apply_auto_rotate_to_first_pipeline(pipelines, false), do: pipelines
+
+  defp apply_auto_rotate_to_first_pipeline(
+         [%PipelineRequest{orientation: %Orientation{} = orientation} = pipeline | pipelines],
+         true
+       ) do
     pipeline = %{
       pipeline
       | orientation: %Orientation{orientation | auto_orient: true},
@@ -321,6 +347,15 @@ defmodule ImagePipe.Parser.Imgproxy.Options do
 
     [pipeline | pipelines]
   end
+
+  defp reject_empty_pipelines(pipelines) do
+    case Enum.reject(pipelines, &pipeline_empty?/1) do
+      [] -> [%PipelineRequest{}]
+      pipelines -> pipelines
+    end
+  end
+
+  defp orientation_requested?(%Orientation{} = orientation), do: orientation != %Orientation{}
 
   defp apply_padding(%PipelineRequest{} = pipeline, values) do
     top = padding_value(Enum.at(values, 0), pipeline.padding_top)

--- a/lib/image_pipe/parser/imgproxy/pipeline_request.ex
+++ b/lib/image_pipe/parser/imgproxy/pipeline_request.ex
@@ -37,6 +37,7 @@ defmodule ImagePipe.Parser.Imgproxy.PipelineRequest do
           gravity_y_offset: gravity_offset(),
           crop: CropRequest.t() | nil,
           orientation_requested: boolean(),
+          auto_rotate_requested: boolean(),
           orientation: Orientation.t()
         }
 
@@ -66,5 +67,6 @@ defmodule ImagePipe.Parser.Imgproxy.PipelineRequest do
             gravity_y_offset: {:pixels, 0.0},
             crop: nil,
             orientation_requested: false,
+            auto_rotate_requested: false,
             orientation: %Orientation{}
 end

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -43,6 +43,23 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
     end
   end
 
+  defmodule ExifOrientationOriginImage do
+    @moduledoc false
+
+    def call(conn, _opts) do
+      body =
+        40
+        |> Image.new!(80, color: :white)
+        |> Image.Draw.rect!(0, 0, 40, 40, color: :red)
+        |> Image.set_orientation!(6)
+        |> Image.write!(:memory, suffix: ".jpg")
+
+      conn
+      |> Plug.Conn.put_resp_content_type("image/jpeg")
+      |> Plug.Conn.send_resp(200, body)
+    end
+  end
+
   @default_opts [
     parser: ImagePipe.Parser.Imgproxy,
     sources: [
@@ -204,6 +221,30 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
       assert content_type(conn) == ["image/jpeg"]
       assert dimensions(conn) == expected_dimensions
     end
+  end
+
+  test "imgproxy auto_rotate config and URL options control EXIF autorotation" do
+    configured_conn =
+      "/_/f:jpeg/plain/images/oriented.jpg"
+      |> call_imgproxy(exif_orientation_origin_opts(imgproxy: [auto_rotate: true]))
+
+    assert configured_conn.status == 200
+    assert content_type(configured_conn) == ["image/jpeg"]
+    assert dimensions(configured_conn) == {80, 40}
+
+    url_enabled_conn =
+      "/_/ar:true/f:jpeg/plain/images/oriented.jpg"
+      |> call_imgproxy(exif_orientation_origin_opts())
+
+    assert url_enabled_conn.status == 200
+    assert dimensions(url_enabled_conn) == {80, 40}
+
+    url_disabled_conn =
+      "/_/ar:false/f:jpeg/plain/images/oriented.jpg"
+      |> call_imgproxy(exif_orientation_origin_opts(imgproxy: [auto_rotate: true]))
+
+    assert url_disabled_conn.status == 200
+    assert dimensions(url_disabled_conn) == {40, 80}
   end
 
   test "invalid signatures, paths, options, and expiry stop before cache and origin access" do
@@ -902,6 +943,20 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
           {RootHTTPAdapter,
            root_url: "http://origin.test", req_options: [plug: {SvgOriginImage, test_pid: self()}]}
       ]
+    )
+  end
+
+  defp exif_orientation_origin_opts(overrides \\ []) do
+    Keyword.merge(
+      [
+        parser: ImagePipe.Parser.Imgproxy,
+        sources: [
+          path:
+            {RootHTTPAdapter,
+             root_url: "http://origin.test", req_options: [plug: ExifOrientationOriginImage]}
+        ]
+      ],
+      overrides
     )
   end
 

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -224,17 +224,24 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
   end
 
   test "imgproxy auto_rotate config and URL options control EXIF autorotation" do
-    configured_conn =
+    default_conn =
       "/_/f:jpeg/plain/images/oriented.jpg"
-      |> call_imgproxy(exif_orientation_origin_opts(imgproxy: [auto_rotate: true]))
+      |> call_imgproxy(exif_orientation_origin_opts())
 
-    assert configured_conn.status == 200
-    assert content_type(configured_conn) == ["image/jpeg"]
-    assert dimensions(configured_conn) == {80, 40}
+    assert default_conn.status == 200
+    assert content_type(default_conn) == ["image/jpeg"]
+    assert dimensions(default_conn) == {80, 40}
+
+    configured_disabled_conn =
+      "/_/f:jpeg/plain/images/oriented.jpg"
+      |> call_imgproxy(exif_orientation_origin_opts(imgproxy: [auto_rotate: false]))
+
+    assert configured_disabled_conn.status == 200
+    assert dimensions(configured_disabled_conn) == {40, 80}
 
     url_enabled_conn =
       "/_/ar:true/f:jpeg/plain/images/oriented.jpg"
-      |> call_imgproxy(exif_orientation_origin_opts())
+      |> call_imgproxy(exif_orientation_origin_opts(imgproxy: [auto_rotate: false]))
 
     assert url_enabled_conn.status == 200
     assert dimensions(url_enabled_conn) == {80, 40}

--- a/test/parser/imgproxy_property_test.exs
+++ b/test/parser/imgproxy_property_test.exs
@@ -10,6 +10,8 @@ defmodule ImagePipe.Parser.ImgproxyPropertyTest do
   alias ImagePipe.Plan.Pipeline
   alias ImagePipe.Plan.Source
 
+  @no_auto_rotate_opts [imgproxy: [auto_rotate: false]]
+
   property "parser returns tagged results for arbitrary processing segments" do
     check all segments <- list_of(processing_segment(), max_length: 5),
               max_runs: 300 do
@@ -79,7 +81,7 @@ defmodule ImagePipe.Parser.ImgproxyPropertyTest do
 
   property "imgproxy composition URL option order does not define operation order" do
     assert {:ok, plan_a} =
-             Imgproxy.parse(conn(:get, "/_/bg:f00/pd:10/w:100/plain/images/cat.jpg"), [])
+             parse_path("/_/bg:f00/pd:10/w:100/plain/images/cat.jpg")
 
     [%ImagePipe.Plan.Pipeline{operations: operations_a}] = plan_a.pipelines
 
@@ -96,7 +98,7 @@ defmodule ImagePipe.Parser.ImgproxyPropertyTest do
     end
   end
 
-  defp parse_path(path), do: Imgproxy.parse(conn(:get, path), [])
+  defp parse_path(path), do: Imgproxy.parse(conn(:get, path), @no_auto_rotate_opts)
 
   defp pixels(value), do: {:px, value}
 

--- a/test/parser/imgproxy_test.exs
+++ b/test/parser/imgproxy_test.exs
@@ -93,6 +93,15 @@ defmodule ImagePipe.Parser.ImgproxyTest do
     end
   end
 
+  test "validates imgproxy auto_rotate config" do
+    assert Imgproxy.validate_options!(auto_rotate: true)[:auto_rotate] == true
+    assert Imgproxy.validate_options!(auto_rotate: false)[:auto_rotate] == false
+
+    assert_raise ArgumentError, ~r/invalid imgproxy config/, fn ->
+      Imgproxy.validate_options!(auto_rotate: "true")
+    end
+  end
+
   test "parse/2 accepts parser options and keeps no-option parse/1 as a delegating helper" do
     conn = conn(:get, "/_/plain/images/cat.jpg")
 
@@ -553,6 +562,25 @@ defmodule ImagePipe.Parser.ImgproxyTest do
              Imgproxy.parse(conn(:get, "/_/crop:10:20/ar:true/plain/images/cat.jpg"), [])
 
     assert operation_names(operations) == [:auto_orient, :crop_guided]
+
+    opts = [imgproxy: [auto_rotate: true]]
+
+    assert {:ok, %Plan{pipelines: [%Pipeline{operations: [%AutoOrient{}]}]}} =
+             Imgproxy.parse(conn(:get, "/_/plain/images/cat.jpg"), opts)
+
+    assert {:ok, %Plan{pipelines: [%Pipeline{operations: []}]}} =
+             Imgproxy.parse(conn(:get, "/_/ar:false/plain/images/cat.jpg"), opts)
+
+    assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
+             Imgproxy.parse(conn(:get, "/_/rot:90/plain/images/cat.jpg"), opts)
+
+    assert operation_names(operations) == [:auto_orient, :rotate]
+
+    assert {:ok, %Plan{pipelines: pipelines}} =
+             Imgproxy.parse(conn(:get, "/_/w:100/-/ar:false/plain/images/cat.jpg"), opts)
+
+    operations = Enum.flat_map(pipelines, & &1.operations)
+    assert operation_names(operations) == [:resize]
 
     for segment <- ~w(extend:false ex:false) do
       assert {:ok, %Plan{pipelines: [%Pipeline{operations: []}]}} =
@@ -1552,7 +1580,9 @@ defmodule ImagePipe.Parser.ImgproxyTest do
   defp operation_names(operations), do: Enum.map(operations, &operation_name/1)
 
   defp operation_name(%AutoOrient{}), do: :auto_orient
+  defp operation_name(%ImagePipe.Transform.Operation.Rotate{}), do: :rotate
   defp operation_name(%Operation.CropGuided{}), do: :crop_guided
+  defp operation_name(%Operation.Resize{}), do: :resize
 
   defp forbidden_parsed_transform_operations(%Plan{} = plan) do
     plan.pipelines

--- a/test/parser/imgproxy_test.exs
+++ b/test/parser/imgproxy_test.exs
@@ -40,11 +40,13 @@ defmodule ImagePipe.Parser.ImgproxyTest do
     ImagePipe.Transform.Operation.Flip
   ]
 
+  @no_auto_rotate_opts [imgproxy: [auto_rotate: false]]
+
   test "parses a plain source with no processing options" do
     assert {:ok,
             %Plan{
               source: %Source.Path{segments: ["images", "cat.jpg"]},
-              pipelines: [%Pipeline{operations: []}],
+              pipelines: [%Pipeline{operations: [%AutoOrient{}]}],
               output: %Output{mode: :automatic}
             }} = Imgproxy.parse(conn(:get, "/_/plain/images/cat.jpg"), [])
   end
@@ -480,13 +482,19 @@ defmodule ImagePipe.Parser.ImgproxyTest do
 
   test "omitted extend argument still parses provided extend gravity tail" do
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
-             Imgproxy.parse(conn(:get, "/_/rs::::::ce::/plain/images/cat.jpg"), [])
+             Imgproxy.parse(
+               conn(:get, "/_/rs::::::ce::/plain/images/cat.jpg"),
+               @no_auto_rotate_opts
+             )
 
     assert [%Operation.Canvas{placement: placement}] = operations
     assert placement == :center
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
-             Imgproxy.parse(conn(:get, "/_/s:::::ce::/plain/images/cat.jpg"), [])
+             Imgproxy.parse(
+               conn(:get, "/_/s:::::ce::/plain/images/cat.jpg"),
+               @no_auto_rotate_opts
+             )
 
     assert [%Operation.Canvas{placement: placement}] = operations
     assert placement == :center
@@ -513,7 +521,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
              Imgproxy.parse(
                conn(:get, "/_/rs:fit:300:200:0:1:ce:0:0/plain/images/cat.jpg"),
-               []
+               @no_auto_rotate_opts
              )
 
     assert Enum.any?(operations, &match?(%Operation.Canvas{}, &1))
@@ -538,13 +546,16 @@ defmodule ImagePipe.Parser.ImgproxyTest do
   test "public parse plans supported geometry pipeline semantics" do
     assert {:ok,
             %Plan{pipelines: [%Pipeline{operations: [%Operation.Resize{mode: :fit} = resize]}]}} =
-             Imgproxy.parse(conn(:get, "/_/z:2/plain/images/cat.jpg"), [])
+             Imgproxy.parse(conn(:get, "/_/z:2/plain/images/cat.jpg"), @no_auto_rotate_opts)
 
     assert resize.zoom_x == 2.0
     assert resize.zoom_y == 2.0
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: [%Operation.CropGuided{} = crop]}]}} =
-             Imgproxy.parse(conn(:get, "/_/crop:10:20/plain/images/cat.jpg"), [])
+             Imgproxy.parse(
+               conn(:get, "/_/crop:10:20/plain/images/cat.jpg"),
+               @no_auto_rotate_opts
+             )
 
     assert crop.width == {:px, 10}
     assert crop.height == {:px, 20}
@@ -555,7 +566,10 @@ defmodule ImagePipe.Parser.ImgproxyTest do
 
     for segment <- ~w(ar:false rot:0 rot:360 fl:false:false) do
       assert {:ok, %Plan{pipelines: [%Pipeline{operations: []}]}} =
-               Imgproxy.parse(conn(:get, "/_/#{segment}/plain/images/cat.jpg"), [])
+               Imgproxy.parse(
+                 conn(:get, "/_/#{segment}/plain/images/cat.jpg"),
+                 @no_auto_rotate_opts
+               )
     end
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
@@ -582,23 +596,53 @@ defmodule ImagePipe.Parser.ImgproxyTest do
     operations = Enum.flat_map(pipelines, & &1.operations)
     assert operation_names(operations) == [:resize]
 
+    assert {:ok, %Plan{pipelines: pipelines}} =
+             Imgproxy.parse(conn(:get, "/_/w:100/-/w:200/plain/images/cat.jpg"), opts)
+
+    assert [
+             %Pipeline{operations: first_pipeline_operations},
+             %Pipeline{operations: second_pipeline_operations}
+           ] = pipelines
+
+    assert operation_names(first_pipeline_operations) == [:auto_orient, :resize]
+    assert operation_names(second_pipeline_operations) == [:resize]
+
+    assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
+             Imgproxy.parse(conn(:get, "/_/w:100/-/ar:true/plain/images/cat.jpg"),
+               imgproxy: [auto_rotate: false]
+             )
+
+    assert operation_names(operations) == [:auto_orient, :resize]
+
+    assert {:ok, %Plan{pipelines: pipelines}} =
+             Imgproxy.parse(conn(:get, "/_/w:100/-/ar:false/plain/images/cat.jpg"), opts)
+
+    assert [%Pipeline{operations: operations}] = pipelines
+    assert operation_names(operations) == [:resize]
+
     for segment <- ~w(extend:false ex:false) do
       assert {:ok, %Plan{pipelines: [%Pipeline{operations: []}]}} =
-               Imgproxy.parse(conn(:get, "/_/#{segment}/plain/images/cat.jpg"), [])
+               Imgproxy.parse(
+                 conn(:get, "/_/#{segment}/plain/images/cat.jpg"),
+                 @no_auto_rotate_opts
+               )
     end
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
-             Imgproxy.parse(conn(:get, "/_/rs:fit:300:200:0:0:ce/plain/images/cat.jpg"), [])
+             Imgproxy.parse(
+               conn(:get, "/_/rs:fit:300:200:0:0:ce/plain/images/cat.jpg"),
+               @no_auto_rotate_opts
+             )
 
     refute Enum.any?(operations, &match?(%Operation.Canvas{}, &1))
   end
 
   test "parses supported resizing type aliases into plans and rejects unsupported values" do
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: []}]}} =
-             Imgproxy.parse(conn(:get, "/_/rt:fit/plain/images/cat.jpg"), [])
+             Imgproxy.parse(conn(:get, "/_/rt:fit/plain/images/cat.jpg"), @no_auto_rotate_opts)
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: []}]}} =
-             Imgproxy.parse(conn(:get, "/_/rt:force/plain/images/cat.jpg"), [])
+             Imgproxy.parse(conn(:get, "/_/rt:force/plain/images/cat.jpg"), @no_auto_rotate_opts)
 
     assert Imgproxy.parse(conn(:get, "/_/rt:fill/plain/images/cat.jpg"), []) ==
              {:error, {:missing_dimensions, :fill}}
@@ -619,7 +663,10 @@ defmodule ImagePipe.Parser.ImgproxyTest do
                 }
               ]
             }} =
-             Imgproxy.parse(conn(:get, "/_/rt:fill-down/w:100/h:100/plain/images/cat.jpg"), [])
+             Imgproxy.parse(
+               conn(:get, "/_/rt:fill-down/w:100/h:100/plain/images/cat.jpg"),
+               @no_auto_rotate_opts
+             )
 
     assert resize.enlargement == :deny
 
@@ -631,7 +678,10 @@ defmodule ImagePipe.Parser.ImgproxyTest do
                 }
               ]
             }} =
-             Imgproxy.parse(conn(:get, "/_/rt:auto/w:100/h:100/plain/images/cat.jpg"), [])
+             Imgproxy.parse(
+               conn(:get, "/_/rt:auto/w:100/h:100/plain/images/cat.jpg"),
+               @no_auto_rotate_opts
+             )
   end
 
   test "invalid resizing type reports supported values" do
@@ -649,7 +699,10 @@ defmodule ImagePipe.Parser.ImgproxyTest do
 
     assert {:ok,
             %Plan{pipelines: [%Pipeline{operations: [%Operation.Resize{mode: :fit} = resize]}]}} =
-             Imgproxy.parse(conn(:get, "/_/w:0/h:0/mw:300/plain/images/cat.jpg"), [])
+             Imgproxy.parse(
+               conn(:get, "/_/w:0/h:0/mw:300/plain/images/cat.jpg"),
+               @no_auto_rotate_opts
+             )
 
     assert resize.width == auto()
     assert resize.height == auto()
@@ -691,7 +744,10 @@ defmodule ImagePipe.Parser.ImgproxyTest do
                 }
               ]
             }} =
-             Imgproxy.parse(conn(:get, "/_/g:nowe/rs:fill:300:200/plain/images/cat.jpg"), [])
+             Imgproxy.parse(
+               conn(:get, "/_/g:nowe/rs:fill:300:200/plain/images/cat.jpg"),
+               @no_auto_rotate_opts
+             )
 
     assert anchor(crop.guide) == {:left, :top}
 
@@ -705,7 +761,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
             }} =
              Imgproxy.parse(
                conn(:get, "/_/gravity:fp:0.5:0.25/rs:fill:300:200/plain/images/cat.jpg"),
-               []
+               @no_auto_rotate_opts
              )
 
     assert focal_point(crop.guide) == {1, 2, 1, 4}
@@ -718,7 +774,10 @@ defmodule ImagePipe.Parser.ImgproxyTest do
                 }
               ]
             } = plan} =
-             Imgproxy.parse(conn(:get, "/_/g:fp:1:0/rs:fill:300:200/plain/images/cat.jpg"), [])
+             Imgproxy.parse(
+               conn(:get, "/_/g:fp:1:0/rs:fill:300:200/plain/images/cat.jpg"),
+               @no_auto_rotate_opts
+             )
 
     assert focal_point(crop.guide) == {1, 1, 0, 1}
     assert {:ok, _pipelines} = ImagePipe.Transform.validate_prefetch_safe_plan(plan)
@@ -733,7 +792,10 @@ defmodule ImagePipe.Parser.ImgproxyTest do
                 }
               ]
             }} =
-             Imgproxy.parse(conn(:get, "/_/g:soea/rt:auto/w:300/h:200/plain/images/cat.jpg"), [])
+             Imgproxy.parse(
+               conn(:get, "/_/g:soea/rt:auto/w:300/h:200/plain/images/cat.jpg"),
+               @no_auto_rotate_opts
+             )
 
     assert anchor(crop.guide) == {:right, :bottom}
 
@@ -749,7 +811,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
             }} =
              Imgproxy.parse(
                conn(:get, "/_/g:soea:8:-0.5/rt:auto/w:300/h:200/plain/images/cat.jpg"),
-               []
+               @no_auto_rotate_opts
              )
 
     assert anchor(crop.guide) == {:right, :bottom}
@@ -768,7 +830,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
             }} =
              Imgproxy.parse(
                conn(:get, "/_/g:soea:12:-0.25/rs:fill:300:200/plain/images/cat.jpg"),
-               []
+               @no_auto_rotate_opts
              )
 
     assert anchor(crop.guide) == {:right, :bottom}
@@ -807,7 +869,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
     assert_output_mode("/_/w:100/-/f:webp/plain/images/cat.jpg", {:explicit, :webp})
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
-             Imgproxy.parse(conn(:get, "/_/f:webp/-/plain/images/cat.jpg"), [])
+             Imgproxy.parse(conn(:get, "/_/f:webp/-/plain/images/cat.jpg"), @no_auto_rotate_opts)
 
     assert operations == []
   end
@@ -1088,10 +1150,10 @@ defmodule ImagePipe.Parser.ImgproxyTest do
 
   test "global-only and empty groups do not become executable pipelines" do
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: []}]}} =
-             Imgproxy.parse(conn(:get, "/_/f:webp/-/plain/images/cat.jpg"), [])
+             Imgproxy.parse(conn(:get, "/_/f:webp/-/plain/images/cat.jpg"), @no_auto_rotate_opts)
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
-             Imgproxy.parse(conn(:get, "/_/-/w:100/plain/images/cat.jpg"), [])
+             Imgproxy.parse(conn(:get, "/_/-/w:100/plain/images/cat.jpg"), @no_auto_rotate_opts)
 
     assert length(operations) == 1
     assert [%{__struct__: _} = operation] = operations
@@ -1398,7 +1460,11 @@ defmodule ImagePipe.Parser.ImgproxyTest do
                 %Pipeline{operations: first_operations},
                 %Pipeline{operations: second_operations}
               ]
-            }} = Imgproxy.parse(conn(:get, "/_/w:500/-/h:200/plain/images/cat.jpg"), [])
+            }} =
+             Imgproxy.parse(
+               conn(:get, "/_/w:500/-/h:200/plain/images/cat.jpg"),
+               @no_auto_rotate_opts
+             )
 
     assert [%Operation.Resize{mode: :fit} = first_params] = first_operations
     assert first_params.width == pixels(500)
@@ -1411,13 +1477,13 @@ defmodule ImagePipe.Parser.ImgproxyTest do
 
   test "ignores empty groups around chained imgproxy pipeline separators" do
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: leading_operations}]}} =
-             Imgproxy.parse(conn(:get, "/_/-/w:500/plain/images/cat.jpg"), [])
+             Imgproxy.parse(conn(:get, "/_/-/w:500/plain/images/cat.jpg"), @no_auto_rotate_opts)
 
     assert [%Operation.Resize{mode: :fit} = leading_params] = leading_operations
     assert leading_params.width == pixels(500)
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: trailing_operations}]}} =
-             Imgproxy.parse(conn(:get, "/_/w:500/-/plain/images/cat.jpg"), [])
+             Imgproxy.parse(conn(:get, "/_/w:500/-/plain/images/cat.jpg"), @no_auto_rotate_opts)
 
     assert [%Operation.Resize{mode: :fit} = trailing_params] = trailing_operations
     assert trailing_params.width == pixels(500)
@@ -1428,7 +1494,11 @@ defmodule ImagePipe.Parser.ImgproxyTest do
                 %Pipeline{operations: first_operations},
                 %Pipeline{operations: second_operations}
               ]
-            }} = Imgproxy.parse(conn(:get, "/_/w:500/-/-/h:200/plain/images/cat.jpg"), [])
+            }} =
+             Imgproxy.parse(
+               conn(:get, "/_/w:500/-/-/h:200/plain/images/cat.jpg"),
+               @no_auto_rotate_opts
+             )
 
     assert [%Operation.Resize{mode: :fit} = first_params] = first_operations
     assert first_params.width == pixels(500)
@@ -1439,7 +1509,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
 
   test "preserves no-op single-pipeline behavior" do
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: []}]}} =
-             Imgproxy.parse(conn(:get, "/_/plain/images/cat.jpg"), [])
+             Imgproxy.parse(conn(:get, "/_/plain/images/cat.jpg"), @no_auto_rotate_opts)
   end
 
   test "later field assignments are scoped to each imgproxy pipeline" do
@@ -1450,7 +1520,10 @@ defmodule ImagePipe.Parser.ImgproxyTest do
                 %Pipeline{operations: second_operations}
               ]
             }} =
-             Imgproxy.parse(conn(:get, "/_/w:500/w:600/-/h:200/h:300/plain/images/cat.jpg"), [])
+             Imgproxy.parse(
+               conn(:get, "/_/w:500/w:600/-/h:200/h:300/plain/images/cat.jpg"),
+               @no_auto_rotate_opts
+             )
 
     assert [%Operation.Resize{mode: :fit} = first_params] = first_operations
     assert first_params.width == pixels(600)
@@ -1517,7 +1590,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
 
   defp operations_for(path) do
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
-             Imgproxy.parse(conn(:get, path), [])
+             Imgproxy.parse(conn(:get, path), @no_auto_rotate_opts)
 
     operations
   end
@@ -1545,7 +1618,10 @@ defmodule ImagePipe.Parser.ImgproxyTest do
 
   defp signed_parser_opts(overrides \\ []) do
     imgproxy_opts =
-      [signature: [keys: ["746573742d6b6579"], salts: ["746573742d73616c74"]]]
+      [
+        auto_rotate: false,
+        signature: [keys: ["746573742d6b6579"], salts: ["746573742d73616c74"]]
+      ]
       |> Keyword.merge(overrides)
       |> Imgproxy.validate_options!()
 
@@ -1553,7 +1629,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
   end
 
   defp preset_opts(definitions) do
-    [imgproxy: Imgproxy.validate_options!(presets: definitions)]
+    [imgproxy: Imgproxy.validate_options!(auto_rotate: false, presets: definitions)]
   end
 
   defp assert_error_status(reason, status) do


### PR DESCRIPTION
## Summary
- add imgproxy parser config `auto_rotate: true | false` for the `IMGPROXY_AUTO_ROTATE` compatibility default
- default imgproxy autorotation to `true`, matching imgproxy's default `IMGPROXY_AUTO_ROTATE` behavior
- treat URL `ar:true` and `ar:false` as request-level overrides, then plan EXIF autorotation once before pipeline processing starts
- cover parser precedence, chained pipeline behavior, and real Plug requests with EXIF orientation metadata

## Behavior
`imgproxy: [auto_rotate: true]` applies EXIF autorotation when the request URL does not specify `auto_rotate`/`ar`. The default value is `true`.

URL-level `ar:true` enables autorotation for the request, and URL-level `ar:false` suppresses the configured default. In chained paths, ImagePipe resolves the effective request value and places the auto-orient operation before pipeline processing so crop/resize geometry uses dimensions after EXIF normalization.

Users should see phone/camera images with EXIF Orientation encoded in visually upright dimensions when autorotation is enabled. With `ar:false` or `imgproxy: [auto_rotate: false]`, the stored pixel orientation is preserved.

## Validation
- `mise exec -- mix test test/parser/imgproxy_test.exs test/image_pipe/imgproxy_wire_conformance_test.exs test/parser/imgproxy/options_test.exs test/image_pipe/request_options_test.exs`
- `VIX_COMPILATION_MODE=PRECOMPILED_LIBVIPS mise exec -- mix compile --warnings-as-errors`
- `mise exec -- vale docs/imgproxy_path_api.md docs/imgproxy_support_matrix.md`
- `VIX_COMPILATION_MODE=PRECOMPILED_LIBVIPS mise exec -- mix test`

Fixes #27
