### PR TITLE
Preserve source stream errors across decode

### DIFF
--- a/lib/image_pipe/request/processor.ex
+++ b/lib/image_pipe/request/processor.ex
@@ -158,7 +158,10 @@ defmodule ImagePipe.Request.Processor do
 
   defp decode_source_response(%Source.Response{} = source_response, decode_options, opts) do
     image_open_module = Keyword.get(opts, :image_open_module, Image)
-    image_open_module.open(source_response.stream, decode_options)
+
+    source_response.stream
+    |> image_open_module.open(decode_options)
+    |> prefer_source_stream_error(source_response)
   rescue
     exception in [Source.StreamError] -> {:error, {:source, exception.reason}}
   catch
@@ -190,6 +193,7 @@ defmodule ImagePipe.Request.Processor do
   defp handle_materialization_result(result, source_response) do
     result
     |> prefer_source_body_limit(source_response)
+    |> prefer_source_stream_error(source_response)
     |> do_handle_materialization_result()
   end
 
@@ -214,6 +218,15 @@ defmodule ImagePipe.Request.Processor do
   end
 
   defp prefer_source_body_limit(result, _source_response), do: result
+
+  defp prefer_source_stream_error({:error, reason}, %Source.Response{} = source_response) do
+    case Source.stream_error_reason(source_response) do
+      {:ok, reason} -> {:error, {:source, reason}}
+      :error -> {:error, reason}
+    end
+  end
+
+  defp prefer_source_stream_error(result, _source_response), do: result
 
   defp validate_input_image(image, opts) do
     max_input_pixels = Keyword.fetch!(opts, :max_input_pixels)

--- a/lib/image_pipe/source.ex
+++ b/lib/image_pipe/source.ex
@@ -108,6 +108,13 @@ defmodule ImagePipe.Source do
 
   def body_limit_exceeded?(%Response{}), do: false
 
+  @spec stream_error_reason(Response.t()) :: {:ok, term()} | :error
+  def stream_error_reason(%Response{stream: %WrappedStream{} = stream}) do
+    WrappedStream.stream_error_reason(stream)
+  end
+
+  def stream_error_reason(%Response{}), do: :error
+
   defp validate_sources(sources) when is_list(sources) do
     with {:ok, source_configs} <- source_configs(sources) do
       {:ok, expand_url_source_config(source_configs)}

--- a/lib/image_pipe/source/wrapped_stream.ex
+++ b/lib/image_pipe/source/wrapped_stream.ex
@@ -1,34 +1,63 @@
 defmodule ImagePipe.Source.WrappedStream do
   @moduledoc false
 
-  @enforce_keys [:stream, :max_body_bytes, :body_limit_ref]
+  @enforce_keys [:stream, :max_body_bytes, :stream_state_ref]
   defstruct @enforce_keys
 
   @type t :: %__MODULE__{
           stream: Enumerable.t(),
           max_body_bytes: non_neg_integer() | :infinity,
-          body_limit_ref: :atomics.atomics_ref()
+          stream_state_ref: :atomics.atomics_ref()
         }
+
+  @body_limit_index 1
+  @stream_error_index 2
+  @stream_error_reasons %{
+    stream_exception: 1,
+    body_too_large: 2,
+    invalid_stream_chunk: 3
+  }
+  @stream_error_reason_by_code %{
+    1 => :stream_exception,
+    2 => :body_too_large,
+    3 => :invalid_stream_chunk
+  }
 
   @spec new(Enumerable.t(), non_neg_integer() | :infinity) :: t()
   def new(stream, max_body_bytes) do
     %__MODULE__{
       stream: stream,
       max_body_bytes: max_body_bytes,
-      body_limit_ref: :atomics.new(1, [])
+      stream_state_ref: :atomics.new(2, [])
     }
   end
 
   @spec body_limit_exceeded?(t()) :: boolean()
-  def body_limit_exceeded?(%__MODULE__{body_limit_ref: body_limit_ref}) do
-    :atomics.get(body_limit_ref, 1) == 1
+  def body_limit_exceeded?(%__MODULE__{stream_state_ref: stream_state_ref}) do
+    :atomics.get(stream_state_ref, @body_limit_index) == 1
   end
 
   @spec mark_body_limit_exceeded(t()) :: :ok
