### PR TITLE
Enable bounded cache + telemetry logging for the dev server

### DIFF
--- a/dev/cache_logger.ex
+++ b/dev/cache_logger.ex
@@ -1,0 +1,119 @@
+defmodule ImagePipe.SimpleServer.CacheLogger do
+  @moduledoc false
+  # Dev-only :telemetry -> Logger bridge for the cache layer. The library emits
+  # telemetry events only (see telemetry guidelines); this handler is the kind
+  # of host-side logging integration a real host would attach itself. It exists
+  # purely so `mix image_pipe.server --cache` shows what the cache is doing:
+  # reads (hit/miss), writes (stored/rejected/error), admission decisions, and
+  # background eviction/flush/cleanup activity.
+
+  require Logger
+
+  @handler_id "image-pipe-dev-cache-logger"
+
+  @events [
+    [:image_pipe, :cache, :lookup, :stop],
+    [:image_pipe, :cache, :lookup, :exception],
+    [:image_pipe, :cache, :write, :stop],
+    [:image_pipe, :cache, :write, :exception],
+    [:image_pipe, :cache, :admission, :stop],
+    [:image_pipe, :cache, :eviction, :stop],
+    [:image_pipe, :cache, :flush, :stop],
+    [:image_pipe, :cache, :cleanup, :stop],
+    [:image_pipe, :cache, :warm_start, :stop],
+    [:image_pipe, :cache, :stage]
+  ]
+
+  @doc """
+  Attach the cache logging handler. Idempotent — a previously attached handler
+  with the same id is detached first so repeated dev-server starts in one VM
+  don't fail with `:already_exists`.
+  """
+  def attach do
+    _ = :telemetry.detach(@handler_id)
+    :telemetry.attach_many(@handler_id, @events, &__MODULE__.handle_event/4, nil)
+  end
+
+  @doc false
+  def handle_event([:image_pipe, :cache, :lookup, :stop], measurements, metadata, _config) do
+    Logger.debug("cache lookup: #{Map.get(metadata, :cache)}#{format_error(metadata)}#{duration(measurements)}")
+  end
+
+  def handle_event([:image_pipe, :cache, :write, :stop], measurements, metadata, _config) do
+    detail =
+      case Map.get(metadata, :cache) do
+        :write -> "stored"
+        :admission_rejected -> "rejected by admission"
+        :write_error -> "error#{format_error(metadata)}"
+        other -> inspect(other)
+      end
+
+    Logger.debug("cache write: #{detail} #{format_format(metadata)}#{duration(measurements)}")
+  end
+
+  def handle_event([:image_pipe, :cache, :admission, :stop], _measurements, metadata, _config) do
+    case Map.get(metadata, :result) do
+      :admitted ->
+        Logger.debug("cache admission: admitted (evicted #{Map.get(metadata, :victim_count, 0)})")
+
+      :rejected ->
+        Logger.debug("cache admission: rejected (reason=#{Map.get(metadata, :reason)})")
+
+      other ->
+        Logger.debug("cache admission: #{inspect(other)}")
+    end
+  end
+
+  def handle_event([:image_pipe, :cache, :eviction, :stop], measurements, metadata, _config) do
+    Logger.debug(
+      "cache eviction: #{Map.get(measurements, :count, 0)} entries, " <>
+        "#{format_bytes(Map.get(measurements, :bytes, 0))} (#{Map.get(metadata, :trigger)})"
+    )
+  end
+
+  def handle_event([:image_pipe, :cache, :flush, :stop], measurements, _metadata, _config) do
+    Logger.debug("cache flush: state persisted (#{format_bytes(Map.get(measurements, :bytes, 0))})")
+  end
+
+  def handle_event([:image_pipe, :cache, :cleanup, :stop], measurements, _metadata, _config) do
+    Logger.debug("cache cleanup: removed #{Map.get(measurements, :removed, 0)} stale peer state files")
+  end
+
+  def handle_event([:image_pipe, :cache, :warm_start, :stop], _measurements, metadata, _config) do
+    Logger.debug(
+      "cache warm start: own_state=#{Map.get(metadata, :own_state_loaded)} " <>
+        "peers=#{Map.get(metadata, :peer_state_files, 0)}"
+    )
+  end
+
+  def handle_event([:image_pipe, :cache, :stage], _measurements, metadata, _config) do
+    Logger.debug("cache stage: #{Map.get(metadata, :cache)}#{format_error(metadata)}")
+  end
+
+  def handle_event([:image_pipe, :cache, _op, :exception], _measurements, metadata, _config) do
+    Logger.warning(
+      "cache exception: #{Map.get(metadata, :kind)} #{inspect(Map.get(metadata, :reason))}"
+    )
+  end
+
+  defp duration(%{duration: native}) do
+    us = System.convert_time_unit(native, :native, :microsecond)
+    " (#{:erlang.float_to_binary(us / 1000, decimals: 1)}ms)"
+  end
+
+  defp duration(_measurements), do: ""
+
+  defp format_error(%{error: error}), do: " error=#{inspect(error)}"
+  defp format_error(_metadata), do: ""
+
+  defp format_format(%{output_format: format}) when not is_nil(format), do: "(format=#{format})"
+  defp format_format(_metadata), do: ""
+
+  defp format_bytes(bytes) when bytes >= 1_000_000,
+    do: "#{:erlang.float_to_binary(bytes / 1_000_000, decimals: 1)}MB"
+
+  defp format_bytes(bytes) when bytes >= 1_000,
+    do: "#{:erlang.float_to_binary(bytes / 1_000, decimals: 1)}KB"
+
+  defp format_bytes(bytes), do: "#{bytes}B"
+end

