### PR TITLE
Strengthen Plan/Transform operation split

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,14 +57,14 @@
 
 - Use `Boundary` declarations to enforce the namespace ownership described above. When adding or moving a top-level namespace, define its dependency direction explicitly instead of relying on implicit compile-time reachability.
 - Keep `deps:` aligned with architecture direction. One line per namespace:
-  - `parser` → `plan`, transform construction APIs
-  - `request` → `plan`, `cache`, `source`, `output`, `response`, `telemetry`, generic transform contract
+  - `parser` → `plan`
+  - `request` → `plan`, `cache`, `source`, `output`, `response`, `telemetry`, generic transform execution contract
   - `source` → `plan` only (must not depend on `cache`, `response`, `parser`)
   - `cache` → `plan`, `output`, transform material
   - `output` → `plan`
   - `transform` → nothing in `parser`, `request`, `source`, `cache`, `output`, `response`
 - Export only behaviours and stable public/internal entry points from each boundary. Do not export implementation helpers just to satisfy a compile error; move the helper to the correct boundary or add a narrow facade.
-- Request, source, and response modules may call generic `ImagePipe.Transform` functions such as `transform_name/1`, `metadata/1`, and `execute/2`, but must not alias or reference concrete operation modules. Parser and planner modules may construct exported concrete operation structs when translating syntax into a product-neutral plan.
+- Request, source, and response modules may call generic `ImagePipe.Transform` functions such as `transform_name/1` and `execute/2`, but must not alias or reference concrete operation modules. Parser and planner modules must emit semantic `ImagePipe.Plan.Operation.*` structs when translating syntax into a product-neutral plan.
 - Boundary rule changes should come with focused architecture tests, especially for request/source/response code avoiding concrete transform modules and parser-specific structs.
 
 ## Elixir architecture guidelines
@@ -73,7 +73,7 @@
 - Validate public options explicitly, preferably with `NimbleOptions` or adapter-owned `validate_options/1`, and reject unknown or malformed options before side effects.
 - For trusted internal behaviour dispatch, call the callback directly and let missing callbacks raise. Do not add runtime duck-typing probes, callback-presence checks, or wrapper functions whose only purpose is to make impossible internal misuse return tidy errors.
 - Constructor APIs should accept the narrowest shape that real callers use. Do not accept both keyword lists and maps, existing structs, or negative guard carve-outs such as `is_map(value) and not is_struct(value)` unless there is a real public caller or contract requiring it.
-- Use pattern matching, small private functions, and `with`/`case` pipelines to keep success paths linear while preserving precise error tags. Avoid catch-all rescues unless a concrete runtime boundary intentionally degrades to a documented safe default; do not rescue trusted transform callback failures such as `metadata/1`.
+- Use pattern matching, small private functions, and `with`/`case` pipelines to keep success paths linear while preserving precise error tags. Avoid catch-all rescues unless a concrete runtime boundary intentionally degrades to a documented safe default; do not rescue trusted transform callback failures.
 
 ## Validation guidelines
 

--- a/docs/operational_notes.md
+++ b/docs/operational_notes.md
@@ -58,13 +58,14 @@ request options, and cache policy.
 ## Decode planning
 
 For transform chains proven safe for one-pass reads, ImagePipe may open the
-source image with libvips sequential access before resizing. The first supported
-shapes cover fit and force resize requests with concrete target dimensions. These
-shapes may use sequential access whether the result downscales or upscales.
+source image with libvips sequential access before executing the first pipeline.
+The supported shapes are auto-orient-only pipelines and fit or stretch resize
+requests with concrete target dimensions. These shapes may use sequential access
+whether the result downscales or upscales.
 
-Chains involving crop, cover, or fill result crops, canvas extension, unknown
-transforms, output-only requests, or no geometry transform continue to use
-random access.
+Chains involving crop, cover result crops, canvas extension, unknown transform
+intent, output-only requests, or no geometry transform continue to use random
+access.
 
 When a parsed plan contains more than one image pipeline, ImagePipe materializes the
 image between pipelines. This preserves the explicit pipeline boundary and lets

--- a/docs/superpowers/plans/2026-05-27-exif-autorotate-default.md
+++ b/docs/superpowers/plans/2026-05-27-exif-autorotate-default.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add imgproxy-compatible default autorotation config while preserving URL-level `auto_rotate` behavior.
 
-**Architecture:** Keep autorotation as `ImagePipe.Plan.Orientation.auto_orient`, which `ImagePipe.Parser.Imgproxy.PlanBuilder` already translates into `ImagePipe.Transform.Operation.AutoOrient` before crop and resize. Add the default in imgproxy parser/options config so request/source/response code continues to see only `ImagePipe.Plan`.
+**Architecture:** Keep autorotation in imgproxy parser request state, then translate it to `ImagePipe.Plan.Operation.AutoOrient` before crop and resize. Transform execution lowers that semantic Plan operation to `ImagePipe.Transform.Operation.AutoOrient` after cache lookup. Add the default in imgproxy parser/options config so request/source/response code continues to see only `ImagePipe.Plan`.
 
 **Tech Stack:** Elixir, ExUnit, Plug test requests, NimbleOptions, Vale.
 
@@ -48,7 +48,7 @@ Expected: tests fail because `:auto_rotate` isn't accepted or applied.
 
 - [ ] **Step 3: Add config/default handling**
 
-Add `auto_rotate: [type: :boolean, default: false]` to the imgproxy NimbleOptions schema and add validation coverage for accepted booleans and a rejected non-boolean value.
+Add `auto_rotate: [type: :boolean, default: true]` to the imgproxy NimbleOptions schema and add validation coverage for accepted booleans and a rejected non-boolean value.
 
 Change `Options.parse/2` to `Options.parse/3`, with a default keyword list for callers that only pass presets. Add `auto_rotate_requested: false` to `PipelineRequest` and set it only when parsed URL assignments contain `auto_orient`.
 
