### PR TITLE
Harden source session supervisor empty assertion

### DIFF
--- a/test/image_pipe/request_runner_test.exs
+++ b/test/image_pipe/request_runner_test.exs
@@ -475,6 +475,7 @@ defmodule ImagePipe.Request.RunnerTest do
       {_id, pid, :worker, _modules} when is_pid(pid) ->
         ref = Process.monitor(pid)
         assert_receive {:DOWN, ^ref, :process, ^pid, _reason}
+        SourceSessionSupervisor.stop_session(supervisor, pid)
 
       _child ->
         :ok


### PR DESCRIPTION
## Summary

- Synchronize the request runner test helper with the dynamic supervisor after a monitored source-session worker exits.
- Keep the worker DOWN assertion, then ask SourceSessionSupervisor to remove the child before asserting count_children/1 is empty.

## Root cause

drain_prepared_stream/1 proves the caller received :done, and the worker DOWN proves the SourceSession process exited. The dynamic supervisor can still briefly report the child before it processes its child-exit bookkeeping, which made the CI assertion timing-sensitive.

## Verification

- VIX_COMPILATION_MODE=PRECOMPILED_LIBVIPS mise exec erlang@27 elixir@1.19.5-otp-27 -- mix test test/image_pipe/request_runner_test.exs:1337 --seed 362703 --max-cases 8
- VIX_COMPILATION_MODE=PRECOMPILED_LIBVIPS mise exec erlang@27 elixir@1.19.5-otp-27 -- mix test test/image_pipe/request_runner_test.exs --seed 362703 --max-cases 8
- VIX_COMPILATION_MODE=PRECOMPILED_LIBVIPS mise exec erlang@27 elixir@1.19.5-otp-27 -- mix test test/image_pipe/request_runner_test.exs:1337 --seed 362703 --max-cases 8 --repeat-until-failure 50 --max-failures 1
- git diff --check