-  def mark_body_limit_exceeded(%__MODULE__{body_limit_ref: body_limit_ref}) do
-    :atomics.put(body_limit_ref, 1, 1)
+  def mark_body_limit_exceeded(%__MODULE__{stream_state_ref: stream_state_ref}) do
+    :atomics.put(stream_state_ref, @body_limit_index, 1)
     :ok
   end
+
+  @spec mark_stream_error(t(), term()) :: :ok
+  def mark_stream_error(%__MODULE__{stream_state_ref: stream_state_ref}, reason) do
+    :atomics.put(stream_state_ref, @stream_error_index, stream_error_code(reason))
+    :ok
+  end
+
+  @spec stream_error_reason(t()) :: {:ok, term()} | :error
+  def stream_error_reason(%__MODULE__{stream_state_ref: stream_state_ref}) do
+    case :atomics.get(stream_state_ref, @stream_error_index) do
+      0 -> :error
+      code -> {:ok, Map.fetch!(@stream_error_reason_by_code, code)}
+    end
+  end
+
+  defp stream_error_code(reason), do: Map.get(@stream_error_reasons, reason, 1)
 end
 
 defimpl Enumerable, for: ImagePipe.Source.WrappedStream do
@@ -49,18 +78,21 @@ defimpl Enumerable, for: ImagePipe.Source.WrappedStream do
     try do
       stream
       |> Enumerable.reduce({:cont, {0, acc}}, reducer(wrapped, fun, consumer_failure_ref))
-      |> unwrap_result(fun, consumer_failure_ref)
+      |> unwrap_result(wrapped, fun, consumer_failure_ref)
     rescue
       error in StreamError ->
+        WrappedStream.mark_stream_error(wrapped, error.reason)
         reraise error, __STACKTRACE__
 
       _error ->
+        WrappedStream.mark_stream_error(wrapped, :stream_exception)
         reraise StreamError.exception(reason: :stream_exception), __STACKTRACE__
     catch
       {^consumer_failure_ref, kind, reason, stacktrace} ->
         :erlang.raise(kind, reason, stacktrace)
 
       _kind, _reason ->
+        WrappedStream.mark_stream_error(wrapped, :stream_exception)
         raise StreamError, reason: :stream_exception
     end
   end
@@ -87,9 +119,11 @@ defimpl Enumerable, for: ImagePipe.Source.WrappedStream do
       else
         {:error, :body_too_large} ->
           WrappedStream.mark_body_limit_exceeded(wrapped)
+          WrappedStream.mark_stream_error(wrapped, :body_too_large)
           raise StreamError, reason: :body_too_large
 
         {:error, reason} ->
+          WrappedStream.mark_stream_error(wrapped, reason)
           raise StreamError, reason: reason
       end
     end
@@ -126,39 +160,45 @@ defimpl Enumerable, for: ImagePipe.Source.WrappedStream do
     end
   end
 
-  defp unwrap_result({:done, {_size, acc}}, _fun, _consumer_failure_ref), do: {:done, acc}
-  defp unwrap_result({:halted, {_size, acc}}, _fun, _consumer_failure_ref), do: {:halted, acc}
+  defp unwrap_result({:done, {_size, acc}}, _wrapped, _fun, _consumer_failure_ref),
+    do: {:done, acc}
 
-  defp unwrap_result({:suspended, {size, acc}, continuation}, fun, consumer_failure_ref) do
-    {:suspended, acc, &continue(continuation, size, &1, fun, consumer_failure_ref)}
+  defp unwrap_result({:halted, {_size, acc}}, _wrapped, _fun, _consumer_failure_ref),
+    do: {:halted, acc}
+
+  defp unwrap_result({:suspended, {size, acc}, continuation}, wrapped, fun, consumer_failure_ref) do
+    {:suspended, acc, &continue(wrapped, continuation, size, &1, fun, consumer_failure_ref)}
   end
 
-  defp continue(continuation, size, {:cont, acc}, fun, consumer_failure_ref) do
-    continue_safely(continuation, {:cont, {size, acc}}, fun, consumer_failure_ref)
+  defp continue(wrapped, continuation, size, {:cont, acc}, fun, consumer_failure_ref) do
+    continue_safely(wrapped, continuation, {:cont, {size, acc}}, fun, consumer_failure_ref)
   end
 
