### PR TITLE
chore: resolve all mix credo --strict findings

### DIFF
--- a/lib/image_pipe/cache/file_system.ex
+++ b/lib/image_pipe/cache/file_system.ex
@@ -371,9 +371,8 @@ defmodule ImagePipe.Cache.FileSystem do
   end
 
   defp validate_filesystem_options(opts) do
-    with :ok <- validate_unknown_options(opts),
-         {:ok, validated_opts} <- validate_known_options(opts) do
-      {:ok, validated_opts}
+    with :ok <- validate_unknown_options(opts) do
+      validate_known_options(opts)
     end
   end
 
@@ -793,18 +792,20 @@ defmodule ImagePipe.Cache.FileSystem do
   def delete_victims(victims, opts) do
     Enum.each(victims, fn victim ->
       with {:ok, victim_paths} <- paths_from_hash(victim.key_hash, opts) do
-        if victim.delete_body? do
-          body_path =
-            Path.join(victim_paths.dir, "#{victim.key_hash}.#{victim.body_sha256}.body")
-
-          rm_tolerant(body_path)
-        end
-
-        if victim.delete_meta? do
-          rm_tolerant(victim_paths.meta_path)
-        end
+        delete_victim_files(victim, victim_paths)
       end
     end)
+  end
+
+  defp delete_victim_files(victim, victim_paths) do
+    if victim.delete_body? do
+      body_path = Path.join(victim_paths.dir, "#{victim.key_hash}.#{victim.body_sha256}.body")
+      rm_tolerant(body_path)
+    end
+
+    if victim.delete_meta? do
+      rm_tolerant(victim_paths.meta_path)
+    end
   end
 
   defp rm_tolerant(path) do

--- a/lib/image_pipe/cache/file_system/admission.ex
+++ b/lib/image_pipe/cache/file_system/admission.ex
@@ -3,12 +3,17 @@ defmodule ImagePipe.Cache.FileSystem.Admission do
 
   use GenServer
 
+  alias ImagePipe.Cache.FileSystem
   alias ImagePipe.Cache.FileSystem.Policy
   alias ImagePipe.Cache.FileSystem.Sketch
   alias ImagePipe.Telemetry
 
   defmodule State do
     @moduledoc false
