### PR TITLE
Add imgproxy brightness contrast saturation

### DIFF
--- a/demo/src/App.svelte
+++ b/demo/src/App.svelte
@@ -204,6 +204,9 @@
       currentState.blurEnabled ? `bl:${currentState.blur}` : null,
       currentState.sharpenEnabled ? `sh:${currentState.sharpen}` : null,
       currentState.pixelateEnabled ? `pix:${currentState.pixelate}` : null,
+      currentState.brightnessEnabled ? `br:${currentState.brightness}` : null,
+      currentState.contrastEnabled ? `co:${currentState.contrast}` : null,
+      currentState.saturationEnabled ? `sa:${currentState.saturation}` : null,
     ].filter((segment): segment is string => segment !== null);
   }
 
@@ -1090,6 +1093,57 @@
                 max={controlLimits.effects.pixelate.max}
                 step={controlLimits.effects.pixelate.step}
                 suffix="px"
+              />
+            {/if}
+
+            <label class="switch-field">
+              <Switch.Root class="switch-root" bind:checked={state.brightnessEnabled}>
+                <Switch.Thumb class="switch-thumb" />
+              </Switch.Root>
+              <span>Brightness</span>
+            </label>
+            {#if state.brightnessEnabled}
+              <RangeNumber
+                label="Brightness"
+                bind:value={state.brightness}
+                min={controlLimits.effects.brightness.min}
+                max={controlLimits.effects.brightness.max}
+                step={controlLimits.effects.brightness.step}
+                suffix="%"
+              />
+            {/if}
+
+            <label class="switch-field">
+              <Switch.Root class="switch-root" bind:checked={state.contrastEnabled}>
+                <Switch.Thumb class="switch-thumb" />
+              </Switch.Root>
+              <span>Contrast</span>
+            </label>
+            {#if state.contrastEnabled}
+              <RangeNumber
+                label="Contrast"
+                bind:value={state.contrast}
+                min={controlLimits.effects.contrast.min}
+                max={controlLimits.effects.contrast.max}
+                step={controlLimits.effects.contrast.step}
+                suffix="%"
+              />
+            {/if}
+
+            <label class="switch-field">
+              <Switch.Root class="switch-root" bind:checked={state.saturationEnabled}>
+                <Switch.Thumb class="switch-thumb" />
+              </Switch.Root>
+              <span>Saturation</span>
+            </label>
+            {#if state.saturationEnabled}
+              <RangeNumber
+                label="Saturation"
+                bind:value={state.saturation}
+                min={controlLimits.effects.saturation.min}
+                max={controlLimits.effects.saturation.max}
+                step={controlLimits.effects.saturation.step}
+                suffix="%"
               />
             {/if}
           </Collapsible.Content>

--- a/demo/src/demo-url-state.ts
+++ b/demo/src/demo-url-state.ts
@@ -87,7 +87,12 @@ export function resetDemoSettings(currentState: DemoState): DemoState {
 export function expandedToolboxesForState(currentState: DemoState): ExpandedToolboxes {
   return {
     effectsOpen:
-      currentState.blurEnabled || currentState.sharpenEnabled || currentState.pixelateEnabled,
+      currentState.blurEnabled ||
+      currentState.sharpenEnabled ||
+      currentState.pixelateEnabled ||
+      currentState.brightnessEnabled ||
+      currentState.contrastEnabled ||
+      currentState.saturationEnabled,
     orientationOpen:
       currentState.autoRotateEnabled || currentState.flip !== "none" || currentState.rotate !== 0,
     requestOpen: true,
@@ -209,6 +214,27 @@ function applyOptionSegment(currentState: DemoState, segment: string): DemoState
       return parseNonNegativeIntegerOption(currentState, args, (value) => ({
         pixelateEnabled: value > 1,
         pixelate: value > 1 ? value : defaultDemoState.pixelate,
+      }));
+
+    case "br":
+    case "brightness":
+      return parseAdjustmentOption(currentState, args, (value) => ({
+        brightnessEnabled: value !== 0,
+        brightness: value !== 0 ? value : defaultDemoState.brightness,
+      }));
+
+    case "co":
+    case "contrast":
+      return parseAdjustmentOption(currentState, args, (value) => ({
+        contrastEnabled: value !== 0,
+        contrast: value !== 0 ? value : defaultDemoState.contrast,
+      }));
+
+    case "sa":
+    case "saturation":
+      return parseAdjustmentOption(currentState, args, (value) => ({
+        saturationEnabled: value !== 0,
+        saturation: value !== 0 ? value : defaultDemoState.saturation,
       }));
 
     case "g":
@@ -418,6 +444,24 @@ function parseNonNegativeIntegerOption(
   const value = parseNumber(args[0]);
 
   if (value === null || !Number.isInteger(value) || value < 0) {
+    return null;
+  }
+
+  return { ...currentState, ...buildPatch(value) };
+}
+
+function parseAdjustmentOption(
+  currentState: DemoState,
+  args: string[],
+  buildPatch: (value: number) => Partial<DemoState>,
+): DemoState | null {
+  if (args.length !== 1) {
+    return null;
+  }
+
+  const value = parseNumber(args[0]);
+
+  if (value === null || value < -100 || value > 100) {
     return null;
   }
 

--- a/demo/src/processing-path.test.ts
+++ b/demo/src/processing-path.test.ts
@@ -317,11 +317,25 @@ describe("processing path generation", () => {
       sharpen: 0.7,
       pixelateEnabled: true,
       pixelate: 8,
+      brightnessEnabled: true,
+      brightness: 20,
+      contrastEnabled: true,
+      contrast: -15,
+      saturationEnabled: true,
+      saturation: 35,
     };
 
-    expect(optionSegments(state)).toEqual(["bg:ffcc00", "bl:2.5", "sh:0.7", "pix:8"]);
+    expect(optionSegments(state)).toEqual([
+      "bg:ffcc00",
+      "bl:2.5",
+      "sh:0.7",
+      "pix:8",
+      "br:20",
+      "co:-15",
+      "sa:35",
+    ]);
     expect(buildProcessingPath(state)).toBe(
-      "/_/bg:ffcc00/bl:2.5/sh:0.7/pix:8/plain/local:///images/dog.jpg",
+      "/_/bg:ffcc00/bl:2.5/sh:0.7/pix:8/br:20/co:-15/sa:35/plain/local:///images/dog.jpg",
     );
   });
 
@@ -719,7 +733,7 @@ describe("demo URL state", () => {
 
   it("parses crop, orientation, scale, canvas, padding, background, and effects options", () => {
     const parsed = parseDemoPath(
-      "/demo/ar:1/fl:0:1/rot:90/c:0.5:0.25:no/z:1.25/dpr:2/mw:320/mh:240/exar:16:9/pd:1:2:3:4/bg:ffcc00/bga:0.42/bl:2.5/sh:0.7/pix:8/plain/local:///images/beach.jpg",
+      "/demo/ar:1/fl:0:1/rot:90/c:0.5:0.25:no/z:1.25/dpr:2/mw:320/mh:240/exar:16:9/pd:1:2:3:4/bg:ffcc00/bga:0.42/bl:2.5/sh:0.7/pix:8/br:20/co:-15/sa:35/plain/local:///images/beach.jpg",
     );
 
     expect(parsed).toMatchObject({
@@ -758,6 +772,25 @@ describe("demo URL state", () => {
       sharpen: 0.7,
       pixelateEnabled: true,
       pixelate: 8,
+      brightnessEnabled: true,
+      brightness: 20,
+      contrastEnabled: true,
+      contrast: -15,
+      saturationEnabled: true,
+      saturation: 35,
+    });
+  });
+
+  it("parses long aliases for color effect options", () => {
+    expect(
+      parseDemoPath("/demo/brightness:20/contrast:-15/saturation:35/plain/local:///images/dog.jpg"),
+    ).toMatchObject({
+      brightnessEnabled: true,
+      brightness: 20,
+      contrastEnabled: true,
+      contrast: -15,
+      saturationEnabled: true,
+      saturation: 35,
     });
   });
 
@@ -770,7 +803,9 @@ describe("demo URL state", () => {
   });
 
   it("treats zero-valued effects as demo no-ops", () => {
-    expect(parseDemoPath("/demo/bl:0/sh:0/pix:0/plain/local:///images/dog.jpg")).toEqual({
+    expect(
+      parseDemoPath("/demo/bl:0/sh:0/pix:0/br:0/co:0/sa:0/plain/local:///images/dog.jpg"),
+    ).toEqual({
       ...defaultDemoState,
       blurEnabled: false,
       blur: defaultDemoState.blur,
@@ -778,11 +813,17 @@ describe("demo URL state", () => {
       sharpen: defaultDemoState.sharpen,
       pixelateEnabled: false,
       pixelate: defaultDemoState.pixelate,
+      brightnessEnabled: false,
+      brightness: defaultDemoState.brightness,
+      contrastEnabled: false,
+      contrast: defaultDemoState.contrast,
+      saturationEnabled: false,
+      saturation: defaultDemoState.saturation,
     });
   });
 
   it("expands accordions that contain active URL state", () => {
-    const state = parseDemoPath("/demo/ar:1/z:1.5/bl:2.5/plain/local:///images/dog.jpg");
+    const state = parseDemoPath("/demo/ar:1/z:1.5/br:20/plain/local:///images/dog.jpg");
 
     expect(expandedToolboxesForState(state)).toEqual({
       effectsOpen: true,
@@ -806,6 +847,12 @@ describe("demo URL state", () => {
     expect(parseDemoPath("/demo/q:-1/plain/local:///images/dog.jpg")).toEqual(defaultDemoState);
     expect(parseDemoPath("/demo/q:101/plain/local:///images/dog.jpg")).toEqual(defaultDemoState);
     expect(parseDemoPath("/demo/q:85.5/plain/local:///images/dog.jpg")).toEqual(defaultDemoState);
+  });
+
+  it("rejects invalid color effect values in demo routes", () => {
+    expect(parseDemoPath("/demo/br:-101/plain/local:///images/dog.jpg")).toEqual(defaultDemoState);
+    expect(parseDemoPath("/demo/co:101/plain/local:///images/dog.jpg")).toEqual(defaultDemoState);
+    expect(parseDemoPath("/demo/sa:100.5/plain/local:///images/dog.jpg")).toEqual(defaultDemoState);
   });
 
   it("resets processing options while keeping source and signature settings", () => {

--- a/demo/src/processing-path.ts
+++ b/demo/src/processing-path.ts
@@ -52,6 +52,12 @@ export type DemoState = {
   sharpen: number;
   pixelateEnabled: boolean;
   pixelate: number;
+  brightnessEnabled: boolean;
+  brightness: number;
+  contrastEnabled: boolean;
+  contrast: number;
+  saturationEnabled: boolean;
+  saturation: number;
   gravityEnabled: boolean;
   gravityMode: GravityMode;
   gravity: Gravity;
@@ -123,6 +129,9 @@ export const controlLimits = {
     blur: { min: 0.1, max: 10, step: 0.1 },
     sharpen: { min: 0.1, max: 10, step: 0.1 },
     pixelate: { min: 2, max: 80, step: 1 },
+    brightness: { min: -100, max: 100, step: 1 },
+    contrast: { min: -100, max: 100, step: 1 },
+    saturation: { min: -100, max: 100, step: 1 },
   },
   focalPoint: { min: 0, max: 1, step: 0.01 },
   gravityOffset: { min: -200, max: 200, step: 0.01 },
@@ -134,7 +143,10 @@ export const controlLimits = {
   aspectCanvas: Record<ImageDimensionAxis, NumericControlLimit>;
   padding: NumericControlLimit;
   alpha: NumericControlLimit;
-  effects: Record<"blur" | "sharpen" | "pixelate", NumericControlLimit>;
+  effects: Record<
+    "blur" | "sharpen" | "pixelate" | "brightness" | "contrast" | "saturation",
+    NumericControlLimit
+  >;
   focalPoint: NumericControlLimit;
   gravityOffset: NumericControlLimit;
   quality: NumericControlLimit;
@@ -219,6 +231,12 @@ export const defaultDemoState: DemoState = {
   sharpen: 1,
   pixelateEnabled: false,
   pixelate: 8,
+  brightnessEnabled: false,
+  brightness: 20,
+  contrastEnabled: false,
+  contrast: 20,
+  saturationEnabled: false,
+  saturation: 20,
   gravityEnabled: false,
   gravityMode: "anchor",
   gravity: "ce",
@@ -326,6 +344,18 @@ export function optionSegments(currentState: DemoState): string[] {
 
   if (currentState.pixelateEnabled) {
     segments.push(`pix:${currentState.pixelate}`);
+  }
+
+  if (currentState.brightnessEnabled) {
+    segments.push(`br:${currentState.brightness}`);
+  }
+
+  if (currentState.contrastEnabled) {
+    segments.push(`co:${currentState.contrast}`);
+  }
+
+  if (currentState.saturationEnabled) {
+    segments.push(`sa:${currentState.saturation}`);
   }
 
   if (currentState.gravityEnabled) {

--- a/docs/imgproxy_path_api.md
+++ b/docs/imgproxy_path_api.md
@@ -133,7 +133,7 @@ Within each pipeline group, ImagePipe uses this fixed operation order:
 2. explicit crop
 3. resize intent, including `mode: :auto`
 4. result crop for `fill`, `fill-down`, and `auto` target geometry
-5. effects, in `blur`, `sharpen`, then `pixelate` order
+5. effects, in `blur`, `sharpen`, `pixelate`, `brightness`, `contrast`, then `saturation` order
 6. canvas extension
 7. padding
 8. background flattening
@@ -226,6 +226,9 @@ Remaining queued groups become trailing pipelines.
 | Blur | `blur`, `bl` | non-negative sigma number. `0` means no-op |
 | Sharpen | `sharpen`, `sh` | non-negative sigma number. `0` means no-op |
 | Pixelate | `pixelate`, `pix` | non-negative integer block size. `0` and `1` mean no-op |
+| Brightness | `brightness`, `br` | number from `-100` to `100`. `0` means no-op |
+| Contrast | `contrast`, `co` | number from `-100` to `100`. `0` means no-op |
+| Saturation | `saturation`, `sa` | number from `-100` to `100`. `0` means no-op |
 | Crop | `crop`, `c` | `<width>:<height>`, optional gravity, optional offsets |
 | Gravity | `gravity`, `g` | anchor, anchor with offsets `<anchor>:<x_offset>:<y_offset>`, or focal point `fp:<x>:<y>` |
 | Auto rotate | `auto_rotate`, `ar` | boolean |
@@ -399,9 +402,15 @@ sigma value of `0` parses and emits no operation.
 non-negative integer. `pix:0` and `pix:1` parse and emit no operation, matching
 Imgproxy's pixelation no-op threshold.
 
+`brightness:%value` and `br:%value` adjust brightness. `contrast:%value` and
+`co:%value` adjust contrast. `saturation:%value` and `sa:%value` adjust
+saturation. Values must be numbers from `-100` to `100`. `0` parses and emits
+no operation.
+
 Effects run after result cropping and before canvas extension, padding, and
 background composition. When more than one effect appears in a pipeline group,
-ImagePipe runs them in `blur`, `sharpen`, then `pixelate` order.
+ImagePipe runs them in `blur`, `sharpen`, `pixelate`, `brightness`, `contrast`,
+then `saturation` order.
 
 ## Output format and quality
 

--- a/docs/imgproxy_support_matrix.md
+++ b/docs/imgproxy_support_matrix.md
@@ -497,10 +497,10 @@ transforms or output encoding.
 | --- | --- | --- | --- |
 | `background` | `bg` | Supported | RGB decimal and 3/6 digit hex colors. `background:` clears previous background color and alpha. |
 | `background_alpha` | `bga` | Supported | Applies an alpha channel to the current or next background color. Without an explicit background color, uses Imgproxy's default black background. |
-| `adjust` | `a` | Missing | Pro meta-option for brightness, contrast, and saturation. |
-| `brightness` | `br` | Missing | Pro color control. |
-| `contrast` | `co` | Missing | Pro color control. |
-| `saturation` | `sa` | Missing | Pro color control. |
+| `adjust` | `a` | Missing | Pro meta-option for brightness, contrast, and saturation. Use the individual options below instead. |
+| `brightness` | `br` | Supported | Number from `-100` to `100`. `0` parses as an Imgproxy-compatible no-op. Runs after pixelate. |
+| `contrast` | `co` | Supported | Number from `-100` to `100`. `0` parses as an Imgproxy-compatible no-op. Runs after brightness. |
+| `saturation` | `sa` | Supported | Number from `-100` to `100`. `0` parses as an Imgproxy-compatible no-op. Runs after contrast. |
 | `monochrome` | `mc` | Missing | Pro color effect. |
 | `duotone` | `dt` | Missing | Pro color effect. |
 | `blur` | `bl` | Supported | Non-negative sigma value. `0` parses as an Imgproxy-compatible no-op. Runs before canvas extension and background flattening. |

--- a/docs/superpowers/plans/2026-05-28-imgproxy-color-controls.md
+++ b/docs/superpowers/plans/2026-05-28-imgproxy-color-controls.md
@@ -1,0 +1,349 @@
+# Imgproxy Color Controls Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Imgproxy-compatible brightness, contrast, and saturation operations, including parser support, transform execution, documentation, support matrix updates, and demo controls.
+
+**Architecture:** Imgproxy parsing stays declarative: `ImagePipe.Parser.Imgproxy.OptionGrammar` parses URL syntax into parser request fields, `ImagePipe.Parser.Imgproxy.PlanBuilder` emits canonical `ImagePipe.Plan.Operation.*` structs in the existing effect phase, and `ImagePipe.Transform.PlanExecutor` lowers semantic operations into executable transforms after cache lookup. The demo emits the same URL segments and parses them back from `/demo/...` paths.
+
+**Tech Stack:** Elixir, ExUnit, Vix/libvips through the `Image` package, Svelte, TypeScript, the demo test runner, Vale.
+
+---
+
+### Task 1: Add Semantic Color Adjustment Operations
+
+**Files:**
+- Create: `lib/image_pipe/plan/operation/brightness.ex`
+- Create: `lib/image_pipe/plan/operation/contrast.ex`
+- Create: `lib/image_pipe/plan/operation/saturation.ex`
+- Modify: `lib/image_pipe/plan.ex`
+- Modify: `lib/image_pipe/plan/operation.ex`
+- Modify: `lib/image_pipe/plan/key_data.ex`
+- Test: `test/image_pipe/plan/operation_test.exs`
+- Test: `test/image_pipe/plan/operation_key_data_test.exs`
+- Test: `test/image_pipe/architecture_boundary_test.exs`
+
+- [ ] **Step 1: Write failing constructor and key-data tests**
+
+Add tests that call `Operation.brightness/1`, `Operation.contrast/1`, and `Operation.saturation/1`.
+
+```elixir
+assert {:ok, %Operation.Brightness{value: 20}} = Operation.brightness(20)
+assert {:ok, %Operation.Contrast{value: -15}} = Operation.contrast(-15)
+assert {:ok, %Operation.Saturation{value: 35}} = Operation.saturation(35)
+
+assert {:error, {:invalid_operation, :brightness, [101]}} = Operation.brightness(101)
+assert {:error, {:invalid_operation, :contrast, [-101]}} = Operation.contrast(-101)
+assert {:error, {:invalid_operation, :saturation, [101]}} = Operation.saturation(101)
+```
+
+Add key-data assertions:
+
+```elixir
+assert KeyData.data(brightness) == [op: :brightness, value: 20]
+assert KeyData.data(contrast) == [op: :contrast, value: -15]
+assert KeyData.data(saturation) == [op: :saturation, value: 35]
+```
+
+Add numeric normalization assertions so matching numeric spellings produce identical operation fields and key data:
+
+```elixir
+assert {:ok, integer_brightness} = Operation.brightness(20)
+assert {:ok, float_brightness} = Operation.brightness(20.0)
+assert integer_brightness == float_brightness
+assert KeyData.data(integer_brightness) == KeyData.data(float_brightness)
+```
+
+- [ ] **Step 2: Run focused tests and verify they fail**
+
+Run: `mise exec -- mix test test/image_pipe/plan/operation_test.exs test/image_pipe/plan/operation_key_data_test.exs test/image_pipe/architecture_boundary_test.exs`
+
+Expected: failures mention missing `Operation.brightness/1`, `Operation.contrast/1`, or `Operation.saturation/1`.
+
+- [ ] **Step 3: Implement semantic structs, constructors, semantic checks, and key data**
+
+Add one enforced-key struct per operation with a numeric `value`. In `ImagePipe.Plan.Operation`, accept integer or float values from `-100` through `100`, normalize whole-number floats to integers, and otherwise store a rounded canonical float so matching requests don't create different cache key material. Reject values outside that range and non-numeric values. Add aliases, semantic type union entries, `semantic?/1` clauses, `ImagePipe.Plan.KeyData.data/1` clauses, and Boundary exports in `ImagePipe.Plan`.
+
+- [ ] **Step 4: Run focused tests and verify they pass**
+
+Run: `mise exec -- mix test test/image_pipe/plan/operation_test.exs test/image_pipe/plan/operation_key_data_test.exs test/image_pipe/architecture_boundary_test.exs`
+
+Expected: all focused tests pass.
+
+### Task 2: Parse And Plan Imgproxy Color Operations
+
+**Files:**
+- Modify: `lib/image_pipe/parser/imgproxy/option_grammar.ex`
+- Modify: `lib/image_pipe/parser/imgproxy/pipeline_request.ex`
+- Modify: `lib/image_pipe/parser/imgproxy/plan_builder.ex`
+- Test: `test/parser/imgproxy_test.exs`
+- Test: `test/parser/imgproxy/options_test.exs`
+- Test: `test/parser/imgproxy/plan_builder_test.exs`
+
+- [ ] **Step 1: Write failing parser and planner tests**
+
+Add tests for short and long aliases:
+
+```elixir
+assert operations_for("/_/br:20/co:-15/sa:35/plain/images/cat.jpg")
+       |> operation_names() == [:brightness, :contrast, :saturation]
+
+assert operations_for("/_/brightness:20/contrast:-15/saturation:35/plain/images/cat.jpg")
+       |> operation_names() == [:brightness, :contrast, :saturation]
+```
+
+Add a canonical-order test with deliberately scrambled URL order and existing effects:
+
+```elixir
+operations = operations_for("/_/sa:35/pix:8/co:-15/sh:0.7/br:20/bl:2.5/plain/images/cat.jpg")
+
+assert operation_names(operations) == [
+         :blur,
+         :sharpen,
+         :pixelate,
+         :brightness,
+         :contrast,
+         :saturation
+       ]
+```
+
+Add no-op tests for `0` values:
+
+```elixir
+assert operations_for("/_/br:0/co:0/sa:0/plain/images/cat.jpg") == []
+```
+
+Add invalid-value tests showing values outside `-100..100` fail at parse/planning time:
+
+```elixir
+assert {:error, _reason} = Imgproxy.parse("/_/br:101/plain/images/cat.jpg")
+assert {:error, _reason} = Imgproxy.parse("/_/co:-101/plain/images/cat.jpg")
+assert {:error, _reason} = Imgproxy.parse("/_/sa:101/plain/images/cat.jpg")
+```
+
+Add cache-key tests proving matching numeric spellings and URL orderings resolve to the same cache key material:
+
+```elixir
+first = plan_for!("/_/br:20.0/co:-15/sa:35/plain/images/cat.jpg")
+second = plan_for!("/_/sa:35/br:20/co:-15.0/plain/images/cat.jpg")
+
+assert canonical_pipeline_key_data(first) == canonical_pipeline_key_data(second)
+```
+
+- [ ] **Step 2: Run focused tests and verify they fail**
+
+Run: `mise exec -- mix test test/parser/imgproxy_test.exs test/parser/imgproxy/options_test.exs test/parser/imgproxy/plan_builder_test.exs`
+
+Expected: failures identify unknown Imgproxy options or missing operation mappings.
+
+- [ ] **Step 3: Implement parser request fields and planner mappings**
+
+Add `brightness`, `contrast`, and `saturation` fields to `PipelineRequest`. Parse `brightness`/`br`, `contrast`/`co`, and `saturation`/`sa` as signed numeric values in `OptionGrammar`, accepting only `-100..100`. Emit semantic operations from `PlanBuilder.effect_operations/1` after blur, sharpen, and pixelate, preserving the documented canonical effect order independent of URL option order: `blur`, `sharpen`, `pixelate`, `brightness`, `contrast`, then `saturation`. Treat `0` as an Imgproxy-compatible no-op, matching the existing blur/sharpen/pixelate no-op pattern.
+
+- [ ] **Step 4: Run focused parser/planner tests and verify they pass**
+
+Run: `mise exec -- mix test test/parser/imgproxy_test.exs test/parser/imgproxy/options_test.exs test/parser/imgproxy/plan_builder_test.exs`
+
+Expected: all focused Imgproxy parser tests pass.
+
+### Task 3: Execute Color Adjustments
+
+**Files:**
+- Create: `lib/image_pipe/transform/operation/brightness.ex`
+- Create: `lib/image_pipe/transform/operation/contrast.ex`
+- Create: `lib/image_pipe/transform/operation/saturation.ex`
+- Modify: `lib/image_pipe/transform.ex`
+- Modify: `lib/image_pipe/transform/decode_planner.ex`
+- Modify: `lib/image_pipe/transform/plan_executor.ex`
+- Test: `test/transform_chain_test.exs`
+- Test: `test/image_pipe/decode_planner_test.exs`
+- Test: `test/image_pipe/transform/plan_executor_test.exs`
+- Test: `test/image_pipe/imgproxy_wire_conformance_test.exs`
+- Test: `test/image_pipe/request_safety_test.exs`
+- Test: `test/image_pipe/architecture_boundary_test.exs`
+
+- [ ] **Step 1: Write failing transform and wire tests**
+
+Add direct transform chain coverage showing `Transform.transform_name/1` delegates correctly for brightness, contrast, and saturation.
+
+Add decode planner coverage asserting color-only requests use random access:
+
+```elixir
+assert DecodePlanner.open_options(plan([brightness])) == [access: :random]
+assert DecodePlanner.open_options(plan([contrast])) == [access: :random]
+assert DecodePlanner.open_options(plan([saturation])) == [access: :random]
+```
+
+Add separate no-geometry request-boundary cases for each operation, using the existing effects fixture or origin pattern:
+
+```elixir
+for path <- [
+      "/_/br:25/f:png/plain/images/effects.png",
+      "/_/co:10/f:png/plain/images/effects.png",
+      "/_/sa:-30/f:png/plain/images/effects.png"
+    ] do
+  adjusted = call_imgproxy(path, opts)
+  baseline = call_imgproxy("/_/f:png/plain/images/effects.png", opts)
+
+  assert adjusted.status == 200
+  assert dimensions(adjusted) == dimensions(baseline)
+  assert decoded_sample_pixels(adjusted) != decoded_sample_pixels(baseline)
+end
+```
+
+Add a Plug-level safety test for invalid color-operation values:
+
+```elixir
+for path <- [
+      "/_/br:101/plain/images/effects.png",
+      "/_/co:-101/plain/images/effects.png",
+      "/_/sa:101/plain/images/effects.png"
+    ] do
+  conn = call_imgproxy(path, opts_with_origin_and_cache_probes)
+
+  assert conn.status == 400
+  refute_received :cache_lookup
+  refute_received :cache_put
+  refute_received :origin_fetch
+end
+```
+
+- [ ] **Step 2: Run focused tests and verify they fail**
+
+Run: `mise exec -- mix test test/transform_chain_test.exs test/image_pipe/decode_planner_test.exs test/image_pipe/transform/plan_executor_test.exs test/image_pipe/imgproxy_wire_conformance_test.exs test/image_pipe/request_safety_test.exs test/image_pipe/architecture_boundary_test.exs`
+
+Expected: failures mention missing executable operation modules, unknown parser options, or unchanged output.
+
+- [ ] **Step 3: Implement executable transforms**
+
+Add executable transform modules with `@behaviour ImagePipe.Transform`, `name/1`, and `execute/2`. Convert Imgproxy `-100..100` values to positive multipliers used by the `Image` package: `0` maps to `1.0`, positive values map above `1.0`, and negative values map below `1.0`. Use `Image.brightness/2`, `Image.contrast/2`, and `Image.saturation/2`, each of which preserves dimensions and handles alpha through the Image package's helper paths.
+
+- [ ] **Step 4: Wire semantic operations into `PlanExecutor`**
+
+Alias the new semantic and executable operations in `ImagePipe.Transform.PlanExecutor`, and add `executable_operations/3` clauses that lower each semantic operation to its executable transform. Add the new executable modules to `ImagePipe.Transform` Boundary exports. Add `DecodePlanner` access-requirement clauses classifying brightness, contrast, and saturation as `:random`, preserving conservative decoding for color-only/no-geometry requests.
+
+- [ ] **Step 5: Run focused transform and wire tests and verify they pass**
+
+Run: `mise exec -- mix test test/transform_chain_test.exs test/image_pipe/decode_planner_test.exs test/image_pipe/transform/plan_executor_test.exs test/image_pipe/imgproxy_wire_conformance_test.exs test/image_pipe/request_safety_test.exs test/image_pipe/architecture_boundary_test.exs`
+
+Expected: all focused transform and wire tests pass.
+
+### Task 4: Update Demo URL State And Controls
+
+**Files:**
+- Modify: `demo/src/processing-path.ts`
+- Modify: `demo/src/demo-url-state.ts`
+- Modify: `demo/src/App.svelte`
+- Test: `demo/src/processing-path.test.ts`
+
+- [ ] **Step 1: Write failing demo path tests**
+
+Add tests proving `optionSegments` emits color operations after existing effects:
+
+```ts
+expect(
+  optionSegments({
+    ...defaultDemoState,
+    blurEnabled: true,
+    blur: 2,
+    sharpenEnabled: true,
+    sharpen: 1,
+    pixelateEnabled: true,
+    pixelate: 8,
+    brightnessEnabled: true,
+    brightness: 20,
+    contrastEnabled: true,
+    contrast: -15,
+    saturationEnabled: true,
+    saturation: 35,
+  }),
+).toEqual(["bl:2", "sh:1", "pix:8", "br:20", "co:-15", "sa:35"]);
+```
+
+Add parse tests for `/demo/brightness:20/contrast:-15/saturation:35/plain/local:///images/dog.jpg`, zero-valued color segments normalizing to inactive defaults, invalid `-101` and `101` values falling back to `defaultDemoState`, and `expandedToolboxesForState` opening Effects when any color operation is active.
+
+- [ ] **Step 2: Run demo tests and verify they fail**
+
+Run: `mise exec -- pnpm demo:test`
+
+Expected: TypeScript tests fail because the state fields and parser cases don't exist.
+
+- [ ] **Step 3: Add demo state fields, limits, URL emission, and URL parsing**
+
+Add `brightnessEnabled`, `brightness`, `contrastEnabled`, `contrast`, `saturationEnabled`, and `saturation` to `DemoState` and `defaultDemoState`. Add control limits from `-100` to `100` with integer steps. Emit `br`, `co`, and `sa` segments only when enabled and non-zero. Parse short and long aliases back into enabled state, with `0` disabling the operation and restoring the default displayed value.
+
+- [ ] **Step 4: Add controls to the existing Effects section**
+
+Extend the current Effects section in `App.svelte` with the existing `label.switch-field`, `Switch.Root`, and `RangeNumber` pattern already used by blur, sharpen, and pixelate. Update `effectSegments` so summaries include `br:20`, `co:-15`, and `sa:35` after `bl`, `sh`, and `pix`.
+
+- [ ] **Step 5: Run demo checks and verify they pass**
+
+Run: `mise exec -- pnpm demo:test`
+
+Run: `mise exec -- pnpm demo:check`
+
+Expected: demo tests pass and `svelte-check` reports 0 errors and 0 warnings.
+
+### Task 5: Update Documentation And Support Matrix
+
+**Files:**
+- Modify: `docs/imgproxy_support_matrix.md`
+- Modify: `docs/transform_operations.md`
+- Modify: `docs/imgproxy_path_api.md`
+
+- [ ] **Step 1: Update docs with code-checked behavior**
+
+Change `brightness`, `contrast`, and `saturation` from `Missing` to `Supported` in the support matrix. Each row must list its alias, accepted value range `-100..100`, and `0` no-op behavior. Keep `adjust` marked `Missing`.
+
+Document the fixed effect order as `blur`, `sharpen`, `pixelate`, `brightness`, `contrast`, then `saturation` in `docs/imgproxy_path_api.md` and `docs/transform_operations.md`. Avoid broad "color controls" wording unless the sentence names these exact operations.
+
+- [ ] **Step 2: Run Vale and fix wording issues**
+
+Run: `mise exec -- vale docs/imgproxy_support_matrix.md docs/transform_operations.md docs/imgproxy_path_api.md`
+
+Expected: Vale passes with 0 errors.
+
+### Task 6: Final Verification
+
+**Files:**
+- All modified Elixir, TypeScript, Svelte, and documentation files.
+
+- [ ] **Step 1: Format changed code**
+
+Run: `mise exec -- mix format`
+
+Run: `mise exec -- pnpm demo:format`
+
+- [ ] **Step 2: Run focused and broad verification**
+
+Run: `mise exec -- mix test`
+
+Run: `mise exec -- mix compile --warnings-as-errors`
+
+Run: `mise exec -- mix credo --strict`
+
+Run: `mise exec -- pnpm demo:test`
+
+Run: `mise exec -- pnpm demo:check`
+
+Run: `mise exec -- pnpm demo:lint`
+
+Run: `mise exec -- vale docs/imgproxy_support_matrix.md docs/transform_operations.md docs/imgproxy_path_api.md`
+
+Expected: all commands pass.
+
+- [ ] **Step 3: Review final diff**
+
+Run: `git diff --stat`
+
+Run: `git diff --check`
+
+Expected: diff contains only the selected operations, docs, tests, and demo changes. `git diff --check` reports no whitespace errors.
+
+---
+
+## Self-Review
+
+- Spec coverage: The plan covers parser support, semantic operations, transform execution, request-boundary safety, request-boundary pixel behavior, demo UI, support matrix, docs, and final verification.
+- Placeholder scan: No `TBD`, `TODO`, or unspecified test commands remain.
+- Type consistency: Operation names use `brightness`, `contrast`, and `saturation` across parser fields, semantic operations, executable operations, key data, demo state, and URL segments.

--- a/docs/transform_operations.md
+++ b/docs/transform_operations.md
@@ -93,6 +93,11 @@ Parser/planner code should use these semantic operations:
 - `ImagePipe.Plan.Operation.Sharpen`: sharpening with a positive sigma.
 - `ImagePipe.Plan.Operation.Pixelate`: pixelation with a block size greater
   than one pixel.
+- `ImagePipe.Plan.Operation.Brightness`: brightness change from `-100` to
+  `100`.
+- `ImagePipe.Plan.Operation.Contrast`: contrast change from `-100` to `100`.
+- `ImagePipe.Plan.Operation.Saturation`: saturation change from `-100` to
+  `100`.
 - `ImagePipe.Plan.Color`: canonical product-neutral sRGB color data with alpha.
 
 Plan pipelines should contain semantic Plan operation structs only. Transform
@@ -117,6 +122,9 @@ describe work over `ImagePipe.Transform.State`, not parser request syntax:
 - `ImagePipe.Transform.Operation.Blur`: executable Gaussian blur.
 - `ImagePipe.Transform.Operation.Sharpen`: executable sharpening.
 - `ImagePipe.Transform.Operation.Pixelate`: executable pixelation.
+- `ImagePipe.Transform.Operation.Brightness`: executable brightness change.
+- `ImagePipe.Transform.Operation.Contrast`: executable contrast change.
+- `ImagePipe.Transform.Operation.Saturation`: executable saturation change.
 
 `ImagePipe.Transform.Operation.AdaptiveResize` is obsolete. Resize
 `mode: :auto` belongs in `ImagePipe.Plan.Operation.Resize`. Parsers must not emit
@@ -192,13 +200,15 @@ not leak into parser request structs, runtime state, or cache key data.
 
 ## Effect operations
 
-Use semantic `Blur`, `Sharpen`, and `Pixelate` when a dialect requests full-image
-effects. These operations are product-neutral image effects. Parser aliases such
-as Imgproxy `bl`, `sh`, and `pix` stay in parser code.
+Use semantic `Blur`, `Sharpen`, `Pixelate`, `Brightness`, `Contrast`, and
+`Saturation` when a dialect requests full-image effects. These operations are
+product-neutral image effects. Parser aliases such as Imgproxy `bl`, `sh`,
+`pix`, `br`, `co`, and `sa` stay in parser code.
 
-Imgproxy effect order is blur, sharpen, then pixelate, after result cropping and
-before canvas extension, padding, and background composition. Imgproxy treats
-blur and sharpen sigma `0` as no-ops, and pixelate sizes of `1` or lower as
+Imgproxy effect order is blur, sharpen, pixelate, brightness, contrast, then
+saturation, after result cropping and before canvas extension, padding, and
+background composition. Imgproxy treats blur and sharpen sigma `0` as no-ops,
+pixelate sizes of `1` or lower as no-ops, and zero-valued color adjustments as
 no-ops. ImagePipe accepts those no-op values in the Imgproxy parser and emits no
 semantic operation.
 
@@ -243,7 +253,7 @@ should describe their own URL syntax.
 | `ar/rot:90/fl:true:false/c:100:100` | `AutoOrient`, `Rotate`, `Flip`, `CropGuided` |
 | `extend:true/w:300/h:200` | `Resize` with `mode: :fit`, `Canvas` |
 | `pd:10/bg:f00` | `Padding`, `Background` |
-| `bl:2/sh:0.7/pix:8` | `Blur`, `Sharpen`, `Pixelate` |
+| `bl:2/sh:0.7/pix:8/br:20/co:-10/sa:35` | `Blur`, `Sharpen`, `Pixelate`, `Brightness`, `Contrast`, `Saturation` |
 
 ## Boundary rules
 

--- a/lib/image_pipe/parser/imgproxy/effects.ex
+++ b/lib/image_pipe/parser/imgproxy/effects.ex
@@ -1,0 +1,19 @@
+defmodule ImagePipe.Parser.Imgproxy.Effects do
+  @moduledoc false
+
+  @type t() :: %__MODULE__{
+          blur: float() | nil,
+          sharpen: float() | nil,
+          pixelate: non_neg_integer() | nil,
+          brightness: number() | nil,
+          contrast: number() | nil,
+          saturation: number() | nil
+        }
+
+  defstruct blur: nil,
+            sharpen: nil,
+            pixelate: nil,
+            brightness: nil,
+            contrast: nil,
+            saturation: nil
+end

--- a/lib/image_pipe/parser/imgproxy/option_grammar.ex
+++ b/lib/image_pipe/parser/imgproxy/option_grammar.ex
@@ -410,6 +410,18 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammar do
     parse_pixelate(args, segment)
   end
 
+  defp parse_special_option(name, args, segment) when name in ["brightness", "br"] do
+    parse_adjustment(:brightness, args, segment)
+  end
+
+  defp parse_special_option(name, args, segment) when name in ["contrast", "co"] do
+    parse_adjustment(:contrast, args, segment)
+  end
+
+  defp parse_special_option(name, args, segment) when name in ["saturation", "sa"] do
+    parse_adjustment(:saturation, args, segment)
+  end
+
   defp parse_special_option(name, _args, _segment), do: {:error, {:unknown_option, name}}
 
   defp parse_effect_float(key, [value], _segment) when value != "" do
@@ -428,6 +440,22 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammar do
   end
 
   defp parse_pixelate(_args, segment), do: {:error, {:invalid_option_segment, segment}}
+
+  defp parse_adjustment(key, [value], _segment) when value != "" do
+    with {:ok, value} <- parse_adjustment_value(value) do
+      {:ok, [{key, value}]}
+    end
+  end
+
+  defp parse_adjustment(_key, _args, segment), do: {:error, {:invalid_option_segment, segment}}
+
+  defp parse_adjustment_value(value) do
+    case parse_number(value) do
+      {:ok, number} when number >= -100 and number <= 100 -> {:ok, number}
+      {:ok, _number} -> {:error, {:invalid_adjustment, value}}
+      {:error, _reason} -> {:error, {:invalid_adjustment, value}}
+    end
+  end
 
   defp parse_padding(args, segment) when length(args) <= 4 do
     with {:ok, parsed_args} <- parse_padding_args(args, segment) do

--- a/lib/image_pipe/parser/imgproxy/options.ex
+++ b/lib/image_pipe/parser/imgproxy/options.ex
@@ -8,6 +8,8 @@ defmodule ImagePipe.Parser.Imgproxy.Options do
   alias ImagePipe.Parser.Imgproxy.Presets
   alias ImagePipe.Plan.Color
 
+  @effect_fields [:blur, :sharpen, :pixelate, :brightness, :contrast, :saturation]
+
   @type request_options :: %{
           pipelines: [PipelineRequest.t()],
           output: ParsedRequest.output_request(),
@@ -212,6 +214,9 @@ defmodule ImagePipe.Parser.Imgproxy.Options do
 
         {:background_alpha, alpha}, pipeline ->
           apply_background_alpha(pipeline, alpha)
+
+        {field, _value} = assignment, pipeline when field in @effect_fields ->
+          %{pipeline | effects: struct!(pipeline.effects, [assignment])}
 
         assignment, pipeline ->
           struct!(pipeline, [assignment])

--- a/lib/image_pipe/parser/imgproxy/pipeline_request.ex
+++ b/lib/image_pipe/parser/imgproxy/pipeline_request.ex
@@ -2,6 +2,7 @@ defmodule ImagePipe.Parser.Imgproxy.PipelineRequest do
   @moduledoc false
 
   alias ImagePipe.Parser.Imgproxy.CropRequest
+  alias ImagePipe.Parser.Imgproxy.Effects
   alias ImagePipe.Parser.Imgproxy.Orientation
   alias ImagePipe.Plan.Color
 
@@ -32,9 +33,7 @@ defmodule ImagePipe.Parser.Imgproxy.PipelineRequest do
           padding_left: non_neg_integer(),
           background_color: Color.t() | nil,
           background_alpha: Color.alpha() | nil,
-          blur: float() | nil,
-          sharpen: float() | nil,
-          pixelate: non_neg_integer() | nil,
+          effects: Effects.t(),
           gravity: gravity(),
           gravity_x_offset: gravity_offset(),
           gravity_y_offset: gravity_offset(),
@@ -65,9 +64,7 @@ defmodule ImagePipe.Parser.Imgproxy.PipelineRequest do
             padding_left: 0,
             background_color: nil,
             background_alpha: nil,
-            blur: nil,
-            sharpen: nil,
-            pixelate: nil,
+            effects: %Effects{},
             gravity: {:anchor, :center, :center},
             gravity_x_offset: {:pixels, 0.0},
             gravity_y_offset: {:pixels, 0.0},

--- a/lib/image_pipe/parser/imgproxy/plan_builder.ex
+++ b/lib/image_pipe/parser/imgproxy/plan_builder.ex
@@ -3,6 +3,7 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilder do
 
   alias ImagePipe.Format
   alias ImagePipe.Parser.Imgproxy.CropRequest
+  alias ImagePipe.Parser.Imgproxy.Effects
   alias ImagePipe.Parser.Imgproxy.Orientation
   alias ImagePipe.Parser.Imgproxy.ParsedRequest
   alias ImagePipe.Parser.Imgproxy.PipelineRequest
@@ -434,28 +435,43 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilder do
     end
   end
 
-  defp effect_operations(%PipelineRequest{} = request) do
+  defp effect_operations(%PipelineRequest{effects: %Effects{} = effects}) do
     [
-      blur_operation(request),
-      sharpen_operation(request),
-      pixelate_operation(request)
+      blur_operation(effects),
+      sharpen_operation(effects),
+      pixelate_operation(effects),
+      brightness_operation(effects),
+      contrast_operation(effects),
+      saturation_operation(effects)
     ]
     |> Enum.reject(&is_nil/1)
     |> reduce_results()
   end
 
-  defp blur_operation(%PipelineRequest{blur: nil}), do: nil
-  defp blur_operation(%PipelineRequest{blur: sigma}) when sigma == 0.0, do: nil
-  defp blur_operation(%PipelineRequest{blur: sigma}), do: Operation.blur(sigma)
+  defp blur_operation(%Effects{blur: nil}), do: nil
+  defp blur_operation(%Effects{blur: sigma}) when sigma == 0.0, do: nil
+  defp blur_operation(%Effects{blur: sigma}), do: Operation.blur(sigma)
 
-  defp sharpen_operation(%PipelineRequest{sharpen: nil}), do: nil
-  defp sharpen_operation(%PipelineRequest{sharpen: sigma}) when sigma == 0.0, do: nil
-  defp sharpen_operation(%PipelineRequest{sharpen: sigma}), do: Operation.sharpen(sigma)
+  defp sharpen_operation(%Effects{sharpen: nil}), do: nil
+  defp sharpen_operation(%Effects{sharpen: sigma}) when sigma == 0.0, do: nil
+  defp sharpen_operation(%Effects{sharpen: sigma}), do: Operation.sharpen(sigma)
 
-  defp pixelate_operation(%PipelineRequest{pixelate: nil}), do: nil
-  defp pixelate_operation(%PipelineRequest{pixelate: 0}), do: nil
-  defp pixelate_operation(%PipelineRequest{pixelate: 1}), do: nil
-  defp pixelate_operation(%PipelineRequest{pixelate: size}), do: Operation.pixelate(size)
+  defp pixelate_operation(%Effects{pixelate: nil}), do: nil
+  defp pixelate_operation(%Effects{pixelate: 0}), do: nil
+  defp pixelate_operation(%Effects{pixelate: 1}), do: nil
+  defp pixelate_operation(%Effects{pixelate: size}), do: Operation.pixelate(size)
+
+  defp brightness_operation(%Effects{brightness: nil}), do: nil
+  defp brightness_operation(%Effects{brightness: 0}), do: nil
+  defp brightness_operation(%Effects{brightness: value}), do: Operation.brightness(value)
+
+  defp contrast_operation(%Effects{contrast: nil}), do: nil
+  defp contrast_operation(%Effects{contrast: 0}), do: nil
+  defp contrast_operation(%Effects{contrast: value}), do: Operation.contrast(value)
+
+  defp saturation_operation(%Effects{saturation: nil}), do: nil
+  defp saturation_operation(%Effects{saturation: 0}), do: nil
+  defp saturation_operation(%Effects{saturation: value}), do: Operation.saturation(value)
 
   defp resize_operation(%PipelineRequest{} = request) do
     with {:ok, width} <- imgproxy_resize_dimension(request.width),

--- a/lib/image_pipe/plan.ex
+++ b/lib/image_pipe/plan.ex
@@ -22,7 +22,9 @@ defmodule ImagePipe.Plan do
       Operation.AutoOrient,
       Operation.Background,
       Operation.Blur,
+      Operation.Brightness,
       Operation.Canvas,
+      Operation.Contrast,
       Operation.CropGuided,
       Operation.CropRegion,
       Operation.Flip,
@@ -30,6 +32,7 @@ defmodule ImagePipe.Plan do
       Operation.Pixelate,
       Operation.Rotate,
       Operation.Resize,
+      Operation.Saturation,
       Operation.Sharpen
     ]
 

--- a/lib/image_pipe/plan/key_data.ex
+++ b/lib/image_pipe/plan/key_data.ex
@@ -11,7 +11,9 @@ defmodule ImagePipe.Plan.KeyData do
   alias ImagePipe.Plan.Operation.AutoOrient
   alias ImagePipe.Plan.Operation.Background
   alias ImagePipe.Plan.Operation.Blur
+  alias ImagePipe.Plan.Operation.Brightness
   alias ImagePipe.Plan.Operation.Canvas
+  alias ImagePipe.Plan.Operation.Contrast
   alias ImagePipe.Plan.Operation.CropGuided
   alias ImagePipe.Plan.Operation.CropRegion
   alias ImagePipe.Plan.Operation.Flip
@@ -19,6 +21,7 @@ defmodule ImagePipe.Plan.KeyData do
   alias ImagePipe.Plan.Operation.Pixelate
   alias ImagePipe.Plan.Operation.Resize
   alias ImagePipe.Plan.Operation.Rotate
+  alias ImagePipe.Plan.Operation.Saturation
   alias ImagePipe.Plan.Operation.Sharpen
 
   @crop_anchor_guides [
@@ -121,6 +124,9 @@ defmodule ImagePipe.Plan.KeyData do
   def data(%Blur{sigma: sigma}), do: [op: :blur, sigma: sigma]
   def data(%Sharpen{sigma: sigma}), do: [op: :sharpen, sigma: sigma]
   def data(%Pixelate{size: size}), do: [op: :pixelate, size: size]
+  def data(%Brightness{value: value}), do: [op: :brightness, value: value]
+  def data(%Contrast{value: value}), do: [op: :contrast, value: value]
+  def data(%Saturation{value: value}), do: [op: :saturation, value: value]
 
   def data(:auto), do: [unit: :auto]
   def data(:full_axis), do: [unit: :full_axis]

--- a/lib/image_pipe/plan/operation.ex
+++ b/lib/image_pipe/plan/operation.ex
@@ -7,7 +7,9 @@ defmodule ImagePipe.Plan.Operation do
   alias ImagePipe.Plan.Operation.AutoOrient
   alias ImagePipe.Plan.Operation.Background
   alias ImagePipe.Plan.Operation.Blur
+  alias ImagePipe.Plan.Operation.Brightness
   alias ImagePipe.Plan.Operation.Canvas
+  alias ImagePipe.Plan.Operation.Contrast
   alias ImagePipe.Plan.Operation.CropGuided
   alias ImagePipe.Plan.Operation.CropRegion
   alias ImagePipe.Plan.Operation.Flip
@@ -15,6 +17,7 @@ defmodule ImagePipe.Plan.Operation do
   alias ImagePipe.Plan.Operation.Pixelate
   alias ImagePipe.Plan.Operation.Resize
   alias ImagePipe.Plan.Operation.Rotate
+  alias ImagePipe.Plan.Operation.Saturation
   alias ImagePipe.Plan.Operation.Sharpen
 
   @enlargements [:allow, :deny]
@@ -49,6 +52,7 @@ defmodule ImagePipe.Plan.Operation do
   @canvas_keys [:fill, :overflow, :x_offset, :y_offset]
   @padding_keys [:pixel_ratio, :fill]
   @effective_padding_modes [:resize, :canvas_preserving]
+  @adjustment_range -100..100
   @type resize_operation :: Resize.t()
 
   @type crop_operation ::
@@ -70,6 +74,9 @@ defmodule ImagePipe.Plan.Operation do
           Blur.t()
           | Sharpen.t()
           | Pixelate.t()
+          | Brightness.t()
+          | Contrast.t()
+          | Saturation.t()
 
   @type semantic_operation ::
           resize_operation()
@@ -109,6 +116,15 @@ defmodule ImagePipe.Plan.Operation do
   @spec pixelate(term()) :: {:ok, Pixelate.t()} | {:error, error()}
   def pixelate(size) when is_integer(size) and size > 1, do: {:ok, %Pixelate{size: size}}
   def pixelate(size), do: invalid(:pixelate, [size])
+
+  @spec brightness(term()) :: {:ok, Brightness.t()} | {:error, error()}
+  def brightness(value), do: adjustment(:brightness, Brightness, value)
+
+  @spec contrast(term()) :: {:ok, Contrast.t()} | {:error, error()}
+  def contrast(value), do: adjustment(:contrast, Contrast, value)
+
+  @spec saturation(term()) :: {:ok, Saturation.t()} | {:error, error()}
+  def saturation(value), do: adjustment(:saturation, Saturation, value)
 
   @spec color(term(), term(), term()) :: {:ok, Color.t()} | {:error, term()}
   def color(red, green, blue), do: Color.rgb(red, green, blue)
@@ -289,9 +305,19 @@ defmodule ImagePipe.Plan.Operation do
   def semantic?(%Blur{} = operation), do: valid_positive_float?(operation.sigma)
   def semantic?(%Sharpen{} = operation), do: valid_positive_float?(operation.sigma)
   def semantic?(%Pixelate{} = operation), do: valid_pixelate_size?(operation.size)
+  def semantic?(%Brightness{} = operation), do: valid_adjustment_value?(operation.value)
+  def semantic?(%Contrast{} = operation), do: valid_adjustment_value?(operation.value)
+  def semantic?(%Saturation{} = operation), do: valid_adjustment_value?(operation.value)
   def semantic?(_operation), do: false
 
   defp invalid(operation, attrs), do: {:error, {:invalid_operation, operation, attrs}}
+
+  defp adjustment(operation, module, value) do
+    case adjustment_value(value) do
+      {:ok, value} -> {:ok, struct!(module, value: value)}
+      {:error, _reason} -> invalid(operation, [value])
+    end
+  end
 
   defp valid_resize?(%Resize{} = operation) do
     with {:ok, mode} <- resize_mode(operation.mode),
@@ -373,6 +399,14 @@ defmodule ImagePipe.Plan.Operation do
 
   defp valid_pixelate_size?(value) when is_integer(value) and value > 1, do: true
   defp valid_pixelate_size?(_value), do: false
+
+  defp valid_adjustment_value?(value) do
+    case adjustment_value(value) do
+      {:ok, ^value} -> true
+      {:ok, _value} -> false
+      {:error, _reason} -> false
+    end
+  end
 
   defp validate_known_options(operation, attrs, known_keys) do
     case Keyword.keys(attrs) -- known_keys do
@@ -685,6 +719,28 @@ defmodule ImagePipe.Plan.Operation do
 
   defp number(value) when is_number(value), do: :ok
   defp number(_value), do: {:error, :number}
+
+  defp adjustment_value(value) when is_integer(value) and value in @adjustment_range,
+    do: {:ok, value}
+
+  defp adjustment_value(value) when is_float(value) and value >= -100.0 and value <= 100.0 do
+    value
+    |> Float.round(7)
+    |> canonical_adjustment_float()
+  end
+
+  defp adjustment_value(_value), do: {:error, :adjustment}
+
+  defp canonical_adjustment_float(value) when value == 0.0, do: {:ok, 0}
+
+  defp canonical_adjustment_float(value) do
+    integer = trunc(value)
+
+    case value == integer do
+      true -> {:ok, integer}
+      false -> {:ok, value}
+    end
+  end
 
   defp tagged_offset(value) when is_number(value), do: :ok
 

--- a/lib/image_pipe/plan/operation/brightness.ex
+++ b/lib/image_pipe/plan/operation/brightness.ex
@@ -1,0 +1,10 @@
+defmodule ImagePipe.Plan.Operation.Brightness do
+  @moduledoc """
+  Semantic brightness adjustment operation.
+  """
+
+  @enforce_keys [:value]
+  defstruct [:value]
+
+  @type t :: %__MODULE__{value: number()}
+end

--- a/lib/image_pipe/plan/operation/contrast.ex
+++ b/lib/image_pipe/plan/operation/contrast.ex
@@ -1,0 +1,10 @@
+defmodule ImagePipe.Plan.Operation.Contrast do
+  @moduledoc """
+  Semantic contrast adjustment operation.
+  """
+
+  @enforce_keys [:value]
+  defstruct [:value]
+
+  @type t :: %__MODULE__{value: number()}
+end

--- a/lib/image_pipe/plan/operation/saturation.ex
+++ b/lib/image_pipe/plan/operation/saturation.ex
@@ -1,0 +1,10 @@
+defmodule ImagePipe.Plan.Operation.Saturation do
+  @moduledoc """
+  Semantic saturation adjustment operation.
+  """
+
+  @enforce_keys [:value]
+  defstruct [:value]
+
+  @type t :: %__MODULE__{value: number()}
+end

--- a/lib/image_pipe/transform.ex
+++ b/lib/image_pipe/transform.ex
@@ -26,7 +26,10 @@ defmodule ImagePipe.Transform do
       Operation.Crop,
       Operation.Blur,
       Operation.Sharpen,
-      Operation.Pixelate
+      Operation.Pixelate,
+      Operation.Brightness,
+      Operation.Contrast,
+      Operation.Saturation
     ]
 
   alias ImagePipe.Plan

--- a/lib/image_pipe/transform/decode_planner.ex
+++ b/lib/image_pipe/transform/decode_planner.ex
@@ -11,7 +11,9 @@ defmodule ImagePipe.Transform.DecodePlanner do
   alias ImagePipe.Plan.Operation.AutoOrient
   alias ImagePipe.Plan.Operation.Background
   alias ImagePipe.Plan.Operation.Blur
+  alias ImagePipe.Plan.Operation.Brightness
   alias ImagePipe.Plan.Operation.Canvas
+  alias ImagePipe.Plan.Operation.Contrast
   alias ImagePipe.Plan.Operation.CropGuided
   alias ImagePipe.Plan.Operation.CropRegion
   alias ImagePipe.Plan.Operation.Flip
@@ -19,6 +21,7 @@ defmodule ImagePipe.Transform.DecodePlanner do
   alias ImagePipe.Plan.Operation.Pixelate
   alias ImagePipe.Plan.Operation.Resize, as: PlanResize
   alias ImagePipe.Plan.Operation.Rotate
+  alias ImagePipe.Plan.Operation.Saturation
   alias ImagePipe.Plan.Operation.Sharpen
 
   @type access_requirement() :: :sequential | :random | :neutral
@@ -51,6 +54,9 @@ defmodule ImagePipe.Transform.DecodePlanner do
   defp access_requirement(%Blur{}), do: :random
   defp access_requirement(%Sharpen{}), do: :random
   defp access_requirement(%Pixelate{}), do: :random
+  defp access_requirement(%Brightness{}), do: :random
+  defp access_requirement(%Contrast{}), do: :random
+  defp access_requirement(%Saturation{}), do: :random
 
   defp resize_access_requirement(%PlanResize{
          width: width,

--- a/lib/image_pipe/transform/operation/brightness.ex
+++ b/lib/image_pipe/transform/operation/brightness.ex
@@ -1,0 +1,29 @@
+defmodule ImagePipe.Transform.Operation.Brightness do
+  @moduledoc """
+  Executable brightness adjustment operation.
+  """
+
+  @behaviour ImagePipe.Transform
+
+  import ImagePipe.Transform.State
+
+  alias ImagePipe.Transform.State
+
+  @enforce_keys [:value]
+  defstruct [:value]
+
+  @type t :: %__MODULE__{value: number()}
+
+  @impl ImagePipe.Transform
+  def name(%__MODULE__{}), do: :brightness
+
+  @impl ImagePipe.Transform
+  def execute(%__MODULE__{value: value}, %State{} = state) do
+    case Image.brightness(state.image, multiplier(value)) do
+      {:ok, image} -> {:ok, set_image(state, image)}
+      {:error, error} -> {:error, {__MODULE__, error}}
+    end
+  end
+
+  defp multiplier(value), do: (100 + value) / 100
+end

--- a/lib/image_pipe/transform/operation/contrast.ex
+++ b/lib/image_pipe/transform/operation/contrast.ex
@@ -1,0 +1,29 @@
+defmodule ImagePipe.Transform.Operation.Contrast do
+  @moduledoc """
+  Executable contrast adjustment operation.
+  """
+
+  @behaviour ImagePipe.Transform
+
+  import ImagePipe.Transform.State
+
+  alias ImagePipe.Transform.State
+
+  @enforce_keys [:value]
+  defstruct [:value]
+
+  @type t :: %__MODULE__{value: number()}
+
+  @impl ImagePipe.Transform
+  def name(%__MODULE__{}), do: :contrast
+
+  @impl ImagePipe.Transform
+  def execute(%__MODULE__{value: value}, %State{} = state) do
+    case Image.contrast(state.image, multiplier(value)) do
+      {:ok, image} -> {:ok, set_image(state, image)}
+      {:error, error} -> {:error, {__MODULE__, error}}
+    end
+  end
+
+  defp multiplier(value), do: (100 + value) / 100
+end

--- a/lib/image_pipe/transform/operation/saturation.ex
+++ b/lib/image_pipe/transform/operation/saturation.ex
@@ -1,0 +1,29 @@
+defmodule ImagePipe.Transform.Operation.Saturation do
+  @moduledoc """
+  Executable saturation adjustment operation.
+  """
+
+  @behaviour ImagePipe.Transform
+
+  import ImagePipe.Transform.State
+
+  alias ImagePipe.Transform.State
+
+  @enforce_keys [:value]
+  defstruct [:value]
+
+  @type t :: %__MODULE__{value: number()}
+
+  @impl ImagePipe.Transform
+  def name(%__MODULE__{}), do: :saturation
+
+  @impl ImagePipe.Transform
+  def execute(%__MODULE__{value: value}, %State{} = state) do
+    case Image.saturation(state.image, multiplier(value)) do
+      {:ok, image} -> {:ok, set_image(state, image)}
+      {:error, error} -> {:error, {__MODULE__, error}}
+    end
+  end
+
+  defp multiplier(value), do: (100 + value) / 100
+end

--- a/lib/image_pipe/transform/plan_executor.ex
+++ b/lib/image_pipe/transform/plan_executor.ex
@@ -6,7 +6,9 @@ defmodule ImagePipe.Transform.PlanExecutor do
   alias ImagePipe.Plan.Operation.AutoOrient, as: PlanAutoOrient
   alias ImagePipe.Plan.Operation.Background, as: PlanBackground
   alias ImagePipe.Plan.Operation.Blur, as: PlanBlur
+  alias ImagePipe.Plan.Operation.Brightness, as: PlanBrightness
   alias ImagePipe.Plan.Operation.Canvas
+  alias ImagePipe.Plan.Operation.Contrast, as: PlanContrast
   alias ImagePipe.Plan.Operation.CropGuided
   alias ImagePipe.Plan.Operation.CropRegion
   alias ImagePipe.Plan.Operation.Flip, as: PlanFlip
@@ -14,12 +16,15 @@ defmodule ImagePipe.Transform.PlanExecutor do
   alias ImagePipe.Plan.Operation.Pixelate, as: PlanPixelate
   alias ImagePipe.Plan.Operation.Resize, as: PlanResize
   alias ImagePipe.Plan.Operation.Rotate, as: PlanRotate
+  alias ImagePipe.Plan.Operation.Saturation, as: PlanSaturation
   alias ImagePipe.Plan.Operation.Sharpen, as: PlanSharpen
   alias ImagePipe.Plan.Pipeline
   alias ImagePipe.Transform.Chain
   alias ImagePipe.Transform.Operation.AutoOrient
   alias ImagePipe.Transform.Operation.Background
   alias ImagePipe.Transform.Operation.Blur
+  alias ImagePipe.Transform.Operation.Brightness
+  alias ImagePipe.Transform.Operation.Contrast
   alias ImagePipe.Transform.Operation.Crop
   alias ImagePipe.Transform.Operation.ExtendCanvas
   alias ImagePipe.Transform.Operation.Flip
@@ -27,6 +32,7 @@ defmodule ImagePipe.Transform.PlanExecutor do
   alias ImagePipe.Transform.Operation.Pixelate
   alias ImagePipe.Transform.Operation.Resize
   alias ImagePipe.Transform.Operation.Rotate
+  alias ImagePipe.Transform.Operation.Saturation
   alias ImagePipe.Transform.Operation.Sharpen
   alias ImagePipe.Transform.State
 
@@ -189,6 +195,15 @@ defmodule ImagePipe.Transform.PlanExecutor do
 
   defp executable_operations(%PlanPixelate{size: size}, %State{}, _context),
     do: [%Pixelate{size: size}]
+
+  defp executable_operations(%PlanBrightness{value: value}, %State{}, _context),
+    do: [%Brightness{value: value}]
+
+  defp executable_operations(%PlanContrast{value: value}, %State{}, _context),
+    do: [%Contrast{value: value}]
+
+  defp executable_operations(%PlanSaturation{value: value}, %State{}, _context),
+    do: [%Saturation{value: value}]
 
   defp tagged_executable_resize_operations(
          :cover,

--- a/test/image_pipe/architecture_boundary_test.exs
+++ b/test/image_pipe/architecture_boundary_test.exs
@@ -392,7 +392,10 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
       ImagePipe.Transform.Operation.Crop,
       ImagePipe.Transform.Operation.Blur,
       ImagePipe.Transform.Operation.Sharpen,
-      ImagePipe.Transform.Operation.Pixelate
+      ImagePipe.Transform.Operation.Pixelate,
+      ImagePipe.Transform.Operation.Brightness,
+      ImagePipe.Transform.Operation.Contrast,
+      ImagePipe.Transform.Operation.Saturation
     ])
   end
 
@@ -417,7 +420,9 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
       ImagePipe.Plan.Operation.AutoOrient,
       ImagePipe.Plan.Operation.Background,
       ImagePipe.Plan.Operation.Blur,
+      ImagePipe.Plan.Operation.Brightness,
       ImagePipe.Plan.Operation.Canvas,
+      ImagePipe.Plan.Operation.Contrast,
       ImagePipe.Plan.Operation.CropGuided,
       ImagePipe.Plan.Operation.CropRegion,
       ImagePipe.Plan.Operation.Flip,
@@ -425,6 +430,7 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
       ImagePipe.Plan.Operation.Pixelate,
       ImagePipe.Plan.Operation.Rotate,
       ImagePipe.Plan.Operation.Resize,
+      ImagePipe.Plan.Operation.Saturation,
       ImagePipe.Plan.Operation.Sharpen
     ])
   end

--- a/test/image_pipe/decode_planner_test.exs
+++ b/test/image_pipe/decode_planner_test.exs
@@ -77,10 +77,16 @@ defmodule ImagePipe.Transform.DecodePlannerTest do
     assert {:ok, blur} = Operation.blur(2.0)
     assert {:ok, sharpen} = Operation.sharpen(0.7)
     assert {:ok, pixelate} = Operation.pixelate(8)
+    assert {:ok, brightness} = Operation.brightness(20)
+    assert {:ok, contrast} = Operation.contrast(-15)
+    assert {:ok, saturation} = Operation.saturation(35)
 
     assert DecodePlanner.open_options([blur]) == [access: :random, fail_on: :error]
     assert DecodePlanner.open_options([sharpen]) == [access: :random, fail_on: :error]
     assert DecodePlanner.open_options([pixelate]) == [access: :random, fail_on: :error]
+    assert DecodePlanner.open_options([brightness]) == [access: :random, fail_on: :error]
+    assert DecodePlanner.open_options([contrast]) == [access: :random, fail_on: :error]
+    assert DecodePlanner.open_options([saturation]) == [access: :random, fail_on: :error]
   end
 
   test "planned options include only access and fail_on" do

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -272,7 +272,10 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
     cases = [
       "/_/bl:4/f:png/plain/images/effects.png",
       "/_/sh:10/f:png/plain/images/effects.png",
-      "/_/pix:8/f:png/plain/images/effects.png"
+      "/_/pix:8/f:png/plain/images/effects.png",
+      "/_/br:25/f:png/plain/images/effects.png",
+      "/_/co:10/f:png/plain/images/effects.png",
+      "/_/sa:-30/f:png/plain/images/effects.png"
     ]
 
     for path <- cases do

--- a/test/image_pipe/plan/operation_key_data_test.exs
+++ b/test/image_pipe/plan/operation_key_data_test.exs
@@ -5,9 +5,12 @@ defmodule ImagePipe.Plan.OperationKeyDataTest do
   alias ImagePipe.Plan.Operation
   alias ImagePipe.Plan.Operation.AutoOrient
   alias ImagePipe.Plan.Operation.Blur
+  alias ImagePipe.Plan.Operation.Brightness
+  alias ImagePipe.Plan.Operation.Contrast
   alias ImagePipe.Plan.Operation.Flip
   alias ImagePipe.Plan.Operation.Pixelate
   alias ImagePipe.Plan.Operation.Rotate
+  alias ImagePipe.Plan.Operation.Saturation
   alias ImagePipe.Plan.Operation.Sharpen
 
   describe "tagged geometry data" do
@@ -196,6 +199,16 @@ defmodule ImagePipe.Plan.OperationKeyDataTest do
       assert KeyData.data(%Blur{sigma: 2.5}) == [op: :blur, sigma: 2.5]
       assert KeyData.data(%Sharpen{sigma: 0.7}) == [op: :sharpen, sigma: 0.7]
       assert KeyData.data(%Pixelate{size: 8}) == [op: :pixelate, size: 8]
+      assert KeyData.data(%Brightness{value: 20}) == [op: :brightness, value: 20]
+      assert KeyData.data(%Contrast{value: -15}) == [op: :contrast, value: -15]
+      assert KeyData.data(%Saturation{value: 35}) == [op: :saturation, value: 35]
+    end
+
+    test "returns identical key data for equivalent adjustment values" do
+      assert {:ok, integer_brightness} = Operation.brightness(20)
+      assert {:ok, float_brightness} = Operation.brightness(20.0)
+
+      assert KeyData.data(integer_brightness) == KeyData.data(float_brightness)
     end
   end
 end

--- a/test/image_pipe/plan/operation_test.exs
+++ b/test/image_pipe/plan/operation_test.exs
@@ -4,9 +4,12 @@ defmodule ImagePipe.Plan.OperationTest do
   alias ImagePipe.Plan.Operation
   alias ImagePipe.Plan.Operation.AutoOrient
   alias ImagePipe.Plan.Operation.Blur
+  alias ImagePipe.Plan.Operation.Brightness
+  alias ImagePipe.Plan.Operation.Contrast
   alias ImagePipe.Plan.Operation.Flip
   alias ImagePipe.Plan.Operation.Pixelate
   alias ImagePipe.Plan.Operation.Rotate
+  alias ImagePipe.Plan.Operation.Saturation
   alias ImagePipe.Plan.Operation.Sharpen
 
   describe "resize constructors" do
@@ -370,10 +373,22 @@ defmodule ImagePipe.Plan.OperationTest do
       assert Operation.blur(2.5) == {:ok, %Blur{sigma: 2.5}}
       assert Operation.sharpen(0.7) == {:ok, %Sharpen{sigma: 0.7}}
       assert Operation.pixelate(8) == {:ok, %Pixelate{size: 8}}
+      assert Operation.brightness(20) == {:ok, %Brightness{value: 20}}
+      assert Operation.contrast(-15) == {:ok, %Contrast{value: -15}}
+      assert Operation.saturation(35) == {:ok, %Saturation{value: 35}}
 
       assert Operation.semantic?(%Blur{sigma: 2.5})
       assert Operation.semantic?(%Sharpen{sigma: 0.7})
       assert Operation.semantic?(%Pixelate{size: 8})
+      assert Operation.semantic?(%Brightness{value: 20})
+      assert Operation.semantic?(%Contrast{value: -15})
+      assert Operation.semantic?(%Saturation{value: 35})
+    end
+
+    test "canonicalizes equivalent adjustment values" do
+      assert Operation.brightness(20) == Operation.brightness(20.0)
+      assert Operation.contrast(-15) == Operation.contrast(-15.0)
+      assert Operation.saturation(35) == Operation.saturation(35.0)
     end
 
     test "rejects non-positive effect values" do
@@ -384,6 +399,16 @@ defmodule ImagePipe.Plan.OperationTest do
       refute Operation.semantic?(%Blur{sigma: 0})
       refute Operation.semantic?(%Sharpen{sigma: -1.0})
       refute Operation.semantic?(%Pixelate{size: 0})
+    end
+
+    test "rejects out-of-range adjustment values" do
+      assert Operation.brightness(101) == {:error, {:invalid_operation, :brightness, [101]}}
+      assert Operation.contrast(-101) == {:error, {:invalid_operation, :contrast, [-101]}}
+      assert Operation.saturation(101) == {:error, {:invalid_operation, :saturation, [101]}}
+
+      refute Operation.semantic?(%Brightness{value: 101})
+      refute Operation.semantic?(%Contrast{value: -101})
+      refute Operation.semantic?(%Saturation{value: 101})
     end
   end
 end

--- a/test/image_pipe/request_safety_test.exs
+++ b/test/image_pipe/request_safety_test.exs
@@ -189,6 +189,26 @@ defmodule ImagePipe.RequestSafetyTest do
     end
   end
 
+  test "invalid imgproxy color effect values return before source identity cache lookup and origin" do
+    for path <- [
+          "/_/br:101/plain/images/cat.jpg",
+          "/_/co:-101/plain/images/cat.jpg",
+          "/_/sa:101/plain/images/cat.jpg"
+        ] do
+      conn =
+        ImagePipe.Plug.call(conn(:get, path),
+          parser: ImagePipe.Parser.Imgproxy,
+          sources: [path: {DenyingSourceAdapter, []}],
+          cache: {CacheProbe, []}
+        )
+
+      assert conn.status == 400
+      refute_received :source_resolve
+      refute_received :cache_lookup
+      refute_received :cache_put
+    end
+  end
+
   test "expired imgproxy requests return before source identity and cache work" do
     conn =
       ImagePipe.Plug.call(conn(:get, "/_/exp:100/plain/images/cat.jpg"),

--- a/test/image_pipe/transform/plan_executor_test.exs
+++ b/test/image_pipe/transform/plan_executor_test.exs
@@ -333,6 +333,24 @@ defmodule ImagePipe.Transform.PlanExecutorTest do
 
       assert dimensions(state.image) == {10, 10}
     end
+
+    test "brightness contrast and saturation preserve dimensions and change pixels" do
+      baseline = state_with_adjustment_image()
+
+      for build_operation <- [
+            &Operation.brightness/1,
+            &Operation.contrast/1,
+            &Operation.saturation/1
+          ] do
+        assert {:ok, operation} = build_operation.(25)
+
+        assert {:ok, %State{} = state} =
+                 Transform.execute_plan(plan([operation]), state_with_adjustment_image(), [])
+
+        assert dimensions(state.image) == dimensions(baseline.image)
+        assert rgb_pixel(state.image, 0, 0) != rgb_pixel(baseline.image, 0, 0)
+      end
+    end
   end
 
   test "resize auto executes against current image state" do
@@ -463,6 +481,15 @@ defmodule ImagePipe.Transform.PlanExecutorTest do
       |> Image.Draw.rect!(1, 0, 1, 2, color: :green)
       |> Image.Draw.rect!(2, 0, 1, 2, color: :blue)
       |> Image.Draw.rect!(3, 0, 1, 2, color: :white)
+
+    %State{image: image}
+  end
+
+  defp state_with_adjustment_image do
+    image =
+      2
+      |> Image.new!(1, color: [128, 96, 64])
+      |> Image.Draw.rect!(1, 0, 1, 1, color: [64, 96, 128])
 
     %State{image: image}
   end

--- a/test/parser/imgproxy/plan_builder_test.exs
+++ b/test/parser/imgproxy/plan_builder_test.exs
@@ -3,6 +3,7 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilderTest do
   use ExUnitProperties
 
   alias ImagePipe.Format
+  alias ImagePipe.Parser.Imgproxy.Effects
   alias ImagePipe.Parser.Imgproxy.ParsedRequest
   alias ImagePipe.Parser.Imgproxy.PipelineRequest
   alias ImagePipe.Parser.Imgproxy.PlanBuilder
@@ -263,7 +264,10 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilderTest do
                background_color: color!(10, 20, 30),
                blur: 2.5,
                sharpen: 0.7,
-               pixelate: 8
+               pixelate: 8,
+               brightness: 20,
+               contrast: -15,
+               saturation: 35
              )
 
     assert [
@@ -271,6 +275,9 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilderTest do
              blur,
              sharpen,
              pixelate,
+             brightness,
+             contrast,
+             saturation,
              %Operation.Padding{},
              %Operation.Background{}
            ] = operations
@@ -281,11 +288,24 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilderTest do
     assert sharpen.sigma == 0.7
     assert pixelate.__struct__ == ImagePipe.Plan.Operation.Pixelate
     assert pixelate.size == 8
+    assert brightness.__struct__ == ImagePipe.Plan.Operation.Brightness
+    assert brightness.value == 20
+    assert contrast.__struct__ == ImagePipe.Plan.Operation.Contrast
+    assert contrast.value == -15
+    assert saturation.__struct__ == ImagePipe.Plan.Operation.Saturation
+    assert saturation.value == 35
   end
 
   test "skips imgproxy effect no-op values" do
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
-             plan_pipeline(blur: 0.0, sharpen: 0.0, pixelate: 0)
+             plan_pipeline(
+               blur: 0.0,
+               sharpen: 0.0,
+               pixelate: 0,
+               brightness: 0,
+               contrast: 0,
+               saturation: 0
+             )
 
     assert operations == []
 
@@ -876,7 +896,10 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilderTest do
   end
 
   defp plan_pipeline(attrs) do
-    attrs = normalize_orientation_attrs(attrs)
+    attrs =
+      attrs
+      |> normalize_orientation_attrs()
+      |> normalize_effect_attrs()
 
     PlanBuilder.to_plan(
       %ParsedRequest{
@@ -908,6 +931,17 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilderTest do
         Keyword.pop(attrs, :orientation, %ImagePipe.Parser.Imgproxy.Orientation{})
 
       Keyword.put(attrs, :orientation, struct!(orientation, orientation_attrs))
+    end
+  end
+
+  defp normalize_effect_attrs(attrs) do
+    {effect_attrs, attrs} =
+      Keyword.split(attrs, [:blur, :sharpen, :pixelate, :brightness, :contrast, :saturation])
+
+    if effect_attrs == [] do
+      attrs
+    else
+      Keyword.put(attrs, :effects, struct!(Effects, effect_attrs))
     end
   end
 

--- a/test/parser/imgproxy_test.exs
+++ b/test/parser/imgproxy_test.exs
@@ -1167,6 +1167,37 @@ defmodule ImagePipe.Parser.ImgproxyTest do
              {:error, {:invalid_format, "auto", ["webp", "avif", "jpeg", "jpg", "png", "best"]}}
   end
 
+  test "parses imgproxy brightness contrast and saturation effects" do
+    assert [:brightness, :contrast, :saturation] =
+             "/_/br:20/co:-15/sa:35/plain/images/cat.jpg"
+             |> operations_for()
+             |> operation_names()
+
+    assert [:brightness, :contrast, :saturation] =
+             "/_/brightness:20/contrast:-15/saturation:35/plain/images/cat.jpg"
+             |> operations_for()
+             |> operation_names()
+  end
+
+  test "plans imgproxy effects in fixed canonical order" do
+    operations =
+      "/_/sa:35/pix:8/co:-15/sh:0.7/br:20/bl:2.5/plain/images/cat.jpg"
+      |> operations_for()
+      |> operation_names()
+
+    assert operations == [:blur, :sharpen, :pixelate, :brightness, :contrast, :saturation]
+  end
+
+  test "skips zero imgproxy brightness contrast and saturation values" do
+    assert operations_for("/_/br:0/co:0/sa:0/plain/images/cat.jpg") == []
+  end
+
+  test "rejects out-of-range imgproxy brightness contrast and saturation values" do
+    assert {:error, _reason} = Imgproxy.parse(conn(:get, "/_/br:101/plain/images/cat.jpg"), [])
+    assert {:error, _reason} = Imgproxy.parse(conn(:get, "/_/co:-101/plain/images/cat.jpg"), [])
+    assert {:error, _reason} = Imgproxy.parse(conn(:get, "/_/sa:101/plain/images/cat.jpg"), [])
+  end
+
   test "parses processing options before validating output extension" do
     assert Imgproxy.parse(conn(:get, "/_/unknown:/plain/images/cat.jpg@unknown"), []) ==
              {:error, {:unknown_option, "unknown"}}
@@ -1653,6 +1684,12 @@ defmodule ImagePipe.Parser.ImgproxyTest do
   defp operation_name(%Operation.Rotate{}), do: :rotate
   defp operation_name(%Operation.CropGuided{}), do: :crop_guided
   defp operation_name(%Operation.Resize{}), do: :resize
+  defp operation_name(%Operation.Blur{}), do: :blur
+  defp operation_name(%Operation.Sharpen{}), do: :sharpen
+  defp operation_name(%Operation.Pixelate{}), do: :pixelate
+  defp operation_name(%Operation.Brightness{}), do: :brightness
+  defp operation_name(%Operation.Contrast{}), do: :contrast
+  defp operation_name(%Operation.Saturation{}), do: :saturation
 
   defp forbidden_parsed_transform_operations(%Plan{} = plan) do
     plan.pipelines

--- a/test/transform_chain_test.exs
+++ b/test/transform_chain_test.exs
@@ -6,9 +6,12 @@ defmodule ImagePipe.Transform.ChainTest do
   alias ImagePipe.Transform.ChainTest.FailingTransform
   alias ImagePipe.Transform.ChainTest.UnexpectedTransform
   alias ImagePipe.Transform.Operation.Background
+  alias ImagePipe.Transform.Operation.Brightness
+  alias ImagePipe.Transform.Operation.Contrast
   alias ImagePipe.Transform.Operation.Crop
   alias ImagePipe.Transform.Operation.ExtendCanvas
   alias ImagePipe.Transform.Operation.Resize
+  alias ImagePipe.Transform.Operation.Saturation
   alias ImagePipe.Transform.State
 
   doctest ImagePipe.Transform.Chain
@@ -17,6 +20,9 @@ defmodule ImagePipe.Transform.ChainTest do
     operation = %Resize{mode: :fit, width: {:pixels, 10}, height: :auto}
 
     assert Transform.transform_name(operation) == :resize
+    assert Transform.transform_name(%Brightness{value: 20}) == :brightness
+    assert Transform.transform_name(%Contrast{value: -15}) == :contrast
+    assert Transform.transform_name(%Saturation{value: 35}) == :saturation
   end
 
   test "stops executing after the first transform error" do


### PR DESCRIPTION
## Summary

- add Imgproxy `brightness`/`br`, `contrast`/`co`, and `saturation`/`sa` parsing, planning, cache key data, decode planning, and transform execution
- document the supported options, no-op behavior, and fixed effect order in the Imgproxy API docs and support matrix
- add the three operations to the demo Effects toolbox and demo URL state parser

Correlates with #32.

## Verification

- `mise exec -- mix compile --warnings-as-errors`
- `mise exec -- mix test`
- `mise exec -- pnpm demo:test`
- `mise exec -- pnpm demo:check`
- `mise exec -- pnpm demo:lint`
- `mise exec -- vale docs/imgproxy_support_matrix.md docs/transform_operations.md docs/imgproxy_path_api.md`
- `git diff --check`

`mise exec -- mix credo --strict` still exits nonzero on existing project-wide style and refactor findings. The new struct-size warning from this change was removed.