@@ -109,7 +109,7 @@ Expected decoded dimensions:
 
 Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs`
 
-Expected: configured-default case fails before implementation; URL-level case should already pass.
+Expected: configured-default case fails before implementation. URL-level case should already pass.
 
 - [ ] **Step 3: Make implementation adjustments if the parser-level change was incomplete**
 
@@ -129,7 +129,7 @@ Expected: pass.
 
 - [ ] **Step 1: Update public docs**
 
-Document `imgproxy: [auto_rotate: true | false]`, state the default is `false`, and state URL `ar:true`/`ar:false` overrides the configured default.
+Document `imgproxy: [auto_rotate: true | false]`, state the default is `true`, and state URL `ar:true`/`ar:false` overrides the configured default.
 
 - [ ] **Step 2: Run focused tests**
 

--- a/docs/transform_operations.md
+++ b/docs/transform_operations.md
@@ -11,7 +11,7 @@ Parser authors should construct canonical semantic operations under
 `ImagePipe.Plan.Operation.*` through `ImagePipe.Plan.Operation`. The executable
 modules under `ImagePipe.Transform.Operation.*` are local execution targets used
 by Transform Plan execution and `ImagePipe.Transform.Chain`. Parsers shouldn't
-emit them except for the explicit first-slice orientation primitive allowlist.
+emit executable transform operations.
 
 ## Request flow
 
@@ -85,12 +85,15 @@ Parser/planner code should use these semantic operations:
 - `ImagePipe.Plan.Operation.Padding`: add edge padding around the current image.
 - `ImagePipe.Plan.Operation.Background`: place an alpha-capable color behind
   the current image.
+- `ImagePipe.Plan.Operation.AutoOrient`: apply embedded orientation metadata.
+- `ImagePipe.Plan.Operation.Rotate`: right-angle rotation intent.
+- `ImagePipe.Plan.Operation.Flip`: horizontal, vertical, or both-axis flip
+  intent.
 - `ImagePipe.Plan.Color`: canonical product-neutral sRGB color data with alpha.
 
-Plan pipelines may also contain the explicit orientation primitive allowlist:
-`ImagePipe.Transform.Operation.AutoOrient`, `ImagePipe.Transform.Operation.Rotate`,
-and `ImagePipe.Transform.Operation.Flip`. Parsers shouldn't use other
-executable Transform operation modules as Plan output.
+Plan pipelines should contain semantic Plan operation structs only. Transform
+execution lowers those structs into executable `ImagePipe.Transform.Operation.*`
+work after cache lookup.
 
 ## Executable operation catalog
 
@@ -107,9 +110,10 @@ describe work over `ImagePipe.Transform.State`, not parser request syntax:
 - `ImagePipe.Transform.Operation.AutoOrient`: executable EXIF autorotation.
 - `ImagePipe.Transform.Operation.Rotate`: executable right-angle rotation.
 - `ImagePipe.Transform.Operation.Flip`: executable flip.
+
 `ImagePipe.Transform.Operation.AdaptiveResize` is obsolete. Resize
-`mode: :auto` belongs in `ImagePipe.Plan.Operation.Resize`; parsers must not
-emit an executable adaptive-resize operation.
+`mode: :auto` belongs in `ImagePipe.Plan.Operation.Resize`. Parsers must not emit
+an executable adaptive-resize operation.
 
 ## Choosing resize-like semantic operations
 
@@ -140,8 +144,8 @@ they expose focus state independently from visible crop/canvas/cover work.
 
 ## Orientation operations
 
-Use the explicit `AutoOrient`, `Rotate`, and `Flip` orientation primitive
-allowlist for orientation intent.
+Use `ImagePipe.Plan.Operation.AutoOrient`, `Rotate`, and `Flip` for orientation
+intent.
 
 Imgproxy orientation suborder is auto-orient, rotate, then flip. Other dialects
 should preserve their own semantics in the adapter layer and emit the ordered
@@ -183,9 +187,10 @@ not leak into parser request structs, runtime state, or cache key data.
 
 Before source metadata is available, decode/open planning must treat semantic
 Plan operations conservatively. After a cache miss, Transform Plan execution may
-discover source metadata and convert semantic intent to executable work. The
-exact executable `metadata/1` contract belongs in the
-`ImagePipe.Transform.Operation.*` module docs.
+discover source metadata and convert semantic intent to executable work.
+`ImagePipe.Transform.DecodePlanner` owns source-open access decisions over
+semantic Plan operations. Executable transform operation modules shouldn't
+define separate decode-access metadata.
 
 ## Cache key data
 

--- a/lib/image_pipe/parser.ex
+++ b/lib/image_pipe/parser.ex
@@ -7,8 +7,7 @@ defmodule ImagePipe.Parser do
     top_level?: true,
     deps: [
       ImagePipe.Format,
-      ImagePipe.Plan,
-      ImagePipe.Transform
+      ImagePipe.Plan
     ],
     exports: [Imgproxy]
 

--- a/lib/image_pipe/parser/imgproxy.ex
+++ b/lib/image_pipe/parser/imgproxy.ex
@@ -7,8 +7,7 @@ defmodule ImagePipe.Parser.Imgproxy do
     deps: [
       ImagePipe.Format,
       ImagePipe.Parser,
-      ImagePipe.Plan,
-      ImagePipe.Transform
+      ImagePipe.Plan
     ],
     exports: [
       SourceScheme

--- a/lib/image_pipe/parser/imgproxy/options.ex
+++ b/lib/image_pipe/parser/imgproxy/options.ex
@@ -2,11 +2,11 @@ defmodule ImagePipe.Parser.Imgproxy.Options do
   @moduledoc false
 
   alias ImagePipe.Parser.Imgproxy.OptionGrammar
+  alias ImagePipe.Parser.Imgproxy.Orientation
   alias ImagePipe.Parser.Imgproxy.ParsedRequest
   alias ImagePipe.Parser.Imgproxy.PipelineRequest
   alias ImagePipe.Parser.Imgproxy.Presets
   alias ImagePipe.Plan.Color
-  alias ImagePipe.Plan.Orientation
 
   @type request_options :: %{
           pipelines: [PipelineRequest.t()],

--- a/lib/image_pipe/parser/imgproxy/orientation.ex
+++ b/lib/image_pipe/parser/imgproxy/orientation.ex
@@ -1,4 +1,4 @@
-defmodule ImagePipe.Plan.Orientation do
+defmodule ImagePipe.Parser.Imgproxy.Orientation do
   @moduledoc false
 
   defstruct auto_orient: false, rotate: 0, flip: nil

--- a/lib/image_pipe/parser/imgproxy/pipeline_request.ex
+++ b/lib/image_pipe/parser/imgproxy/pipeline_request.ex
@@ -2,8 +2,8 @@ defmodule ImagePipe.Parser.Imgproxy.PipelineRequest do
   @moduledoc false
 
   alias ImagePipe.Parser.Imgproxy.CropRequest
+  alias ImagePipe.Parser.Imgproxy.Orientation
   alias ImagePipe.Plan.Color
-  alias ImagePipe.Plan.Orientation
 
   @type resizing_type() :: :fit | :fill | :fill_down | :force | :auto
   @type gravity_anchor() :: {:anchor, :left | :center | :right, :top | :center | :bottom}

--- a/lib/image_pipe/parser/imgproxy/plan_builder.ex
+++ b/lib/image_pipe/parser/imgproxy/plan_builder.ex
@@ -2,12 +2,12 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilder do
   @moduledoc false
 
   alias ImagePipe.Parser.Imgproxy.CropRequest
+  alias ImagePipe.Parser.Imgproxy.Orientation
   alias ImagePipe.Parser.Imgproxy.ParsedRequest
   alias ImagePipe.Parser.Imgproxy.PipelineRequest
   alias ImagePipe.Parser.Imgproxy.Source, as: ImgproxySource
   alias ImagePipe.Plan
   alias ImagePipe.Plan.Operation
-  alias ImagePipe.Plan.Orientation
   alias ImagePipe.Plan.Output
   alias ImagePipe.Plan.Pipeline
   alias ImagePipe.Plan.Response
@@ -16,9 +16,6 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilder do
   alias ImagePipe.Plan.Source.Reference
   alias ImagePipe.Plan.Source.URL
   alias ImagePipe.Format
-  alias ImagePipe.Transform.Operation.AutoOrient
-  alias ImagePipe.Transform.Operation.Flip
-  alias ImagePipe.Transform.Operation.Rotate
 
   @default_gravity {:anchor, :center, :center}
 
@@ -262,19 +259,19 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilder do
   end
 
   defp auto_orient_operation(%Orientation{auto_orient: true}),
-    do: {:ok, %AutoOrient{}}
+    do: Operation.auto_orient()
 
   defp auto_orient_operation(%Orientation{}), do: nil
 
   defp rotate_operation(%Orientation{rotate: 0}), do: nil
 
   defp rotate_operation(%Orientation{rotate: angle}) when angle in [90, 180, 270],
-    do: {:ok, %Rotate{angle: angle}}
+    do: Operation.rotate(angle)
 
   defp flip_operation(%Orientation{flip: nil}), do: nil
 
   defp flip_operation(%Orientation{flip: axis}) when axis in [:horizontal, :vertical, :both],
-    do: {:ok, %Flip{axis: axis}}
+    do: Operation.flip(axis)
 
   defp result_crop_x_offset(%PipelineRequest{} = request) do
     offset = request.gravity_x_offset

--- a/lib/image_pipe/plan.ex
+++ b/lib/image_pipe/plan.ex
@@ -8,7 +8,6 @@ defmodule ImagePipe.Plan do
     deps: [ImagePipe.Format],
     exports: [
       Pipeline,
-      Orientation,
       Output,
       Response,
       Color,
@@ -20,11 +19,14 @@ defmodule ImagePipe.Plan do
       Source.Object,
       Source.Reference,
       Operation,
+      Operation.AutoOrient,
       Operation.Background,
+      Operation.Canvas,
       Operation.CropGuided,
       Operation.CropRegion,
-      Operation.Canvas,
+      Operation.Flip,
       Operation.Padding,
+      Operation.Rotate,
       Operation.Resize
     ]
 

--- a/lib/image_pipe/plan/key_data.ex
+++ b/lib/image_pipe/plan/key_data.ex
@@ -8,16 +8,15 @@ defmodule ImagePipe.Plan.KeyData do
   """
 
   alias ImagePipe.Plan.Color
+  alias ImagePipe.Plan.Operation.AutoOrient
   alias ImagePipe.Plan.Operation.Background
   alias ImagePipe.Plan.Operation.Canvas
   alias ImagePipe.Plan.Operation.CropGuided
   alias ImagePipe.Plan.Operation.CropRegion
+  alias ImagePipe.Plan.Operation.Flip
   alias ImagePipe.Plan.Operation.Padding
+  alias ImagePipe.Plan.Operation.Rotate
   alias ImagePipe.Plan.Operation.Resize
-
-  @auto_orient_module :"Elixir.ImagePipe.Transform.Operation.AutoOrient"
-  @rotate_module :"Elixir.ImagePipe.Transform.Operation.Rotate"
-  @flip_module :"Elixir.ImagePipe.Transform.Operation.Flip"
 
   @crop_anchor_guides [
     :center,
@@ -113,9 +112,9 @@ defmodule ImagePipe.Plan.KeyData do
     [op: :background, color: Color.key_data(operation.color)]
   end
 
-  def data(%{__struct__: @auto_orient_module}), do: [op: :auto_orient]
-  def data(%{__struct__: @rotate_module, angle: angle}), do: [op: :rotate, angle: angle]
-  def data(%{__struct__: @flip_module, axis: axis}), do: [op: :flip, axis: axis]
+  def data(%AutoOrient{}), do: [op: :auto_orient]
+  def data(%Rotate{angle: angle}), do: [op: :rotate, angle: angle]
+  def data(%Flip{axis: axis}), do: [op: :flip, axis: axis]
 
   def data(:auto), do: [unit: :auto]
   def data(:full_axis), do: [unit: :full_axis]

--- a/lib/image_pipe/plan/operation.ex
+++ b/lib/image_pipe/plan/operation.ex
@@ -3,16 +3,19 @@ defmodule ImagePipe.Plan.Operation do
   Constructor facade for canonical semantic Plan operations.
   """
 
+  alias ImagePipe.Plan.Color
+  alias ImagePipe.Plan.Operation.AutoOrient
   alias ImagePipe.Plan.Operation.Background
   alias ImagePipe.Plan.Operation.Canvas
   alias ImagePipe.Plan.Operation.CropGuided
   alias ImagePipe.Plan.Operation.CropRegion
+  alias ImagePipe.Plan.Operation.Flip
   alias ImagePipe.Plan.Operation.Padding
+  alias ImagePipe.Plan.Operation.Rotate
   alias ImagePipe.Plan.Operation.Resize
-  alias ImagePipe.Plan.Color
 
   @enlargements [:allow, :deny]
-  @right_angles [0, 90, 180, 270]
+  @right_angles [90, 180, 270]
   @flip_axes [:horizontal, :vertical, :both]
   @x_anchors [:left, :center, :right]
   @y_anchors [:top, :center, :bottom]
@@ -43,12 +46,6 @@ defmodule ImagePipe.Plan.Operation do
   @canvas_keys [:fill, :overflow, :x_offset, :y_offset]
   @padding_keys [:pixel_ratio, :fill]
   @effective_padding_modes [:resize, :canvas_preserving]
-  # Keep the orientation primitive allowlist centralized without importing
-  # executable operation modules into the Plan operation facade.
-  @auto_orient_module :"Elixir.ImagePipe.Transform.Operation.AutoOrient"
-  @rotate_module :"Elixir.ImagePipe.Transform.Operation.Rotate"
-  @flip_module :"Elixir.ImagePipe.Transform.Operation.Flip"
-
   @type resize_operation :: Resize.t()
 
   @type crop_operation ::
@@ -62,9 +59,9 @@ defmodule ImagePipe.Plan.Operation do
   @type background_operation :: Background.t()
 
   @type orientation_operation ::
-          ImagePipe.Transform.Operation.AutoOrient.t()
-          | ImagePipe.Transform.Operation.Rotate.t()
-          | ImagePipe.Transform.Operation.Flip.t()
+          AutoOrient.t()
+          | Rotate.t()
+          | Flip.t()
 
   @type semantic_operation ::
           resize_operation()
@@ -76,6 +73,17 @@ defmodule ImagePipe.Plan.Operation do
 
   @type error ::
           {:invalid_operation, atom(), term()} | {:unknown_operation_options, atom(), [atom()]}
+
+  @spec auto_orient() :: {:ok, AutoOrient.t()}
+  def auto_orient, do: {:ok, %AutoOrient{}}
+
+  @spec rotate(term()) :: {:ok, Rotate.t()} | {:error, error()}
+  def rotate(angle) when angle in @right_angles, do: {:ok, %Rotate{angle: angle}}
+  def rotate(angle), do: invalid(:rotate, [angle])
+
+  @spec flip(term()) :: {:ok, Flip.t()} | {:error, error()}
+  def flip(axis) when axis in @flip_axes, do: {:ok, %Flip{axis: axis}}
+  def flip(axis), do: invalid(:flip, [axis])
 
   @spec color(term(), term(), term()) :: {:ok, Color.t()} | {:error, term()}
   def color(red, green, blue), do: Color.rgb(red, green, blue)
@@ -250,9 +258,9 @@ defmodule ImagePipe.Plan.Operation do
   def semantic?(%Canvas{} = operation), do: valid_canvas?(operation)
   def semantic?(%Padding{} = operation), do: valid_padding?(operation)
   def semantic?(%Background{} = operation), do: valid_background?(operation)
-  def semantic?(%{__struct__: @auto_orient_module}), do: true
-  def semantic?(%{__struct__: @rotate_module, angle: angle}) when angle in @right_angles, do: true
-  def semantic?(%{__struct__: @flip_module, axis: axis}) when axis in @flip_axes, do: true
+  def semantic?(%AutoOrient{}), do: true
+  def semantic?(%Rotate{angle: angle}) when angle in @right_angles, do: true
+  def semantic?(%Flip{axis: axis}) when axis in @flip_axes, do: true
   def semantic?(_operation), do: false
 
   defp invalid(operation, attrs), do: {:error, {:invalid_operation, operation, attrs}}

--- a/lib/image_pipe/plan/operation/auto_orient.ex
+++ b/lib/image_pipe/plan/operation/auto_orient.ex
@@ -1,0 +1,9 @@
+defmodule ImagePipe.Plan.Operation.AutoOrient do
+  @moduledoc """
+  Semantic request to apply embedded image orientation metadata.
+  """
+
+  defstruct []
+
+  @type t :: %__MODULE__{}
+end

--- a/lib/image_pipe/plan/operation/flip.ex
+++ b/lib/image_pipe/plan/operation/flip.ex
@@ -1,0 +1,11 @@
+defmodule ImagePipe.Plan.Operation.Flip do
+  @moduledoc """
+  Semantic request to flip the image on one or both axes.
+  """
+
+  @enforce_keys [:axis]
+  defstruct @enforce_keys
+
+  @type axis :: :horizontal | :vertical | :both
+  @type t :: %__MODULE__{axis: axis()}
+end

--- a/lib/image_pipe/plan/operation/rotate.ex
+++ b/lib/image_pipe/plan/operation/rotate.ex
@@ -1,0 +1,11 @@
+defmodule ImagePipe.Plan.Operation.Rotate do
+  @moduledoc """
+  Semantic request to rotate the image by a right angle.
+  """
+
+  @enforce_keys [:angle]
+  defstruct @enforce_keys
+
+  @type angle :: 90 | 180 | 270
+  @type t :: %__MODULE__{angle: angle()}
+end

--- a/lib/image_pipe/plan/pipeline.ex
+++ b/lib/image_pipe/plan/pipeline.ex
@@ -8,8 +8,5 @@ defmodule ImagePipe.Plan.Pipeline do
 
   @type operation ::
           ImagePipe.Plan.Operation.semantic_operation()
-          | ImagePipe.Transform.Operation.AutoOrient.t()
-          | ImagePipe.Transform.Operation.Rotate.t()
-          | ImagePipe.Transform.Operation.Flip.t()
   @type t :: %__MODULE__{operations: [operation()]}
 end

--- a/lib/image_pipe/transform.ex
+++ b/lib/image_pipe/transform.ex
@@ -2,10 +2,10 @@ defmodule ImagePipe.Transform do
   @moduledoc """
   Behaviour and dispatch facade for transform operations.
 
-  Operation modules implement this behaviour with constructors, metadata, a
-  stable transform name, and execution over `ImagePipe.Transform.State`.
-  Runtime callers dispatch through this module's generic functions so the
-  runtime boundary does not need to know concrete operation modules.
+  Operation modules implement this behaviour with a stable transform name and
+  execution over `ImagePipe.Transform.State`. Runtime callers dispatch through
+  this module's generic functions so the runtime boundary does not need to know
+  concrete operation modules.
   """
 
   use Boundary,
@@ -35,7 +35,6 @@ defmodule ImagePipe.Transform do
   @type operation() :: struct()
 
   @callback name(operation()) :: atom()
-  @callback metadata(operation()) :: map()
   @callback execute(operation(), State.t()) :: {:ok, State.t()} | {:error, term()}
 
   @spec transform_name(operation()) :: atom()
@@ -50,11 +49,6 @@ defmodule ImagePipe.Transform do
       {:ok, %Plan{}} -> Plan.validated_pipelines(plan)
       {:error, _reason} = error -> error
     end
-  end
-
-  @spec metadata(operation()) :: map()
-  def metadata(%module{} = operation) do
-    module.metadata(operation)
   end
 
   @spec execute(operation(), State.t()) :: {:ok, State.t()} | {:error, term()}

--- a/lib/image_pipe/transform/chain.ex
+++ b/lib/image_pipe/transform/chain.ex
@@ -2,8 +2,8 @@ defmodule ImagePipe.Transform.Chain do
   @moduledoc """
   Executes ordered transform operation chains.
 
-  A chain is the ordered list of product-neutral operation structs already
-  selected by parser or planner code. Execution proceeds left to right through
+  A chain is the ordered list of executable transform operation structs selected
+  by transform execution. Execution proceeds left to right through
   `ImagePipe.Transform` and stops at the first operation error.
   """
 

--- a/lib/image_pipe/transform/decode_planner.ex
+++ b/lib/image_pipe/transform/decode_planner.ex
@@ -1,22 +1,22 @@
 defmodule ImagePipe.Transform.DecodePlanner do
   @moduledoc """
-  Chooses image decode access from transform operation metadata.
+  Chooses image decode access for semantic Plan operations.
 
-  Decode planning interprets each operation's product-neutral metadata and
-  reduces the chain to either sequential or random image access. It is
-  intentionally conservative for valid metadata: empty chains and neutral
-  access both fall back to random access.
+  Decode planning reduces a source-fetch-free Plan operation chain to either
+  sequential or random image access. It is intentionally conservative for valid
+  semantic operations: empty chains and neutral access both fall back to random
+  access.
   """
 
+  alias ImagePipe.Plan.Operation.AutoOrient
   alias ImagePipe.Plan.Operation.Background
   alias ImagePipe.Plan.Operation.Canvas
   alias ImagePipe.Plan.Operation.CropGuided
   alias ImagePipe.Plan.Operation.CropRegion
+  alias ImagePipe.Plan.Operation.Flip
   alias ImagePipe.Plan.Operation.Padding
+  alias ImagePipe.Plan.Operation.Rotate
   alias ImagePipe.Plan.Operation.Resize, as: PlanResize
-  alias ImagePipe.Transform.Operation.AutoOrient
-  alias ImagePipe.Transform.Operation.Flip
-  alias ImagePipe.Transform.Operation.Rotate
 
   @type access_requirement() :: :sequential | :random | :neutral
 

--- a/lib/image_pipe/transform/operation/auto_orient.ex
+++ b/lib/image_pipe/transform/operation/auto_orient.ex
@@ -5,9 +5,9 @@ defmodule ImagePipe.Transform.Operation.AutoOrient do
 
   ## Construct When
 
-  Transform Plan execution may pass this narrow executable primitive through
-  unchanged. Parser modules should construct semantic `ImagePipe.Plan.Operation.*`
-  through Plan constructors for non-orientation transform intent.
+  Transform Plan execution creates this executable primitive from semantic
+  `ImagePipe.Plan.Operation.AutoOrient` intent. Parser modules should construct
+  semantic `ImagePipe.Plan.Operation.*` structs through Plan constructors.
 
   ## Fields
 
@@ -23,13 +23,6 @@ defmodule ImagePipe.Transform.Operation.AutoOrient do
   resulting image, not parser-specific orientation metadata.
 
   If autorotation fails, execution returns `{:error, {__MODULE__, error}}`.
-
-  ## Decode Planning Metadata
-
-  `metadata/1` returns `%{access: :sequential}`. Auto-orientation can be used
-  with optimized sequential source access because it does not require choosing
-  an arbitrary crop rectangle, result crop, canvas expansion, or other
-  random-access geometry during decode planning.
 
   ## Examples
 
@@ -48,9 +41,6 @@ defmodule ImagePipe.Transform.Operation.AutoOrient do
 
   @impl ImagePipe.Transform
   def name(%__MODULE__{}), do: :auto_orient
-
-  @impl ImagePipe.Transform
-  def metadata(%__MODULE__{}), do: %{access: :sequential}
 
   @impl ImagePipe.Transform
   def execute(%__MODULE__{}, %State{} = state) do

--- a/lib/image_pipe/transform/operation/background.ex
+++ b/lib/image_pipe/transform/operation/background.ex
@@ -19,9 +19,6 @@ defmodule ImagePipe.Transform.Operation.Background do
   def name(%__MODULE__{}), do: :background
 
   @impl ImagePipe.Transform
-  def metadata(%__MODULE__{}), do: %{access: :random}
-
-  @impl ImagePipe.Transform
   def execute(%__MODULE__{color: [red, green, blue, 255]}, %State{} = state) do
     case Image.flatten(state.image, background_color: [red, green, blue]) do
       {:ok, image} -> {:ok, set_image(state, image)}

--- a/lib/image_pipe/transform/operation/crop.ex
+++ b/lib/image_pipe/transform/operation/crop.ex
@@ -59,12 +59,6 @@ defmodule ImagePipe.Transform.Operation.Crop do
   For coordinate crops, `crop_from` is the requested top-left crop position
   before the rectangle is clamped to image bounds.
 
-  ## Decode Planning Metadata
-
-  `metadata/1` returns `%{access: :random}`. Crops need random source access
-  because execution may read from any bounded rectangle rather than consuming
-  pixels safely in a single sequential pass.
-
   ## Examples
 
       crop = %ImagePipe.Transform.Operation.Crop{
@@ -132,9 +126,6 @@ defmodule ImagePipe.Transform.Operation.Crop do
 
   @impl ImagePipe.Transform
   def name(%__MODULE__{}), do: :crop
-
-  @impl ImagePipe.Transform
-  def metadata(%__MODULE__{}), do: %{access: :random}
 
   @impl ImagePipe.Transform
   def execute(%__MODULE__{} = params, %State{} = state) do

--- a/lib/image_pipe/transform/operation/extend_canvas.ex
+++ b/lib/image_pipe/transform/operation/extend_canvas.ex
@@ -55,12 +55,6 @@ defmodule ImagePipe.Transform.Operation.ExtendCanvas do
   rounded and added to that placement after gravity resolution, then passed to
   image embedding.
 
-  ## Decode Planning Metadata
-
-  `metadata/1` returns `%{access: :random}`. Canvas extension needs the whole
-  current image available for embedding into a new canvas and is not treated as
-  safe for optimized sequential source decoding.
-
   ## Examples
 
       canvas = %ImagePipe.Transform.Operation.ExtendCanvas{
@@ -107,9 +101,6 @@ defmodule ImagePipe.Transform.Operation.ExtendCanvas do
 
   @impl ImagePipe.Transform
   def name(%__MODULE__{}), do: :extend_canvas
-
-  @impl ImagePipe.Transform
-  def metadata(%__MODULE__{}), do: %{access: :random}
 
   @impl ImagePipe.Transform
   def execute(%__MODULE__{} = operation, %State{} = state) do

--- a/lib/image_pipe/transform/operation/flip.ex
+++ b/lib/image_pipe/transform/operation/flip.ex
@@ -5,9 +5,9 @@ defmodule ImagePipe.Transform.Operation.Flip do
 
   ## Construct When
 
-  Transform Plan execution may pass this narrow executable primitive through
-  unchanged. Parser modules should construct semantic `ImagePipe.Plan.Operation.*`
-  through Plan constructors for non-orientation transform intent.
+  Transform Plan execution creates this executable primitive from semantic
+  `ImagePipe.Plan.Operation.Flip` intent. Parser modules should construct
+  semantic `ImagePipe.Plan.Operation.*` structs through Plan constructors.
 
   ## Fields
 
@@ -29,12 +29,6 @@ defmodule ImagePipe.Transform.Operation.Flip do
   vertical flip, then stores the resulting image in state. If any flip fails,
   execution returns `{:error, {__MODULE__, error}}`.
 
-  ## Decode Planning Metadata
-
-  `metadata/1` returns `%{access: :random}`. Flipping is not treated as safe for
-  optimized sequential source decoding because the transform may need the full
-  decoded image to remap pixels.
-
   ## Examples
 
       flip = %ImagePipe.Transform.Operation.Flip{axis: :horizontal}
@@ -52,9 +46,6 @@ defmodule ImagePipe.Transform.Operation.Flip do
 
   @impl ImagePipe.Transform
   def name(%__MODULE__{}), do: :flip
-
-  @impl ImagePipe.Transform
-  def metadata(%__MODULE__{}), do: %{access: :random}
 
   @impl ImagePipe.Transform
   def execute(%__MODULE__{axis: :both}, %State{} = state) do

--- a/lib/image_pipe/transform/operation/padding.ex
+++ b/lib/image_pipe/transform/operation/padding.ex
@@ -23,9 +23,6 @@ defmodule ImagePipe.Transform.Operation.Padding do
   def name(%__MODULE__{}), do: :padding
 
   @impl ImagePipe.Transform
-  def metadata(%__MODULE__{}), do: %{access: :random}
-
-  @impl ImagePipe.Transform
   def execute(%__MODULE__{top: 0, right: 0, bottom: 0, left: 0}, %State{} = state),
     do: {:ok, state}
 

--- a/lib/image_pipe/transform/operation/resize.ex
+++ b/lib/image_pipe/transform/operation/resize.ex
@@ -59,24 +59,6 @@ defmodule ImagePipe.Transform.Operation.Resize do
   def name(%__MODULE__{}), do: :resize
 
   @impl ImagePipe.Transform
-  def metadata(%__MODULE__{
-        mode: mode,
-        width: width,
-        height: height,
-        min_width: nil,
-        min_height: nil
-      })
-      when mode in [:fit, :force] do
-    if requested_dimension?(width) or requested_dimension?(height) do
-      %{access: :sequential}
-    else
-      %{access: :random}
-    end
-  end
-
-  def metadata(%__MODULE__{}), do: %{access: :random}
-
-  @impl ImagePipe.Transform
   def execute(%__MODULE__{} = operation, %State{} = state) do
     dimensions =
       resolve_dimensions(operation,
@@ -370,8 +352,4 @@ defmodule ImagePipe.Transform.Operation.Resize do
     |> round()
     |> max(1)
   end
-
-  defp requested_dimension?(:auto), do: false
-  defp requested_dimension?({:pixels, value}) when is_number(value) and value <= 0, do: false
-  defp requested_dimension?(_dimension), do: true
 end

--- a/lib/image_pipe/transform/operation/rotate.ex
+++ b/lib/image_pipe/transform/operation/rotate.ex
@@ -5,9 +5,9 @@ defmodule ImagePipe.Transform.Operation.Rotate do
 
   ## Construct When
 
-  Transform Plan execution may pass this narrow executable primitive through
-  unchanged. Parser modules should construct semantic `ImagePipe.Plan.Operation.*`
-  through Plan constructors for non-orientation transform intent.
+  Transform Plan execution creates this executable primitive from semantic
+  `ImagePipe.Plan.Operation.Rotate` intent. Parser modules should construct
+  semantic `ImagePipe.Plan.Operation.*` structs through Plan constructors.
 
   ## Fields
 
@@ -28,12 +28,6 @@ defmodule ImagePipe.Transform.Operation.Rotate do
   `ImagePipe.Transform.State.image` and stores the rotated image back into
   state. If rotation fails, execution returns `{:error, {__MODULE__, error}}`.
 
-  ## Decode Planning Metadata
-
-  `metadata/1` returns `%{access: :random}`. Rotation is not treated as safe for
-  optimized sequential source decoding because the transform may need the full
-  decoded image to remap pixels and dimensions.
-
   ## Examples
 
       rotate = %ImagePipe.Transform.Operation.Rotate{angle: 90}
@@ -51,9 +45,6 @@ defmodule ImagePipe.Transform.Operation.Rotate do
 
   @impl ImagePipe.Transform
   def name(%__MODULE__{}), do: :rotate
-
-  @impl ImagePipe.Transform
-  def metadata(%__MODULE__{}), do: %{access: :random}
 
   @impl ImagePipe.Transform
   def execute(%__MODULE__{angle: 0}, %State{} = state), do: {:ok, state}

--- a/lib/image_pipe/transform/plan_executor.ex
+++ b/lib/image_pipe/transform/plan_executor.ex
@@ -3,11 +3,14 @@ defmodule ImagePipe.Transform.PlanExecutor do
 
   alias ImagePipe.Plan
   alias ImagePipe.Plan.Color
+  alias ImagePipe.Plan.Operation.AutoOrient, as: PlanAutoOrient
   alias ImagePipe.Plan.Operation.Background, as: PlanBackground
   alias ImagePipe.Plan.Operation.Canvas
   alias ImagePipe.Plan.Operation.CropGuided
   alias ImagePipe.Plan.Operation.CropRegion
+  alias ImagePipe.Plan.Operation.Flip, as: PlanFlip
   alias ImagePipe.Plan.Operation.Padding, as: PlanPadding
+  alias ImagePipe.Plan.Operation.Rotate, as: PlanRotate
   alias ImagePipe.Plan.Operation.Resize, as: PlanResize
   alias ImagePipe.Plan.Pipeline
   alias ImagePipe.Transform.Chain
@@ -164,11 +167,13 @@ defmodule ImagePipe.Transform.PlanExecutor do
     [%Background{color: Color.to_rgba_list(operation.color)}]
   end
 
-  defp executable_operations(%AutoOrient{} = operation, %State{}, _context),
-    do: [operation]
+  defp executable_operations(%PlanAutoOrient{}, %State{}, _context), do: [%AutoOrient{}]
 
-  defp executable_operations(%Rotate{} = operation, %State{}, _context), do: [operation]
-  defp executable_operations(%Flip{} = operation, %State{}, _context), do: [operation]
+  defp executable_operations(%PlanRotate{angle: angle}, %State{}, _context),
+    do: [%Rotate{angle: angle}]
+
+  defp executable_operations(%PlanFlip{axis: axis}, %State{}, _context),
+    do: [%Flip{axis: axis}]
 
   defp tagged_executable_resize_operations(
          :cover,

--- a/test/image_pipe/architecture_boundary_test.exs
+++ b/test/image_pipe/architecture_boundary_test.exs
@@ -21,9 +21,9 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
     "lib/image_pipe/output.ex",
     "lib/image_pipe/output/**/*.ex"
   ]
-  @imgproxy_parser_globs [
-    "lib/image_pipe/parser/imgproxy.ex",
-    "lib/image_pipe/parser/imgproxy/**/*.ex"
+  @parser_globs [
+    "lib/image_pipe/parser.ex",
+    "lib/image_pipe/parser/**/*.ex"
   ]
   @cache_key_files ["lib/image_pipe/cache/key.ex"]
   @boundary_files %{
@@ -42,11 +42,14 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
     ImagePipe.Transform => "lib/image_pipe/transform.ex"
   }
   @concrete_plan_names [
+    :AutoOrient,
     :Background,
     :Canvas,
     :CropGuided,
     :CropRegion,
+    :Flip,
     :Padding,
+    :Rotate,
     :Resize
   ]
   @concrete_transform_names [
@@ -64,11 +67,6 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
     :Padding,
     :AdaptiveResize
   ]
-  @orientation_transform_modules [
-    "ImagePipe.Transform.Operation.AutoOrient",
-    "ImagePipe.Transform.Operation.Rotate",
-    "ImagePipe.Transform.Operation.Flip"
-  ]
   @post_fetch_transform_state_modules [
     ImagePipe.Transform.PlanExecutor
   ]
@@ -80,29 +78,27 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
     :execute_plan
   ]
 
-  test "parser boundary declarations stay limited to format, parser, plan, and transform construction APIs" do
+  test "parser boundary declarations stay limited to format, parser, and plan APIs" do
     parser = boundary_declaration(ImagePipe.Parser)
     imgproxy = boundary_declaration(ImagePipe.Parser.Imgproxy)
 
-    assert_boundary_deps(parser, [ImagePipe.Format, ImagePipe.Plan, ImagePipe.Transform])
+    assert_boundary_deps(parser, [ImagePipe.Format, ImagePipe.Plan])
     assert_boundary_exports(parser, [ImagePipe.Parser.Imgproxy])
 
     assert_boundary_deps(imgproxy, [
       ImagePipe.Format,
       ImagePipe.Parser,
-      ImagePipe.Plan,
-      ImagePipe.Transform
+      ImagePipe.Plan
     ])
 
     assert_boundary_exports(imgproxy, [ImagePipe.Parser.Imgproxy.SourceScheme])
 
-    assert_allowed_deps(parser, [ImagePipe.Format, ImagePipe.Plan, ImagePipe.Transform])
+    assert_allowed_deps(parser, [ImagePipe.Format, ImagePipe.Plan])
 
     assert_allowed_deps(imgproxy, [
       ImagePipe.Format,
       ImagePipe.Parser,
-      ImagePipe.Plan,
-      ImagePipe.Transform
+      ImagePipe.Plan
     ])
   end
 
@@ -397,16 +393,33 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
     ])
   end
 
-  test "plan boundary exports canonical composition modules and depends only on formats" do
+  test "plan boundary exports canonical modules and depends only on formats" do
     plan = boundary_declaration(ImagePipe.Plan)
 
     assert_boundary_deps(plan, [ImagePipe.Format])
 
-    assert_boundary_exports_include(plan, [
+    assert_boundary_exports(plan, [
+      ImagePipe.Plan.Pipeline,
+      ImagePipe.Plan.Output,
+      ImagePipe.Plan.Response,
       ImagePipe.Plan.Color,
       ImagePipe.Plan.KeyData,
+      ImagePipe.Plan.Source,
+      ImagePipe.Plan.Source.Identity,
+      ImagePipe.Plan.Source.Path,
+      ImagePipe.Plan.Source.URL,
+      ImagePipe.Plan.Source.Object,
+      ImagePipe.Plan.Source.Reference,
+      ImagePipe.Plan.Operation,
+      ImagePipe.Plan.Operation.AutoOrient,
+      ImagePipe.Plan.Operation.Background,
+      ImagePipe.Plan.Operation.Canvas,
+      ImagePipe.Plan.Operation.CropGuided,
+      ImagePipe.Plan.Operation.CropRegion,
+      ImagePipe.Plan.Operation.Flip,
       ImagePipe.Plan.Operation.Padding,
-      ImagePipe.Plan.Operation.Background
+      ImagePipe.Plan.Operation.Rotate,
+      ImagePipe.Plan.Operation.Resize
     ])
   end
 
@@ -435,11 +448,10 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
     assert violations == []
   end
 
-  test "imgproxy parser does not depend on executable transform operation modules" do
+  test "parser code does not depend on executable transform operation modules" do
     violations =
-      for file <- imgproxy_parser_files(),
-          violation <- concrete_transform_references(file),
-          violation.module not in @orientation_transform_modules do
+      for file <- parser_files(),
+          violation <- concrete_transform_references(file) do
         "#{file}:#{violation.line} must not name #{violation.module}; parser output is semantic Plan operations"
       end
 
@@ -454,6 +466,13 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
 
   defp parser_forbidden_files do
     @parser_forbidden_globs
+    |> Enum.flat_map(&Path.wildcard/1)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp parser_files do
+    @parser_globs
     |> Enum.flat_map(&Path.wildcard/1)
     |> Enum.uniq()
     |> Enum.sort()
@@ -611,12 +630,6 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
   end
 
   defp module_alias({:__aliases__, _meta, parts}), do: Module.concat(parts)
-
-  defp imgproxy_parser_files do
-    @imgproxy_parser_globs
-    |> Enum.flat_map(&Path.wildcard/1)
-    |> Enum.sort()
-  end
 
   defp concrete_plan_references(file) do
     {:ok, ast} = file |> File.read!() |> Code.string_to_quoted()

--- a/test/image_pipe/decode_planner_test.exs
+++ b/test/image_pipe/decode_planner_test.exs
@@ -2,8 +2,8 @@ defmodule ImagePipe.Transform.DecodePlannerTest do
   use ExUnit.Case, async: true
 
   alias ImagePipe.Plan.Operation
+  alias ImagePipe.Plan.Operation.AutoOrient
   alias ImagePipe.Transform.DecodePlanner
-  alias ImagePipe.Transform.Operation.AutoOrient
 
   test "empty chains open randomly with fail_on error" do
     assert DecodePlanner.open_options([]) == [access: :random, fail_on: :error]

--- a/test/image_pipe/plan/operation_key_data_test.exs
+++ b/test/image_pipe/plan/operation_key_data_test.exs
@@ -3,9 +3,9 @@ defmodule ImagePipe.Plan.OperationKeyDataTest do
 
   alias ImagePipe.Plan.Operation
   alias ImagePipe.Plan.KeyData
-  alias ImagePipe.Transform.Operation.AutoOrient
-  alias ImagePipe.Transform.Operation.Flip
-  alias ImagePipe.Transform.Operation.Rotate
+  alias ImagePipe.Plan.Operation.AutoOrient
+  alias ImagePipe.Plan.Operation.Flip
+  alias ImagePipe.Plan.Operation.Rotate
 
   describe "tagged geometry data" do
     test "returns key data for symbolic dimensions" do
@@ -180,8 +180,8 @@ defmodule ImagePipe.Plan.OperationKeyDataTest do
     end
   end
 
-  describe "orientation primitive data" do
-    test "returns key data for allowed orientation primitives" do
+  describe "orientation operation data" do
+    test "returns key data for semantic orientation operations" do
       assert KeyData.data(%AutoOrient{}) == [op: :auto_orient]
       assert KeyData.data(%Rotate{angle: 270}) == [op: :rotate, angle: 270]
       assert KeyData.data(%Flip{axis: :both}) == [op: :flip, axis: :both]

--- a/test/image_pipe/plan/operation_test.exs
+++ b/test/image_pipe/plan/operation_test.exs
@@ -2,9 +2,9 @@ defmodule ImagePipe.Plan.OperationTest do
   use ExUnit.Case, async: true
 
   alias ImagePipe.Plan.Operation
-  alias ImagePipe.Transform.Operation.AutoOrient
-  alias ImagePipe.Transform.Operation.Flip
-  alias ImagePipe.Transform.Operation.Rotate
+  alias ImagePipe.Plan.Operation.AutoOrient
+  alias ImagePipe.Plan.Operation.Flip
+  alias ImagePipe.Plan.Operation.Rotate
 
   describe "resize constructors" do
     test "build unified resize operations through exported constructor" do
@@ -332,16 +332,33 @@ defmodule ImagePipe.Plan.OperationTest do
     end
   end
 
-  describe "orientation primitive allowlist" do
-    test "allows executable orientation primitives as semantic plan operations" do
+  describe "orientation operations" do
+    test "allows semantic orientation operations" do
       assert Operation.semantic?(%AutoOrient{})
       assert Operation.semantic?(%Rotate{angle: 90})
       assert Operation.semantic?(%Flip{axis: :horizontal})
     end
 
-    test "rejects orientation primitive values outside the explicit allowlist" do
+    test "constructs semantic orientation operations" do
+      assert Operation.auto_orient() == {:ok, %AutoOrient{}}
+      assert Operation.rotate(90) == {:ok, %Rotate{angle: 90}}
+      assert Operation.flip(:both) == {:ok, %Flip{axis: :both}}
+    end
+
+    test "rejects orientation values outside the explicit allowlist" do
+      assert Operation.rotate(0) == {:error, {:invalid_operation, :rotate, [0]}}
+      assert Operation.rotate(45) == {:error, {:invalid_operation, :rotate, [45]}}
+      assert Operation.flip(:diagonal) == {:error, {:invalid_operation, :flip, [:diagonal]}}
+
+      refute Operation.semantic?(%Rotate{angle: 0})
       refute Operation.semantic?(%Rotate{angle: 45})
       refute Operation.semantic?(%Flip{axis: :diagonal})
+    end
+
+    test "rejects executable transform orientation structs as semantic operations" do
+      refute Operation.semantic?(%ImagePipe.Transform.Operation.AutoOrient{})
+      refute Operation.semantic?(%ImagePipe.Transform.Operation.Rotate{angle: 90})
+      refute Operation.semantic?(%ImagePipe.Transform.Operation.Flip{axis: :horizontal})
     end
   end
 end

--- a/test/image_pipe/plan_test.exs
+++ b/test/image_pipe/plan_test.exs
@@ -7,9 +7,9 @@ defmodule ImagePipe.PlanTest do
   alias ImagePipe.Plan.Pipeline
   alias ImagePipe.Plan.Response
   alias ImagePipe.Plan.Source
-  alias ImagePipe.Transform.Operation.AutoOrient
-  alias ImagePipe.Transform.Operation.Flip
-  alias ImagePipe.Transform.Operation.Rotate
+  alias ImagePipe.Plan.Operation.AutoOrient
+  alias ImagePipe.Plan.Operation.Flip
+  alias ImagePipe.Plan.Operation.Rotate
 
   test "validated pipelines accept semantic operation structs" do
     operation = resize_operation()
@@ -23,7 +23,7 @@ defmodule ImagePipe.PlanTest do
     assert {:ok, [%Pipeline{operations: [^operation]}]} = Plan.validated_pipelines(plan)
   end
 
-  test "validated pipelines accept explicit orientation primitive allowlist" do
+  test "validated pipelines accept semantic orientation operations" do
     operations = [%AutoOrient{}, %Rotate{angle: 90}, %Flip{axis: :horizontal}]
 
     plan =

--- a/test/image_pipe/transform/plan_executor_test.exs
+++ b/test/image_pipe/transform/plan_executor_test.exs
@@ -3,12 +3,12 @@ defmodule ImagePipe.Transform.PlanExecutorTest do
 
   alias ImagePipe.Plan
   alias ImagePipe.Plan.Operation
+  alias ImagePipe.Plan.Operation.AutoOrient
+  alias ImagePipe.Plan.Operation.Flip
+  alias ImagePipe.Plan.Operation.Rotate
   alias ImagePipe.Plan.Pipeline
   alias ImagePipe.Plan.Source
   alias ImagePipe.Transform
-  alias ImagePipe.Transform.Operation.AutoOrient
-  alias ImagePipe.Transform.Operation.Flip
-  alias ImagePipe.Transform.Operation.Rotate
   alias ImagePipe.Transform.State
 
   describe "resize execution" do

--- a/test/image_pipe/transform/prefetch_validation_test.exs
+++ b/test/image_pipe/transform/prefetch_validation_test.exs
@@ -3,13 +3,13 @@ defmodule ImagePipe.Transform.PrefetchValidationTest do
 
   alias ImagePipe.Plan
   alias ImagePipe.Plan.Operation
+  alias ImagePipe.Plan.Operation.AutoOrient
+  alias ImagePipe.Plan.Operation.Flip
+  alias ImagePipe.Plan.Operation.Rotate
   alias ImagePipe.Plan.Output
   alias ImagePipe.Plan.Pipeline
   alias ImagePipe.Plan.Source
   alias ImagePipe.Transform
-  alias ImagePipe.Transform.Operation.AutoOrient
-  alias ImagePipe.Transform.Operation.Flip
-  alias ImagePipe.Transform.Operation.Rotate
 
   test "semantic Plan operations pass source-independent validation" do
     assert {:ok, operation} = Operation.resize(:auto, {:px, 100}, {:px, 100}, enlargement: :deny)
@@ -33,7 +33,7 @@ defmodule ImagePipe.Transform.PrefetchValidationTest do
              Transform.validate_prefetch_safe_plan(plan([resize, crop]))
   end
 
-  test "executable orientation primitives pass source-independent validation" do
+  test "semantic orientation operations pass source-independent validation" do
     operations = [%AutoOrient{}, %Rotate{angle: 90}, %Flip{axis: :horizontal}]
 
     assert {:ok, [%Pipeline{operations: ^operations}]} =

--- a/test/parser/imgproxy/plan_builder_test.exs
+++ b/test/parser/imgproxy/plan_builder_test.exs
@@ -12,9 +12,9 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilderTest do
   alias ImagePipe.Plan.Pipeline
   alias ImagePipe.Plan.Response
   alias ImagePipe.Plan.Source
-  alias ImagePipe.Transform.Operation.AutoOrient
-  alias ImagePipe.Transform.Operation.Flip
-  alias ImagePipe.Transform.Operation.Rotate
+  alias ImagePipe.Plan.Operation.AutoOrient
+  alias ImagePipe.Plan.Operation.Flip
+  alias ImagePipe.Plan.Operation.Rotate
 
   test "converts one imgproxy pipeline request into a product-neutral plan" do
     request = %ParsedRequest{
@@ -539,7 +539,9 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilderTest do
              plan_pipeline(crop: struct(ImagePipe.Parser.Imgproxy.CropRequest))
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: [%AutoOrient{}]}]}} =
-             plan_pipeline(orientation: struct(ImagePipe.Plan.Orientation, auto_orient: true))
+             plan_pipeline(
+               orientation: struct(ImagePipe.Parser.Imgproxy.Orientation, auto_orient: true)
+             )
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: []}]}} =
              plan_pipeline(orientation_requested: true)
@@ -547,7 +549,7 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilderTest do
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
              plan_pipeline(
                crop: struct(ImagePipe.Parser.Imgproxy.CropRequest),
-               orientation: struct(ImagePipe.Plan.Orientation, auto_orient: true)
+               orientation: struct(ImagePipe.Parser.Imgproxy.Orientation, auto_orient: true)
              )
 
     assert operation_names(operations) == [:auto_orient, :crop_guided]
@@ -862,7 +864,9 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilderTest do
     if orientation_attrs == [] do
       attrs
     else
-      {orientation, attrs} = Keyword.pop(attrs, :orientation, %ImagePipe.Plan.Orientation{})
+      {orientation, attrs} =
+        Keyword.pop(attrs, :orientation, %ImagePipe.Parser.Imgproxy.Orientation{})
+
       Keyword.put(attrs, :orientation, struct!(orientation, orientation_attrs))
     end
   end

--- a/test/parser/imgproxy_test.exs
+++ b/test/parser/imgproxy_test.exs
@@ -11,7 +11,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
   alias ImagePipe.Plan.Pipeline
   alias ImagePipe.Plan.Response
   alias ImagePipe.Plan.Source
-  alias ImagePipe.Transform.Operation.AutoOrient
+  alias ImagePipe.Plan.Operation.AutoOrient
 
   defmodule FoobarTranslator do
     @behaviour ImagePipe.Parser.Imgproxy.SourceScheme
@@ -33,12 +33,6 @@ defmodule ImagePipe.Parser.ImgproxyTest do
   defmodule InvalidTranslator do
     @moduledoc false
   end
-
-  @allowed_parsed_transform_operations [
-    ImagePipe.Transform.Operation.AutoOrient,
-    ImagePipe.Transform.Operation.Rotate,
-    ImagePipe.Transform.Operation.Flip
-  ]
 
   @no_auto_rotate_opts [imgproxy: [auto_rotate: false]]
 
@@ -721,7 +715,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
     end
   end
 
-  test "parsed plans contain no executable transform operations except orientation primitives" do
+  test "parsed plans contain no executable transform operations" do
     for path <- [
           "/_/rt:force/w:0/h:200/plain/images/cat.jpg",
           "/_/g:fp:0.25:0.75/rs:fill:300:200/plain/images/cat.jpg",
@@ -1656,7 +1650,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
   defp operation_names(operations), do: Enum.map(operations, &operation_name/1)
 
   defp operation_name(%AutoOrient{}), do: :auto_orient
-  defp operation_name(%ImagePipe.Transform.Operation.Rotate{}), do: :rotate
+  defp operation_name(%Operation.Rotate{}), do: :rotate
   defp operation_name(%Operation.CropGuided{}), do: :crop_guided
   defp operation_name(%Operation.Resize{}), do: :resize
 
@@ -1667,7 +1661,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
   end
 
   defp forbidden_parsed_transform_operation?(%{__struct__: module}) do
-    transform_operation_module?(module) and module not in @allowed_parsed_transform_operations
+    transform_operation_module?(module)
   end
 
   defp forbidden_parsed_transform_operation?(_operation), do: false

--- a/test/support/image_pipe/transform/chain_test/failing_transform.ex
+++ b/test/support/image_pipe/transform/chain_test/failing_transform.ex
@@ -4,7 +4,6 @@ defmodule ImagePipe.Transform.ChainTest.FailingTransform do
   defstruct []
 
   def name(%__MODULE__{}), do: :failing
-  def metadata(%__MODULE__{}), do: %{access: :random}
 
   def execute(%__MODULE__{}, _state), do: {:error, {__MODULE__, :failed}}
 end

--- a/test/support/image_pipe/transform/chain_test/unexpected_transform.ex
+++ b/test/support/image_pipe/transform/chain_test/unexpected_transform.ex
@@ -4,7 +4,6 @@ defmodule ImagePipe.Transform.ChainTest.UnexpectedTransform do
   defstruct []
 
   def name(%__MODULE__{}), do: :unexpected
-  def metadata(%__MODULE__{}), do: %{access: :random}
 
   def execute(%__MODULE__{}, _state), do: {:error, {__MODULE__, :should_not_run}}
 end

--- a/test/transform_chain_test.exs
+++ b/test/transform_chain_test.exs
@@ -19,22 +19,6 @@ defmodule ImagePipe.Transform.ChainTest do
     assert Transform.transform_name(operation) == :resize
   end
 
-  test "metadata is delegated to operation module" do
-    operation = %Resize{mode: :fit, width: {:pixels, 10}, height: :auto}
-
-    assert Transform.metadata(operation) == %{access: :sequential}
-  end
-
-  test "zero-dimension resize rules stay random access" do
-    operation = %Resize{
-      mode: :fit,
-      width: {:pixels, 0},
-      height: :auto
-    }
-
-    assert Transform.metadata(operation) == %{access: :random}
-  end
-
   test "stops executing after the first transform error" do
     {:ok, image} = Image.new(20, 20, color: :white)
 


### PR DESCRIPTION
## Summary

- add semantic Plan orientation operations for auto-orient, rotate, and flip
- keep imgproxy orientation request state inside the parser boundary
- lower semantic Plan operations to executable Transform operations only in Transform execution
- remove the unused Transform metadata callback so decode planning has one owner
- tighten architecture tests around parser/transform references and Plan exports

## Verification

- `mise exec -- mix format`
- `mise exec -- mix compile --warnings-as-errors`
- `VIX_COMPILATION_MODE=PRECOMPILED_LIBVIPS mise exec -- mix test`
- `mise exec -- vale docs/transform_operations.md docs/operational_notes.md docs/superpowers/plans/2026-05-27-exif-autorotate-default.md`

Closes #105


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architectural guidelines and operational specifications for image processing pipelines.
  * Clarified default EXIF autorotation behavior and how it integrates with URL parameters.

* **Refactor**
  * Reorganized internal operation management and architectural boundaries for improved code clarity.
  * Simplified operation metadata handling across the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hlindset/image_plug/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->