+    # Long-lived GenServer state aggregating independent configuration,
+    # ETS table handles, byte counters, and scan lifecycle fields. These
+    # are deliberately flat rather than split into artificial sub-structs.
+    # credo:disable-for-next-line Credo.Check.Warning.StructFieldAmount
     defstruct [
       :registry,
       :root,
@@ -203,17 +208,19 @@ defmodule ImagePipe.Cache.FileSystem.Admission do
       {:ok, files} ->
         own = "#{state.node_id}.state"
         now = System.system_time(:millisecond)
-
-        Enum.reduce(files, state, fn f, acc ->
-          if String.ends_with?(f, ".state") and f != own and within_ttl?(acc, f, now) do
-            merge_peer_file(acc, f)
-          else
-            acc
-          end
-        end)
+        Enum.reduce(files, state, &maybe_merge_peer_file(&1, &2, own, now))
 
       {:error, _} ->
         state
+    end
+  end
+
+  defp maybe_merge_peer_file(filename, state, own, now) do
+    if String.ends_with?(filename, ".state") and filename != own and
+         within_ttl?(state, filename, now) do
+      merge_peer_file(state, filename)
+    else
+      state
     end
   end
 
@@ -246,12 +253,10 @@ defmodule ImagePipe.Cache.FileSystem.Admission do
   end
 
   defp decode_state_payload(binary, _state) do
-    try do
-      payload = :erlang.binary_to_term(binary, [:safe])
-      validate_state_payload(payload)
-    rescue
-      ArgumentError -> {:error, :decode_failed}
-    end
+    payload = :erlang.binary_to_term(binary, [:safe])
+    validate_state_payload(payload)
+  rescue
+    ArgumentError -> {:error, :decode_failed}
   end
 
   defp validate_state_payload(
@@ -361,7 +366,7 @@ defmodule ImagePipe.Cache.FileSystem.Admission do
   defp build_descriptor_map(entry_root) do
     walk_meta_files(entry_root)
     |> Enum.flat_map(fn meta_path ->
-      case ImagePipe.Cache.FileSystem.read_descriptor(meta_path) do
+      case FileSystem.read_descriptor(meta_path) do
         {:ok, descriptor, mtime} ->
           [{descriptor.key_hash, Map.put(descriptor, :mtime, mtime)}]
 
@@ -380,18 +385,20 @@ defmodule ImagePipe.Cache.FileSystem.Admission do
       {:ok, entries} ->
         entries
         |> Enum.reject(&(&1 == ".cache_state"))
-        |> Enum.flat_map(fn entry ->
-          path = Path.join(entry_root, entry)
-
-          cond do
-            File.dir?(path) -> walk_meta_files(path)
-            String.ends_with?(entry, ".meta") -> [path]
-            true -> []
-          end
-        end)
+        |> Enum.flat_map(&meta_files_in(entry_root, &1))
 
       {:error, _} ->
         []
+    end
+  end
+
+  defp meta_files_in(entry_root, entry) do
+    path = Path.join(entry_root, entry)
+
+    cond do
+      File.dir?(path) -> walk_meta_files(path)
+      String.ends_with?(entry, ".meta") -> [path]
+      true -> []
     end
   end
 
@@ -533,33 +540,33 @@ defmodule ImagePipe.Cache.FileSystem.Admission do
   end
 
   def handle_call({:apply_protected_batch, hashes, descriptor_map}, _from, state) do
-    state =
-      Enum.reduce(hashes, state, fn hash, acc ->
-        case Map.fetch(descriptor_map, hash) do
-          {:ok, entry} ->
-            if already_tracked?(acc, hash) do
-              acc
-            else
-              # Drop the scan-only `:mtime` field so queued descriptors
-              # have the same shape regardless of which queue they land in.
-              descriptor = Map.delete(entry, :mtime)
-              {pos, acc} = next_position(acc)
-              :ets.insert(acc.protected, {{pos, hash}, descriptor})
-              Map.update!(acc, :protected_bytes, &(&1 + descriptor.size_bytes))
-            end
-
-          :error ->
-            # Persisted protected hash whose meta no longer exists on
-            # disk. Skip silently — same-key delete or external sweep.
-            acc
-        end
-      end)
-
+    state = Enum.reduce(hashes, state, &apply_protected_hash(&1, &2, descriptor_map))
     {:reply, :ok, state}
   end
 
   def handle_call(:reconcile_to_cap, _from, state) do
     {:reply, :ok, reconcile_to_cap(state, [])}
+  end
+
+  defp apply_protected_hash(hash, state, descriptor_map) do
+    case Map.fetch(descriptor_map, hash) do
+      {:ok, entry} ->
+        if already_tracked?(state, hash) do
+          state
+        else
+          # Drop the scan-only `:mtime` field so queued descriptors
+          # have the same shape regardless of which queue they land in.
+          descriptor = Map.delete(entry, :mtime)
+          {pos, state} = next_position(state)
+          :ets.insert(state.protected, {{pos, hash}, descriptor})
+          Map.update!(state, :protected_bytes, &(&1 + descriptor.size_bytes))
+        end
+
+      :error ->
+        # Persisted protected hash whose meta no longer exists on
+        # disk. Skip silently — same-key delete or external sweep.
+        state
+    end
   end
 
   defp decide_admission(state, descriptor) do
@@ -993,31 +1000,29 @@ defmodule ImagePipe.Cache.FileSystem.Admission do
   defp reconcile_to_cap(state, evicted_descriptors) do
     total = state.window_bytes + state.probationary_bytes + state.protected_bytes
 
-    cond do
-      total <= state.max_size_bytes ->
-        # Delete the evicted entries' files. Admission owns deletion here
-        # (no request process is in the loop for boot/periodic
-        # reconciliation), calling the adapter's `delete_victims/2`
-        # in-boundary. See `emit_reconciliation_evictions/2`.
-        emit_reconciliation_evictions(state, evicted_descriptors)
-        state
+    if total <= state.max_size_bytes do
+      # Delete the evicted entries' files. Admission owns deletion here
+      # (no request process is in the loop for boot/periodic
+      # reconciliation), calling the adapter's `delete_victims/2`
+      # in-boundary. See `emit_reconciliation_evictions/2`.
+      emit_reconciliation_evictions(state, evicted_descriptors)
+      state
+    else
+      # Evict LRU from probationary first, then protected.
+      {evicted, state} = evict_one_lru(state)
 
-      true ->
-        # Evict LRU from probationary first, then protected.
-        {evicted, state} = evict_one_lru(state)
+      case evicted do
+        nil ->
+          # No more entries to evict but still over cap. Bug or empty
+          # cache with impossibly low max_size_bytes; log and stop.
+          require Logger
+          Logger.warning("cache: reconciliation cannot bring usage under cap")
+          emit_reconciliation_evictions(state, evicted_descriptors)
+          state
 
-        case evicted do
-          nil ->
-            # No more entries to evict but still over cap. Bug or empty
-            # cache with impossibly low max_size_bytes; log and stop.
-            require Logger
-            Logger.warning("cache: reconciliation cannot bring usage under cap")
-            emit_reconciliation_evictions(state, evicted_descriptors)
-            state
-
-          descriptor ->
-            reconcile_to_cap(state, [descriptor | evicted_descriptors])
-        end
+        descriptor ->
+          reconcile_to_cap(state, [descriptor | evicted_descriptors])
+      end
     end
   end
 
@@ -1055,7 +1060,7 @@ defmodule ImagePipe.Cache.FileSystem.Admission do
     # briefly is acceptable.
     victims = Enum.map(descriptors, &full_eviction_victim/1)
     opts = [root: state.root, path_prefix: state.path_prefix]
-    ImagePipe.Cache.FileSystem.delete_victims(victims, opts)
+    FileSystem.delete_victims(victims, opts)
 
     bytes = Enum.reduce(descriptors, 0, fn descriptor, acc -> acc + descriptor.size_bytes end)
 

--- a/lib/image_pipe/cache/key.ex
+++ b/lib/image_pipe/cache/key.ex
@@ -7,9 +7,9 @@ defmodule ImagePipe.Cache.Key do
 
   alias ImagePipe.Output.Negotiation
   alias ImagePipe.Plan
+  alias ImagePipe.Plan.KeyData
   alias ImagePipe.Plan.Output
   alias ImagePipe.Plan.Pipeline
-  alias ImagePipe.Plan.KeyData
   alias ImagePipe.Plan.Source.Identity
 
   @schema_version 2

--- a/lib/image_pipe/output/negotiation.ex
+++ b/lib/image_pipe/output/negotiation.ex
@@ -3,6 +3,7 @@ defmodule ImagePipe.Output.Negotiation do
 
   alias ImagePipe.Format
   alias ImagePipe.Output.Capabilities
+  alias Plug.Conn.Utils
 
   @modern_formats [avif: "image/avif", webp: "image/webp"]
 
@@ -91,13 +92,13 @@ defmodule ImagePipe.Output.Negotiation do
 
   defp parse_accept(accept_header) do
     accept_header
-    |> Plug.Conn.Utils.list()
+    |> Utils.list()
     |> Enum.map(&parse_accept_entry/1)
     |> Enum.reject(&is_nil/1)
   end
 
   defp parse_accept_entry(entry) do
-    case Plug.Conn.Utils.media_type(entry) do
+    case Utils.media_type(entry) do
       {:ok, type, subtype, params} -> {type <> "/" <> subtype, quality_from_params(params)}
       :error -> nil
     end

--- a/lib/image_pipe/parser/imgproxy/option_grammar.ex
+++ b/lib/image_pipe/parser/imgproxy/option_grammar.ex
@@ -581,9 +581,8 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammar do
   defp parse_background([""], _segment), do: {:ok, [background_color: nil]}
 
   defp parse_background([hex], _segment) when hex != "" do
-    with {:ok, color} <- Color.rgb_hex(hex) do
-      {:ok, [background_color: color]}
-    else
+    case Color.rgb_hex(hex) do
+      {:ok, color} -> {:ok, [background_color: color]}
       {:error, _reason} -> {:error, {:invalid_background, hex}}
     end
   end
@@ -603,9 +602,8 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammar do
   defp parse_background(args, _segment), do: {:error, {:invalid_background, args}}
 
   defp parse_background_alpha([alpha], _segment) when alpha != "" do
-    with {:ok, alpha} <- parse_alpha_ratio(alpha) do
-      {:ok, [background_alpha: alpha]}
-    else
+    case parse_alpha_ratio(alpha) do
+      {:ok, alpha} -> {:ok, [background_alpha: alpha]}
       {:error, _reason} -> {:error, {:invalid_background_alpha, alpha}}
     end
   end

--- a/lib/image_pipe/parser/imgproxy/pipeline_request.ex
+++ b/lib/image_pipe/parser/imgproxy/pipeline_request.ex
@@ -48,6 +48,10 @@ defmodule ImagePipe.Parser.Imgproxy.PipelineRequest do
           orientation: Orientation.t()
         }
 
+  # One flat accumulator for the many independent imgproxy URL options a
+  # single pipeline can carry; the fields are deliberately wide rather
+  # than grouped into artificial sub-structs.
+  # credo:disable-for-next-line Credo.Check.Warning.StructFieldAmount
   defstruct width: nil,
             height: nil,
             min_width: nil,

--- a/lib/image_pipe/parser/imgproxy/plan_builder.ex
+++ b/lib/image_pipe/parser/imgproxy/plan_builder.ex
@@ -339,15 +339,19 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilder do
   defp resize_from_rule(%PipelineRequest{} = request) do
     with {:ok, width} <- imgproxy_resize_dimension(request.width),
          {:ok, height} <- imgproxy_resize_dimension(request.height) do
-      case {width, height, resize_rule_requested?(request)} do
-        {:auto, :auto, false} ->
-          {:ok, []}
+      resize_operations_for(request, width, height)
+    end
+  end
 
-        {_planned_width, _planned_height, _rule_requested?} ->
-          with {:ok, operation} <- resize_operation(request) do
-            {:ok, [operation]}
-          end
-      end
+  defp resize_operations_for(request, width, height) do
+    case {width, height, resize_rule_requested?(request)} do
+      {:auto, :auto, false} ->
+        {:ok, []}
+
+      {_planned_width, _planned_height, _rule_requested?} ->
+        with {:ok, operation} <- resize_operation(request) do
+          {:ok, [operation]}
+        end
     end
   end
 

--- a/lib/image_pipe/parser/imgproxy/source.ex
+++ b/lib/image_pipe/parser/imgproxy/source.ex
@@ -117,13 +117,7 @@ defmodule ImagePipe.Parser.Imgproxy.Source do
     case source_schemes do
       %{^scheme => {translator, translator_opts}}
       when is_atom(translator) and is_list(translator_opts) ->
-        with {:ok, decoded_source} <- decode_percent_encoded(source) do
-          case translator.translate(decoded_source, translator_opts) do
-            {:ok, %_{} = plan_source} -> {:ok, plan_source}
-            {:error, _reason} -> {:error, {:source_scheme_error, scheme}}
-            _other -> {:error, {:source_scheme_error, scheme}}
-          end
-        end
+        translate_source(scheme, source, translator, translator_opts)
 
       _source_schemes ->
         {:error, {:unsupported_source_scheme, scheme}}
@@ -132,6 +126,16 @@ defmodule ImagePipe.Parser.Imgproxy.Source do
     _error -> {:error, {:source_scheme_error, scheme}}
   catch
     _kind, _reason -> {:error, {:source_scheme_error, scheme}}
+  end
+
+  defp translate_source(scheme, source, translator, translator_opts) do
+    with {:ok, decoded_source} <- decode_percent_encoded(source) do
+      case translator.translate(decoded_source, translator_opts) do
+        {:ok, %_{} = plan_source} -> {:ok, plan_source}
+        {:error, _reason} -> {:error, {:source_scheme_error, scheme}}
+        _other -> {:error, {:source_scheme_error, scheme}}
+      end
+    end
   end
 
   defp split_source_query(source) do

--- a/lib/image_pipe/plan/color.ex
+++ b/lib/image_pipe/plan/color.ex
@@ -7,6 +7,8 @@ defmodule ImagePipe.Plan.Color do
   data do not depend on third-party structs.
   """
 
+  alias Elixir.Color.SRGB
+
   @enforce_keys [:space, :channels, :alpha]
   defstruct @enforce_keys
 
@@ -29,8 +31,8 @@ defmodule ImagePipe.Plan.Color do
 
   @spec rgb_hex(term()) :: {:ok, t()} | {:error, term()}
   def rgb_hex(hex) when is_binary(hex) and byte_size(hex) in [3, 6] do
-    with {:ok, %Elixir.Color.SRGB{} = external} <- Elixir.Color.SRGB.parse("#" <> hex),
-         {red, green, blue} <- Elixir.Color.SRGB.scale255(external) do
+    with {:ok, %SRGB{} = external} <- SRGB.parse("#" <> hex),
+         {red, green, blue} <- SRGB.scale255(external) do
       rgb(round(red), round(green), round(blue))
     else
       {:error, _reason} -> {:error, {:invalid_color, [hex]}}

--- a/lib/image_pipe/plug.ex
+++ b/lib/image_pipe/plug.ex
@@ -54,28 +54,7 @@ defmodule ImagePipe.Plug do
          {:ok, %Source.Resolved{} = resolved_source} <-
            Source.resolve(plan.source, opts, Options.source_runtime_opts(opts)) do
       prepared_http_cache = HTTPCache.prepare(conn, plan, resolved_source, opts)
-
-      case HTTPCache.evaluate_conditional(conn, prepared_http_cache, opts) do
-        {:not_modified, prepared} ->
-          result = :not_modified
-
-          {conn, send_metadata} =
-            send_response(conn, opts, result, fn ->
-              Sender.send_not_modified(conn, prepared)
-            end)
-
-          {conn, request_stop_metadata(result, send_metadata)}
-
-        :proceed ->
-          result = Runner.run(conn, plan, resolved_source, prepared_http_cache, opts)
-
-          {conn, send_metadata} =
-            send_response(conn, opts, request_result(result), fn ->
-              Sender.send_result(conn, result, opts)
-            end)
-
-          {conn, request_stop_metadata(result, send_metadata)}
-      end
+      send_conditional_response(conn, plan, resolved_source, prepared_http_cache, opts)
     else
       {:error, {:parser, error}} ->
         {conn, _send_metadata} =
@@ -96,6 +75,30 @@ defmodule ImagePipe.Plug do
           send_response(conn, opts, :source_error, fn -> Sender.send_source_error(conn, error) end)
 
         {conn, %{result: :source_error, error: Error.tag(error)}}
+    end
+  end
+
+  defp send_conditional_response(conn, plan, resolved_source, prepared_http_cache, opts) do
+    case HTTPCache.evaluate_conditional(conn, prepared_http_cache, opts) do
+      {:not_modified, prepared} ->
+        result = :not_modified
+
+        {conn, send_metadata} =
+          send_response(conn, opts, result, fn ->
+            Sender.send_not_modified(conn, prepared)
+          end)
+
+        {conn, request_stop_metadata(result, send_metadata)}
+
+      :proceed ->
+        result = Runner.run(conn, plan, resolved_source, prepared_http_cache, opts)
+
+        {conn, send_metadata} =
+          send_response(conn, opts, request_result(result), fn ->
+            Sender.send_result(conn, result, opts)
+          end)
+
+        {conn, request_stop_metadata(result, send_metadata)}
     end
   end
 

--- a/lib/image_pipe/request/http_cache.ex
+++ b/lib/image_pipe/request/http_cache.ex
@@ -144,16 +144,21 @@ defmodule ImagePipe.Request.HTTPCache do
         {[{"cache-control", @generated_cache_control}, {"etag", etag}], etag, nil}
 
       :not_generated ->
-        case resolved.cache_semantics do
-          %CacheSemantics{byte_identity: :none} ->
-            {[{"cache-control", @no_store}], nil, :missing_byte_identity}
-
-          %CacheSemantics{byte_identity: {:strong, _seed}, stable?: true} ->
-            if has_resp_header?(conn, "etag"),
-              do: {[{"cache-control", @generated_cache_control}], nil, nil},
-              else: {[], nil, nil}
-        end
+        cache_control_without_etag(conn, resolved.cache_semantics)
     end
+  end
+
+  defp cache_control_without_etag(_conn, %CacheSemantics{byte_identity: :none}) do
+    {[{"cache-control", @no_store}], nil, :missing_byte_identity}
+  end
+
+  defp cache_control_without_etag(conn, %CacheSemantics{
+         byte_identity: {:strong, _seed},
+         stable?: true
+       }) do
+    if has_resp_header?(conn, "etag"),
+      do: {[{"cache-control", @generated_cache_control}], nil, nil},
+      else: {[], nil, nil}
   end
 
   defp generated_etag_only(conn, plan, resolved, opts) do

--- a/lib/image_pipe/request/processor.ex
+++ b/lib/image_pipe/request/processor.ex
@@ -248,9 +248,8 @@ defmodule ImagePipe.Request.Processor do
     pixels = width * height
 
     with :ok <- check_result_width(width, Keyword.fetch!(opts, :max_result_width)),
-         :ok <- check_result_height(height, Keyword.fetch!(opts, :max_result_height)),
-         :ok <- check_result_pixels(pixels, Keyword.fetch!(opts, :max_result_pixels)) do
-      :ok
+         :ok <- check_result_height(height, Keyword.fetch!(opts, :max_result_height)) do
+      check_result_pixels(pixels, Keyword.fetch!(opts, :max_result_pixels))
     end
   end
 

--- a/lib/image_pipe/request/source_format.ex
+++ b/lib/image_pipe/request/source_format.ex
@@ -9,9 +9,8 @@ defmodule ImagePipe.Request.SourceFormat do
 
   @spec from_image(VipsImage.t()) :: {:ok, source_format()} | {:error, error()}
   def from_image(image) do
-    with {:ok, loader} <- header_value(image, "vips-loader") do
-      classify_loader(loader, &header_value(image, &1))
-    else
+    case header_value(image, "vips-loader") do
+      {:ok, loader} -> classify_loader(loader, &header_value(image, &1))
       :error -> unsupported(:unknown)
     end
   end

--- a/lib/image_pipe/response/sender.ex
+++ b/lib/image_pipe/response/sender.ex
@@ -427,14 +427,16 @@ defmodule ImagePipe.Response.Sender do
     Enum.reduce(new_headers, headers, fn {name, value}, headers ->
       name = String.downcase(name)
 
-      if Enum.any?(headers, fn {existing_name, _value} ->
-           String.downcase(existing_name) == name
-         end) do
+      if header_present?(headers, name) do
         headers
       else
         headers ++ [{name, value}]
       end
     end)
+  end
+
+  defp header_present?(headers, name) do
+    Enum.any?(headers, fn {existing_name, _value} -> String.downcase(existing_name) == name end)
   end
 
   defp merge_authoritative_header_list(headers, new_headers) do

--- a/lib/image_pipe/source.ex
+++ b/lib/image_pipe/source.ex
@@ -14,9 +14,9 @@ defmodule ImagePipe.Source do
       S3
     ]
 
+  alias ImagePipe.Error
   alias ImagePipe.Plan.Source, as: PlanSource
   alias ImagePipe.Plan.Source.Identity
-  alias ImagePipe.Error
   alias ImagePipe.Source.CacheSemantics
   alias ImagePipe.Source.Resolved
   alias ImagePipe.Source.Response
@@ -61,15 +61,17 @@ defmodule ImagePipe.Source do
       telemetry_opts = Telemetry.telemetry_opts(runtime_opts)
 
       Telemetry.span(telemetry_opts, [:source, :resolve], source_metadata, fn ->
-        result =
-          case module.resolve(source, adapter_opts, runtime_opts) do
-            {:ok, %Resolved{} = resolved} -> validate_resolved(resolved, adapter)
-            {:error, {:source, _reason}} = error -> error
-            _other -> {:error, {:source, :invalid_adapter_result}}
-          end
-
+        result = run_resolve(module, source, adapter_opts, runtime_opts, adapter)
         {result, result_metadata(result)}
       end)
+    end
+  end
+
+  defp run_resolve(module, source, adapter_opts, runtime_opts, adapter) do
+    case module.resolve(source, adapter_opts, runtime_opts) do
+      {:ok, %Resolved{} = resolved} -> validate_resolved(resolved, adapter)
+      {:error, {:source, _reason}} = error -> error
+      _other -> {:error, {:source, :invalid_adapter_result}}
     end
   end
 
@@ -81,15 +83,17 @@ defmodule ImagePipe.Source do
       telemetry_opts = Telemetry.telemetry_opts(runtime_opts)
 
       Telemetry.span(telemetry_opts, [:source, :fetch], source_metadata, fn ->
-        result =
-          case module.fetch(resolved, adapter_opts, runtime_opts) do
-            {:ok, %Response{} = response} -> wrap_response(response, runtime_opts)
-            {:error, {:source, _reason}} = error -> error
-            _other -> {:error, {:source, :invalid_adapter_result}}
-          end
-
+        result = run_fetch(module, resolved, adapter_opts, runtime_opts)
         {result, result_metadata(result)}
       end)
+    end
+  end
+
+  defp run_fetch(module, resolved, adapter_opts, runtime_opts) do
+    case module.fetch(resolved, adapter_opts, runtime_opts) do
+      {:ok, %Response{} = response} -> wrap_response(response, runtime_opts)
+      {:error, {:source, _reason}} = error -> error
+      _other -> {:error, {:source, :invalid_adapter_result}}
     end
   end
 

--- a/lib/image_pipe/source/http.ex
+++ b/lib/image_pipe/source/http.ex
@@ -155,9 +155,9 @@ defmodule ImagePipe.Source.HTTP do
 
   defp build_url(%URL{} = source) do
     path =
-      source.path
-      |> Enum.map(fn segment -> URI.encode(segment, &URI.char_unreserved?/1) end)
-      |> Enum.join("/")
+      Enum.map_join(source.path, "/", fn segment ->
+        URI.encode(segment, &URI.char_unreserved?/1)
+      end)
 
     path = "/" <> path
     port = source.port || Map.fetch!(@default_ports, source.scheme)

--- a/lib/image_pipe/source/s3.ex
+++ b/lib/image_pipe/source/s3.ex
@@ -154,20 +154,11 @@ defmodule ImagePipe.Source.S3 do
   end
 
   defp validate_buckets(buckets, default) when is_map(buckets) do
-    buckets
-    |> Enum.reduce_while({:ok, %{}}, fn
+    Enum.reduce_while(buckets, {:ok, %{}}, fn
       {bucket, opts}, {:ok, acc} when is_binary(bucket) and bucket != "" and is_list(opts) ->
-        merged = Keyword.merge(default, opts)
-
-        case validate_config(merged) do
-          {:ok, config} ->
-            case require_credentials(config) do
-              :ok -> {:cont, {:ok, Map.put(acc, bucket, config)}}
-              {:error, reason} -> {:halt, {:error, reason}}
-            end
-
-          {:error, reason} ->
-            {:halt, {:error, reason}}
+        case validate_bucket(default, opts) do
+          {:ok, config} -> {:cont, {:ok, Map.put(acc, bucket, config)}}
+          {:error, reason} -> {:halt, {:error, reason}}
         end
 
       _entry, _acc ->
@@ -177,6 +168,15 @@ defmodule ImagePipe.Source.S3 do
 
   defp validate_buckets(_buckets, _default),
     do: {:error, {:invalid_source_config, :invalid_bucket_config}}
+
+  defp validate_bucket(default, opts) do
+    merged = Keyword.merge(default, opts)
+
+    with {:ok, config} <- validate_config(merged),
+         :ok <- require_credentials(config) do
+      {:ok, config}
+    end
+  end
 
   defp validate_config(opts) do
     case NimbleOptions.validate(opts, @config_schema) do

--- a/lib/image_pipe/source/s3/credentials.ex
+++ b/lib/image_pipe/source/s3/credentials.ex
@@ -5,9 +5,8 @@ defmodule ImagePipe.Source.S3.Credentials do
 
   @spec validate(term()) :: {:ok, term()} | {:error, {:invalid_source_config, term()}}
   def validate({:static, opts}) when is_list(opts) do
-    with {:ok, credentials} <- normalize(opts) do
-      {:ok, {:static, credentials}}
-    else
+    case normalize(opts) do
+      {:ok, credentials} -> {:ok, {:static, credentials}}
       {:error, reason} -> {:error, {:invalid_source_config, reason}}
     end
   end

--- a/lib/image_pipe/source/wrapped_stream.ex
+++ b/lib/image_pipe/source/wrapped_stream.ex
@@ -111,11 +111,7 @@ defimpl Enumerable, for: ImagePipe.Source.WrappedStream do
     fn chunk, {size, acc} ->
       with {:ok, binary} <- validate_chunk(chunk),
            {:ok, new_size} <- add_size(size, binary, max_body_bytes) do
-        case call_consumer(fun, binary, acc, consumer_failure_ref) do
-          {:cont, acc} -> {:cont, {new_size, acc}}
-          {:halt, acc} -> {:halt, {new_size, acc}}
-          {:suspend, acc} -> {:suspend, {new_size, acc}}
-        end
+        advance_consumer(fun, binary, acc, new_size, consumer_failure_ref)
       else
         {:error, :body_too_large} ->
           WrappedStream.mark_body_limit_exceeded(wrapped)
@@ -126,6 +122,14 @@ defimpl Enumerable, for: ImagePipe.Source.WrappedStream do
           WrappedStream.mark_stream_error(wrapped, reason)
           raise StreamError, reason: reason
       end
+    end
+  end
+
+  defp advance_consumer(fun, binary, acc, new_size, consumer_failure_ref) do
+    case call_consumer(fun, binary, acc, consumer_failure_ref) do
+      {:cont, acc} -> {:cont, {new_size, acc}}
+      {:halt, acc} -> {:halt, {new_size, acc}}
+      {:suspend, acc} -> {:suspend, {new_size, acc}}
     end
   end
 

--- a/lib/image_pipe/transform/operation/resize.ex
+++ b/lib/image_pipe/transform/operation/resize.ex
@@ -109,15 +109,13 @@ defmodule ImagePipe.Transform.Operation.Resize do
     source_width = image_width(state)
     source_height = image_height(state)
 
-    cond do
-      width == source_width and height == source_height ->
-        {:ok, state.image}
+    if width == source_width and height == source_height do
+      {:ok, state.image}
+    else
+      width_scale = width / source_width
+      height_scale = height / source_height
 
-      true ->
-        width_scale = width / source_width
-        height_scale = height / source_height
-
-        Image.resize(state.image, width_scale, vertical_scale: height_scale)
+      Image.resize(state.image, width_scale, vertical_scale: height_scale)
     end
   end
 

--- a/lib/mix/tasks/image_pipe.server.ex
+++ b/lib/mix/tasks/image_pipe.server.ex
@@ -140,7 +140,7 @@ defmodule Mix.Tasks.ImagePipe.Server do
   defp start_bandit(port) do
     with {:module, Bandit} <- Code.ensure_loaded(Bandit),
          {:module, ImagePipe.SimpleServer} <- Code.ensure_loaded(ImagePipe.SimpleServer) do
-      apply(Bandit, :start_link, [[plug: ImagePipe.SimpleServer, port: port]])
+      Bandit.start_link(plug: ImagePipe.SimpleServer, port: port)
     else
       _missing -> Mix.raise("ImagePipe simple server is only available in dev and test")
     end

--- a/test/image_pipe/cache/file_system_bounded_test.exs
+++ b/test/image_pipe/cache/file_system_bounded_test.exs
@@ -115,14 +115,16 @@ defmodule ImagePipe.Cache.FileSystemBoundedTest do
   defp walk_files(path) do
     case File.ls(path) do
       {:ok, entries} ->
-        Enum.flat_map(entries, fn entry ->
-          child = Path.join(path, entry)
-          if File.dir?(child), do: walk_files(child), else: [child]
-        end)
+        Enum.flat_map(entries, &walk_entry(path, &1))
 
       {:error, _} ->
         []
     end
+  end
+
+  defp walk_entry(path, entry) do
+    child = Path.join(path, entry)
+    if File.dir?(child), do: walk_files(child), else: [child]
   end
 
   setup context do

--- a/test/image_pipe/cache/key_test.exs
+++ b/test/image_pipe/cache/key_test.exs
@@ -5,8 +5,8 @@ defmodule ImagePipe.Cache.KeyTest do
   import Plug.Test
 
   alias ImagePipe.Cache.Key
-  alias ImagePipe.Parser.Imgproxy
   alias ImagePipe.Cache.KeyTest.ForwardingProbe
+  alias ImagePipe.Parser.Imgproxy
   alias ImagePipe.Plan
   alias ImagePipe.Plan.Operation
   alias ImagePipe.Plan.Output

--- a/test/image_pipe/plan_test.exs
+++ b/test/image_pipe/plan_test.exs
@@ -3,13 +3,13 @@ defmodule ImagePipe.PlanTest do
 
   alias ImagePipe.Plan
   alias ImagePipe.Plan.Operation
+  alias ImagePipe.Plan.Operation.AutoOrient
+  alias ImagePipe.Plan.Operation.Flip
+  alias ImagePipe.Plan.Operation.Rotate
   alias ImagePipe.Plan.Output
   alias ImagePipe.Plan.Pipeline
   alias ImagePipe.Plan.Response
   alias ImagePipe.Plan.Source
-  alias ImagePipe.Plan.Operation.AutoOrient
-  alias ImagePipe.Plan.Operation.Flip
-  alias ImagePipe.Plan.Operation.Rotate
 
   test "validated pipelines accept semantic operation structs" do
     operation = resize_operation()

--- a/test/image_pipe/plug_test.exs
+++ b/test/image_pipe/plug_test.exs
@@ -9,15 +9,16 @@ defmodule ImagePipe.PlugTest do
 
   @slow_origin_first_chunk_timeout 5_000
 
+  alias ImagePipe.Parser.Imgproxy.Presets
   alias ImagePipe.Parser.Imgproxy.Signature
-  alias ImagePipe.PlugTest.ConsumeLargeSourceImage
-  alias ImagePipe.PlugTest.ConsumeSourceThenDecodeErrorImage
-  alias ImagePipe.PlugTest.LargeBodyOrigin
   alias ImagePipe.Plan
   alias ImagePipe.Plan.Operation
   alias ImagePipe.Plan.Output
   alias ImagePipe.Plan.Pipeline
   alias ImagePipe.Plan.Source.Path, as: SourcePath
+  alias ImagePipe.PlugTest.ConsumeLargeSourceImage
+  alias ImagePipe.PlugTest.ConsumeSourceThenDecodeErrorImage
+  alias ImagePipe.PlugTest.LargeBodyOrigin
   alias ImagePipe.SourceTest.RootHTTPAdapter
 
   defmodule CacheProbe do
@@ -627,19 +628,19 @@ defmodule ImagePipe.PlugTest do
     imgproxy = Keyword.fetch!(opts, :imgproxy)
 
     assert %Signature{mode: :disabled} = Keyword.fetch!(imgproxy, :signature)
-    assert %ImagePipe.Parser.Imgproxy.Presets{} = presets = Keyword.fetch!(imgproxy, :presets)
+    assert %Presets{} = presets = Keyword.fetch!(imgproxy, :presets)
 
     assert {:ok, [["rt:fill", "el:1"]]} =
-             ImagePipe.Parser.Imgproxy.Presets.fetch(presets, "default")
+             Presets.fetch(presets, "default")
 
     assert {:ok, [["rs:fit:120:120"]]} =
-             ImagePipe.Parser.Imgproxy.Presets.fetch(presets, "thumb")
+             Presets.fetch(presets, "thumb")
 
     assert {:ok, [["w:900"], ["w:450"]]} =
-             ImagePipe.Parser.Imgproxy.Presets.fetch(presets, "responsive")
+             Presets.fetch(presets, "responsive")
 
     assert {:ok, [["watermark:0.5"]]} =
-             ImagePipe.Parser.Imgproxy.Presets.fetch(presets, "future")
+             Presets.fetch(presets, "future")
   end
 
   test "init rejects malformed imgproxy presets before requests" do
@@ -655,7 +656,7 @@ defmodule ImagePipe.PlugTest do
       [presets: %{"thumb" => "pr: other"}],
       [presets: %{"thumb" => "pr:other "}],
       [presets: %{"thumb" => "w:100//h:100"}],
-      [presets: %ImagePipe.Parser.Imgproxy.Presets{definitions: %{"thumb" => [["w:100"]]}}]
+      [presets: %Presets{definitions: %{"thumb" => [["w:100"]]}}]
     ]
 
     for imgproxy <- invalid_configs do

--- a/test/image_pipe/request/http_cache_test.exs
+++ b/test/image_pipe/request/http_cache_test.exs
@@ -6,6 +6,7 @@ defmodule ImagePipe.Request.HTTPCacheTest do
   import Plug.Test
   import StreamData
 
+  alias ImagePipe.Cache.Key
   alias ImagePipe.Plan
   alias ImagePipe.Plan.Output
   alias ImagePipe.Plan.Pipeline
@@ -254,10 +255,10 @@ defmodule ImagePipe.Request.HTTPCacheTest do
     plug_conn = conn(:get, "/image")
 
     assert {:ok, base_key} =
-             ImagePipe.Cache.Key.build(plug_conn, base_plan, resolved().identity, opts())
+             Key.build(plug_conn, base_plan, resolved().identity, opts())
 
     assert {:ok, busted_key} =
-             ImagePipe.Cache.Key.build(plug_conn, busted_plan, resolved().identity, opts())
+             Key.build(plug_conn, busted_plan, resolved().identity, opts())
 
     assert base_key.data[:cache] != busted_key.data[:cache]
 
@@ -313,7 +314,7 @@ defmodule ImagePipe.Request.HTTPCacheTest do
     assert {:ok, material} = HTTPCache.etag_material(conn(:get, "/image"), plan(), seed, opts())
 
     assert material[:plan][:representation] == [
-             version: ImagePipe.Cache.Key.representation_version()
+             version: Key.representation_version()
            ]
   end
 

--- a/test/image_pipe/request/source_session_test.exs
+++ b/test/image_pipe/request/source_session_test.exs
@@ -264,8 +264,8 @@ defmodule ImagePipe.Request.SourceSessionTest do
   defmodule StreamFetchAdapter do
     @behaviour ImagePipe.Source
 
-    alias ImagePipe.Source.Response
     alias ImagePipe.Source.Resolved
+    alias ImagePipe.Source.Response
 
     @impl ImagePipe.Source
     def validate_options(opts), do: {:ok, opts}

--- a/test/image_pipe/request_runner_test.exs
+++ b/test/image_pipe/request_runner_test.exs
@@ -16,6 +16,7 @@ defmodule ImagePipe.Request.RunnerTest do
   alias ImagePipe.Request.SourceSessionSupervisor
   alias ImagePipe.Response.CacheHeaders
   alias ImagePipe.Response.PreparedStream
+  alias ImagePipe.Response.Sender
   alias ImagePipe.Source.CacheSemantics
   alias ImagePipe.Source.Resolved, as: SourceResolved
   alias ImagePipe.Source.Response, as: SourceResponse
@@ -971,7 +972,7 @@ defmodule ImagePipe.Request.RunnerTest do
     assert_supervisor_active(supervisor)
 
     conn =
-      ImagePipe.Response.Sender.send_result(
+      Sender.send_result(
         conn(:get, "/image"),
         {:ok, {:prepared_stream, prepared, response, empty_cache_headers()}},
         []
@@ -1031,7 +1032,7 @@ defmodule ImagePipe.Request.RunnerTest do
       :get
       |> conn("/image")
       |> Map.put(:adapter, {ClosingAfterFirstChunkAdapter, %{chunks: nil}})
-      |> ImagePipe.Response.Sender.send_result(
+      |> Sender.send_result(
         {:ok, {:prepared_stream, prepared, response, empty_cache_headers()}},
         []
       )
@@ -1062,7 +1063,7 @@ defmodule ImagePipe.Request.RunnerTest do
       :get
       |> conn("/image")
       |> Map.put(:adapter, {FailingChunkedAdapter, %{}})
-      |> ImagePipe.Response.Sender.send_result(
+      |> Sender.send_result(
         {:ok, {:prepared_stream, prepared, response, empty_cache_headers()}},
         []
       )
@@ -1093,7 +1094,7 @@ defmodule ImagePipe.Request.RunnerTest do
       :get
       |> conn("/image")
       |> Map.put(:adapter, {FirstChunkClosedAdapter, %{}})
-      |> ImagePipe.Response.Sender.send_result(
+      |> Sender.send_result(
         {:ok, {:prepared_stream, prepared, response, empty_cache_headers()}},
         []
       )
@@ -1123,7 +1124,7 @@ defmodule ImagePipe.Request.RunnerTest do
              )
 
     conn =
-      ImagePipe.Response.Sender.send_result(
+      Sender.send_result(
         conn(:get, "/image"),
         {:ok, {:prepared_stream, prepared, response, empty_cache_headers()}},
         []

--- a/test/parser/imgproxy/plan_builder_test.exs
+++ b/test/parser/imgproxy/plan_builder_test.exs
@@ -9,13 +9,13 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilderTest do
   alias ImagePipe.Parser.Imgproxy.PlanBuilder
   alias ImagePipe.Plan
   alias ImagePipe.Plan.Operation
+  alias ImagePipe.Plan.Operation.AutoOrient
+  alias ImagePipe.Plan.Operation.Flip
+  alias ImagePipe.Plan.Operation.Rotate
   alias ImagePipe.Plan.Output
   alias ImagePipe.Plan.Pipeline
   alias ImagePipe.Plan.Response
   alias ImagePipe.Plan.Source
-  alias ImagePipe.Plan.Operation.AutoOrient
-  alias ImagePipe.Plan.Operation.Flip
-  alias ImagePipe.Plan.Operation.Rotate
 
   test "converts one imgproxy pipeline request into a product-neutral plan" do
     request = %ParsedRequest{

--- a/test/parser/imgproxy_test.exs
+++ b/test/parser/imgproxy_test.exs
@@ -7,11 +7,11 @@ defmodule ImagePipe.Parser.ImgproxyTest do
   alias ImagePipe.Parser.Imgproxy
   alias ImagePipe.Plan
   alias ImagePipe.Plan.Operation
+  alias ImagePipe.Plan.Operation.AutoOrient
   alias ImagePipe.Plan.Output
   alias ImagePipe.Plan.Pipeline
   alias ImagePipe.Plan.Response
   alias ImagePipe.Plan.Source
-  alias ImagePipe.Plan.Operation.AutoOrient
 
   defmodule FoobarTranslator do
     @behaviour ImagePipe.Parser.Imgproxy.SourceScheme

--- a/test/support/image_pipe/cache/key_test/forwarding_probe.ex
+++ b/test/support/image_pipe/cache/key_test/forwarding_probe.ex
@@ -1,4 +1,5 @@
 defmodule ImagePipe.Cache.KeyTest.ForwardingProbe do
+  @moduledoc false
   @behaviour ImagePipe.Cache
 
   def get(_key, _opts), do: :miss

--- a/test/support/image_pipe/plug_test/consume_large_source_image.ex
+++ b/test/support/image_pipe/plug_test/consume_large_source_image.ex
@@ -1,4 +1,5 @@
 defmodule ImagePipe.PlugTest.ConsumeLargeSourceImage do
+  @moduledoc false
   def open(stream, decode_options) do
     _chunks = Enum.to_list(stream)
 

--- a/test/support/image_pipe/plug_test/consume_source_then_decode_error_image.ex
+++ b/test/support/image_pipe/plug_test/consume_source_then_decode_error_image.ex
@@ -1,4 +1,5 @@
 defmodule ImagePipe.PlugTest.ConsumeSourceThenDecodeErrorImage do
+  @moduledoc false
   def open(stream, _decode_options) do
     _chunks = Enum.to_list(stream)
     {:error, :forced_decode_error}

--- a/test/support/image_pipe/plug_test/large_body_origin.ex
+++ b/test/support/image_pipe/plug_test/large_body_origin.ex
@@ -1,4 +1,5 @@
 defmodule ImagePipe.PlugTest.LargeBodyOrigin do
+  @moduledoc false
   def call(conn, _opts) do
     body = :binary.copy("a", 10_000_001)
 

--- a/test/support/image_pipe/source_test/root_http_adapter.ex
+++ b/test/support/image_pipe/source_test/root_http_adapter.ex
@@ -55,9 +55,9 @@ defmodule ImagePipe.SourceTest.RootHTTPAdapter do
 
   defp build_url(root_url, segments) do
     path =
-      segments
-      |> Enum.map(fn segment -> URI.encode(segment, &URI.char_unreserved?/1) end)
-      |> Enum.join("/")
+      Enum.map_join(segments, "/", fn segment ->
+        URI.encode(segment, &URI.char_unreserved?/1)
+      end)
 
     root_url = String.trim_trailing(root_url, "/")
     root_url <> "/" <> path


### PR DESCRIPTION
## Summary

Clears all 58 `mix credo --strict` findings that had accumulated against credo's default ruleset (the project has no `.credo.exs`). All changes are behavior-preserving.

**Mechanical fixes (44)**
- **AliasOrder (8)** — reordered alias groups alphabetically.
- **AliasUsage (18)** — aliased repeatedly fully-qualified nested modules (`Plug.Conn.Utils`, `Color.SRGB`, `Cache.FileSystem`, `Cache.Key`, `Response.Sender`, `Imgproxy.Presets`).
- **ModuleDoc (4)** — `@moduledoc false` on test support modules.
- **MapJoin / Apply / PreferImplicitTry / CondStatements / RedundantWithClauseResult / WithSingleClause** — straightforward idiom swaps.

**Nesting (14)**
- Extracted helper functions to keep bodies at max depth 2 across the plug, source, cache (filesystem + admission), imgproxy parser, and a couple of tests. Kept `handle_call`/`validate_buckets` clauses contiguous to avoid grouping warnings.

**StructFieldAmount (2)**
- `Imgproxy.PipelineRequest` (34 fields) and `Admission.State` (34 fields) are deliberately flat aggregations (a URL-option accumulator and GenServer state). Splitting them into sub-structs purely for a field count would be artificial and ripple through every accessor, so each is marked with a targeted `# credo:disable-for-next-line` plus a justifying comment — keeping the project on default credo config.

## Verification

`mise run precommit` is green:
- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix credo --strict` → **found no issues**
- `mix test` → 1 doctest, 34 properties, 1094 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)