--- a/dev/simple_server.ex
+++ b/dev/simple_server.ex
@@ -3,6 +3,7 @@ defmodule ImagePipe.SimpleServer do
 
   use Boundary,
     top_level?: true,
+    exports: [CacheLogger],
     deps: [
       ImagePipe,
       ImagePipe.Parser
@@ -45,7 +46,9 @@ defmodule ImagePipe.SimpleServer do
     [
       parser: ImagePipe.Parser.Imgproxy,
       sources: [
-        path: {ImagePipe.Source.File, root: "priv/static", root_id: "static"}
+        path:
+          {ImagePipe.Source.File,
+           root: "priv/static", root_id: "static", stable: :trusted}
       ],
       imgproxy: [
         signature: [

--- a/lib/mix/tasks/image_pipe.server.ex
+++ b/lib/mix/tasks/image_pipe.server.ex
@@ -19,6 +19,7 @@ defmodule Mix.Tasks.ImagePipe.Server do
   @default_port 4000
   @default_vite_port 5173
   @default_cache_root "_build/dev/image_pipe/cache"
+  @default_cache_max_size_bytes 500_000_000
   @port_range 1..65_535
   @vite_startup_timeout 5_000
   @vite_ready_marker "ready in"
@@ -72,14 +73,17 @@ defmodule Mix.Tasks.ImagePipe.Server do
   defp start_server(%{cache?: cache?, port: port, vite?: vite?}) do
     server_url = "http://localhost:#{port}"
     vite_origin = "http://localhost:#{@default_vite_port}"
+    cache = cache_config(cache?)
 
     Application.put_env(:image_pipe, ImagePipe.SimpleServer,
-      cache: cache_config(cache?),
+      cache: cache,
       vite_origin: vite_origin
     )
 
     Mix.Task.run("app.start")
 
+    maybe_start_cache(cache)
+    maybe_attach_cache_logger(cache)
     maybe_start_vite(vite?)
     {:ok, _pid} = start_bandit(port)
 
@@ -96,8 +100,33 @@ defmodule Mix.Tasks.ImagePipe.Server do
      root: Path.expand(@default_cache_root),
      path_prefix: "processed",
      max_body_bytes: 10_000_000,
+     max_size_bytes: @default_cache_max_size_bytes,
+     node_id: "dev",
      key_headers: [],
      key_cookies: []}
+  end
+
+  # Bounded mode (max_size_bytes set) needs the cache's Registry + Admission
+  # supervisor running, otherwise every write is skipped (file_system.ex
+  # commit_sink falls into the :unavailable branch). child_spec/1 returns
+  # :ignore for unbounded configs, so this is a no-op when bounded mode is off.
+  defp maybe_start_cache(nil), do: :ok
+
+  defp maybe_start_cache({module, opts}) do
+    case module.child_spec(opts) do
+      :ignore -> :ok
+      spec -> {:ok, _pid} = Supervisor.start_link([spec], strategy: :one_for_one)
+    end
+  end
+
+  # Dev ergonomics: bridge the cache's telemetry events to the Logger so the
+  # server output shows reads, writes, rejections, and eviction activity. Only
+  # meaningful when a cache is configured.
+  defp maybe_attach_cache_logger(nil), do: :ok
+
+  defp maybe_attach_cache_logger(_cache) do
+    ImagePipe.SimpleServer.CacheLogger.attach()
+    :ok
   end
 
   defp start_bandit(port) do
@@ -217,7 +246,11 @@ defmodule Mix.Tasks.ImagePipe.Server do
   defp maybe_print_cache_info(false), do: :ok
 
   defp maybe_print_cache_info(true) do
-    Mix.shell().info("Filesystem cache enabled at #{Path.expand(@default_cache_root)}")
+    size_mb = div(@default_cache_max_size_bytes, 1_000_000)
+
+    Mix.shell().info(
+      "Filesystem cache enabled at #{Path.expand(@default_cache_root)} (bounded, #{size_mb} MB)"
+    )
   end
 
   defp maybe_print_vite_info(_vite_origin, false), do: :ok


### PR DESCRIPTION
## Why

`mix image_pipe.server --cache` configured the FileSystem cache backend but nothing was ever stored, so every request re-ran the transform pipeline. Two reasons:

1. The demo File source defaulted to `stable: :auto`, which resolves `internal_cache` to `:disabled`. The request runner then ran with a **nil cache key** — no lookup, no write.
2. Even with caching reaching the adapter, the `--cache` config used **unbounded** mode (the bounded W-TinyLFU mode from #113 is opt-in via `max_size_bytes`).

## What changed (all dev/test-only)

- **`dev/simple_server.ex`** — mark the demo File source `stable: :trusted` (`priv/static` is immutable bundled content). This enables internal caching and strong byte identity. Also exports `CacheLogger` from the `SimpleServer` boundary.
- **`lib/mix/tasks/image_pipe.server.ex`** — `--cache` now runs the cache in **bounded mode** (500 MB cap + `node_id`) and starts the Admission supervisor (without it, bounded writes are silently skipped). Attaches the cache logger.
- **`dev/cache_logger.ex`** (new) — dev-only `:telemetry → Logger` bridge. The library emits telemetry events only (per telemetry guidelines); this is the host-side logging integration a real host would attach itself.

`dev/` is excluded from prod compilation (`elixirc_paths`), so no library behavior changed.

## Verification

Confirmed working live (`--cache`): first request logs `cache lookup: miss → admission admitted → write stored`, repeat requests log `cache lookup: hit` with no transform lines, and `cache flush: state persisted` fires in the background.

```
cache lookup: miss (3.7ms)
cache admission: admitted (evicted 0)
cache write: stored (format=avif) (3.4ms)
cache flush: state persisted (160.2KB)
cache lookup: hit (2.3ms)
```

Not yet exercised: `mix compile --warnings-as-errors` / `mix credo --strict` (Bash classifier was unavailable during the session). The dev-server run proves it compiles and behaves correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)