-  defp continue(continuation, size, {:halt, acc}, fun, consumer_failure_ref) do
-    continue_safely(continuation, {:halt, {size, acc}}, fun, consumer_failure_ref)
+  defp continue(wrapped, continuation, size, {:halt, acc}, fun, consumer_failure_ref) do
+    continue_safely(wrapped, continuation, {:halt, {size, acc}}, fun, consumer_failure_ref)
   end
 
-  defp continue(continuation, size, {:suspend, acc}, fun, consumer_failure_ref) do
-    continue_safely(continuation, {:suspend, {size, acc}}, fun, consumer_failure_ref)
+  defp continue(wrapped, continuation, size, {:suspend, acc}, fun, consumer_failure_ref) do
+    continue_safely(wrapped, continuation, {:suspend, {size, acc}}, fun, consumer_failure_ref)
   end
 
-  defp continue_safely(continuation, command, fun, consumer_failure_ref) do
+  defp continue_safely(wrapped, continuation, command, fun, consumer_failure_ref) do
     continuation.(command)
-    |> unwrap_result(fun, consumer_failure_ref)
+    |> unwrap_result(wrapped, fun, consumer_failure_ref)
   rescue
     error in StreamError ->
+      WrappedStream.mark_stream_error(wrapped, error.reason)
       reraise error, __STACKTRACE__
 
     _error ->
+      WrappedStream.mark_stream_error(wrapped, :stream_exception)
       reraise StreamError.exception(reason: :stream_exception), __STACKTRACE__
   catch
     {^consumer_failure_ref, kind, reason, stacktrace} ->
       :erlang.raise(kind, reason, stacktrace)
 
     _kind, _reason ->
+      WrappedStream.mark_stream_error(wrapped, :stream_exception)
       raise StreamError, reason: :stream_exception
   end
 end

--- a/test/image_pipe/processor_test.exs
+++ b/test/image_pipe/processor_test.exs
@@ -49,6 +49,31 @@ defmodule ImagePipe.Request.ProcessorTest do
     end
   end
 
+  defmodule DecodeConsumesStreamErrorThenReturnsDecodeError do
+    def open(stream, _decode_options) do
+      parent = self()
+      ref = make_ref()
+
+      spawn(fn ->
+        result =
+          try do
+            _ = Enum.to_list(stream)
+            :completed
+          rescue
+            exception in [Source.StreamError] -> {:source_error, exception.reason}
+          end
+
+        send(parent, {ref, result})
+      end)
+
+      receive do
+        {^ref, {:source_error, :stream_exception}} -> {:error, :forced_decode_error}
+      after
+        1_000 -> {:error, :stream_did_not_fail}
+      end
+    end
+  end
+
   defp opts do
     [
       sources: %{path: {ValidAdapter, []}},
@@ -298,6 +323,22 @@ defmodule ImagePipe.Request.ProcessorTest do
                |> Keyword.put(
                  :image_open_module,
                  DecodeConsumesBodyLimitThenReturnsDecodeError
+               )
+             )
+  end
+
+  test "source stream errors beat later decode errors from another stream consumer process" do
+    response = %Response{stream: Stream.map([:raise], fn _ -> raise "raw stream failure" end)}
+    assert {:ok, response} = Source.wrap_response(response, max_body_bytes: 20)
+
+    assert {:error, {:source, :stream_exception}} =
+             Processor.decode_validate_source_response(
+               response,
+               plan(),
+               Keyword.put(
+                 opts(),
+                 :image_open_module,
+                 DecodeConsumesStreamErrorThenReturnsDecodeError
                )
              )
   end


### PR DESCRIPTION
## Summary
- Record wrapped source stream failures in shared stream state.
- Prefer recorded source stream errors over later decode or materialization errors.
- Add a regression for a separate decode reader process returning a generic decode error after a source stream failure.

## Root Cause
Vix reads enum-backed sources in a separate process. When that reader process raises ImagePipe.Source.StreamError, the caller can still receive a generic decode failure from libvips. ImagePipe then returned HTTP 415 instead of the expected source error response.

## Validation
- mise exec -- mix format --check-formatted
- mise exec -- mix compile --warnings-as-errors
- mise exec -- mix test: 982 passed
- mise exec -- mix test test/image_pipe/request_safety_test.exs:371 test/image_pipe/request_safety_test.exs:386 --seed 613274 --repeat-until-failure 50 --max-failures 1