### PR TITLE
imgproxy metadata & color-profile controls (sm/kcr/scp) (#30)

### DIFF
--- a/demo/src/App.svelte
+++ b/demo/src/App.svelte
@@ -136,6 +136,7 @@
     ? `bg:${state.backgroundColor.replace(/^#/, "")}${backgroundOpacitySummary(state.backgroundAlpha)}`
     : "Off";
   $: effectsSummary = effectSegments(state).join("/") || "Off";
+  $: metadataSummary = metadataSegments(state).join("/") || "On";
   $: cropSummary = state.cropEnabled ? (cropOptionSegment(state) ?? "Off") : "Off";
   $: cropAspectRatioSummary = state.cropAspectRatioEnabled
     ? state.cropAspectRatioEnlarge
@@ -204,6 +205,22 @@
     }
 
     return `/bga:${alpha}`;
+  }
+
+  function metadataSegments(currentState: DemoState): string[] {
+    const segs: string[] = [];
+
+    if (!currentState.stripMetadata) {
+      segs.push("sm:0");
+    } else if (!currentState.keepCopyright) {
+      segs.push("kcr:0");
+    }
+
+    if (!currentState.stripColorProfile) {
+      segs.push("scp:0");
+    }
+
+    return segs;
   }
 
   function effectSegments(currentState: DemoState): string[] {
@@ -482,6 +499,14 @@
 
   function setThemeMode(nextMode: string): void {
     themeMode = storedThemeMode(nextMode);
+  }
+
+  function updateStripMetadata(checked: boolean): void {
+    state.stripMetadata = checked;
+
+    if (!checked) {
+      state.keepCopyright = false;
+    }
   }
 
   function resetSettings(): void {
@@ -1279,6 +1304,44 @@
           />
         {/if}
       </section>
+
+      <section class="tool-section">
+        <div class="accordion-heading">
+          <div>
+            <h2>Metadata &amp; color</h2>
+            <p>{metadataSummary}</p>
+          </div>
+        </div>
+
+        <label class="switch-field">
+          <Switch.Root
+            class="switch-root"
+            checked={state.stripMetadata}
+            onCheckedChange={updateStripMetadata}
+          >
+            <Switch.Thumb class="switch-thumb" />
+          </Switch.Root>
+          <span>Strip metadata (sm)</span>
+        </label>
+
+        <label class="switch-field">
+          <Switch.Root
+            class="switch-root"
+            bind:checked={state.keepCopyright}
+            disabled={!state.stripMetadata}
+          >
+            <Switch.Thumb class="switch-thumb" />
+          </Switch.Root>
+          <span class:muted-label={!state.stripMetadata}>Keep copyright (kcr)</span>
+        </label>
+
+        <label class="switch-field">
+          <Switch.Root class="switch-root" bind:checked={state.stripColorProfile}>
+            <Switch.Thumb class="switch-thumb" />
+          </Switch.Root>
+          <span>Strip color profile (scp)</span>
+        </label>
+      </section>
     </div>
 
     <div class="drawer-actions">
@@ -1960,6 +2023,10 @@
     display: flex;
     align-items: center;
     gap: 10px;
+  }
+
+  .muted-label {
+    color: var(--text-muted);
   }
 
   .fiddle-shell :global(.switch-root) {

--- a/demo/src/demo-url-state.ts
+++ b/demo/src/demo-url-state.ts
@@ -791,9 +791,12 @@ function parseKeepCopyright(currentState: DemoState, args: string[]): DemoState 
     return null;
   }
 
+  // keep_copyright is only meaningful when metadata is being stripped; clamp it
+  // to false otherwise so the parsed state matches the backend normalization,
+  // regardless of segment order (e.g. "sm:0/kcr:1").
   return {
     ...currentState,
-    keepCopyright: value,
+    keepCopyright: currentState.stripMetadata ? value : false,
   };
 }
 

--- a/demo/src/demo-url-state.ts
+++ b/demo/src/demo-url-state.ts
@@ -261,6 +261,15 @@ function applyOptionSegment(currentState: DemoState, segment: string): DemoState
     case "q":
       return parseQuality(currentState, args);
 
+    case "sm":
+      return parseStripMetadata(currentState, args);
+
+    case "kcr":
+      return parseKeepCopyright(currentState, args);
+
+    case "scp":
+      return parseStripColorProfile(currentState, args);
+
     default:
       return null;
   }
@@ -751,6 +760,70 @@ function parseQuality(currentState: DemoState, args: string[]): DemoState | null
     qualityEnabled: true,
     quality,
   };
+}
+
+function parseStripMetadata(currentState: DemoState, args: string[]): DemoState | null {
+  if (args.length !== 1) {
+    return null;
+  }
+
+  const value = parseBooleanValue(args[0]);
+
+  if (value === null) {
+    return null;
+  }
+
+  return {
+    ...currentState,
+    stripMetadata: value,
+    keepCopyright: value ? currentState.keepCopyright : false,
+  };
+}
+
+function parseKeepCopyright(currentState: DemoState, args: string[]): DemoState | null {
+  if (args.length !== 1) {
+    return null;
+  }
+
+  const value = parseBooleanValue(args[0]);
+
+  if (value === null) {
+    return null;
+  }
+
+  return {
+    ...currentState,
+    keepCopyright: value,
+  };
+}
+
+function parseStripColorProfile(currentState: DemoState, args: string[]): DemoState | null {
+  if (args.length !== 1) {
+    return null;
+  }
+
+  const value = parseBooleanValue(args[0]);
+
+  if (value === null) {
+    return null;
+  }
+
+  return {
+    ...currentState,
+    stripColorProfile: value,
+  };
+}
+
+function parseBooleanValue(value: string | undefined): boolean | null {
+  if (value === "1" || value === "t" || value === "true") {
+    return true;
+  }
+
+  if (value === "0" || value === "f" || value === "false") {
+    return false;
+  }
+
+  return null;
 }
 
 function isGravity(value: string): value is Gravity {

--- a/demo/src/processing-path.test.ts
+++ b/demo/src/processing-path.test.ts
@@ -967,6 +967,102 @@ describe("demo URL state", () => {
     );
   });
 
+  it("emits nothing for default metadata and color-profile state (all true)", () => {
+    expect(optionSegments(defaultDemoState)).toEqual([]);
+  });
+
+  it("emits sm:0 when stripMetadata is false", () => {
+    const state = { ...defaultDemoState, stripMetadata: false, keepCopyright: false };
+
+    expect(optionSegments(state)).toContain("sm:0");
+    expect(optionSegments(state)).not.toContain("kcr:0");
+  });
+
+  it("emits kcr:0 when stripMetadata is true but keepCopyright is false", () => {
+    const state = { ...defaultDemoState, stripMetadata: true, keepCopyright: false };
+
+    expect(optionSegments(state)).toContain("kcr:0");
+    expect(optionSegments(state)).not.toContain("sm:0");
+  });
+
+  it("does not emit kcr when stripMetadata is false (canonical omission)", () => {
+    const state = { ...defaultDemoState, stripMetadata: false, keepCopyright: true };
+
+    const segments = optionSegments(state);
+
+    expect(segments).toContain("sm:0");
+    expect(segments).not.toContain("kcr:0");
+    expect(segments).not.toContain("kcr:1");
+  });
+
+  it("emits scp:0 when stripColorProfile is false", () => {
+    const state = { ...defaultDemoState, stripColorProfile: false };
+
+    expect(optionSegments(state)).toContain("scp:0");
+  });
+
+  it("round-trips sm:0 through parse and emit", () => {
+    const parsed = parseDemoPath("/demo/sm:0/plain/local:///images/dog.jpg");
+
+    expect(parsed).toMatchObject({ stripMetadata: false, keepCopyright: false });
+    expect(optionSegments(parsed)).toContain("sm:0");
+    expect(optionSegments(parsed)).not.toContain("kcr:0");
+  });
+
+  it("round-trips kcr:0 through parse and emit", () => {
+    const parsed = parseDemoPath("/demo/kcr:0/plain/local:///images/dog.jpg");
+
+    expect(parsed).toMatchObject({ stripMetadata: true, keepCopyright: false });
+    expect(optionSegments(parsed)).toContain("kcr:0");
+    expect(optionSegments(parsed)).not.toContain("sm:0");
+  });
+
+  it("round-trips scp:0 through parse and emit", () => {
+    const parsed = parseDemoPath("/demo/scp:0/plain/local:///images/dog.jpg");
+
+    expect(parsed).toMatchObject({ stripColorProfile: false });
+    expect(optionSegments(parsed)).toContain("scp:0");
+  });
+
+  it("normalizes keepCopyright to false when sm:0 is parsed without kcr", () => {
+    const parsedSmOnly = parseDemoPath("/demo/sm:0/plain/local:///images/dog.jpg");
+
+    expect(parsedSmOnly).toMatchObject({ stripMetadata: false, keepCopyright: false });
+  });
+
+  it("accepts boolean aliases for sm, kcr, and scp", () => {
+    expect(parseDemoPath("/demo/sm:1/plain/local:///images/dog.jpg")).toMatchObject({
+      stripMetadata: true,
+    });
+    expect(parseDemoPath("/demo/sm:t/plain/local:///images/dog.jpg")).toMatchObject({
+      stripMetadata: true,
+    });
+    expect(parseDemoPath("/demo/sm:true/plain/local:///images/dog.jpg")).toMatchObject({
+      stripMetadata: true,
+    });
+    expect(parseDemoPath("/demo/sm:f/plain/local:///images/dog.jpg")).toMatchObject({
+      stripMetadata: false,
+    });
+    expect(parseDemoPath("/demo/sm:false/plain/local:///images/dog.jpg")).toMatchObject({
+      stripMetadata: false,
+    });
+    expect(parseDemoPath("/demo/kcr:0/plain/local:///images/dog.jpg")).toMatchObject({
+      keepCopyright: false,
+    });
+    expect(parseDemoPath("/demo/scp:f/plain/local:///images/dog.jpg")).toMatchObject({
+      stripColorProfile: false,
+    });
+  });
+
+  it("rejects invalid sm/kcr/scp values in demo routes", () => {
+    expect(parseDemoPath("/demo/sm:yes/plain/local:///images/dog.jpg")).toEqual(defaultDemoState);
+    expect(parseDemoPath("/demo/kcr:2/plain/local:///images/dog.jpg")).toEqual(defaultDemoState);
+    expect(parseDemoPath("/demo/scp:/plain/local:///images/dog.jpg")).toEqual(defaultDemoState);
+    expect(parseDemoPath("/demo/sm:0:extra/plain/local:///images/dog.jpg")).toEqual(
+      defaultDemoState,
+    );
+  });
+
   it("resets processing options while keeping source and signature settings", () => {
     const reset = resetDemoSettings({
       ...defaultDemoState,

--- a/demo/src/processing-path.test.ts
+++ b/demo/src/processing-path.test.ts
@@ -1030,6 +1030,14 @@ describe("demo URL state", () => {
     expect(parsedSmOnly).toMatchObject({ stripMetadata: false, keepCopyright: false });
   });
 
+  it("normalizes keepCopyright to false regardless of sm/kcr segment order", () => {
+    const kcrThenSm = parseDemoPath("/demo/kcr:1/sm:0/plain/local:///images/dog.jpg");
+    const smThenKcr = parseDemoPath("/demo/sm:0/kcr:1/plain/local:///images/dog.jpg");
+
+    expect(kcrThenSm).toMatchObject({ stripMetadata: false, keepCopyright: false });
+    expect(smThenKcr).toMatchObject({ stripMetadata: false, keepCopyright: false });
+  });
+
   it("accepts boolean aliases for sm, kcr, and scp", () => {
     expect(parseDemoPath("/demo/sm:1/plain/local:///images/dog.jpg")).toMatchObject({
       stripMetadata: true,

--- a/demo/src/processing-path.ts
+++ b/demo/src/processing-path.ts
@@ -87,6 +87,9 @@ export type DemoState = {
   format: OutputFormat;
   qualityEnabled: boolean;
   quality: number;
+  stripMetadata: boolean;
+  keepCopyright: boolean;
+  stripColorProfile: boolean;
 };
 
 export type ProcessedImageMetadata = {
@@ -271,6 +274,9 @@ export const defaultDemoState: DemoState = {
   format: "jpeg",
   qualityEnabled: false,
   quality: 85,
+  stripMetadata: true,
+  keepCopyright: true,
+  stripColorProfile: true,
 };
 
 export function optionSegments(currentState: DemoState): string[] {
@@ -413,6 +419,16 @@ export function optionSegments(currentState: DemoState): string[] {
 
   if (currentState.qualityEnabled) {
     segments.push(`q:${currentState.quality}`);
+  }
+
+  if (!currentState.stripMetadata) {
+    segments.push("sm:0");
+  } else if (!currentState.keepCopyright) {
+    segments.push("kcr:0");
+  }
+
+  if (!currentState.stripColorProfile) {
+    segments.push("scp:0");
   }
 
   return segments;

--- a/docs/imgproxy_support_matrix.md
+++ b/docs/imgproxy_support_matrix.md
@@ -278,9 +278,10 @@ XL output.
 ### Metadata, color profile, HDR, and default autorotation policy
 
 ImagePipe supports URL `auto_rotate` and the matching parser config default:
-`imgproxy: [auto_rotate: true]`, which is also the default. Global metadata
-stripping, profile handling, HDR preservation, and thumbnail-source selection
-aren't configurable.
+`imgproxy: [auto_rotate: true]`, which is also the default. URL `strip_metadata`,
+`keep_copyright`, and `strip_color_profile` are supported with parser-owned
+defaults and per-request URL overrides. HDR preservation and thumbnail-source
+selection aren't configurable.
 
 URL `auto_rotate`/`ar` resolves as request-scoped EXIF decode policy. If the URL
 contains more than one `ar`, the last value in path order wins. When the
@@ -288,10 +289,10 @@ resolved policy is `true`, ImagePipe represents it as one `AutoOrient` operation
 at the start of the first produced pipeline. Cache keys, ETags, and transform
 execution then use the normal canonical plan machinery.
 
-- ⭕ `IMGPROXY_STRIP_METADATA`
-- ⭕ `IMGPROXY_KEEP_COPYRIGHT`
+- ✅ `IMGPROXY_STRIP_METADATA` — Parser config default: `imgproxy: [strip_metadata: true]`. URL override: `sm:0` disables. Strips EXIF, XMP, and IPTC at encode time via `ImagePipe.Plan.Output` metadata policy.
+- ✅ `IMGPROXY_KEEP_COPYRIGHT` — Parser config default: `imgproxy: [keep_copyright: true]`. URL override: `kcr:0` disables. **Diverges from imgproxy**: preserves EXIF copyright/artist fields only; imgproxy retains full XMP/IPTC blobs. ImagePipe strips XMP/IPTC even when `kcr` is on (privacy-conservative).
 - ⭕ `IMGPROXY_STRIP_METADATA_DPI`
-- ⭕ `IMGPROXY_STRIP_COLOR_PROFILE`
+- ✅ `IMGPROXY_STRIP_COLOR_PROFILE` — Parser config default: `imgproxy: [strip_color_profile: true]`. URL override: `scp:0` disables. Implemented as a `NormalizeColorProfile` transform operation (ICC-aware sRGB conversion) positioned after geometry and before effects; the embedded profile header is dropped at encode. **Diverges from imgproxy**: imgproxy color-manages every image into a working space regardless of `scp`; ImagePipe only converts when `scp` is on (tracked in issue #124). With `scp:0` plus a tone effect on a wide-gamut source, effects run in the source profile space.
 - ⭕ `IMGPROXY_COLOR_PROFILES_DIR`
 - ⭕ `IMGPROXY_PRESERVE_HDR`
 - ✅ `IMGPROXY_AUTO_ROTATE`
@@ -530,10 +531,10 @@ transforms or output encoding.
 
 | Imgproxy option | Aliases | Status | Notes |
 | --- | --- | --- | --- |
-| `strip_metadata` | `sm` | Missing | No request-level metadata stripping override. |
-| `keep_copyright` | `kcr` | Missing | Depends on metadata stripping support. |
+| `strip_metadata` | `sm` | Supported | Default on. Parser config: `imgproxy: [strip_metadata: true]`. URL override `sm:0` disables. Strips EXIF, XMP, and IPTC at encode time via `ImagePipe.Plan.Output` metadata policy. |
+| `keep_copyright` | `kcr` | Supported | Default on. Parser config: `imgproxy: [keep_copyright: true]`. URL override `kcr:0` disables. **Diverges from imgproxy**: preserves EXIF copyright/artist fields only; imgproxy retains full XMP/IPTC blobs. ImagePipe strips XMP/IPTC even when `kcr` is on (privacy-conservative). |
 | `dpi` | | Missing | Pro metadata rewrite. |
-| `strip_color_profile` | `scp` | Missing | No color profile transform/output control. |
+| `strip_color_profile` | `scp` | Supported | Default on. Parser config: `imgproxy: [strip_color_profile: true]`. URL override `scp:0` disables. Implemented as a `NormalizeColorProfile` transform operation (ICC-aware sRGB conversion) positioned after geometry and before effects; the embedded profile header is dropped at encode. **Diverges from imgproxy**: imgproxy color-manages every image regardless of `scp`; ImagePipe only converts when `scp` is on (tracked in issue #124). With `scp:0` plus a tone effect on a wide-gamut source, effects run in the source profile space. |
 | `preserve_hdr` | `ph` | Missing | No HDR preservation toggle. |
 | `color_profile` | `cp`, `icc` | Missing | Pro profile conversion/embedding. |
 | `enforce_thumbnail` | `eth` | Missing | No embedded thumbnail decode selection. |

--- a/docs/superpowers/plans/2026-05-30-imgproxy-metadata-color-profile.md
+++ b/docs/superpowers/plans/2026-05-30-imgproxy-metadata-color-profile.md
@@ -231,13 +231,23 @@ git commit -m "feat(transform): add NormalizeColorProfile operation (scp)"
 
 ## Task 2: Parser emits `NormalizeColorProfile` for `scp`
 
+**Prerequisite:** Task 1 must be complete — the test references `ImagePipe.Plan.Operation.NormalizeColorProfile` and won't compile otherwise.
+
 **Files:**
 - Modify: `lib/image_pipe/parser/imgproxy/option_grammar.ex`, `lib/image_pipe/parser/imgproxy/pipeline_request.ex`, `lib/image_pipe/parser/imgproxy/options.ex`, `lib/image_pipe/parser/imgproxy/plan_builder.ex`, `lib/image_pipe/parser/imgproxy.ex`
 - Test: `test/parser/imgproxy_test.exs`
 
-- [ ] **Step 1: Write the failing parser test**
+- [ ] **Step 1: Extend the helper, then write the failing parser test**
 
-Add to `test/parser/imgproxy_test.exs` (reuse the file's existing aliases `Plan`, `Pipeline`, `Imgproxy`, `operation_names/1`, and `@no_auto_rotate_opts`):
+First extend the test's operation-name mapping. The parser test maps operation structs to atoms with `defp operation_name/1` clauses (`test/parser/imgproxy_test.exs:1683+`, ending at `:saturation`). Add a clause:
+
+```elixir
+  defp operation_name(%Operation.NormalizeColorProfile{}), do: :normalize_color_profile
+```
+
+Confirm `@no_auto_rotate_opts` is `[imgproxy: [auto_rotate: false]]` (and does **not** set `strip_color_profile`), so scp stays default-on below.
+
+Then add the test (reuse aliases `Plan`, `Pipeline`, `Imgproxy`, `Operation`, `operation_names/1`, `@no_auto_rotate_opts`):
 
 ```elixir
   test "strip_color_profile emits NormalizeColorProfile after geometry, before effects" do
@@ -278,12 +288,12 @@ If `@no_auto_rotate_opts` is `[imgproxy: [auto_rotate: false]]`, extend it to al
 
 - [ ] **Step 2: Run it to verify failure**
 
-Run: `mise exec -- mix test test/parser/imgproxy_test.exs -k "strip_color_profile emits"`
+Run: `mise exec -- mix test test/parser/imgproxy_test.exs`
 Expected: FAIL — scp not parsed; no `:normalize_color_profile` operation.
 
 - [ ] **Step 3: Add `scp` parsing to the grammar**
 
-In `lib/image_pipe/parser/imgproxy/option_grammar.ex`, add a `parse_special_option/3` clause (beside the `auto_rotate`/`flip` clauses):
+In `lib/image_pipe/parser/imgproxy/option_grammar.ex`, add a `parse_special_option/3` clause immediately after the existing `flip` clause (currently around line 397):
 
 ```elixir
   defp parse_special_option(name, args, segment)
@@ -447,7 +457,7 @@ Update `request_defaults/1`:
 
 - [ ] **Step 9: Run the parser test**
 
-Run: `mise exec -- mix test test/parser/imgproxy_test.exs -k "strip_color_profile emits"`
+Run: `mise exec -- mix test test/parser/imgproxy_test.exs`
 Expected: PASS.
 
 - [ ] **Step 10: Commit**
@@ -494,7 +504,7 @@ Add to `test/parser/imgproxy_test.exs` (alias `ImagePipe.Plan.Output` if not pre
 
 - [ ] **Step 2: Run it to verify failure**
 
-Run: `mise exec -- mix test test/parser/imgproxy_test.exs -k "strip_metadata/keep_copyright"`
+Run: `mise exec -- mix test test/parser/imgproxy_test.exs`
 Expected: FAIL — `Output` has no `strip_metadata`/`keep_copyright`.
 
 - [ ] **Step 3: Add fields to `Plan.Output`**
@@ -557,15 +567,13 @@ Add `parse_field/2` clauses (beside `parse_field(:enlarge, ...)`):
   defp parse_field(:keep_copyright, value), do: parse_boolean(value)
 ```
 
-Add a `scoped_assignments/2` clause routing them to `:output` (before the catch-all):
+**Extend the existing** `scoped_assignments/2` clause (currently `when kind in [:format, :quality, :format_quality]`, around line 105) by adding the two new kinds to its `when` guard — do not add a second clause:
 
 ```elixir
   defp scoped_assignments(kind, assignments)
        when kind in [:format, :quality, :format_quality, :strip_metadata, :keep_copyright],
        do: {:output, assignments}
 ```
-
-(Remove the now-duplicated narrower `:format, :quality, :format_quality` clause — merge it into the line above.)
 
 - [ ] **Step 5: Add fields to the parsed-output map**
 
@@ -595,7 +603,7 @@ In `lib/image_pipe/parser/imgproxy/parsed_request.ex`, update `@default_output` 
 
 - [ ] **Step 6: Resolve sm/kcr defaults + normalize in `options.ex`**
 
-Extend `apply_request_defaults/2` to also resolve the output map (add `output:` to the destructure and the return):
+**This replaces the `apply_request_defaults/2` you wrote in Task 2 Step 6** — it is the final form, a superset that resolves `auto_rotate`, `scp`, **and** the output `sm`/`kcr` defaults. Confirm the scp logic from Task 2 is preserved verbatim below (add `output:` to the destructure and the return):
 
 ```elixir
   defp apply_request_defaults(%{pipelines: pipelines, output: output} = options, defaults) do
@@ -665,7 +673,7 @@ In both `output_plan/1` clauses (`:automatic` and `{:explicit, format}`), add th
 
 - [ ] **Step 8: Run the parser test**
 
-Run: `mise exec -- mix test test/parser/imgproxy_test.exs -k "strip_metadata/keep_copyright"`
+Run: `mise exec -- mix test test/parser/imgproxy_test.exs`
 Expected: PASS.
 
 - [ ] **Step 9: Commit**
@@ -685,13 +693,13 @@ git commit -m "feat(parser): map imgproxy sm/kcr to Plan.Output with normalizati
 
 - [ ] **Step 1: Write the failing cache-key distinctness test**
 
-Add to `test/parser/imgproxy_test.exs` (alias `ImagePipe.Cache.Key`; build keys from parsed plans via the same call the runtime uses — confirm the arity by reading `Cache.Key` public functions, e.g. `Key.build/4`):
+Add to `test/parser/imgproxy_test.exs` (alias `ImagePipe.Cache.Key`). **Verified signature:** `Cache.Key.build(conn, %Plan{} = plan, source_identity, opts \\ [])` — conn first, plan second, then a `source_identity` term. A constant binary `source_identity` is fine here: we only vary `sm`/`kcr`/`scp`, so everything else in the key stays constant.
 
 ```elixir
   test "sm/kcr/scp produce distinct cache keys" do
     key = fn path ->
       {:ok, plan} = Imgproxy.parse(conn(:get, path), [])
-      ImagePipe.Cache.Key.build(plan, conn(:get, path), %{}, [])
+      ImagePipe.Cache.Key.build(conn(:get, path), plan, "source-identity")
     end
 
     base = key.("/_/sm:1/kcr:1/scp:1/plain/images/cat.jpg")
@@ -702,11 +710,11 @@ Add to `test/parser/imgproxy_test.exs` (alias `ImagePipe.Cache.Key`; build keys 
   end
 ```
 
-(Adjust `Key.build/4` to the real signature found in `lib/image_pipe/cache/key.ex`. `scp` distinctness already works via Task 1's KeyData; this test also guards it.)
+(`scp` distinctness already works via Task 1's KeyData; this test also guards it. If `Cache.Key.build/3,4` returns `{:ok, key}` rather than a bare key, unwrap accordingly — read `lib/image_pipe/cache/key.ex:30`.)
 
 - [ ] **Step 2: Run it to verify failure**
 
-Run: `mise exec -- mix test test/parser/imgproxy_test.exs -k "distinct cache keys"`
+Run: `mise exec -- mix test test/parser/imgproxy_test.exs`
 Expected: FAIL on the `sm:0` and `kcr:0` cases (keys equal) — `output_plan_data` ignores sm/kcr. (The `scp:0` case should already pass.)
 
 - [ ] **Step 3: Add sm/kcr to `output_plan_data/2`**
@@ -744,7 +752,7 @@ In `lib/image_pipe/cache/key.ex`, add the two fields to **both** clauses:
 
 - [ ] **Step 4: Run the cache-key test**
 
-Run: `mise exec -- mix test test/parser/imgproxy_test.exs -k "distinct cache keys"`
+Run: `mise exec -- mix test test/parser/imgproxy_test.exs`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
@@ -853,9 +861,13 @@ Rewrite `lib/image_pipe/output/encoder.ex` `stream_output/3` to finalize before 
   end
 
   defp strip_metadata(image, %Resolved{}) do
-    Vix.Vips.Image.mutate!(image, fn mut ->
-      Enum.each(["exif-data", "xmp-data", "iptc-data"], &Vix.Vips.MutableImage.remove(mut, &1))
-    end)
+    {:ok, image} =
+      Vix.Vips.Image.mutate(image, fn mut ->
+        Enum.each(["exif-data", "xmp-data", "iptc-data"], &Vix.Vips.MutableImage.remove(mut, &1))
+        :ok
+      end)
+
+    image
   end
 
   defp header_value(image, field) do
@@ -868,13 +880,19 @@ Rewrite `lib/image_pipe/output/encoder.ex` `stream_output/3` to finalize before 
   defp restore_icc(image, nil), do: image
 
   defp restore_icc(image, icc) do
-    Vix.Vips.Image.mutate!(image, fn mut ->
-      Vix.Vips.MutableImage.set(mut, "icc-profile-data", :VipsBlob, icc)
-    end)
+    {:ok, image} =
+      Vix.Vips.Image.mutate(image, fn mut ->
+        Vix.Vips.MutableImage.set(mut, "icc-profile-data", :VipsBlob, icc)
+        :ok
+      end)
+
+    image
   end
 ```
 
-Confirm `Vix.Vips.Image.mutate!/2` exists; if only `mutate/2` is available, bind `{:ok, img} = Vix.Vips.Image.mutate(...)` and return `img`. Confirm `Image.minimize_metadata!/2` is the bang variant (it is, per `image.ex`).
+**Verified:** `Vix.Vips.Image.mutate!/2` does **not** exist — only `mutate/2`, which returns `{:ok, image}`; the callback must return `:ok` (or `{:ok, term}`). `Image.minimize_metadata!/2` is the real bang variant.
+
+**ICC round-trip caveat (validate during Task 6/7 TDD):** `header_value/2` returns the blob as an Erlang term; re-setting it via `MutableImage.set(.., :VipsBlob, value)` may not round-trip for every libvips build. If the `scp:0 + kcr:1 + profiled source` wire case shows the profile lost, switch the backup/restore to `Vix.Vips.Image.header_value_as_string/2` + base64 decode, or capture/re-add EXIF copyright fields directly without `minimize_metadata!`. This path is exercised only by the non-default `scp:0 + kcr:1` combination.
 
 - [ ] **Step 4: Compile**
 
@@ -983,14 +1001,14 @@ In `test/image_pipe/imgproxy_wire_conformance_test.exs`, add an origin Plug that
 
 - [ ] **Step 3: Run to verify failure**
 
-Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs -k "strips EXIF"`
+Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs`
 Expected: FAIL initially if the source route name differs — register the `images/meta.jpg` path the same way the suite registers `images/oriented.jpg` (reuse the existing source-path convention in this file). Then FAIL on assertions until Tasks 3 & 5 behavior is exercised (they are already merged, so failures here indicate fixture/round-trip issues to resolve per Step 1's note).
 
 - [ ] **Step 4: Make tests pass**
 
 Resolve fixture round-trip per Step 1's note (most likely: assert on the fields that survive JPEG encode for your libvips build, or use a committed fixture). No production code change should be needed if Tasks 3 & 5 are correct; if `Image.exif/1` returns no copyright, verify the encoder's `kcr` branch ran (`minimize_metadata!(keep: [:copyright, :artist])`).
 
-Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs -k "strips EXIF" && mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs -k "kcr:1 keeps"`
+Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs && mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
@@ -1052,7 +1070,7 @@ Add `wide_gamut_origin_opts/0` mirroring `metadata_origin_opts/1` with `WideGamu
 
 - [ ] **Step 3: Run to verify failure, then pass**
 
-Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs -k "scp:1 outputs sRGB"`
+Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs`
 Expected: initially FAIL (resolve fixture round-trip per Step 1); PASS once the wide-gamut profile round-trips. No production change needed if Tasks 1–2 are correct.
 
 - [ ] **Step 4: Commit**
@@ -1207,6 +1225,6 @@ Expected: all pass. Fix any credo/format issues (e.g. alias ordering) inline.
 ## Notes for the implementer
 
 - **TDD seams:** this codebase tests at boundaries (parser→plan, wire-level `ImagePipe.call/2` decoding the body, cache key). Do **not** hand-build `Transform.State`, `Plan.Pipeline`, or operation structs in tests to assert internals — it violates the repo's test guidelines.
-- **Verify two library calls during TDD** (flagged inline): `Vix.Vips.Image.mutate!/2` vs `mutate/2`, and whether synthetic EXIF/XMP/IPTC/ICC survive the encode round-trip (Tasks 6–7). Resolve with the real API before finalizing assertions.
+- **Validate during TDD** (flagged inline): whether synthetic EXIF/XMP/IPTC/ICC survive the encode round-trip (Tasks 6–7), and the ICC backup/restore round-trip in the encoder `kcr` branch (Task 5). Resolve against the real API before finalizing assertions. (`mutate/2` vs `mutate!/2` is already resolved — only `mutate/2` exists.)
 - **`Cache.Key.build/4`** signature in Task 4 must match the real function — read `lib/image_pipe/cache/key.ex` and adjust.
-- Run focused tests with `mise exec -- mix test <file> -k "<name fragment>"` while iterating.
+- Run focused tests with `mise exec -- mix test <file>` while iterating.

--- a/docs/superpowers/plans/2026-05-30-imgproxy-metadata-color-profile.md
+++ b/docs/superpowers/plans/2026-05-30-imgproxy-metadata-color-profile.md
@@ -133,9 +133,7 @@ defmodule ImagePipe.Transform.Operation.NormalizeColorProfile do
 
   defp normalize(image) do
     if profile?(image) do
-      with {:ok, srgb} <- Image.to_colorspace(image, :srgb, []) do
-        drop_profile(srgb)
-      end
+      Image.to_colorspace(image, :srgb, [])
     else
       {:ok, image}
     end
@@ -147,15 +145,16 @@ defmodule ImagePipe.Transform.Operation.NormalizeColorProfile do
       _ -> false
     end
   end
-
-  defp drop_profile(image) do
-    Vix.Vips.Image.mutate(image, fn mut ->
-      _ = Vix.Vips.MutableImage.remove(mut, @icc_field)
-      :ok
-    end)
-  end
 end
 ```
+
+> **R1 (post-review):** the op is **conversion-only** — it does NOT drop the
+> `icc-profile-data` header. Metadata removal requires `Vix` `mutate` →
+> `copy_memory`, which inside the lazy chain crashes the producer (500) on
+> corrupt sources instead of degrading to 415 (and `Chain.execute` re-tags op
+> errors as `:transform_error` → 500 anyway). The profile-header drop happens at
+> the encoder finalize (Task 5), which realizes catchably before any `mutate`.
+> The `@icc_field` module attribute is still used by `profile?/1`.
 
 - [ ] **Step 5: Add the constructor, type, and `semantic?/1` clause in `plan/operation.ex`**
 
@@ -474,6 +473,15 @@ git commit -m "feat(parser): map imgproxy scp to NormalizeColorProfile with pars
 
 ## Task 3: `Plan.Output` `sm`/`kcr` fields + parser mapping & normalization
 
+> **R1 (post-review) addendum:** also add `strip_color_profile` to `Plan.Output`
+> (default `true`) — the encoder (Task 5) needs it to drop the profile header.
+> In `apply_request_defaults/2`, set `output.strip_color_profile` from the same
+> resolved `scp?` value that drives op emission (Task 2), so they stay
+> consistent; and add `strip_color_profile: nil` to `@default_output` so the key
+> exists. Do NOT add `strip_color_profile` to the cache key's `output_plan_data`
+> (Task 4) — it is already keyed via the `NormalizeColorProfile` op's `KeyData`.
+> See the design spec's "Metadata policy" / "Output encode path" sections.
+
 **Files:**
 - Modify: `lib/image_pipe/plan/output.ex`, `lib/image_pipe/parser/imgproxy/option_grammar.ex`, `lib/image_pipe/parser/imgproxy/parsed_request.ex`, `lib/image_pipe/parser/imgproxy/options.ex`, `lib/image_pipe/parser/imgproxy/plan_builder.ex`
 - Test: `test/parser/imgproxy_test.exs`
@@ -767,11 +775,30 @@ git commit -m "feat(cache): include strip_metadata/keep_copyright in output cach
 
 ---
 
-## Task 5: Thread `sm`/`kcr` to the encoder and strip metadata
+## Task 5: Thread `sm`/`kcr`/`scp` to the encoder and strip metadata (R1)
+
+> **R1 (post-review) — this task is rewritten.** The authoritative design is the
+> spec's "Output encode path: sm/kcr/scp metadata via Vix mutate (after a safe
+> realize)". Key differences from the steps below:
+> - Thread **three** flags — `strip_metadata`, `keep_copyright`,
+>   **`strip_color_profile`** — through `Policy` and `Resolved` (add all three to
+>   `@enforce_keys` and `Policy.resolved/2`).
+> - `Encoder.stream_output/3` must **realize once via `Vix.Vips.Image.copy_memory/1`
+>   before any `mutate`**, and only when stripping is needed
+>   (`strip_metadata or strip_color_profile`). On `copy_memory` `{:error, reason}`
+>   return `{:error, {:decode, reason}}` (→ 415), NOT a crash.
+> - The strip step handles `scp` too: drop `icc-profile-data` when
+>   `strip_color_profile` is true; the `kcr` branch restores the ICC profile only
+>   when `scp` is **off**. Exact logic is in the spec's `finalize`/`strip`
+>   pseudocode.
+> - Required code comments: the `copy_memory`-before-`mutate` rationale, the
+>   `"xmp-dataa"` typo, and `minimize_metadata`'s ICC over-strip.
+> The dispatched implementer prompt will carry the full R1 code. The steps below
+> are the pre-R1 version, retained for context only.
 
 **Files:**
 - Modify: `lib/image_pipe/output/policy.ex`, `lib/image_pipe/output/resolved.ex`, `lib/image_pipe/output/encoder.ex`
-- Test: covered end-to-end by Task 6 wire tests (no isolated unit test — `Resolved`/encoder are exercised through `ImagePipe.call/2`, per the repo's no-hand-built-struct rule).
+- Test: covered end-to-end by Task 6 (`sm`/`kcr`) and Task 7 (`scp`) wire tests, including a corrupt-source test asserting 415 (no producer crash).
 
 - [ ] **Step 1: Add fields to `Output.Resolved`**
 

--- a/docs/superpowers/plans/2026-05-30-imgproxy-metadata-color-profile.md
+++ b/docs/superpowers/plans/2026-05-30-imgproxy-metadata-color-profile.md
@@ -1,0 +1,1212 @@
+# Imgproxy Metadata & Color-Profile Controls Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement imgproxy's `strip_metadata` (`sm`), `keep_copyright` (`kcr`), and `strip_color_profile` (`scp`) controls — default-on, parser-owned defaults, URL overrides — closing the EXIF/XMP/GPS privacy gap (#30).
+
+**Architecture:** `sm`/`kcr` are encode-time metadata policy on `ImagePipe.Plan.Output`, threaded `Policy → Resolved → Encoder` and applied with Vix `mutate` (explicit field names). `scp` is a product-neutral transform op `NormalizeColorProfile` (mirroring `AutoOrient`), positioned after geometry and before the effect chain, cache-keyed as a pipeline op. All four metadata/orientation defaults (`auto_rotate`, `strip_metadata`, `keep_copyright`, `strip_color_profile`) live in the imgproxy parser config.
+
+**Tech Stack:** Elixir, `image`/Vix (libvips), NimbleOptions, ExUnit, Boundary; demo is Svelte/TypeScript.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-30-imgproxy-metadata-color-profile-design.md`
+
+**Verified library facts (do not re-derive):**
+- `Image.to_colorspace/3` (`image, :srgb, opts`) is ICC-aware (`Vix.Vips.Operation.icc_transform`). The 2-arity `to_colorspace/2` is interpretation-only — **do not use it**.
+- `Image.remove_metadata(img, :xmp)` is a **no-op** (`image` v0.67 maps `:xmp` → `"xmp-dataa"`, a typo). Use explicit string field names.
+- `Image.minimize_metadata/1,2` and default `remove_metadata/1` remove **all** header fields **including `icc-profile-data`**. Preserve the profile explicitly where needed.
+- `Vix.Vips.Image.header_field_names/1` lists fields; `Vix.Vips.MutableImage.remove/2` removes one by name.
+
+**Run commands from the worktree root.** Use `mise exec -- mix ...` (deps are installed in the main checkout; if the worktree lacks deps, run `mise run setup` first).
+
+---
+
+## File Structure
+
+**Create:**
+- `lib/image_pipe/plan/operation/normalize_color_profile.ex` — semantic op (no fields).
+- `lib/image_pipe/transform/operation/normalize_color_profile.ex` — executable op (ICC→sRGB + drop profile).
+
+**Modify (Elixir):**
+- `lib/image_pipe/plan/operation.ex` — `normalize_color_profile/0` constructor, `semantic?/1` clause, type union.
+- `lib/image_pipe/transform.ex` — Boundary `exports:` add `Operation.NormalizeColorProfile`.
+- `lib/image_pipe/transform/plan_executor.ex` — lowering clause.
+- `lib/image_pipe/plan/key_data.ex` — alias + `data/1` clause.
+- `lib/image_pipe/plan/output.ex` — `strip_metadata`/`keep_copyright` fields.
+- `lib/image_pipe/parser/imgproxy.ex` — config schema + `request_defaults/1`.
+- `lib/image_pipe/parser/imgproxy/option_grammar.ex` — option specs, scope, boolean parsing, `scp` special option.
+- `lib/image_pipe/parser/imgproxy/parsed_request.ex` — `@default_output` adds `strip_metadata`/`keep_copyright`.
+- `lib/image_pipe/parser/imgproxy/pipeline_request.ex` — `strip_color_profile`/`strip_color_profile_requested` fields.
+- `lib/image_pipe/parser/imgproxy/options.ex` — `update_current_pipeline` scp branch, `apply_request_defaults` resolves sm/kcr/scp.
+- `lib/image_pipe/parser/imgproxy/plan_builder.ex` — `output_plan/1` sets sm/kcr; `plan_geometry/1` inserts color-profile op.
+- `lib/image_pipe/output/policy.ex` — thread sm/kcr.
+- `lib/image_pipe/output/resolved.ex` — sm/kcr fields.
+- `lib/image_pipe/output/encoder.ex` — finalize (strip metadata).
+- `lib/image_pipe/cache/key.ex` — `output_plan_data/2` adds sm/kcr.
+- `docs/imgproxy_support_matrix.md`, `docs/transform_operations.md` — docs.
+
+**Modify (demo):**
+- `demo/src/processing-path.ts` — `DemoState` fields + defaults + `optionSegments` emit.
+- `demo/src/demo-url-state.ts` — parse `sm`/`kcr`/`scp`.
+- `demo/src/App.svelte` — "Metadata & Color" controls.
+
+**Tests:**
+- `test/parser/imgproxy_test.exs` — parse→plan for sm/kcr/scp.
+- `test/image_pipe/imgproxy_wire_conformance_test.exs` — wire tests + metadata/wide-gamut origin generators.
+- `test/image_pipe/architecture_boundary_test.exs` — add new export to assertion.
+
+---
+
+## Task 1: `NormalizeColorProfile` operation + plumbing
+
+**Files:**
+- Create: `lib/image_pipe/plan/operation/normalize_color_profile.ex`
+- Create: `lib/image_pipe/transform/operation/normalize_color_profile.ex`
+- Modify: `lib/image_pipe/plan/operation.ex`, `lib/image_pipe/transform.ex`, `lib/image_pipe/transform/plan_executor.ex`, `lib/image_pipe/plan/key_data.ex`
+- Test: `test/image_pipe/architecture_boundary_test.exs`
+
+- [ ] **Step 1: Add the new export to the architecture boundary test (failing test)**
+
+In `test/image_pipe/architecture_boundary_test.exs`, add to the `assert_boundary_exports_include(transform, [...])` list (after `ImagePipe.Transform.Operation.Saturation`):
+
+```elixir
+      ImagePipe.Transform.Operation.Saturation,
+      ImagePipe.Transform.Operation.NormalizeColorProfile
+```
+
+- [ ] **Step 2: Run it to verify failure**
+
+Run: `mise exec -- mix test test/image_pipe/architecture_boundary_test.exs`
+Expected: FAIL — `ImagePipe.Transform.Operation.NormalizeColorProfile` is not exported / does not exist.
+
+- [ ] **Step 3: Create the semantic plan operation**
+
+Create `lib/image_pipe/plan/operation/normalize_color_profile.ex`:
+
+```elixir
+defmodule ImagePipe.Plan.Operation.NormalizeColorProfile do
+  @moduledoc """
+  Semantic request to normalize the image to sRGB and drop the embedded ICC
+  profile. Product-neutral; the imgproxy `strip_color_profile` (`scp`) option
+  maps to this. A future target-profile field is the `cp` (#119) seam.
+  """
+
+  defstruct []
+
+  @type t :: %__MODULE__{}
+end
+```
+
+- [ ] **Step 4: Create the executable transform operation**
+
+Create `lib/image_pipe/transform/operation/normalize_color_profile.ex`:
+
+```elixir
+defmodule ImagePipe.Transform.Operation.NormalizeColorProfile do
+  @moduledoc """
+  Executable color-profile normalization: convert the embedded ICC profile to
+  sRGB (ICC-aware, via `Image.to_colorspace/3` -> `icc_transform`) and drop the
+  profile so the output embeds none. No-op when the image carries no profile.
+  """
+
+  @behaviour ImagePipe.Transform
+
+  import ImagePipe.Transform.State
+
+  alias ImagePipe.Transform.State
+
+  @icc_field "icc-profile-data"
+
+  defstruct []
+
+  @type t :: %__MODULE__{}
+
+  @impl ImagePipe.Transform
+  def name(%__MODULE__{}), do: :normalize_color_profile
+
+  @impl ImagePipe.Transform
+  def execute(%__MODULE__{}, %State{} = state) do
+    case normalize(state.image) do
+      {:ok, image} -> {:ok, set_image(state, image)}
+      {:error, error} -> {:error, {__MODULE__, error}}
+    end
+  end
+
+  defp normalize(image) do
+    if profile?(image) do
+      with {:ok, srgb} <- Image.to_colorspace(image, :srgb, []) do
+        drop_profile(srgb)
+      end
+    else
+      {:ok, image}
+    end
+  end
+
+  defp profile?(image) do
+    case Vix.Vips.Image.header_field_names(image) do
+      {:ok, names} -> @icc_field in names
+      _ -> false
+    end
+  end
+
+  defp drop_profile(image) do
+    Vix.Vips.Image.mutate(image, fn mut ->
+      _ = Vix.Vips.MutableImage.remove(mut, @icc_field)
+      :ok
+    end)
+  end
+end
+```
+
+- [ ] **Step 5: Add the constructor, type, and `semantic?/1` clause in `plan/operation.ex`**
+
+Add a `NormalizeColorProfile` alias near the other operation aliases. Add to the `@type semantic_operation` union (append `| NormalizeColorProfile.t()`). Add a constructor next to `auto_orient/0`:
+
+```elixir
+  @spec normalize_color_profile() :: NormalizeColorProfile.t()
+  def normalize_color_profile, do: %NormalizeColorProfile{}
+```
+
+Add the `semantic?/1` clause beside `semantic?(%AutoOrient{})`:
+
+```elixir
+  def semantic?(%NormalizeColorProfile{}), do: true
+```
+
+- [ ] **Step 6: Export from the Transform boundary**
+
+In `lib/image_pipe/transform.ex`, add to the `exports:` list after `Operation.Saturation`:
+
+```elixir
+      Operation.Saturation,
+      Operation.NormalizeColorProfile
+```
+
+- [ ] **Step 7: Add the KeyData clause**
+
+In `lib/image_pipe/plan/key_data.ex`, add the alias (alphabetical, after `Monochrome`):
+
+```elixir
+  alias ImagePipe.Plan.Operation.NormalizeColorProfile
+```
+
+Add the `data/1` clause beside the `AutoOrient` clause:
+
+```elixir
+  def data(%NormalizeColorProfile{}), do: [op: :normalize_color_profile]
+```
+
+- [ ] **Step 8: Add the PlanExecutor lowering clause**
+
+In `lib/image_pipe/transform/plan_executor.ex`, add aliases for both the plan op and the executable op (follow the existing alias style, e.g. `PlanAutoOrient`/`AutoOrient`):
+
+```elixir
+  alias ImagePipe.Plan.Operation.NormalizeColorProfile, as: PlanNormalizeColorProfile
+  alias ImagePipe.Transform.Operation.NormalizeColorProfile
+```
+
+Add the lowering clause beside the `AutoOrient` clause:
+
+```elixir
+  defp executable_operations(%PlanNormalizeColorProfile{}, %State{}, _context),
+    do: [%NormalizeColorProfile{}]
+```
+
+- [ ] **Step 9: Run the boundary test + compile**
+
+Run: `mise exec -- mix compile --warnings-as-errors && mise exec -- mix test test/image_pipe/architecture_boundary_test.exs`
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add lib/image_pipe/plan/operation/normalize_color_profile.ex \
+        lib/image_pipe/transform/operation/normalize_color_profile.ex \
+        lib/image_pipe/plan/operation.ex lib/image_pipe/transform.ex \
+        lib/image_pipe/transform/plan_executor.ex lib/image_pipe/plan/key_data.ex \
+        test/image_pipe/architecture_boundary_test.exs
+git commit -m "feat(transform): add NormalizeColorProfile operation (scp)"
+```
+
+---
+
+## Task 2: Parser emits `NormalizeColorProfile` for `scp`
+
+**Files:**
+- Modify: `lib/image_pipe/parser/imgproxy/option_grammar.ex`, `lib/image_pipe/parser/imgproxy/pipeline_request.ex`, `lib/image_pipe/parser/imgproxy/options.ex`, `lib/image_pipe/parser/imgproxy/plan_builder.ex`, `lib/image_pipe/parser/imgproxy.ex`
+- Test: `test/parser/imgproxy_test.exs`
+
+- [ ] **Step 1: Write the failing parser test**
+
+Add to `test/parser/imgproxy_test.exs` (reuse the file's existing aliases `Plan`, `Pipeline`, `Imgproxy`, `operation_names/1`, and `@no_auto_rotate_opts`):
+
+```elixir
+  test "strip_color_profile emits NormalizeColorProfile after geometry, before effects" do
+    # default config: scp on
+    assert {:ok, %Plan{pipelines: [%Pipeline{operations: ops}]}} =
+             Imgproxy.parse(conn(:get, "/_/plain/images/cat.jpg"), @no_auto_rotate_opts)
+    assert :normalize_color_profile in operation_names(ops)
+
+    # explicit scp:0 disables
+    assert {:ok, %Plan{pipelines: [%Pipeline{operations: ops0}]}} =
+             Imgproxy.parse(conn(:get, "/_/scp:0/plain/images/cat.jpg"), @no_auto_rotate_opts)
+    refute :normalize_color_profile in operation_names(ops0)
+
+    # config default off, URL scp:1 re-enables
+    assert {:ok, %Plan{pipelines: [%Pipeline{operations: ops1}]}} =
+             Imgproxy.parse(
+               conn(:get, "/_/scp:1/plain/images/cat.jpg"),
+               imgproxy: [strip_color_profile: false]
+             )
+    assert :normalize_color_profile in operation_names(ops1)
+
+    # position: after resize, before blur
+    assert {:ok, %Plan{pipelines: [%Pipeline{operations: pos_ops}]}} =
+             Imgproxy.parse(
+               conn(:get, "/_/w:10/bl:2/plain/images/cat.jpg"),
+               @no_auto_rotate_opts
+             )
+
+    names = operation_names(pos_ops)
+    assert Enum.find_index(names, &(&1 == :resize)) <
+             Enum.find_index(names, &(&1 == :normalize_color_profile))
+    assert Enum.find_index(names, &(&1 == :normalize_color_profile)) <
+             Enum.find_index(names, &(&1 == :blur))
+  end
+```
+
+If `@no_auto_rotate_opts` is `[imgproxy: [auto_rotate: false]]`, extend it to also disable scp where the test needs only resize/effect ordering — but here we WANT scp on, so `@no_auto_rotate_opts` (auto_rotate off, scp default on) is correct. Confirm `@no_auto_rotate_opts` does not set `strip_color_profile`.
+
+- [ ] **Step 2: Run it to verify failure**
+
+Run: `mise exec -- mix test test/parser/imgproxy_test.exs -k "strip_color_profile emits"`
+Expected: FAIL — scp not parsed; no `:normalize_color_profile` operation.
+
+- [ ] **Step 3: Add `scp` parsing to the grammar**
+
+In `lib/image_pipe/parser/imgproxy/option_grammar.ex`, add a `parse_special_option/3` clause (beside the `auto_rotate`/`flip` clauses):
+
+```elixir
+  defp parse_special_option(name, args, segment)
+       when name in ["strip_color_profile", "scp"] do
+    parse_strip_color_profile(args, segment)
+  end
+```
+
+Add the helper (near `parse_auto_rotate/2`):
+
+```elixir
+  defp parse_strip_color_profile([], _segment),
+    do: {:ok, [strip_color_profile: true]}
+
+  defp parse_strip_color_profile([value], _segment) when value != "" do
+    with {:ok, value?} <- parse_boolean(value) do
+      {:ok, [strip_color_profile: value?]}
+    end
+  end
+
+  defp parse_strip_color_profile(_args, segment),
+    do: {:error, {:invalid_option_segment, segment}}
+```
+
+(Special options return `{:pipeline, assignments}` via `parse_non_preset_option/3`, so no `@option_specs`/scope change is needed.)
+
+- [ ] **Step 4: Add fields to `PipelineRequest`**
+
+In `lib/image_pipe/parser/imgproxy/pipeline_request.ex`, add to the `@type t()` (e.g. after `auto_rotate_requested`):
+
+```elixir
+          auto_rotate_requested: boolean(),
+          strip_color_profile: boolean(),
+          strip_color_profile_requested: boolean(),
+```
+
+And to `defstruct` (matching defaults — both `false`):
+
+```elixir
+            auto_rotate_requested: false,
+            strip_color_profile: false,
+            strip_color_profile_requested: false,
+```
+
+- [ ] **Step 5: Apply the scp assignment in `options.ex`**
+
+In `lib/image_pipe/parser/imgproxy/options.ex`, inside `update_current_pipeline/2`'s `Enum.reduce` (before the catch-all `assignment, pipeline -> struct!(...)`):
+
+```elixir
+        {:strip_color_profile, value}, pipeline ->
+          %{pipeline | strip_color_profile: value, strip_color_profile_requested: true}
+```
+
+- [ ] **Step 6: Resolve the scp default request-wide in `apply_request_defaults/2`**
+
+Replace `apply_request_defaults/2` body so it resolves scp alongside auto_rotate (mirroring the auto_rotate helpers):
+
+```elixir
+  defp apply_request_defaults(%{pipelines: pipelines} = options, defaults) do
+    auto_rotate? = effective_auto_rotate(pipelines, Keyword.get(defaults, :auto_rotate, false))
+
+    scp? =
+      effective_strip_color_profile(pipelines, Keyword.get(defaults, :strip_color_profile, true))
+
+    pipelines =
+      pipelines
+      |> Enum.map(&consume_auto_rotate_request/1)
+      |> Enum.map(&consume_strip_color_profile_request/1)
+      |> apply_auto_rotate_to_first_pipeline(auto_rotate?)
+      |> apply_strip_color_profile_to_first_pipeline(scp?)
+      |> reject_empty_pipelines()
+
+    %{options | pipelines: pipelines}
+  end
+```
+
+Add the helpers (beside the auto_rotate ones):
+
+```elixir
+  defp effective_strip_color_profile(pipelines, default) do
+    Enum.reduce(pipelines, default, fn
+      %PipelineRequest{strip_color_profile_requested: true, strip_color_profile: value}, _acc ->
+        value
+
+      %PipelineRequest{}, acc ->
+        acc
+    end)
+  end
+
+  defp consume_strip_color_profile_request(%PipelineRequest{} = pipeline),
+    do: %{pipeline | strip_color_profile: false, strip_color_profile_requested: false}
+
+  defp apply_strip_color_profile_to_first_pipeline(pipelines, false), do: pipelines
+
+  defp apply_strip_color_profile_to_first_pipeline([first | rest], true),
+    do: [%{first | strip_color_profile: true} | rest]
+```
+
+- [ ] **Step 7: Emit the operation in `plan_builder.ex`**
+
+In `lib/image_pipe/parser/imgproxy/plan_builder.ex`, add a clause function:
+
+```elixir
+  defp color_profile_operations(%PipelineRequest{strip_color_profile: true}),
+    do: {:ok, [Operation.normalize_color_profile()]}
+
+  defp color_profile_operations(%PipelineRequest{}), do: {:ok, []}
+```
+
+In `plan_geometry/1`, add it to the `with` and insert it **between resize and effects**:
+
+```elixir
+  defp plan_geometry(%PipelineRequest{} = request) do
+    with {:ok, orientation_operations} <- orientation_operations(request),
+         {:ok, crop_operations} <- crop_operations(request),
+         {:ok, resize_operations} <- resize_operations(request),
+         {:ok, color_profile_operations} <- color_profile_operations(request),
+         {:ok, effect_operations} <- effect_operations(request),
+         {:ok, canvas_operations} <- canvas_operations(request),
+         {:ok, padding_operations} <- padding_operations(request),
+         {:ok, background_operations} <- background_operations(request) do
+      {:ok,
+       orientation_operations ++
+         crop_operations ++
+         resize_operations ++
+         color_profile_operations ++
+         effect_operations ++
+         canvas_operations ++
+         padding_operations ++
+         background_operations}
+    end
+  end
+```
+
+- [ ] **Step 8: Add the config option + request default in `imgproxy.ex`**
+
+In `@imgproxy_schema`, add after `auto_rotate`:
+
+```elixir
+                     auto_rotate: [
+                       type: :boolean,
+                       default: true
+                     ],
+                     strip_metadata: [type: :boolean, default: true],
+                     keep_copyright: [type: :boolean, default: true],
+                     strip_color_profile: [type: :boolean, default: true]
+```
+
+Update `request_defaults/1`:
+
+```elixir
+  defp request_defaults(imgproxy_opts) do
+    [
+      auto_rotate: Keyword.get(imgproxy_opts, :auto_rotate, true),
+      strip_metadata: Keyword.get(imgproxy_opts, :strip_metadata, true),
+      keep_copyright: Keyword.get(imgproxy_opts, :keep_copyright, true),
+      strip_color_profile: Keyword.get(imgproxy_opts, :strip_color_profile, true)
+    ]
+  end
+```
+
+- [ ] **Step 9: Run the parser test**
+
+Run: `mise exec -- mix test test/parser/imgproxy_test.exs -k "strip_color_profile emits"`
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add lib/image_pipe/parser/imgproxy/ lib/image_pipe/parser/imgproxy.ex test/parser/imgproxy_test.exs
+git commit -m "feat(parser): map imgproxy scp to NormalizeColorProfile with parser-owned default"
+```
+
+---
+
+## Task 3: `Plan.Output` `sm`/`kcr` fields + parser mapping & normalization
+
+**Files:**
+- Modify: `lib/image_pipe/plan/output.ex`, `lib/image_pipe/parser/imgproxy/option_grammar.ex`, `lib/image_pipe/parser/imgproxy/parsed_request.ex`, `lib/image_pipe/parser/imgproxy/options.ex`, `lib/image_pipe/parser/imgproxy/plan_builder.ex`
+- Test: `test/parser/imgproxy_test.exs`
+
+- [ ] **Step 1: Write the failing parser test**
+
+Add to `test/parser/imgproxy_test.exs` (alias `ImagePipe.Plan.Output` if not present):
+
+```elixir
+  test "strip_metadata/keep_copyright map to Plan.Output with kcr normalization" do
+    # defaults: both on
+    assert {:ok, %Plan{output: %Output{strip_metadata: true, keep_copyright: true}}} =
+             Imgproxy.parse(conn(:get, "/_/plain/images/cat.jpg"), [])
+
+    # sm:0 forces keep_copyright to false (normalization)
+    assert {:ok, %Plan{output: %Output{strip_metadata: false, keep_copyright: false}}} =
+             Imgproxy.parse(conn(:get, "/_/sm:0/kcr:1/plain/images/cat.jpg"), [])
+
+    # kcr:0 with stripping on
+    assert {:ok, %Plan{output: %Output{strip_metadata: true, keep_copyright: false}}} =
+             Imgproxy.parse(conn(:get, "/_/kcr:0/plain/images/cat.jpg"), [])
+
+    # config default off, URL re-enables
+    assert {:ok, %Plan{output: %Output{strip_metadata: true}}} =
+             Imgproxy.parse(
+               conn(:get, "/_/sm:1/plain/images/cat.jpg"),
+               imgproxy: [strip_metadata: false]
+             )
+  end
+```
+
+- [ ] **Step 2: Run it to verify failure**
+
+Run: `mise exec -- mix test test/parser/imgproxy_test.exs -k "strip_metadata/keep_copyright"`
+Expected: FAIL — `Output` has no `strip_metadata`/`keep_copyright`.
+
+- [ ] **Step 3: Add fields to `Plan.Output`**
+
+Replace the struct/typespec in `lib/image_pipe/plan/output.ex`:
+
+```elixir
+  @enforce_keys [:mode]
+  defstruct mode: :automatic,
+            quality: :default,
+            format_qualities: %{},
+            strip_metadata: true,
+            keep_copyright: true
+
+  @type format :: :avif | :webp | :jpeg | :png
+  @type quality :: :default | {:quality, 1..100}
+  @type t :: %__MODULE__{
+          mode: :automatic | {:explicit, format()},
+          quality: quality(),
+          format_qualities: %{optional(format()) => quality()},
+          strip_metadata: boolean(),
+          keep_copyright: boolean()
+        }
+```
+
+- [ ] **Step 4: Add `sm`/`kcr` to the grammar**
+
+In `option_grammar.ex` `@option_specs`, add:
+
+```elixir
+    "strip_metadata" => {:strip_metadata, [:strip_metadata]},
+    "sm" => {:strip_metadata, [:strip_metadata]},
+    "keep_copyright" => {:keep_copyright, [:keep_copyright]},
+    "kcr" => {:keep_copyright, [:keep_copyright]},
+```
+
+Add to the `parse_known_option/4` guard list (the clause that calls `parse_exact_fields`):
+
+```elixir
+  defp parse_known_option(kind, fields, args, segment)
+       when kind in [
+              :resizing_type,
+              :width,
+              :height,
+              :min_width,
+              :min_height,
+              :enlarge,
+              :format,
+              :strip_metadata,
+              :keep_copyright
+            ] do
+    parse_exact_fields(fields, args, segment)
+  end
+```
+
+Add `parse_field/2` clauses (beside `parse_field(:enlarge, ...)`):
+
+```elixir
+  defp parse_field(:strip_metadata, value), do: parse_boolean(value)
+  defp parse_field(:keep_copyright, value), do: parse_boolean(value)
+```
+
+Add a `scoped_assignments/2` clause routing them to `:output` (before the catch-all):
+
+```elixir
+  defp scoped_assignments(kind, assignments)
+       when kind in [:format, :quality, :format_quality, :strip_metadata, :keep_copyright],
+       do: {:output, assignments}
+```
+
+(Remove the now-duplicated narrower `:format, :quality, :format_quality` clause — merge it into the line above.)
+
+- [ ] **Step 5: Add fields to the parsed-output map**
+
+In `lib/image_pipe/parser/imgproxy/parsed_request.ex`, update `@default_output` and the `output_request()` type to carry the (initially unset) values:
+
+```elixir
+  @default_output %{
+    format: nil,
+    quality: :default,
+    format_qualities: %{},
+    strip_metadata: nil,
+    keep_copyright: nil
+  }
+```
+
+```elixir
+  @type output_request() :: %{
+          required(:format) => output_format() | nil,
+          required(:quality) => quality(),
+          required(:format_qualities) => %{optional(output_format()) => quality()},
+          required(:strip_metadata) => boolean() | nil,
+          required(:keep_copyright) => boolean() | nil
+        }
+```
+
+(`update_output/2` already merges arbitrary known output keys via `merge_request_map`, so no change there.)
+
+- [ ] **Step 6: Resolve sm/kcr defaults + normalize in `options.ex`**
+
+Extend `apply_request_defaults/2` to also resolve the output map (add `output:` to the destructure and the return):
+
+```elixir
+  defp apply_request_defaults(%{pipelines: pipelines, output: output} = options, defaults) do
+    auto_rotate? = effective_auto_rotate(pipelines, Keyword.get(defaults, :auto_rotate, false))
+
+    scp? =
+      effective_strip_color_profile(pipelines, Keyword.get(defaults, :strip_color_profile, true))
+
+    pipelines =
+      pipelines
+      |> Enum.map(&consume_auto_rotate_request/1)
+      |> Enum.map(&consume_strip_color_profile_request/1)
+      |> apply_auto_rotate_to_first_pipeline(auto_rotate?)
+      |> apply_strip_color_profile_to_first_pipeline(scp?)
+      |> reject_empty_pipelines()
+
+    %{options | pipelines: pipelines, output: resolve_metadata_defaults(output, defaults)}
+  end
+
+  defp resolve_metadata_defaults(output, defaults) do
+    strip = resolve_bool(output.strip_metadata, Keyword.get(defaults, :strip_metadata, true))
+    keep = resolve_bool(output.keep_copyright, Keyword.get(defaults, :keep_copyright, true))
+    %{output | strip_metadata: strip, keep_copyright: strip and keep}
+  end
+
+  defp resolve_bool(nil, default), do: default
+  defp resolve_bool(value, _default) when is_boolean(value), do: value
+```
+
+- [ ] **Step 7: Read the fields in `plan_builder.ex` `output_plan/1`**
+
+In both `output_plan/1` clauses (`:automatic` and `{:explicit, format}`), add the two fields to the `%Output{}`:
+
+```elixir
+  defp output_plan(%{format: nil} = request) do
+    {:ok,
+     %Output{
+       mode: :automatic,
+       quality: request.quality,
+       format_qualities: request.format_qualities,
+       strip_metadata: request.strip_metadata,
+       keep_copyright: request.keep_copyright
+     }}
+  end
+```
+
+```elixir
+  defp output_plan(%{format: format} = request) do
+    case Format.output_format?(format) do
+      true ->
+        {:ok,
+         %Output{
+           mode: {:explicit, format},
+           quality: request.quality,
+           format_qualities: request.format_qualities,
+           strip_metadata: request.strip_metadata,
+           keep_copyright: request.keep_copyright
+         }}
+
+      false ->
+        {:error, {:unsupported_output_format, format}}
+    end
+  end
+```
+
+(Leave the `%{format: :best}` clause unchanged.)
+
+- [ ] **Step 8: Run the parser test**
+
+Run: `mise exec -- mix test test/parser/imgproxy_test.exs -k "strip_metadata/keep_copyright"`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add lib/image_pipe/plan/output.ex lib/image_pipe/parser/imgproxy/ test/parser/imgproxy_test.exs
+git commit -m "feat(parser): map imgproxy sm/kcr to Plan.Output with normalization"
+```
+
+---
+
+## Task 4: Cache key includes `sm`/`kcr`
+
+**Files:**
+- Modify: `lib/image_pipe/cache/key.ex`
+- Test: `test/parser/imgproxy_test.exs` (or the cache-key test module if one exists; this asserts via parsed plans + `ImagePipe.Cache.Key`)
+
+- [ ] **Step 1: Write the failing cache-key distinctness test**
+
+Add to `test/parser/imgproxy_test.exs` (alias `ImagePipe.Cache.Key`; build keys from parsed plans via the same call the runtime uses — confirm the arity by reading `Cache.Key` public functions, e.g. `Key.build/4`):
+
+```elixir
+  test "sm/kcr/scp produce distinct cache keys" do
+    key = fn path ->
+      {:ok, plan} = Imgproxy.parse(conn(:get, path), [])
+      ImagePipe.Cache.Key.build(plan, conn(:get, path), %{}, [])
+    end
+
+    base = key.("/_/sm:1/kcr:1/scp:1/plain/images/cat.jpg")
+
+    refute base == key.("/_/sm:0/kcr:1/scp:1/plain/images/cat.jpg")
+    refute base == key.("/_/sm:1/kcr:0/scp:1/plain/images/cat.jpg")
+    refute base == key.("/_/sm:1/kcr:1/scp:0/plain/images/cat.jpg")
+  end
+```
+
+(Adjust `Key.build/4` to the real signature found in `lib/image_pipe/cache/key.ex`. `scp` distinctness already works via Task 1's KeyData; this test also guards it.)
+
+- [ ] **Step 2: Run it to verify failure**
+
+Run: `mise exec -- mix test test/parser/imgproxy_test.exs -k "distinct cache keys"`
+Expected: FAIL on the `sm:0` and `kcr:0` cases (keys equal) — `output_plan_data` ignores sm/kcr. (The `scp:0` case should already pass.)
+
+- [ ] **Step 3: Add sm/kcr to `output_plan_data/2`**
+
+In `lib/image_pipe/cache/key.ex`, add the two fields to **both** clauses:
+
+```elixir
+  defp output_plan_data(%Output{mode: :automatic} = output, opts) do
+    {:ok,
+     [
+       mode: :automatic,
+       auto: [
+         avif: Keyword.get(opts, :auto_avif, true),
+         webp: Keyword.get(opts, :auto_webp, true)
+       ],
+       quality: output.quality,
+       format_qualities: output.format_qualities,
+       strip_metadata: output.strip_metadata,
+       keep_copyright: output.keep_copyright
+     ]}
+  end
+
+  defp output_plan_data(%Output{mode: {:explicit, format}} = output, _opts) do
+    {:ok,
+     [
+       mode: :explicit,
+       format: format,
+       quality: output.quality,
+       format_qualities: output.format_qualities,
+       strip_metadata: output.strip_metadata,
+       keep_copyright: output.keep_copyright
+     ]}
+  end
+```
+
+- [ ] **Step 4: Run the cache-key test**
+
+Run: `mise exec -- mix test test/parser/imgproxy_test.exs -k "distinct cache keys"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/cache/key.ex test/parser/imgproxy_test.exs
+git commit -m "feat(cache): include strip_metadata/keep_copyright in output cache key"
+```
+
+---
+
+## Task 5: Thread `sm`/`kcr` to the encoder and strip metadata
+
+**Files:**
+- Modify: `lib/image_pipe/output/policy.ex`, `lib/image_pipe/output/resolved.ex`, `lib/image_pipe/output/encoder.ex`
+- Test: covered end-to-end by Task 6 wire tests (no isolated unit test — `Resolved`/encoder are exercised through `ImagePipe.call/2`, per the repo's no-hand-built-struct rule).
+
+- [ ] **Step 1: Add fields to `Output.Resolved`**
+
+In `lib/image_pipe/output/resolved.ex`:
+
+```elixir
+  @enforce_keys [:format, :quality, :response_headers, :strip_metadata, :keep_copyright]
+  defstruct @enforce_keys
+
+  @type format :: ImagePipe.Format.output_format()
+  @type quality :: :default | {:quality, 1..100}
+  @type t :: %__MODULE__{
+          format: format(),
+          quality: quality(),
+          response_headers: [{String.t(), String.t()}],
+          strip_metadata: boolean(),
+          keep_copyright: boolean()
+        }
+```
+
+- [ ] **Step 2: Thread through `Output.Policy`**
+
+In `lib/image_pipe/output/policy.ex`: add `:strip_metadata, :keep_copyright` to `@enforce_keys`, the `@type t()`, and **both** `from_output_plan/3` clauses (copy from `output`), then set them in `resolved/2`:
+
+```elixir
+  @enforce_keys [
+    :mode,
+    :modern_candidates,
+    :headers,
+    :quality,
+    :format_qualities,
+    :strip_metadata,
+    :keep_copyright
+  ]
+```
+
+In each `from_output_plan/3` clause add:
+
+```elixir
+      strip_metadata: output.strip_metadata,
+      keep_copyright: output.keep_copyright
+```
+
+In `resolved/2`:
+
+```elixir
+  defp resolved(%__MODULE__{} = policy, format) do
+    %Resolved{
+      format: format,
+      quality: effective_quality(policy, format),
+      response_headers: policy.headers,
+      strip_metadata: policy.strip_metadata,
+      keep_copyright: policy.keep_copyright
+    }
+  end
+```
+
+- [ ] **Step 3: Apply stripping in `Output.Encoder`**
+
+Rewrite `lib/image_pipe/output/encoder.ex` `stream_output/3` to finalize before streaming:
+
+```elixir
+  def stream_output(%Vix.Vips.Image{} = image, %Resolved{} = resolved_output, opts) do
+    with {:ok, mime_type, suffix} <- output_format(resolved_output) do
+      image_module = Keyword.get(opts, :image_module, Image)
+      finalized = strip_metadata(image, resolved_output)
+      stream = image_module.stream!(finalized, output_options(suffix, resolved_output))
+      {:ok, stream, mime_type}
+    end
+  rescue
+    exception -> {:error, {:encode, exception, __STACKTRACE__}}
+  end
+
+  # Metadata stripping uses explicit libvips header field names via Vix mutate.
+  # We deliberately avoid:
+  #   * the libvips `strip` write flag — it also removes the ICC profile, but
+  #     `scp` (NormalizeColorProfile) owns profile handling independently;
+  #   * `Image.remove_metadata(img, :xmp)` — `image` v0.67 maps `:xmp` to
+  #     "xmp-dataa" (a typo), so it silently leaves XMP in;
+  #   * default `remove_metadata`/`minimize_metadata` for the no-kcr path — they
+  #     enumerate and remove ALL header fields, including `icc-profile-data`.
+  defp strip_metadata(image, %Resolved{strip_metadata: false}), do: image
+
+  defp strip_metadata(image, %Resolved{keep_copyright: true} = _resolved) do
+    icc = header_value(image, "icc-profile-data")
+
+    image
+    |> Image.minimize_metadata!(keep: [:copyright, :artist])
+    |> restore_icc(icc)
+  end
+
+  defp strip_metadata(image, %Resolved{}) do
+    Vix.Vips.Image.mutate!(image, fn mut ->
+      Enum.each(["exif-data", "xmp-data", "iptc-data"], &Vix.Vips.MutableImage.remove(mut, &1))
+    end)
+  end
+
+  defp header_value(image, field) do
+    case Vix.Vips.Image.header_value(image, field) do
+      {:ok, value} -> value
+      _ -> nil
+    end
+  end
+
+  defp restore_icc(image, nil), do: image
+
+  defp restore_icc(image, icc) do
+    Vix.Vips.Image.mutate!(image, fn mut ->
+      Vix.Vips.MutableImage.set(mut, "icc-profile-data", :VipsBlob, icc)
+    end)
+  end
+```
+
+Confirm `Vix.Vips.Image.mutate!/2` exists; if only `mutate/2` is available, bind `{:ok, img} = Vix.Vips.Image.mutate(...)` and return `img`. Confirm `Image.minimize_metadata!/2` is the bang variant (it is, per `image.ex`).
+
+- [ ] **Step 4: Compile**
+
+Run: `mise exec -- mix compile --warnings-as-errors`
+Expected: success.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/output/resolved.ex lib/image_pipe/output/policy.ex lib/image_pipe/output/encoder.ex
+git commit -m "feat(output): apply strip_metadata/keep_copyright at encode (Vix mutate)"
+```
+
+---
+
+## Task 6: Wire tests for `sm`/`kcr` (metadata fixtures)
+
+**Files:**
+- Test: `test/image_pipe/imgproxy_wire_conformance_test.exs`
+
+- [ ] **Step 1: Add a metadata-bearing origin image generator + helper**
+
+In `test/image_pipe/imgproxy_wire_conformance_test.exs`, add an origin Plug that emits a JPEG carrying EXIF (incl. copyright/artist), XMP, and IPTC header fields (mirror `ExifOrientationOriginImage`):
+
+```elixir
+  defmodule MetadataOriginImage do
+    @moduledoc false
+
+    def call(conn, _opts) do
+      {:ok, img} =
+        40
+        |> Image.new!(40, color: :red)
+        |> Vix.Vips.Image.mutate(fn m ->
+          :ok = Vix.Vips.MutableImage.set(m, "exif-ifd0-Copyright", :gchararray, "(c) ACME")
+          :ok = Vix.Vips.MutableImage.set(m, "exif-ifd0-Artist", :gchararray, "ACME")
+          :ok = Vix.Vips.MutableImage.set(m, "exif-ifd0-ImageDescription", :gchararray, "secret")
+          :ok = Vix.Vips.MutableImage.set(m, "xmp-data", :VipsBlob, "<x:xmpmeta/>")
+          :ok = Vix.Vips.MutableImage.set(m, "iptc-data", :VipsBlob, "iptc")
+          :ok
+        end)
+
+      body = Image.write!(img, :memory, suffix: ".jpg")
+
+      conn
+      |> Plug.Conn.put_resp_content_type("image/jpeg")
+      |> Plug.Conn.send_resp(200, body)
+    end
+  end
+
+  defp metadata_origin_opts(overrides \\ []) do
+    Keyword.merge(
+      [
+        parser: ImagePipe.Parser.Imgproxy,
+        sources: [
+          path:
+            {RootHTTPAdapter,
+             root_url: "http://origin.test", req_options: [plug: MetadataOriginImage]}
+        ]
+      ],
+      overrides
+    )
+  end
+
+  defp response_fields(conn) do
+    {:ok, img} = Image.open(conn.resp_body)
+    {:ok, names} = Vix.Vips.Image.header_field_names(img)
+    {img, names}
+  end
+```
+
+**Note (validate during TDD):** raw EXIF/XMP/IPTC set on a synthetic image must survive the JPEG round-trip for these assertions to be meaningful. If libvips drops them on `write!`, first assert presence on the **non-stripped** (`sm:0`) response; if even `sm:0` lacks them, switch the fixture to a committed real JPEG that carries the metadata, or adjust which fields you assert on. Resolve this before writing Step 2's assertions.
+
+- [ ] **Step 2: Write the failing wire tests**
+
+```elixir
+  test "imgproxy default strips EXIF/XMP/IPTC; sm:0 keeps them" do
+    stripped =
+      "/_/scp:0/f:jpeg/plain/images/meta.jpg"
+      |> call_imgproxy(metadata_origin_opts())
+
+    assert stripped.status == 200
+    {_img, names} = response_fields(stripped)
+    refute "exif-data" in names
+    refute "xmp-data" in names
+    refute "iptc-data" in names
+
+    kept =
+      "/_/sm:0/scp:0/f:jpeg/plain/images/meta.jpg"
+      |> call_imgproxy(metadata_origin_opts())
+
+    {_img2, kept_names} = response_fields(kept)
+    assert "exif-data" in kept_names
+  end
+
+  test "imgproxy kcr:1 keeps EXIF copyright while stripping the rest" do
+    conn =
+      "/_/sm:1/kcr:1/scp:0/f:jpeg/plain/images/meta.jpg"
+      |> call_imgproxy(metadata_origin_opts())
+
+    assert conn.status == 200
+    {img, _names} = response_fields(conn)
+    {:ok, exif} = Image.exif(img)
+    assert exif[:copyright] == "(c) ACME"
+  end
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs -k "strips EXIF"`
+Expected: FAIL initially if the source route name differs — register the `images/meta.jpg` path the same way the suite registers `images/oriented.jpg` (reuse the existing source-path convention in this file). Then FAIL on assertions until Tasks 3 & 5 behavior is exercised (they are already merged, so failures here indicate fixture/round-trip issues to resolve per Step 1's note).
+
+- [ ] **Step 4: Make tests pass**
+
+Resolve fixture round-trip per Step 1's note (most likely: assert on the fields that survive JPEG encode for your libvips build, or use a committed fixture). No production code change should be needed if Tasks 3 & 5 are correct; if `Image.exif/1` returns no copyright, verify the encoder's `kcr` branch ran (`minimize_metadata!(keep: [:copyright, :artist])`).
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs -k "strips EXIF" && mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs -k "kcr:1 keeps"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/image_pipe/imgproxy_wire_conformance_test.exs
+git commit -m "test(imgproxy): wire tests for sm/kcr metadata stripping"
+```
+
+---
+
+## Task 7: Wire test for `scp` (wide-gamut fixture)
+
+**Files:**
+- Test: `test/image_pipe/imgproxy_wire_conformance_test.exs`
+
+- [ ] **Step 1: Add a wide-gamut origin generator**
+
+```elixir
+  defmodule WideGamutOriginImage do
+    @moduledoc false
+
+    def call(conn, _opts) do
+      # Start from sRGB pixels, attach a non-sRGB profile so scp has work to do.
+      {:ok, p3} = Image.to_colorspace(Image.new!(40, 40, color: [200, 50, 50]), :p3, [])
+      body = Image.write!(p3, :memory, suffix: ".png")
+
+      conn
+      |> Plug.Conn.put_resp_content_type("image/png")
+      |> Plug.Conn.send_resp(200, body)
+    end
+  end
+```
+
+**Validate during TDD:** confirm `Image.to_colorspace(img, :p3, [])` produces a PNG whose decoded form carries `icc-profile-data` (assert on the `scp:0` response below). If `:p3` embedding doesn't round-trip in your libvips build, substitute a committed wide-gamut fixture (Display-P3 PNG/JPEG).
+
+- [ ] **Step 2: Write the failing test**
+
+```elixir
+  test "imgproxy scp:1 outputs sRGB with no embedded profile; scp:0 keeps it" do
+    dropped =
+      "/_/scp:1/f:png/plain/images/wide.png"
+      |> call_imgproxy(wide_gamut_origin_opts())
+
+    assert dropped.status == 200
+    {_img, names} = response_fields(dropped)
+    refute "icc-profile-data" in names
+
+    kept =
+      "/_/scp:0/f:png/plain/images/wide.png"
+      |> call_imgproxy(wide_gamut_origin_opts())
+
+    {_img2, kept_names} = response_fields(kept)
+    assert "icc-profile-data" in kept_names
+  end
+```
+
+Add `wide_gamut_origin_opts/0` mirroring `metadata_origin_opts/1` with `WideGamutOriginImage`, and register the `images/wide.png` source path.
+
+- [ ] **Step 3: Run to verify failure, then pass**
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs -k "scp:1 outputs sRGB"`
+Expected: initially FAIL (resolve fixture round-trip per Step 1); PASS once the wide-gamut profile round-trips. No production change needed if Tasks 1–2 are correct.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/image_pipe/imgproxy_wire_conformance_test.exs
+git commit -m "test(imgproxy): wire test for scp color-profile normalization"
+```
+
+> **On the spec's pixel-ordering test:** the spec proposed a `scp:1 + tone effect`
+> wire test comparing pixels against `scp:0` with a tolerance. The *structural*
+> guarantee (conversion runs after resize, before the effect chain) is asserted
+> deterministically in Task 2 Step 1 (`resize < normalize_color_profile < blur`),
+> which is robust. A pixel-distance comparison across libvips resampling is
+> brittle and adds little over the structural assertion + the profile-presence
+> assertions here, so it is intentionally omitted. Add it only if a regression
+> motivates it.
+
+---
+
+## Task 8: Demo controls + URL state
+
+**Files:**
+- Modify: `demo/src/processing-path.ts`, `demo/src/demo-url-state.ts`, `demo/src/App.svelte`
+
+- [ ] **Step 1: Add state fields + defaults**
+
+In `demo/src/processing-path.ts` `DemoState`, add (near `autoRotateEnabled`):
+
+```typescript
+  stripMetadata: boolean;
+  keepCopyright: boolean;
+  stripColorProfile: boolean;
+```
+
+In `defaultDemoState`, add (defaults true, matching the backend):
+
+```typescript
+  stripMetadata: true,
+  keepCopyright: true,
+  stripColorProfile: true,
+```
+
+- [ ] **Step 2: Emit URL segments (canonical)**
+
+In `optionSegments()` (the function that builds segments in `processing-path.ts`), add — emitting only non-default values, and **skipping `kcr` when `stripMetadata` is false** so the URL matches the planner normalization:
+
+```typescript
+  if (!currentState.stripMetadata) {
+    segments.push("sm:0");
+  } else if (!currentState.keepCopyright) {
+    segments.push("kcr:0");
+  }
+
+  if (!currentState.stripColorProfile) {
+    segments.push("scp:0");
+  }
+```
+
+- [ ] **Step 3: Parse URL segments**
+
+In `demo/src/demo-url-state.ts`, add cases to `applyOptionSegment` and parse helpers (mirroring `parseAutoRotate`), accepting `1`/`t`/`true` and `0`/`f`/`false`:
+
+```typescript
+    case "sm":
+      return parseBoolOption(currentState, args, "stripMetadata");
+    case "kcr":
+      return parseBoolOption(currentState, args, "keepCopyright");
+    case "scp":
+      return parseBoolOption(currentState, args, "stripColorProfile");
+```
+
+```typescript
+function parseBoolOption(
+  currentState: DemoState,
+  args: string[],
+  key: "stripMetadata" | "keepCopyright" | "stripColorProfile",
+): DemoState | null {
+  if (args.length !== 1) return null;
+  const v = args[0];
+  if (["1", "t", "true"].includes(v)) return { ...currentState, [key]: true };
+  if (["0", "f", "false"].includes(v)) return { ...currentState, [key]: false };
+  return null;
+}
+```
+
+On parse, normalize: if `stripMetadata` is false, force `keepCopyright` false (mirror the backend). Add to the relevant post-parse normalization, or in `parseBoolOption` when key is `stripMetadata` and value false also set `keepCopyright: false`.
+
+- [ ] **Step 4: Add UI controls**
+
+In `demo/src/App.svelte`, add a "Metadata & Color" collapsible section (mirror the Orientation/Effects switch pattern) with three switches bound to `state.stripMetadata`, `state.keepCopyright`, `state.stripColorProfile`. Disable the `keepCopyright` switch when `!state.stripMetadata`:
+
+```svelte
+            <label class="switch-field">
+              <Switch.Root class="switch-root" bind:checked={state.keepCopyright} disabled={!state.stripMetadata}>
+                <Switch.Thumb class="switch-thumb" />
+              </Switch.Root>
+              <span>Keep copyright when stripping</span>
+            </label>
+```
+
+- [ ] **Step 5: Run the demo verify suite**
+
+Run: `mise run precommit:demo`
+Expected: PASS (Elixir gate + `mix demo.verify`). Fix any demo URL-state round-trip test failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add demo/src/processing-path.ts demo/src/demo-url-state.ts demo/src/App.svelte
+git commit -m "feat(demo): add metadata & color-profile controls"
+```
+
+---
+
+## Task 9: Documentation
+
+**Files:**
+- Modify: `docs/imgproxy_support_matrix.md`, `docs/transform_operations.md`
+
+- [ ] **Step 1: Update the support matrix**
+
+In `docs/imgproxy_support_matrix.md`:
+- Change `strip_metadata` (`sm`), `keep_copyright` (`kcr`), `strip_color_profile` (`scp`) rows from Missing to **Supported**; note default-on and that the imgproxy config (`strip_metadata`/`keep_copyright`/`strip_color_profile`, default true) owns the defaults.
+- Change the config rows `IMGPROXY_STRIP_METADATA`, `IMGPROXY_KEEP_COPYRIGHT`, `IMGPROXY_STRIP_COLOR_PROFILE` from ⭕ to ✅ (URL-only/config as appropriate).
+- Document the two deliberate divergences: `keep_copyright` keeps **EXIF copyright/artist only** (XMP/IPTC stripped); no full import/export color management yet (link #124).
+
+- [ ] **Step 2: Update transform operations doc**
+
+In `docs/transform_operations.md`, add a "Color profile" subsection documenting `NormalizeColorProfile` (semantic + executable), its sRGB-convert-and-drop behavior, and its fixed position: after geometry, immediately before the effect chain.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/imgproxy_support_matrix.md docs/transform_operations.md
+git commit -m "docs: mark imgproxy sm/kcr/scp supported; document NormalizeColorProfile"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full gate**
+
+Run: `mise run precommit` (format check, `compile --warnings-as-errors`, `credo --strict`, `mix test`), then `mise run precommit:demo`.
+Expected: all pass. Fix any credo/format issues (e.g. alias ordering) inline.
+
+- [ ] **Confirm spec divergences hold:** default request strips EXIF/XMP/GPS and normalizes to sRGB; `sm:0`/`scp:0`/`kcr` behave per the wire tests; cache keys distinct.
+
+---
+
+## Notes for the implementer
+
+- **TDD seams:** this codebase tests at boundaries (parser→plan, wire-level `ImagePipe.call/2` decoding the body, cache key). Do **not** hand-build `Transform.State`, `Plan.Pipeline`, or operation structs in tests to assert internals — it violates the repo's test guidelines.
+- **Verify two library calls during TDD** (flagged inline): `Vix.Vips.Image.mutate!/2` vs `mutate/2`, and whether synthetic EXIF/XMP/IPTC/ICC survive the encode round-trip (Tasks 6–7). Resolve with the real API before finalizing assertions.
+- **`Cache.Key.build/4`** signature in Task 4 must match the real function — read `lib/image_pipe/cache/key.ex` and adjust.
+- Run focused tests with `mise exec -- mix test <file> -k "<name fragment>"` while iterating.

--- a/docs/superpowers/plans/2026-05-30-imgproxy-metadata-color-profile.md
+++ b/docs/superpowers/plans/2026-05-30-imgproxy-metadata-color-profile.md
@@ -394,11 +394,14 @@ Add the helpers (beside the auto_rotate ones):
 
 - [ ] **Step 7: Emit the operation in `plan_builder.ex`**
 
-In `lib/image_pipe/parser/imgproxy/plan_builder.ex`, add a clause function:
+In `lib/image_pipe/parser/imgproxy/plan_builder.ex`, add a clause function. `Operation.normalize_color_profile/0` returns `{:ok, struct}` (like every constructor), so unwrap it:
 
 ```elixir
-  defp color_profile_operations(%PipelineRequest{strip_color_profile: true}),
-    do: {:ok, [Operation.normalize_color_profile()]}
+  defp color_profile_operations(%PipelineRequest{strip_color_profile: true}) do
+    with {:ok, operation} <- Operation.normalize_color_profile() do
+      {:ok, [operation]}
+    end
+  end
 
   defp color_profile_operations(%PipelineRequest{}), do: {:ok, []}
 ```

--- a/docs/superpowers/specs/2026-05-30-imgproxy-metadata-color-profile-design.md
+++ b/docs/superpowers/specs/2026-05-30-imgproxy-metadata-color-profile-design.md
@@ -1,0 +1,349 @@
+# Imgproxy Metadata & Color-Profile Controls Design
+
+> Revised after a parallel disjoint-reviewer cycle (architecture, image/imgproxy
+> fidelity, cache/safety, testing/demo). Key corrections: use the ICC-aware
+> conversion path; strip metadata via Vix `mutate` (the `image` v0.67 helper has
+> an XMP field-name bug); explicit wiring checklist; test discipline fixes;
+> concrete demo plan. The `scp` pipeline position (before effects) was challenged
+> and **confirmed correct** against imgproxy source — see "Color-profile
+> normalization".
+
+## Scope
+
+This slice implements imgproxy's output metadata and color-profile controls
+([#30](https://github.com/hlindset/image_plug/issues/30)):
+
+- **`strip_metadata` (`sm`)** — strip EXIF/IPTC/XMP from the output. Encode-time
+  metadata policy on `ImagePipe.Plan.Output`.
+- **`keep_copyright` (`kcr`)** — when stripping, retain copyright/artist. Encode-
+  time metadata policy on `ImagePipe.Plan.Output`.
+- **`strip_color_profile` (`scp`)** — convert the embedded ICC profile to sRGB
+  and drop it. A **transform pipeline operation**, modeled like
+  `auto_rotate`/`AutoOrient`, because the conversion is a pixel mutation whose
+  position relative to color effects is significant.
+
+All three default to **on**. Following the `auto_rotate` precedent, **all four
+defaults — `auto_rotate`, `strip_metadata`, `keep_copyright`,
+`strip_color_profile` — are owned by the imgproxy parser config**
+(`ImagePipe.Parser.Imgproxy.validate_options!`), with per-request URL options
+overriding. The imgproxy compatibility layer is the single control surface.
+
+### Why `scp` is a transform op but `sm`/`kcr` are not
+
+The codebase models **every pixel mutation as a transform operation** with a
+fixed, parser-owned order. `scp`'s ICC→sRGB conversion is a pixel mutation, so it
+follows that rule and gets a fixed pipeline position. `sm`/`kcr` touch only
+header fields, never pixels, so they stay as encode-time output policy.
+
+### Out of scope (deferred, tracked separately)
+
+- **`color_profile` / `cp` / `icc`** — convert to *and embed* a chosen profile
+  ([#119](https://github.com/hlindset/image_plug/issues/119)). The new
+  `NormalizeColorProfile` op is the `cp`-ready seam.
+- **Full import/export color management** — imgproxy color-manages *every* image
+  into a working space before processing and re-embeds the source profile when
+  `scp` is off (see below). This slice does not; it converts only when `scp` is
+  on. Tracked in [#124](https://github.com/hlindset/image_plug/issues/124)
+  (distinct from #119, which is output-profile embedding).
+- **`dpi`, `strip_metadata_dpi`** ([#120](https://github.com/hlindset/image_plug/issues/120)),
+  **`preserve_hdr`** ([#121](https://github.com/hlindset/image_plug/issues/121)),
+  **`enforce_thumbnail`** ([#122](https://github.com/hlindset/image_plug/issues/122)),
+  **`page`/`pages`/`disable_animation`** ([#123](https://github.com/hlindset/image_plug/issues/123)).
+
+## Current State
+
+### ImagePipe keeps all metadata today
+
+`ImagePipe.Output.Encoder.stream_output/3` (`lib/image_pipe/output/encoder.ex`)
+calls `Image.stream!/2` with only `suffix` and `quality` — no strip flag — so
+libvips preserves EXIF (including GPS), IPTC, XMP, and the ICC profile into every
+response. This is the privacy gap behind [#30](https://github.com/hlindset/image_plug/issues/30)
+(`priority:P1` / `type:security`).
+
+### imgproxy behavior (verified against source)
+
+Defaults (`local/imgproxy-master/processing/config.go`): `StripMetadata: true`,
+`KeepCopyright: true`, `StripColorProfile: true`.
+
+**Color management** (`processing/processing.go`, `colorspace_to_processing.go`,
+`colorspace_to_result.go`):
+
+- `mainPipeline` runs `colorspaceToProcessing` **early — before crop/scale/
+  `applyFilters`**. It imports the embedded ICC profile and converts pixels to a
+  standard working space (sRGB, or 16-bit RGB for HDR-capable formats). So
+  **effects run in a standard (sRGB-ish) working space, not the raw embedded-
+  profile space.**
+- `finalizePipeline` runs `colorspaceToResult` then `stripMetadata`.
+  `colorspaceToResult` decides: keep the profile (re-export/embed) when
+  `scp` is off and the format supports profiles, or drop it when `scp` is on
+  (pixels are already in the standard space, so it just removes the profile).
+
+**Metadata strip** (`processing/strip_metadata.go`): `stripMetadata` is a no-op
+unless `StripMetadata`. With `KeepCopyright`, imgproxy backs up the full IPTC
+(PS3) and XMP blobs, runs `Strip(keepCopyright)` (libvips strip that retains
+EXIF copyright fields), then restores the IPTC and XMP blobs.
+
+### Precedents this slice reuses
+
+- **`auto_rotate` / `AutoOrient`** — parser config default; plan builder emits a
+  semantic `Plan.Operation.AutoOrient`; `PlanExecutor` lowers to
+  `Transform.Operation.AutoOrient`; `Plan.KeyData` covers it; exported from the
+  `ImagePipe.Transform` boundary. `scp` mirrors this exactly.
+- **Output threading** — `Plan.Output` → `Output.Policy.from_output_plan/3`
+  (`output/policy.ex:30`) → `Policy.resolve/2` → `Output.Resolved`
+  (`output/resolved.ex`) → `Encoder.stream_output/3`. `sm`/`kcr` thread through;
+  they are independent of Accept negotiation.
+
+### `image` library primitives (v0.67) — verified
+
+- `Image.to_colorspace/2` (`image.ex:8292`) is an **interpretation-only**
+  conversion — **not** ICC-profile-aware. The ICC-aware path is
+  `Image.to_colorspace/3` (`image.ex:8351`), which delegates to
+  `Vix.Vips.Operation.icc_transform/3` using the embedded profile as input.
+  **This slice uses the `/3` (icc_transform) path.**
+- **Verified empirically (see below); two relevant `image` v0.67 behaviors:**
+  - The **`:xmp` atom selector is broken**: `@metadata_fields` (`image.ex:6671`)
+    maps `xmp: "xmp-dataa"` (typo), so `remove_metadata(img, :xmp)` /
+    `[:xmp]` is a silent no-op. `:exif`/`:iptc` work; the literal `"xmp-data"`
+    string works. (Filed upstream.)
+  - **`remove_metadata/1` default (no fields) and `minimize_metadata/1,2`
+    over-strip**: they enumerate `header_field_names/1` and remove *all* of them,
+    **including `icc-profile-data`**. So `minimize_metadata` does **not** preserve
+    the ICC profile.
+- **Consequence:** to strip exactly EXIF/XMP/IPTC while preserving the ICC
+  profile (required for `sm`/`scp` independence), this slice removes the explicit
+  string fields `"exif-data"`/`"xmp-data"`/`"iptc-data"` via Vix `mutate` — never
+  the `:xmp` atom, never the default/`minimize` path. The `kcr` path additionally
+  preserves the profile by backing up and restoring `icc-profile-data`.
+
+### Verified behavior (probe, `image` 0.67.0)
+
+| call | result |
+| --- | --- |
+| `remove_metadata(img, :xmp)` | nothing removed (XMP retained) |
+| `remove_metadata(img)` / `minimize_metadata(img)` | all metadata **and ICC profile** removed |
+| `remove_metadata(img, ["exif-data","xmp-data","iptc-data"])` | those three removed, **ICC kept** |
+| raw `MutableImage.remove/2` per field | precise per-field removal |
+
+## Design
+
+### Color-profile normalization: new transform operation (`scp`)
+
+Operation pair mirroring `AutoOrient`:
+
+- **`ImagePipe.Plan.Operation.NormalizeColorProfile`** — semantic intent, no
+  fields in this slice (sRGB implicit). This struct is the `cp`-ready seam
+  ([#119](https://github.com/hlindset/image_plug/issues/119) adds a target).
+- **`ImagePipe.Transform.Operation.NormalizeColorProfile`** — executable.
+  `execute/2`:
+  - if the image carries an embedded ICC profile: convert to sRGB via the
+    **ICC-aware** path (`Image.to_colorspace/3` → `icc_transform`, sRGB output,
+    embedded profile as input), then drop the `icc-profile-data` header so the
+    output embeds no profile; store back into `Transform.State`;
+  - else: no-op.
+  - failures → `{:error, {__MODULE__, error}}`.
+- **`Plan.KeyData`** clause: `data(%NormalizeColorProfile{}) ->
+  [op: :normalize_color_profile]`.
+- **`PlanExecutor`** clause lowering the semantic op to the executable op
+  (mirrors the `AutoOrient` clause).
+
+**Fixed pipeline position: after geometry (resize/crop), immediately before the
+effect chain.** Verified faithful to imgproxy for the default `scp:1`: imgproxy
+imports color to a standard working space *before* `applyFilters`, so effects
+run on sRGB pixels and the output carries no profile. Converting on already-
+downscaled pixels also keeps cost bounded.
+
+**Documented limitation (vs imgproxy):** imgproxy color-manages *every* image
+into a working space before processing regardless of `scp`, and re-embeds the
+source profile when `scp` is off. This slice converts **only when `scp` is on**.
+Consequence: with `scp:0` **and** a tone effect on a wide-gamut source,
+ImagePipe applies the effect in the source profile's space rather than a working
+space — a minor fidelity gap for a non-default combination. Full import/export
+color management is out of scope (tracked in
+[#124](https://github.com/hlindset/image_plug/issues/124)).
+
+**Decode planning:** the conversion is a point-wise op and is **sequential-safe
+(one-pass)**; it does not force random access or change decode/open planning.
+
+**Emission:** the imgproxy plan builder emits `NormalizeColorProfile` when the
+resolved `scp` is true, nothing when false. `scp` is a plain boolean.
+
+### Metadata policy: `ImagePipe.Plan.Output` (`sm`/`kcr`)
+
+Add two boolean fields (`strip_color_profile` is the transform op, not here):
+
+```elixir
+defstruct mode: :automatic, quality: :default, format_qualities: %{},
+          strip_metadata: true, keep_copyright: true
+```
+
+Struct defaults are safe fallbacks for direct constructors; the imgproxy parser
+always sets them from its config, so the parser owns the effective default.
+
+**Canonicalization.** `keep_copyright` only matters when `strip_metadata` is
+true. The plan builder normalizes `keep_copyright` to `false` whenever
+`strip_metadata` is `false`, keeping cache keys/ETags deterministic.
+
+### Output encode path: `sm`/`kcr` via Vix `mutate`
+
+Thread `strip_metadata` + `keep_copyright` through `Policy` and `Resolved`
+(both gain the two fields; populated in `Policy.resolved/2` from `Plan.Output`).
+`Encoder.stream_output/3` applies them to the materialized Vix image before
+streaming, **never** using the blunt libvips `strip` write flag (it would also
+remove the ICC profile) **and not relying on `Image.remove_metadata`** (XMP bug):
+
+```
+finalize(image, resolved):
+  cond do
+    not resolved.strip_metadata ->
+      image                                              # keep all metadata
+    resolved.keep_copyright ->
+      icc = header_value(image, "icc-profile-data")      # may be absent (scp dropped it upstream)
+      image
+      |> minimize_metadata!(keep: [:copyright, :artist]) # strips exif(except copyright/artist)+xmp+iptc+ICC
+      |> restore(icc)                                     # re-attach the profile (minimize over-strips it)
+    true ->
+      mutate(image, remove ["exif-data", "xmp-data", "iptc-data"])  # ICC preserved
+  end
+  |> stream!(suffix: suffix, quality: quality)   # no libvips strip flag
+```
+
+- The non-`kcr` strip uses `Vix.Vips.Image.mutate/2` + `MutableImage.remove/2`
+  with explicit field names, preserving `icc-profile-data`.
+- The `kcr` path reuses `minimize_metadata` for EXIF copyright/artist retention,
+  but **must back up and restore `icc-profile-data`** because `minimize_metadata`
+  removes it. When `scp` already dropped the profile upstream, the backup is
+  empty and the restore is a no-op — consistent.
+- **Required code comments** at the strip site: (a) `image` v0.67's
+  `@metadata_fields` maps `xmp: "xmp-dataa"` (typo) so the `:xmp` atom selector
+  is a no-op — hence explicit string field names; (b) `minimize_metadata`/default
+  `remove_metadata` over-strip the ICC profile, hence explicit field removal and
+  the `kcr` backup/restore.
+- `scp` is **not** handled here — by encode time the `NormalizeColorProfile` op
+  (if emitted) has already converted and dropped the profile.
+- The EXIF Orientation tag is stripped safely: `AutoOrient` runs first and bakes
+  orientation into pixels, so removing the tag afterward cannot mis-orient.
+- Errors fold into the existing `{:error, {:encode, exception, stacktrace}}`
+  rescue. No new error category.
+
+**`keep_copyright` fidelity (deliberate divergence):** imgproxy preserves the
+full XMP + IPTC blobs plus EXIF copyright. This slice **intentionally** preserves
+**EXIF copyright/artist only** and still strips XMP/IPTC — a privacy-conservative
+choice (XMP/IPTC can carry GPS/personal data; strip more when uncertain). This is
+a decided behavior, not a gap: full XMP/IPTC retention is not planned. Documented
+in the support matrix.
+
+### Cache key: `ImagePipe.Cache.Key`
+
+- `sm`/`kcr` (post-normalization) → add to both `output_plan_data/2` clauses
+  (`cache/key.ex:101`, `:114`). They change encoded bytes, so they belong in the
+  key and (via `plan_material` in `request/http_cache.ex`) the ETag.
+- `scp` → keyed via the `NormalizeColorProfile` op's `KeyData`; nothing extra in
+  `output_plan_data`.
+
+Greenfield: reshape key data in place — no key-data version bump.
+
+### Wiring checklist (mirrors `AutoOrient`)
+
+1. `Plan.Operation.NormalizeColorProfile` + `Transform.Operation.NormalizeColorProfile`.
+2. Export `Operation.NormalizeColorProfile` from the `ImagePipe.Transform`
+   boundary (`lib/image_pipe/transform.ex`).
+3. `Plan.KeyData.data/1` clause + alias.
+4. `PlanExecutor.executable_operations/3` clause.
+5. imgproxy plan builder emits the op (parser-owned `scp` default).
+6. `Plan.Output` gains `strip_metadata`/`keep_copyright`; `Policy` + `Resolved`
+   thread them; `Encoder` applies them.
+7. `output_plan_data/2` includes `sm`/`kcr` (post-normalization).
+
+### Boundaries
+
+`parser → plan`, `output → plan`, `cache → plan, output`, transform-execution
+contract — all existing edges. Request/source/response code must not name the
+concrete `Transform.Operation.NormalizeColorProfile`; dispatch via
+`ImagePipe.Transform`. Covered by the existing architecture boundary test.
+
+## Testing
+
+Boundary-focused; decode the response body for pixel/metadata-visible changes.
+No hand-built `Plan.Output`/transform-state/op structs (per repo test
+guidelines) — exercise the parser→plan→execute→encode path end to end, following
+the `auto_rotate` wire-conformance pattern.
+
+- **Parser** (`test/parser/imgproxy*`): boolean + alias parsing for `sm`/`kcr`/
+  `scp`; config defaults; URL-overrides-config; order-insensitivity; repeated
+  last-value-wins.
+- **Parse→plan boundary**: `sm:0/kcr:1` yields a `Plan.Output` with
+  `keep_copyright` normalized to `false`; `scp:1` emits exactly one
+  `NormalizeColorProfile` at the correct position, `scp:0` emits none. (Asserted
+  via parse+plan of a URL, not by constructing structs by hand.)
+- **Wire-level Plug** (real `ImagePipe.call/2`, read the response bytes):
+  - default → EXIF/GPS **and XMP** absent; default `scp` → output sRGB, no
+    embedded profile;
+  - `sm:0` → EXIF retained;
+  - `kcr:1` → EXIF copyright retained, other EXIF + XMP/IPTC stripped;
+  - `scp:1` on a wide-gamut fixture → output sRGB, no profile; `scp:0` → profile
+    retained, pixels unconverted;
+  - **ordering** (`scp:1` + tone effect on wide-gamut): assert the output is
+    sRGB with no profile and differs from the `scp:0` output by a bounded
+    pixel-distance **tolerance** (mean channel delta over a threshold), not exact
+    bytes — libvips resampling/rounding makes exact pixels brittle.
+- **Cache**: equivalent requests reuse; `sm`/`kcr`/`scp` variations produce
+  **distinct** keys/ETags (assert `Cache.Key` outputs differ), no cross-serving.
+
+### Response-metadata assertion mechanism (validate in TDD before writing tests)
+
+The plan assumes tests can read EXIF/XMP/ICC from response **bytes**. Confirm the
+concrete API first (e.g. `Image.open` the bytes then read header fields / a
+metadata accessor for `exif-data`/`xmp-data`/`icc-profile-data`). If the `image`
+public API can't read these post-encode, decide between a small header probe and
+escalating — do this proof-of-concept before committing to the assertions above.
+
+### Fixtures
+
+No suitable fixtures exist (`test/support` images are generated on the fly; cf.
+`ExifOrientationOriginImage` in `imgproxy_wire_conformance_test.exs`). Mirror that
+pattern with origin-image generators that embed metadata/profile:
+- an EXIF+GPS+copyright JPEG generator, and
+- a wide-gamut (Display-P3 / Adobe RGB) source with an embedded ICC profile.
+Validate that generation can actually embed EXIF/ICC via the `image`/Vix API as
+part of TDD.
+
+## Demo (`demo/` Svelte app)
+
+Concrete changes:
+- **`DemoState`** (`processing-path.ts`): add `stripMetadata: boolean`,
+  `keepCopyright: boolean`, `stripColorProfile: boolean` (defaults `true`).
+- **URL state** (`demo-url-state.ts`): parse/emit `sm:`, `kcr:`, `scp:` with the
+  boolean alias logic (`1`/`t`/`true` → true). On emit, **skip `kcr:` when
+  `stripMetadata` is false** so the URL is always canonical (matches the planner
+  normalization); normalize on parse too.
+- **UI** (`App.svelte`): a "Metadata & Color" section with three checkboxes;
+  the `keep_copyright` checkbox is **disabled when `strip_metadata` is off**.
+
+## Documentation
+
+- `docs/imgproxy_support_matrix.md`: mark `sm`, `kcr`, `scp` ✅ Supported and the
+  matching `IMGPROXY_*` rows; note default-on behavior and the documented
+  divergences (no full import/export color management; `keep_copyright` keeps
+  EXIF copyright only).
+- `docs/transform_operations.md`: add `NormalizeColorProfile` and its fixed
+  position.
+- `docs/imgproxy_path_api.md`: update if it enumerates the ordered op chain.
+
+## Open Questions (pin via TDD, not blocking design)
+
+1. **Profile removal in the *encoded output***: the probe confirms removing the
+   `icc-profile-data` header drops it from the in-memory image; still confirm the
+   *encoded bytes* (after `stream!`) carry no embedded profile on a wide-gamut
+   fixture for each output format.
+
+Resolved during design (probe, `image` 0.67.0):
+
+- **Profile presence / removal mechanism** — `header_field_names/1` reports
+  `icc-profile-data`; `MutableImage.remove/2` drops it precisely. The op no-ops
+  when the field is absent.
+- **Response-metadata read API** — tests `Image.open` the response bytes and
+  assert on `Vix.Vips.Image.header_field_names/1` (presence/absence of
+  `exif-data`/`xmp-data`/`iptc-data`/`icc-profile-data`).
+- **`keep_copyright` scope** — decided: EXIF copyright/artist only, XMP/IPTC
+  stripped (privacy-conservative); not a gap.

--- a/docs/superpowers/specs/2026-05-30-imgproxy-metadata-color-profile-design.md
+++ b/docs/superpowers/specs/2026-05-30-imgproxy-metadata-color-profile-design.md
@@ -134,14 +134,21 @@ Operation pair mirroring `AutoOrient`:
 - **`ImagePipe.Plan.Operation.NormalizeColorProfile`** — semantic intent, no
   fields in this slice (sRGB implicit). This struct is the `cp`-ready seam
   ([#119](https://github.com/hlindset/image_plug/issues/119) adds a target).
-- **`ImagePipe.Transform.Operation.NormalizeColorProfile`** — executable.
-  `execute/2`:
+- **`ImagePipe.Transform.Operation.NormalizeColorProfile`** — executable,
+  **conversion-only**. `execute/2`:
   - if the image carries an embedded ICC profile: convert to sRGB via the
     **ICC-aware** path (`Image.to_colorspace/3` → `icc_transform`, sRGB output,
-    embedded profile as input), then drop the `icc-profile-data` header so the
-    output embeds no profile; store back into `Transform.State`;
+    embedded profile as input); store back into `Transform.State`;
   - else: no-op.
   - failures → `{:error, {__MODULE__, error}}`.
+  - It deliberately does **not** remove the `icc-profile-data` header. Metadata
+    removal requires realizing pixels (`Vix` `mutate` → `copy_memory`), which
+    inside the lazy transform chain turns a corrupt-source decode failure into an
+    **uncatchable producer crash (500)** instead of a graceful decode error
+    (415) — `Chain.execute` also re-tags every op error as `:transform_error`
+    (→ 500), so a transform op can never yield the 415 the contract requires.
+    The profile-header drop therefore happens at the output encoder's finalize
+    (below), where realization failures map to a decode error.
 - **`Plan.KeyData`** clause: `data(%NormalizeColorProfile{}) ->
   [op: :normalize_color_profile]`.
 - **`PlanExecutor`** clause lowering the semantic op to the executable op
@@ -168,63 +175,87 @@ color management is out of scope (tracked in
 **Emission:** the imgproxy plan builder emits `NormalizeColorProfile` when the
 resolved `scp` is true, nothing when false. `scp` is a plain boolean.
 
-### Metadata policy: `ImagePipe.Plan.Output` (`sm`/`kcr`)
+### Metadata policy: `ImagePipe.Plan.Output` (`sm`/`kcr`/`scp`)
 
-Add two boolean fields (`strip_color_profile` is the transform op, not here):
+Add three boolean fields. `strip_color_profile` lives here too (in addition to
+driving the transform op) so the encoder finalize can drop the profile header:
 
 ```elixir
 defstruct mode: :automatic, quality: :default, format_qualities: %{},
-          strip_metadata: true, keep_copyright: true
+          strip_metadata: true, keep_copyright: true, strip_color_profile: true
 ```
 
 Struct defaults are safe fallbacks for direct constructors; the imgproxy parser
-always sets them from its config, so the parser owns the effective default.
+always sets them from its config, so the parser owns the effective default. The
+parser resolves `scp` once and sets **both** the first pipeline's op-emission
+flag and `Plan.Output.strip_color_profile` from it, so they stay consistent.
 
 **Canonicalization.** `keep_copyright` only matters when `strip_metadata` is
 true. The plan builder normalizes `keep_copyright` to `false` whenever
 `strip_metadata` is `false`, keeping cache keys/ETags deterministic.
 
-### Output encode path: `sm`/`kcr` via Vix `mutate`
+### Output encode path: `sm`/`kcr`/`scp` metadata via Vix `mutate` (after a safe realize)
 
-Thread `strip_metadata` + `keep_copyright` through `Policy` and `Resolved`
-(both gain the two fields; populated in `Policy.resolved/2` from `Plan.Output`).
-`Encoder.stream_output/3` applies them to the materialized Vix image before
-streaming, **never** using the blunt libvips `strip` write flag (it would also
-remove the ICC profile) **and not relying on `Image.remove_metadata`** (XMP bug):
+Thread `strip_metadata`, `keep_copyright`, **and `strip_color_profile`** through
+`Plan.Output` → `Policy` → `Resolved` (all three gain the fields; populated in
+`Policy.resolved/2`). The `NormalizeColorProfile` transform op converts pixels to
+sRGB; this encode step drops the now-redundant `icc-profile-data` header when
+`scp` is on, alongside the `sm`/`kcr` metadata strip. Doing all metadata removal
+here (not in the transform chain) is what lets corrupt sources degrade to 415.
+
+`Encoder.stream_output/3` **realizes the image once via `Vix.Vips.Image.copy_memory/1`
+before any `mutate`** — and only when stripping is actually needed:
 
 ```
 finalize(image, resolved):
-  cond do
-    not resolved.strip_metadata ->
-      image                                              # keep all metadata
-    resolved.keep_copyright ->
-      icc = header_value(image, "icc-profile-data")      # may be absent (scp dropped it upstream)
-      image
-      |> minimize_metadata!(keep: [:copyright, :artist]) # strips exif(except copyright/artist)+xmp+iptc+ICC
-      |> restore(icc)                                     # re-attach the profile (minimize over-strips it)
-    true ->
-      mutate(image, remove ["exif-data", "xmp-data", "iptc-data"])  # ICC preserved
+  if not resolved.strip_metadata and not resolved.strip_color_profile do
+    {:ok, image}                                   # nothing to strip; stay lazy
+  else
+    with {:ok, mem} <- copy_memory(image) do       # catchable realize; corrupt -> {:error, reason}
+      {:ok, strip(mem, resolved)}
+    end
   end
-  |> stream!(suffix: suffix, quality: quality)   # no libvips strip flag
+
+strip(mem, resolved):
+  cond do
+    not resolved.strip_metadata ->                 # scp only: drop just the profile
+      mutate(mem, remove ["icc-profile-data"])
+    resolved.keep_copyright ->                     # keep EXIF copyright; strip xmp/iptc; drop icc iff scp
+      icc = if resolved.strip_color_profile, do: nil, else: header_value(mem, "icc-profile-data")
+      mem |> minimize_metadata!(keep: [:copyright, :artist]) |> restore_icc(icc)
+    true ->                                        # strip exif/xmp/iptc; drop icc iff scp
+      fields = ["exif-data", "xmp-data", "iptc-data"] ++ icc_fields(resolved)
+      mutate(mem, remove fields)
+  end
+
+icc_fields(%{strip_color_profile: true}) -> ["icc-profile-data"]
+icc_fields(_) -> []
 ```
 
-- The non-`kcr` strip uses `Vix.Vips.Image.mutate/2` + `MutableImage.remove/2`
-  with explicit field names, preserving `icc-profile-data`.
-- The `kcr` path reuses `minimize_metadata` for EXIF copyright/artist retention,
-  but **must back up and restore `icc-profile-data`** because `minimize_metadata`
-  removes it. When `scp` already dropped the profile upstream, the backup is
-  empty and the restore is a no-op — consistent.
-- **Required code comments** at the strip site: (a) `image` v0.67's
-  `@metadata_fields` maps `xmp: "xmp-dataa"` (typo) so the `:xmp` atom selector
-  is a no-op — hence explicit string field names; (b) `minimize_metadata`/default
-  `remove_metadata` over-strip the ICC profile, hence explicit field removal and
-  the `kcr` backup/restore.
-- `scp` is **not** handled here — by encode time the `NormalizeColorProfile` op
-  (if emitted) has already converted and dropped the profile.
+`stream_output/3` then calls `stream!` on the finalized image (no libvips `strip`
+flag). On a `copy_memory` `{:error, reason}` it returns `{:error, {:decode, reason}}`
+so `prepare_first_chunk` maps it to a **415 decode error** rather than crashing
+the producer.
+
+- **Why `copy_memory` first:** `Vix` `mutate` realizes pixels inside a *linked*
+  `MutableImage` GenServer whose `init` `copy_memory` failure kills the producer
+  (uncatchable → 500). Realizing first, in the producer's own stack, makes the
+  failure a returnable `{:error, …}` (→ 415); subsequent `mutate`s run on the
+  in-memory image and can't fail that way.
+- **Never** use the blunt libvips `strip` write flag (removes EXIF *and* ICC
+  together) and **never** use `Image.remove_metadata(_, :xmp)` (`image` v0.67
+  maps `:xmp` → `"xmp-dataa"`, a typo, so XMP is silently retained) or the
+  default `remove_metadata`/`minimize_metadata` field-enumeration for the
+  non-`kcr` paths (they over-strip the ICC profile). Use explicit string field
+  names; the `kcr` path uses `minimize_metadata` for EXIF copyright retention and
+  restores the ICC profile when `scp` is off (since `minimize_metadata` removes it).
+- **Required code comments** at the strip site documenting (a) the `copy_memory`-
+  before-`mutate` rationale (corrupt → 415), (b) the `"xmp-dataa"` typo, and
+  (c) `minimize_metadata`'s ICC over-strip.
 - The EXIF Orientation tag is stripped safely: `AutoOrient` runs first and bakes
-  orientation into pixels, so removing the tag afterward cannot mis-orient.
-- Errors fold into the existing `{:error, {:encode, exception, stacktrace}}`
-  rescue. No new error category.
+  orientation into pixels.
+- Errors fold into the existing `{:error, {:encode, …}}` / `{:error, {:decode, …}}`
+  handling. No new error category.
 
 **`keep_copyright` fidelity (deliberate divergence):** imgproxy preserves the
 full XMP + IPTC blobs plus EXIF copyright. This slice **intentionally** preserves

--- a/docs/transform_operations.md
+++ b/docs/transform_operations.md
@@ -86,6 +86,9 @@ Parser/planner code should use these semantic operations:
 - `ImagePipe.Plan.Operation.Background`: place an alpha-capable color behind
   the current image.
 - `ImagePipe.Plan.Operation.AutoOrient`: apply embedded orientation metadata.
+- `ImagePipe.Plan.Operation.NormalizeColorProfile`: convert the embedded ICC
+  profile to sRGB. Positioned after geometry (resize/crop) and before the effect
+  chain.
 - `ImagePipe.Plan.Operation.Rotate`: right-angle rotation intent.
 - `ImagePipe.Plan.Operation.Flip`: horizontal, vertical, or both-axis flip
   intent.
@@ -117,6 +120,9 @@ describe work over `ImagePipe.Transform.State`, not parser request syntax:
 - `ImagePipe.Transform.Operation.Padding`: resolved edge-padding work.
 - `ImagePipe.Transform.Operation.Background`: resolved background composition.
 - `ImagePipe.Transform.Operation.AutoOrient`: executable EXIF autorotation.
+- `ImagePipe.Transform.Operation.NormalizeColorProfile`: ICC-aware sRGB
+  conversion. Runs after geometry, before effects. The embedded profile header
+  is dropped at the output encoder finalize step, not here.
 - `ImagePipe.Transform.Operation.Rotate`: executable right-angle rotation.
 - `ImagePipe.Transform.Operation.Flip`: executable flip.
 - `ImagePipe.Transform.Operation.Blur`: executable Gaussian blur.
@@ -172,6 +178,27 @@ intent.
 Imgproxy orientation suborder is auto-orient, rotate, then flip. Other dialects
 should preserve their own semantics in the adapter layer and emit the ordered
 Plan operation chain that matches those semantics.
+
+## Color profile operations
+
+Use `ImagePipe.Plan.Operation.NormalizeColorProfile` when a dialect requests
+ICC profile normalization. The operation converts the embedded ICC profile to
+sRGB using ICC-aware color math. It is a conversion-only operation: the
+embedded profile header is dropped at the output encoder finalize step, not
+by the transform operation itself.
+
+`NormalizeColorProfile` is positioned after geometry (resize and crop) and
+immediately before the effect chain. Effects such as brightness, contrast,
+saturation, monochrome, and duotone therefore operate in sRGB space when
+normalization is active.
+
+This operation does not perform full input/output color management. When
+`NormalizeColorProfile` is absent from the pipeline (for example, because the
+corresponding dialect option is disabled), effects run in the source profile
+space. Wide-gamut sources without normalization may produce visually different
+results from sRGB sources. See issue #124.
+
+Imgproxy `strip_color_profile`/`scp` maps to this operation when enabled.
 
 ## Canvas operations
 
@@ -274,6 +301,7 @@ should describe their own URL syntax.
 | `ar/rot:90/fl:true:false/c:100:100` | `AutoOrient`, `Rotate`, `Flip`, `CropGuided` |
 | `extend:true/w:300/h:200` | `Resize` with `mode: :fit`, `Canvas` |
 | `pd:10/bg:f00` | `Padding`, `Background` |
+| `scp` (default on) | `NormalizeColorProfile` |
 | `bl:2/sh:0.7/pix:8/br:20/co:-10/sa:35` | `Blur`, `Sharpen`, `Pixelate`, `Brightness`, `Contrast`, `Saturation` |
 
 ## Boundary rules

--- a/lib/image_pipe/cache/key.ex
+++ b/lib/image_pipe/cache/key.ex
@@ -107,7 +107,9 @@ defmodule ImagePipe.Cache.Key do
          webp: Keyword.get(opts, :auto_webp, true)
        ],
        quality: output.quality,
-       format_qualities: output.format_qualities
+       format_qualities: output.format_qualities,
+       strip_metadata: output.strip_metadata,
+       keep_copyright: output.keep_copyright
      ]}
   end
 
@@ -117,7 +119,9 @@ defmodule ImagePipe.Cache.Key do
        mode: :explicit,
        format: format,
        quality: output.quality,
-       format_qualities: output.format_qualities
+       format_qualities: output.format_qualities,
+       strip_metadata: output.strip_metadata,
+       keep_copyright: output.keep_copyright
      ]}
   end
 
@@ -135,7 +139,9 @@ defmodule ImagePipe.Cache.Key do
          webp: Keyword.get(opts, :auto_webp, true)
        ],
        quality: output.quality,
-       format_qualities: output.format_qualities
+       format_qualities: output.format_qualities,
+       strip_metadata: output.strip_metadata,
+       keep_copyright: output.keep_copyright
      ]}
   end
 

--- a/lib/image_pipe/output/encoder.ex
+++ b/lib/image_pipe/output/encoder.ex
@@ -43,25 +43,28 @@ defmodule ImagePipe.Output.Encoder do
   defp strip(image, %Resolved{strip_metadata: false}),
     do: remove_fields(image, ["icc-profile-data"])
 
-  # keep EXIF copyright/artist, strip xmp/iptc; drop icc iff scp. minimize_metadata
-  # removes ALL metadata incl. the ICC profile, so restore the profile when scp is off.
-  # If minimize_metadata fails (e.g. image has malformed/missing EXIF), fall back to
-  # full metadata removal — copyright preservation is moot when the EXIF is invalid.
-  defp strip(image, %Resolved{keep_copyright: true} = resolved) do
+  # strip_metadata true: remove EXIF/XMP/IPTC, keeping copyright/artist iff kcr.
+  # `minimize_metadata` enumerates and removes ALL metadata header fields — crucially
+  # the individual `exif-ifd0-*`/`exif-gps-*` entries, which survive removing just the
+  # serialized "exif-data" blob and would otherwise be re-serialized into EXIF on
+  # encode (leaking GPS/copyright). It also removes the ICC profile, so restore the
+  # profile when scp is off. If minimize_metadata fails (malformed/absent EXIF), fall
+  # back to blob removal — there is no valid copyright to preserve in that case.
+  defp strip(image, %Resolved{} = resolved) do
+    keep = if resolved.keep_copyright, do: [:copyright, :artist], else: []
     icc = if resolved.strip_color_profile, do: nil, else: header_value(image, "icc-profile-data")
 
-    case Image.minimize_metadata(image, keep: [:copyright, :artist]) do
-      {:ok, minimized} ->
-        restore_icc(minimized, icc)
+    minimized =
+      case Image.minimize_metadata(image, keep: keep) do
+        {:ok, stripped} ->
+          stripped
 
-      {:error, _} ->
-        remove_fields(image, ["exif-data", "xmp-data", "iptc-data"] ++ icc_fields(resolved))
-    end
+        {:error, _} ->
+          remove_fields(image, ["exif-data", "xmp-data", "iptc-data"] ++ icc_fields(resolved))
+      end
+
+    restore_icc(minimized, icc)
   end
-
-  # strip exif/xmp/iptc; drop icc iff scp.
-  defp strip(image, %Resolved{} = resolved),
-    do: remove_fields(image, ["exif-data", "xmp-data", "iptc-data"] ++ icc_fields(resolved))
 
   defp icc_fields(%Resolved{strip_color_profile: true}), do: ["icc-profile-data"]
   defp icc_fields(%Resolved{}), do: []

--- a/lib/image_pipe/output/encoder.ex
+++ b/lib/image_pipe/output/encoder.ex
@@ -51,8 +51,11 @@ defmodule ImagePipe.Output.Encoder do
     icc = if resolved.strip_color_profile, do: nil, else: header_value(image, "icc-profile-data")
 
     case Image.minimize_metadata(image, keep: [:copyright, :artist]) do
-      {:ok, minimized} -> restore_icc(minimized, icc)
-      {:error, _} -> remove_fields(image, ["exif-data", "xmp-data", "iptc-data"] ++ icc_fields(resolved))
+      {:ok, minimized} ->
+        restore_icc(minimized, icc)
+
+      {:error, _} ->
+        remove_fields(image, ["exif-data", "xmp-data", "iptc-data"] ++ icc_fields(resolved))
     end
   end
 

--- a/lib/image_pipe/output/encoder.ex
+++ b/lib/image_pipe/output/encoder.ex
@@ -3,18 +3,97 @@ defmodule ImagePipe.Output.Encoder do
 
   alias ImagePipe.Format
   alias ImagePipe.Output.Resolved
+  alias Vix.Vips.Image, as: VixImage
+  alias Vix.Vips.MutableImage, as: VixMutableImage
 
-  @spec stream_output(Vix.Vips.Image.t(), Resolved.t(), keyword()) ::
+  @spec stream_output(VixImage.t(), Resolved.t(), keyword()) ::
           {:ok, Enumerable.t(), String.t()} | {:error, {:encode, Exception.t(), list()}}
-  def stream_output(%Vix.Vips.Image{} = image, %Resolved{} = resolved_output, opts) do
-    with {:ok, mime_type, suffix} <- output_format(resolved_output) do
+  def stream_output(%VixImage{} = image, %Resolved{} = resolved_output, opts) do
+    with {:ok, mime_type, suffix} <- output_format(resolved_output),
+         {:ok, finalized} <- finalize(image, resolved_output) do
       image_module = Keyword.get(opts, :image_module, Image)
-      stream = image_module.stream!(image, output_options(suffix, resolved_output))
-
+      stream = image_module.stream!(finalized, output_options(suffix, resolved_output))
       {:ok, stream, mime_type}
     end
   rescue
     exception -> {:error, {:encode, exception, __STACKTRACE__}}
+  end
+
+  # Metadata removal requires realizing pixels (Vix `mutate` -> `copy_memory`).
+  # We realize ONCE via copy_memory here, in the producer's own call stack, so a
+  # corrupt-source failure is a returnable {:error, ...} (mapped to a 415 decode
+  # error) instead of the uncatchable producer crash that an in-`mutate`
+  # copy_memory (linked MutableImage GenServer) would cause. Subsequent mutates
+  # run on the in-memory image and cannot fail that way. Stay lazy when there is
+  # nothing to strip.
+  defp finalize(image, %Resolved{strip_metadata: false, strip_color_profile: false}),
+    do: {:ok, image}
+
+  defp finalize(image, %Resolved{} = resolved) do
+    case VixImage.copy_memory(image) do
+      {:ok, mem} -> {:ok, strip(mem, resolved)}
+      {:error, reason} -> {:error, {:decode, reason}}
+    end
+  end
+
+  # scp only (strip_metadata is false here, so we reached finalize via scp): drop
+  # just the ICC profile, keep exif/xmp/iptc.
+  defp strip(image, %Resolved{strip_metadata: false}),
+    do: remove_fields(image, ["icc-profile-data"])
+
+  # keep EXIF copyright/artist, strip xmp/iptc; drop icc iff scp. minimize_metadata
+  # removes ALL metadata incl. the ICC profile, so restore the profile when scp is off.
+  # If minimize_metadata fails (e.g. image has malformed/missing EXIF), fall back to
+  # full metadata removal — copyright preservation is moot when the EXIF is invalid.
+  defp strip(image, %Resolved{keep_copyright: true} = resolved) do
+    icc = if resolved.strip_color_profile, do: nil, else: header_value(image, "icc-profile-data")
+
+    case Image.minimize_metadata(image, keep: [:copyright, :artist]) do
+      {:ok, minimized} -> restore_icc(minimized, icc)
+      {:error, _} -> remove_fields(image, ["exif-data", "xmp-data", "iptc-data"] ++ icc_fields(resolved))
+    end
+  end
+
+  # strip exif/xmp/iptc; drop icc iff scp.
+  defp strip(image, %Resolved{} = resolved),
+    do: remove_fields(image, ["exif-data", "xmp-data", "iptc-data"] ++ icc_fields(resolved))
+
+  defp icc_fields(%Resolved{strip_color_profile: true}), do: ["icc-profile-data"]
+  defp icc_fields(%Resolved{}), do: []
+
+  # Explicit string field names via Vix mutate. We deliberately avoid:
+  #   * the libvips `strip` write flag (it also removes the ICC profile);
+  #   * `Image.remove_metadata(_, :xmp)` — `image` v0.67 maps :xmp -> "xmp-dataa"
+  #     (a typo), silently retaining XMP;
+  #   * default `remove_metadata`/`minimize_metadata` field-enumeration on the
+  #     non-kcr paths — they over-strip the ICC profile.
+  defp remove_fields(image, fields) do
+    {:ok, image} =
+      VixImage.mutate(image, fn mut ->
+        Enum.each(fields, &VixMutableImage.remove(mut, &1))
+        :ok
+      end)
+
+    image
+  end
+
+  defp header_value(image, field) do
+    case VixImage.header_value(image, field) do
+      {:ok, value} -> value
+      _ -> nil
+    end
+  end
+
+  defp restore_icc(image, nil), do: image
+
+  defp restore_icc(image, icc) do
+    {:ok, image} =
+      VixImage.mutate(image, fn mut ->
+        VixMutableImage.set(mut, "icc-profile-data", :VipsBlob, icc)
+        :ok
+      end)
+
+    image
   end
 
   defp output_format(%Resolved{format: format}) when is_atom(format) do

--- a/lib/image_pipe/output/encoder.ex
+++ b/lib/image_pipe/output/encoder.ex
@@ -7,7 +7,9 @@ defmodule ImagePipe.Output.Encoder do
   alias Vix.Vips.MutableImage, as: VixMutableImage
 
   @spec stream_output(VixImage.t(), Resolved.t(), keyword()) ::
-          {:ok, Enumerable.t(), String.t()} | {:error, {:encode, Exception.t(), list()}}
+          {:ok, Enumerable.t(), String.t()}
+          | {:error, {:encode, Exception.t(), list()}}
+          | {:error, {:decode, term()}}
   def stream_output(%VixImage{} = image, %Resolved{} = resolved_output, opts) do
     with {:ok, mime_type, suffix} <- output_format(resolved_output),
          {:ok, finalized} <- finalize(image, resolved_output) do

--- a/lib/image_pipe/output/policy.ex
+++ b/lib/image_pipe/output/policy.ex
@@ -9,7 +9,16 @@ defmodule ImagePipe.Output.Policy do
   alias ImagePipe.Output.Resolved
   alias ImagePipe.Plan.Output
 
-  @enforce_keys [:mode, :modern_candidates, :headers, :quality, :format_qualities]
+  @enforce_keys [
+    :mode,
+    :modern_candidates,
+    :headers,
+    :quality,
+    :format_qualities,
+    :strip_metadata,
+    :keep_copyright,
+    :strip_color_profile
+  ]
   defstruct @enforce_keys
 
   @passthrough_source_formats [:jpeg, :png]
@@ -24,7 +33,10 @@ defmodule ImagePipe.Output.Policy do
           modern_candidates: [format()],
           headers: [{String.t(), String.t()}],
           quality: quality(),
-          format_qualities: %{optional(format()) => quality()}
+          format_qualities: %{optional(format()) => quality()},
+          strip_metadata: boolean(),
+          keep_copyright: boolean(),
+          strip_color_profile: boolean()
         }
 
   @spec from_output_plan(Plug.Conn.t(), Output.t(), keyword()) :: t()
@@ -34,7 +46,10 @@ defmodule ImagePipe.Output.Policy do
       modern_candidates: Negotiation.modern_candidates(accept_header(conn), opts),
       headers: automatic_headers(),
       quality: output.quality,
-      format_qualities: output.format_qualities
+      format_qualities: output.format_qualities,
+      strip_metadata: output.strip_metadata,
+      keep_copyright: output.keep_copyright,
+      strip_color_profile: output.strip_color_profile
     }
   end
 
@@ -44,7 +59,10 @@ defmodule ImagePipe.Output.Policy do
       modern_candidates: [],
       headers: [],
       quality: output.quality,
-      format_qualities: output.format_qualities
+      format_qualities: output.format_qualities,
+      strip_metadata: output.strip_metadata,
+      keep_copyright: output.keep_copyright,
+      strip_color_profile: output.strip_color_profile
     }
   end
 
@@ -115,7 +133,10 @@ defmodule ImagePipe.Output.Policy do
     %Resolved{
       format: format,
       quality: effective_quality(policy, format),
-      response_headers: policy.headers
+      response_headers: policy.headers,
+      strip_metadata: policy.strip_metadata,
+      keep_copyright: policy.keep_copyright,
+      strip_color_profile: policy.strip_color_profile
     }
   end
 

--- a/lib/image_pipe/output/resolved.ex
+++ b/lib/image_pipe/output/resolved.ex
@@ -1,7 +1,14 @@
 defmodule ImagePipe.Output.Resolved do
   @moduledoc false
 
-  @enforce_keys [:format, :quality, :response_headers]
+  @enforce_keys [
+    :format,
+    :quality,
+    :response_headers,
+    :strip_metadata,
+    :keep_copyright,
+    :strip_color_profile
+  ]
   defstruct @enforce_keys
 
   @type format :: ImagePipe.Format.output_format()
@@ -9,6 +16,9 @@ defmodule ImagePipe.Output.Resolved do
   @type t :: %__MODULE__{
           format: format(),
           quality: quality(),
-          response_headers: [{String.t(), String.t()}]
+          response_headers: [{String.t(), String.t()}],
+          strip_metadata: boolean(),
+          keep_copyright: boolean(),
+          strip_color_profile: boolean()
         }
 end

--- a/lib/image_pipe/parser/imgproxy.ex
+++ b/lib/image_pipe/parser/imgproxy.ex
@@ -44,7 +44,10 @@ defmodule ImagePipe.Parser.Imgproxy do
                      auto_rotate: [
                        type: :boolean,
                        default: true
-                     ]
+                     ],
+                     strip_metadata: [type: :boolean, default: true],
+                     keep_copyright: [type: :boolean, default: true],
+                     strip_color_profile: [type: :boolean, default: true]
                    )
 
   def parse(%Plug.Conn{} = conn), do: parse(conn, [])
@@ -172,7 +175,12 @@ defmodule ImagePipe.Parser.Imgproxy do
   end
 
   defp request_defaults(imgproxy_opts) do
-    [auto_rotate: Keyword.get(imgproxy_opts, :auto_rotate, true)]
+    [
+      auto_rotate: Keyword.get(imgproxy_opts, :auto_rotate, true),
+      strip_metadata: Keyword.get(imgproxy_opts, :strip_metadata, true),
+      keep_copyright: Keyword.get(imgproxy_opts, :keep_copyright, true),
+      strip_color_profile: Keyword.get(imgproxy_opts, :strip_color_profile, true)
+    ]
   end
 
   defp source_parsing_config(opts) do

--- a/lib/image_pipe/parser/imgproxy/option_grammar.ex
+++ b/lib/image_pipe/parser/imgproxy/option_grammar.ex
@@ -49,7 +49,11 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammar do
     "filename" => {:filename, [:filename]},
     "fn" => {:filename, [:filename]},
     "return_attachment" => {:return_attachment, [:return_attachment]},
-    "att" => {:return_attachment, [:return_attachment]}
+    "att" => {:return_attachment, [:return_attachment]},
+    "strip_metadata" => {:strip_metadata, [:strip_metadata]},
+    "sm" => {:strip_metadata, [:strip_metadata]},
+    "keep_copyright" => {:keep_copyright, [:keep_copyright]},
+    "kcr" => {:keep_copyright, [:keep_copyright]}
   }
 
   @gravity_anchors %{
@@ -102,8 +106,9 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammar do
     end
   end
 
-  defp scoped_assignments(kind, assignments) when kind in [:format, :quality, :format_quality],
-    do: {:output, assignments}
+  defp scoped_assignments(kind, assignments)
+       when kind in [:format, :quality, :format_quality, :strip_metadata, :keep_copyright],
+       do: {:output, assignments}
 
   defp scoped_assignments(:cachebuster, assignments), do: {:cache, assignments}
 
@@ -115,7 +120,17 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammar do
   defp scoped_assignments(_kind, assignments), do: {:pipeline, assignments}
 
   defp parse_known_option(kind, fields, args, segment)
-       when kind in [:resizing_type, :width, :height, :min_width, :min_height, :enlarge, :format] do
+       when kind in [
+              :resizing_type,
+              :width,
+              :height,
+              :min_width,
+              :min_height,
+              :enlarge,
+              :format,
+              :strip_metadata,
+              :keep_copyright
+            ] do
     parse_exact_fields(fields, args, segment)
   end
 
@@ -293,6 +308,8 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammar do
   defp parse_field(:min_height, value), do: parse_pixels(value)
   defp parse_field(:enlarge, value), do: parse_boolean(value)
   defp parse_field(:extend, value), do: parse_boolean(value)
+  defp parse_field(:strip_metadata, value), do: parse_boolean(value)
+  defp parse_field(:keep_copyright, value), do: parse_boolean(value)
   defp parse_field(:format, value), do: Format.parse(value)
   defp parse_field(:quality, value), do: parse_quality(value)
 

--- a/lib/image_pipe/parser/imgproxy/option_grammar.ex
+++ b/lib/image_pipe/parser/imgproxy/option_grammar.ex
@@ -397,6 +397,11 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammar do
     parse_flip(args, segment)
   end
 
+  defp parse_special_option(name, args, segment)
+       when name in ["strip_color_profile", "scp"] do
+    parse_strip_color_profile(args, segment)
+  end
+
   defp parse_special_option(name, args, segment) when name in ["gravity", "g"] do
     parse_gravity(args, segment)
   end
@@ -783,6 +788,18 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammar do
   end
 
   defp parse_auto_rotate(_args, segment), do: {:error, {:invalid_option_segment, segment}}
+
+  defp parse_strip_color_profile([], _segment),
+    do: {:ok, [strip_color_profile: true]}
+
+  defp parse_strip_color_profile([value], _segment) when value != "" do
+    with {:ok, value?} <- parse_boolean(value) do
+      {:ok, [strip_color_profile: value?]}
+    end
+  end
+
+  defp parse_strip_color_profile(_args, segment),
+    do: {:error, {:invalid_option_segment, segment}}
 
   defp parse_rotate([value], _segment) when value != "" do
     case Integer.parse(value) do

--- a/lib/image_pipe/parser/imgproxy/options.ex
+++ b/lib/image_pipe/parser/imgproxy/options.ex
@@ -292,7 +292,7 @@ defmodule ImagePipe.Parser.Imgproxy.Options do
 
   defp normalize_zero_offset(offset), do: offset
 
-  defp apply_request_defaults(%{pipelines: pipelines} = options, defaults) do
+  defp apply_request_defaults(%{pipelines: pipelines, output: output} = options, defaults) do
     auto_rotate? = effective_auto_rotate(pipelines, Keyword.get(defaults, :auto_rotate, false))
 
     strip_color_profile? =
@@ -306,8 +306,22 @@ defmodule ImagePipe.Parser.Imgproxy.Options do
       |> apply_strip_color_profile_to_first_pipeline(strip_color_profile?)
       |> reject_empty_pipelines()
 
-    %{options | pipelines: pipelines}
+    output =
+      output
+      |> resolve_metadata_defaults(defaults)
+      |> Map.put(:strip_color_profile, strip_color_profile?)
+
+    %{options | pipelines: pipelines, output: output}
   end
+
+  defp resolve_metadata_defaults(output, defaults) do
+    strip = resolve_bool(output.strip_metadata, Keyword.get(defaults, :strip_metadata, true))
+    keep = resolve_bool(output.keep_copyright, Keyword.get(defaults, :keep_copyright, true))
+    %{output | strip_metadata: strip, keep_copyright: strip and keep}
+  end
+
+  defp resolve_bool(nil, default), do: default
+  defp resolve_bool(value, _default) when is_boolean(value), do: value
 
   defp effective_auto_rotate(pipelines, default) do
     Enum.reduce(pipelines, default, fn

--- a/lib/image_pipe/parser/imgproxy/options.ex
+++ b/lib/image_pipe/parser/imgproxy/options.ex
@@ -317,6 +317,8 @@ defmodule ImagePipe.Parser.Imgproxy.Options do
   defp resolve_metadata_defaults(output, defaults) do
     strip = resolve_bool(output.strip_metadata, Keyword.get(defaults, :strip_metadata, true))
     keep = resolve_bool(output.keep_copyright, Keyword.get(defaults, :keep_copyright, true))
+    # keep_copyright is only meaningful when metadata is being stripped; force it
+    # false otherwise so byte-identical outputs share one canonical cache key.
     %{output | strip_metadata: strip, keep_copyright: strip and keep}
   end
 

--- a/lib/image_pipe/parser/imgproxy/options.ex
+++ b/lib/image_pipe/parser/imgproxy/options.ex
@@ -295,7 +295,7 @@ defmodule ImagePipe.Parser.Imgproxy.Options do
   defp apply_request_defaults(%{pipelines: pipelines} = options, defaults) do
     auto_rotate? = effective_auto_rotate(pipelines, Keyword.get(defaults, :auto_rotate, false))
 
-    scp? =
+    strip_color_profile? =
       effective_strip_color_profile(pipelines, Keyword.get(defaults, :strip_color_profile, true))
 
     pipelines =
@@ -303,7 +303,7 @@ defmodule ImagePipe.Parser.Imgproxy.Options do
       |> Enum.map(&consume_auto_rotate_request/1)
       |> Enum.map(&consume_strip_color_profile_request/1)
       |> apply_auto_rotate_to_first_pipeline(auto_rotate?)
-      |> apply_strip_color_profile_to_first_pipeline(scp?)
+      |> apply_strip_color_profile_to_first_pipeline(strip_color_profile?)
       |> reject_empty_pipelines()
 
     %{options | pipelines: pipelines}

--- a/lib/image_pipe/parser/imgproxy/options.ex
+++ b/lib/image_pipe/parser/imgproxy/options.ex
@@ -227,6 +227,9 @@ defmodule ImagePipe.Parser.Imgproxy.Options do
         {field, _value} = assignment, pipeline when field in @effect_fields ->
           %{pipeline | effects: struct!(pipeline.effects, [assignment])}
 
+        {:strip_color_profile, value}, pipeline ->
+          %{pipeline | strip_color_profile: value, strip_color_profile_requested: true}
+
         assignment, pipeline ->
           struct!(pipeline, [assignment])
       end)
@@ -292,10 +295,15 @@ defmodule ImagePipe.Parser.Imgproxy.Options do
   defp apply_request_defaults(%{pipelines: pipelines} = options, defaults) do
     auto_rotate? = effective_auto_rotate(pipelines, Keyword.get(defaults, :auto_rotate, false))
 
+    scp? =
+      effective_strip_color_profile(pipelines, Keyword.get(defaults, :strip_color_profile, true))
+
     pipelines =
       pipelines
       |> Enum.map(&consume_auto_rotate_request/1)
+      |> Enum.map(&consume_strip_color_profile_request/1)
       |> apply_auto_rotate_to_first_pipeline(auto_rotate?)
+      |> apply_strip_color_profile_to_first_pipeline(scp?)
       |> reject_empty_pipelines()
 
     %{options | pipelines: pipelines}
@@ -342,6 +350,24 @@ defmodule ImagePipe.Parser.Imgproxy.Options do
 
     [pipeline | pipelines]
   end
+
+  defp effective_strip_color_profile(pipelines, default) do
+    Enum.reduce(pipelines, default, fn
+      %PipelineRequest{strip_color_profile_requested: true, strip_color_profile: value}, _acc ->
+        value
+
+      %PipelineRequest{}, acc ->
+        acc
+    end)
+  end
+
+  defp consume_strip_color_profile_request(%PipelineRequest{} = pipeline),
+    do: %{pipeline | strip_color_profile: false, strip_color_profile_requested: false}
+
+  defp apply_strip_color_profile_to_first_pipeline(pipelines, false), do: pipelines
+
+  defp apply_strip_color_profile_to_first_pipeline([first | rest], true),
+    do: [%{first | strip_color_profile: true} | rest]
 
   defp reject_empty_pipelines(pipelines) do
     case Enum.reject(pipelines, &pipeline_empty?/1) do

--- a/lib/image_pipe/parser/imgproxy/parsed_request.ex
+++ b/lib/image_pipe/parser/imgproxy/parsed_request.ex
@@ -3,7 +3,14 @@ defmodule ImagePipe.Parser.Imgproxy.ParsedRequest do
 
   alias ImagePipe.Parser.Imgproxy.PipelineRequest
 
-  @default_output %{format: nil, quality: :default, format_qualities: %{}}
+  @default_output %{
+    format: nil,
+    quality: :default,
+    format_qualities: %{},
+    strip_metadata: nil,
+    keep_copyright: nil,
+    strip_color_profile: nil
+  }
   @default_policy %{expires: 0}
   @default_cache %{cachebuster: nil}
   @default_response %{filename: nil, disposition: :default}
@@ -22,7 +29,10 @@ defmodule ImagePipe.Parser.Imgproxy.ParsedRequest do
   @type output_request() :: %{
           required(:format) => output_format() | nil,
           required(:quality) => quality(),
-          required(:format_qualities) => %{optional(output_format()) => quality()}
+          required(:format_qualities) => %{optional(output_format()) => quality()},
+          required(:strip_metadata) => boolean() | nil,
+          required(:keep_copyright) => boolean() | nil,
+          required(:strip_color_profile) => boolean() | nil
         }
   @type policy_request() :: %{required(:expires) => non_neg_integer()}
   @type cache_request() :: %{required(:cachebuster) => String.t() | nil}

--- a/lib/image_pipe/parser/imgproxy/pipeline_request.ex
+++ b/lib/image_pipe/parser/imgproxy/pipeline_request.ex
@@ -45,6 +45,8 @@ defmodule ImagePipe.Parser.Imgproxy.PipelineRequest do
           crop_aspect_ratio_enlarge: boolean(),
           orientation_requested: boolean(),
           auto_rotate_requested: boolean(),
+          strip_color_profile: boolean(),
+          strip_color_profile_requested: boolean(),
           orientation: Orientation.t()
         }
 
@@ -85,5 +87,7 @@ defmodule ImagePipe.Parser.Imgproxy.PipelineRequest do
             crop_aspect_ratio_enlarge: false,
             orientation_requested: false,
             auto_rotate_requested: false,
+            strip_color_profile: false,
+            strip_color_profile_requested: false,
             orientation: %Orientation{}
 end

--- a/lib/image_pipe/parser/imgproxy/plan_builder.ex
+++ b/lib/image_pipe/parser/imgproxy/plan_builder.ex
@@ -216,6 +216,7 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilder do
     with {:ok, orientation_operations} <- orientation_operations(request),
          {:ok, crop_operations} <- crop_operations(request),
          {:ok, resize_operations} <- resize_operations(request),
+         {:ok, color_profile_operations} <- color_profile_operations(request),
          {:ok, effect_operations} <- effect_operations(request),
          {:ok, canvas_operations} <- canvas_operations(request),
          {:ok, padding_operations} <- padding_operations(request),
@@ -224,12 +225,21 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilder do
        orientation_operations ++
          crop_operations ++
          resize_operations ++
+         color_profile_operations ++
          effect_operations ++
          canvas_operations ++
          padding_operations ++
          background_operations}
     end
   end
+
+  defp color_profile_operations(%PipelineRequest{strip_color_profile: true}) do
+    with {:ok, operation} <- Operation.normalize_color_profile() do
+      {:ok, [operation]}
+    end
+  end
+
+  defp color_profile_operations(%PipelineRequest{}), do: {:ok, []}
 
   defp crop_operations(%PipelineRequest{crop: nil}), do: {:ok, []}
 

--- a/lib/image_pipe/parser/imgproxy/plan_builder.ex
+++ b/lib/image_pipe/parser/imgproxy/plan_builder.ex
@@ -88,7 +88,10 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilder do
      %Output{
        mode: :automatic,
        quality: request.quality,
-       format_qualities: request.format_qualities
+       format_qualities: request.format_qualities,
+       strip_metadata: request.strip_metadata,
+       keep_copyright: request.keep_copyright,
+       strip_color_profile: request.strip_color_profile
      }}
   end
 
@@ -102,7 +105,10 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilder do
          %Output{
            mode: {:explicit, format},
            quality: request.quality,
-           format_qualities: request.format_qualities
+           format_qualities: request.format_qualities,
+           strip_metadata: request.strip_metadata,
+           keep_copyright: request.keep_copyright,
+           strip_color_profile: request.strip_color_profile
          }}
 
       false ->

--- a/lib/image_pipe/plan.ex
+++ b/lib/image_pipe/plan.ex
@@ -30,6 +30,7 @@ defmodule ImagePipe.Plan do
       Operation.Duotone,
       Operation.Flip,
       Operation.Monochrome,
+      Operation.NormalizeColorProfile,
       Operation.Padding,
       Operation.Pixelate,
       Operation.Rotate,

--- a/lib/image_pipe/plan/key_data.ex
+++ b/lib/image_pipe/plan/key_data.ex
@@ -19,6 +19,7 @@ defmodule ImagePipe.Plan.KeyData do
   alias ImagePipe.Plan.Operation.Duotone
   alias ImagePipe.Plan.Operation.Flip
   alias ImagePipe.Plan.Operation.Monochrome
+  alias ImagePipe.Plan.Operation.NormalizeColorProfile
   alias ImagePipe.Plan.Operation.Padding
   alias ImagePipe.Plan.Operation.Pixelate
   alias ImagePipe.Plan.Operation.Resize
@@ -123,6 +124,7 @@ defmodule ImagePipe.Plan.KeyData do
   end
 
   def data(%AutoOrient{}), do: [op: :auto_orient]
+  def data(%NormalizeColorProfile{}), do: [op: :normalize_color_profile]
   def data(%Rotate{angle: angle}), do: [op: :rotate, angle: angle]
   def data(%Flip{axis: axis}), do: [op: :flip, axis: axis]
   def data(%Blur{sigma: sigma}), do: [op: :blur, sigma: sigma]

--- a/lib/image_pipe/plan/operation.ex
+++ b/lib/image_pipe/plan/operation.ex
@@ -99,8 +99,8 @@ defmodule ImagePipe.Plan.Operation do
   @spec auto_orient() :: {:ok, AutoOrient.t()}
   def auto_orient, do: {:ok, %AutoOrient{}}
 
-  @spec normalize_color_profile() :: NormalizeColorProfile.t()
-  def normalize_color_profile, do: %NormalizeColorProfile{}
+  @spec normalize_color_profile() :: {:ok, NormalizeColorProfile.t()}
+  def normalize_color_profile, do: {:ok, %NormalizeColorProfile{}}
 
   @spec rotate(term()) :: {:ok, Rotate.t()} | {:error, error()}
   def rotate(angle) when angle in @right_angles, do: {:ok, %Rotate{angle: angle}}

--- a/lib/image_pipe/plan/operation.ex
+++ b/lib/image_pipe/plan/operation.ex
@@ -15,6 +15,7 @@ defmodule ImagePipe.Plan.Operation do
   alias ImagePipe.Plan.Operation.Duotone
   alias ImagePipe.Plan.Operation.Flip
   alias ImagePipe.Plan.Operation.Monochrome
+  alias ImagePipe.Plan.Operation.NormalizeColorProfile
   alias ImagePipe.Plan.Operation.Padding
   alias ImagePipe.Plan.Operation.Pixelate
   alias ImagePipe.Plan.Operation.Resize
@@ -90,12 +91,16 @@ defmodule ImagePipe.Plan.Operation do
           | background_operation()
           | orientation_operation()
           | effect_operation()
+          | NormalizeColorProfile.t()
 
   @type error ::
           {:invalid_operation, atom(), term()} | {:unknown_operation_options, atom(), [atom()]}
 
   @spec auto_orient() :: {:ok, AutoOrient.t()}
   def auto_orient, do: {:ok, %AutoOrient{}}
+
+  @spec normalize_color_profile() :: NormalizeColorProfile.t()
+  def normalize_color_profile, do: %NormalizeColorProfile{}
 
   @spec rotate(term()) :: {:ok, Rotate.t()} | {:error, error()}
   def rotate(angle) when angle in @right_angles, do: {:ok, %Rotate{angle: angle}}
@@ -334,6 +339,7 @@ defmodule ImagePipe.Plan.Operation do
   def semantic?(%Padding{} = operation), do: valid_padding?(operation)
   def semantic?(%Background{} = operation), do: valid_background?(operation)
   def semantic?(%AutoOrient{}), do: true
+  def semantic?(%NormalizeColorProfile{}), do: true
   def semantic?(%Rotate{angle: angle}) when angle in @right_angles, do: true
   def semantic?(%Flip{axis: axis}) when axis in @flip_axes, do: true
   def semantic?(%Blur{} = operation), do: valid_positive_float?(operation.sigma)

--- a/lib/image_pipe/plan/operation/normalize_color_profile.ex
+++ b/lib/image_pipe/plan/operation/normalize_color_profile.ex
@@ -1,0 +1,11 @@
+defmodule ImagePipe.Plan.Operation.NormalizeColorProfile do
+  @moduledoc """
+  Semantic request to normalize the image to sRGB and drop the embedded ICC
+  profile. Product-neutral; the imgproxy `strip_color_profile` (`scp`) option
+  maps to this. A future target-profile field is the `cp` (#119) seam.
+  """
+
+  defstruct []
+
+  @type t :: %__MODULE__{}
+end

--- a/lib/image_pipe/plan/output.ex
+++ b/lib/image_pipe/plan/output.ex
@@ -1,6 +1,11 @@
 defmodule ImagePipe.Plan.Output do
   @moduledoc """
   Requested output intent before runtime format negotiation.
+
+  `strip_metadata`, `keep_copyright`, and `strip_color_profile` are resolved
+  booleans (never `nil`): a parser resolves its config defaults / URL options
+  into concrete values before building a plan (the imgproxy parser does this in
+  `apply_request_defaults/2`). They drive the encoder's metadata finalize.
   """
 
   @enforce_keys [:mode]

--- a/lib/image_pipe/plan/output.ex
+++ b/lib/image_pipe/plan/output.ex
@@ -4,13 +4,21 @@ defmodule ImagePipe.Plan.Output do
   """
 
   @enforce_keys [:mode]
-  defstruct mode: :automatic, quality: :default, format_qualities: %{}
+  defstruct mode: :automatic,
+            quality: :default,
+            format_qualities: %{},
+            strip_metadata: true,
+            keep_copyright: true,
+            strip_color_profile: true
 
   @type format :: :avif | :webp | :jpeg | :png
   @type quality :: :default | {:quality, 1..100}
   @type t :: %__MODULE__{
           mode: :automatic | {:explicit, format()},
           quality: quality(),
-          format_qualities: %{optional(format()) => quality()}
+          format_qualities: %{optional(format()) => quality()},
+          strip_metadata: boolean(),
+          keep_copyright: boolean(),
+          strip_color_profile: boolean()
         }
 end

--- a/lib/image_pipe/transform.ex
+++ b/lib/image_pipe/transform.ex
@@ -31,7 +31,8 @@ defmodule ImagePipe.Transform do
       Operation.Duotone,
       Operation.Brightness,
       Operation.Contrast,
-      Operation.Saturation
+      Operation.Saturation,
+      Operation.NormalizeColorProfile
     ]
 
   alias ImagePipe.Plan

--- a/lib/image_pipe/transform/decode_planner.ex
+++ b/lib/image_pipe/transform/decode_planner.ex
@@ -19,6 +19,7 @@ defmodule ImagePipe.Transform.DecodePlanner do
   alias ImagePipe.Plan.Operation.Duotone
   alias ImagePipe.Plan.Operation.Flip
   alias ImagePipe.Plan.Operation.Monochrome
+  alias ImagePipe.Plan.Operation.NormalizeColorProfile
   alias ImagePipe.Plan.Operation.Padding
   alias ImagePipe.Plan.Operation.Pixelate
   alias ImagePipe.Plan.Operation.Resize, as: PlanResize
@@ -61,6 +62,7 @@ defmodule ImagePipe.Transform.DecodePlanner do
   defp access_requirement(%Brightness{}), do: :random
   defp access_requirement(%Contrast{}), do: :random
   defp access_requirement(%Saturation{}), do: :random
+  defp access_requirement(%NormalizeColorProfile{}), do: :neutral
 
   defp resize_access_requirement(%PlanResize{
          width: width,

--- a/lib/image_pipe/transform/operation/normalize_color_profile.ex
+++ b/lib/image_pipe/transform/operation/normalize_color_profile.ex
@@ -1,8 +1,16 @@
 defmodule ImagePipe.Transform.Operation.NormalizeColorProfile do
   @moduledoc """
   Executable color-profile normalization: convert the embedded ICC profile to
-  sRGB (ICC-aware, via `Image.to_colorspace/3` -> `icc_transform`).
-  No-op when the image carries no profile.
+  sRGB (ICC-aware, via `Image.to_colorspace/3` -> `icc_transform`). No-op when
+  the image carries no profile.
+
+  This operation only converts pixels; it deliberately does **not** remove the
+  embedded ICC profile. Metadata/profile removal requires realizing pixels
+  (`Vix` `mutate` -> `copy_memory`), which inside the lazy transform chain turns
+  a corrupt-source decode failure into an uncatchable producer crash (HTTP 500)
+  instead of a graceful decode error (HTTP 415). The profile header is therefore
+  dropped at the output encoder's finalize step, where realization failures map
+  to a decode error. See `ImagePipe.Output.Encoder`.
   """
 
   @behaviour ImagePipe.Transform

--- a/lib/image_pipe/transform/operation/normalize_color_profile.ex
+++ b/lib/image_pipe/transform/operation/normalize_color_profile.ex
@@ -1,8 +1,8 @@
 defmodule ImagePipe.Transform.Operation.NormalizeColorProfile do
   @moduledoc """
   Executable color-profile normalization: convert the embedded ICC profile to
-  sRGB (ICC-aware, via `Image.to_colorspace/3` -> `icc_transform`) and drop the
-  profile so the output embeds none. No-op when the image carries no profile.
+  sRGB (ICC-aware, via `Image.to_colorspace/3` -> `icc_transform`).
+  No-op when the image carries no profile.
   """
 
   @behaviour ImagePipe.Transform
@@ -11,7 +11,6 @@ defmodule ImagePipe.Transform.Operation.NormalizeColorProfile do
 
   alias ImagePipe.Transform.State
   alias Vix.Vips.Image, as: VixImage
-  alias Vix.Vips.MutableImage
 
   @icc_field "icc-profile-data"
 
@@ -32,9 +31,7 @@ defmodule ImagePipe.Transform.Operation.NormalizeColorProfile do
 
   defp normalize(image) do
     if profile?(image) do
-      with {:ok, srgb} <- Image.to_colorspace(image, :srgb, []) do
-        drop_profile(srgb)
-      end
+      Image.to_colorspace(image, :srgb, [])
     else
       {:ok, image}
     end
@@ -45,12 +42,5 @@ defmodule ImagePipe.Transform.Operation.NormalizeColorProfile do
       {:ok, names} -> @icc_field in names
       _ -> false
     end
-  end
-
-  defp drop_profile(image) do
-    VixImage.mutate(image, fn mut ->
-      _ = MutableImage.remove(mut, @icc_field)
-      :ok
-    end)
   end
 end

--- a/lib/image_pipe/transform/operation/normalize_color_profile.ex
+++ b/lib/image_pipe/transform/operation/normalize_color_profile.ex
@@ -1,0 +1,56 @@
+defmodule ImagePipe.Transform.Operation.NormalizeColorProfile do
+  @moduledoc """
+  Executable color-profile normalization: convert the embedded ICC profile to
+  sRGB (ICC-aware, via `Image.to_colorspace/3` -> `icc_transform`) and drop the
+  profile so the output embeds none. No-op when the image carries no profile.
+  """
+
+  @behaviour ImagePipe.Transform
+
+  import ImagePipe.Transform.State
+
+  alias ImagePipe.Transform.State
+  alias Vix.Vips.Image, as: VixImage
+  alias Vix.Vips.MutableImage
+
+  @icc_field "icc-profile-data"
+
+  defstruct []
+
+  @type t :: %__MODULE__{}
+
+  @impl ImagePipe.Transform
+  def name(%__MODULE__{}), do: :normalize_color_profile
+
+  @impl ImagePipe.Transform
+  def execute(%__MODULE__{}, %State{} = state) do
+    case normalize(state.image) do
+      {:ok, image} -> {:ok, set_image(state, image)}
+      {:error, error} -> {:error, {__MODULE__, error}}
+    end
+  end
+
+  defp normalize(image) do
+    if profile?(image) do
+      with {:ok, srgb} <- Image.to_colorspace(image, :srgb, []) do
+        drop_profile(srgb)
+      end
+    else
+      {:ok, image}
+    end
+  end
+
+  defp profile?(image) do
+    case VixImage.header_field_names(image) do
+      {:ok, names} -> @icc_field in names
+      _ -> false
+    end
+  end
+
+  defp drop_profile(image) do
+    VixImage.mutate(image, fn mut ->
+      _ = MutableImage.remove(mut, @icc_field)
+      :ok
+    end)
+  end
+end

--- a/lib/image_pipe/transform/plan_executor.ex
+++ b/lib/image_pipe/transform/plan_executor.ex
@@ -14,6 +14,7 @@ defmodule ImagePipe.Transform.PlanExecutor do
   alias ImagePipe.Plan.Operation.Duotone, as: PlanDuotone
   alias ImagePipe.Plan.Operation.Flip, as: PlanFlip
   alias ImagePipe.Plan.Operation.Monochrome, as: PlanMonochrome
+  alias ImagePipe.Plan.Operation.NormalizeColorProfile, as: PlanNormalizeColorProfile
   alias ImagePipe.Plan.Operation.Padding, as: PlanPadding
   alias ImagePipe.Plan.Operation.Pixelate, as: PlanPixelate
   alias ImagePipe.Plan.Operation.Resize, as: PlanResize
@@ -32,6 +33,7 @@ defmodule ImagePipe.Transform.PlanExecutor do
   alias ImagePipe.Transform.Operation.ExtendCanvas
   alias ImagePipe.Transform.Operation.Flip
   alias ImagePipe.Transform.Operation.Monochrome
+  alias ImagePipe.Transform.Operation.NormalizeColorProfile
   alias ImagePipe.Transform.Operation.Padding
   alias ImagePipe.Transform.Operation.Pixelate
   alias ImagePipe.Transform.Operation.Resize
@@ -186,6 +188,9 @@ defmodule ImagePipe.Transform.PlanExecutor do
   end
 
   defp executable_operations(%PlanAutoOrient{}, %State{}, _context), do: [%AutoOrient{}]
+
+  defp executable_operations(%PlanNormalizeColorProfile{}, %State{}, _context),
+    do: [%NormalizeColorProfile{}]
 
   defp executable_operations(%PlanRotate{angle: angle}, %State{}, _context),
     do: [%Rotate{angle: angle}]

--- a/test/image_pipe/architecture_boundary_test.exs
+++ b/test/image_pipe/architecture_boundary_test.exs
@@ -48,6 +48,7 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
     :CropGuided,
     :CropRegion,
     :Flip,
+    :NormalizeColorProfile,
     :Padding,
     :Rotate,
     :Resize
@@ -63,6 +64,7 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
     :Flip,
     :Background,
     :AutoOrient,
+    :NormalizeColorProfile,
     :ExtendCanvas,
     :Padding,
     :AdaptiveResize

--- a/test/image_pipe/architecture_boundary_test.exs
+++ b/test/image_pipe/architecture_boundary_test.exs
@@ -424,7 +424,8 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
       ImagePipe.Transform.Operation.Duotone,
       ImagePipe.Transform.Operation.Brightness,
       ImagePipe.Transform.Operation.Contrast,
-      ImagePipe.Transform.Operation.Saturation
+      ImagePipe.Transform.Operation.Saturation,
+      ImagePipe.Transform.Operation.NormalizeColorProfile
     ])
   end
 
@@ -457,6 +458,7 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
       ImagePipe.Plan.Operation.Duotone,
       ImagePipe.Plan.Operation.Flip,
       ImagePipe.Plan.Operation.Monochrome,
+      ImagePipe.Plan.Operation.NormalizeColorProfile,
       ImagePipe.Plan.Operation.Padding,
       ImagePipe.Plan.Operation.Pixelate,
       ImagePipe.Plan.Operation.Rotate,

--- a/test/image_pipe/cache/key_test.exs
+++ b/test/image_pipe/cache/key_test.exs
@@ -180,7 +180,9 @@ defmodule ImagePipe.Cache.KeyTest do
                mode: :explicit,
                format: :webp,
                quality: :default,
-               format_qualities: %{}
+               format_qualities: %{},
+               strip_metadata: true,
+               keep_copyright: true
              ],
              representation: [version: 1],
              cache: [cachebuster: nil],
@@ -831,7 +833,9 @@ defmodule ImagePipe.Cache.KeyTest do
              modern_candidates: [:avif, :webp],
              auto: [avif: true, webp: true],
              quality: :default,
-             format_qualities: %{}
+             format_qualities: %{},
+             strip_metadata: true,
+             keep_copyright: true
            ]
 
     refute inspect(key_one.data) =~ "image/webp"
@@ -861,7 +865,9 @@ defmodule ImagePipe.Cache.KeyTest do
                modern_candidates: [],
                auto: [avif: true, webp: true],
                quality: :default,
-               format_qualities: %{}
+               format_qualities: %{},
+               strip_metadata: true,
+               keep_copyright: true
              ]
 
       refute inspect(key.data) =~ "*/*"
@@ -907,7 +913,9 @@ defmodule ImagePipe.Cache.KeyTest do
              modern_candidates: [:webp],
              auto: [avif: false, webp: true],
              quality: :default,
-             format_qualities: %{}
+             format_qualities: %{},
+             strip_metadata: true,
+             keep_copyright: true
            ]
   end
 
@@ -923,7 +931,9 @@ defmodule ImagePipe.Cache.KeyTest do
              mode: :explicit,
              format: :webp,
              quality: :default,
-             format_qualities: %{}
+             format_qualities: %{},
+             strip_metadata: true,
+             keep_copyright: true
            ]
 
     refute inspect(key.data) =~ "image/jpeg"

--- a/test/image_pipe/cache_test.exs
+++ b/test/image_pipe/cache_test.exs
@@ -226,7 +226,14 @@ defmodule ImagePipe.CacheTest do
   end
 
   defp resolved_output do
-    %Resolved{format: :webp, quality: nil, response_headers: []}
+    %Resolved{
+      format: :webp,
+      quality: nil,
+      response_headers: [],
+      strip_metadata: true,
+      keep_copyright: true,
+      strip_color_profile: true
+    }
   end
 
   test "returns disabled when no cache is configured" do
@@ -456,7 +463,10 @@ defmodule ImagePipe.CacheTest do
     resolved_output = %Resolved{
       format: :webp,
       quality: nil,
-      response_headers: [{"Vary", "Accept"}, {"x-private", "drop"}]
+      response_headers: [{"Vary", "Accept"}, {"x-private", "drop"}],
+      strip_metadata: true,
+      keep_copyright: true,
+      strip_color_profile: true
     }
 
     sink =

--- a/test/image_pipe/cache_test.exs
+++ b/test/image_pipe/cache_test.exs
@@ -379,7 +379,9 @@ defmodule ImagePipe.CacheTest do
              modern_candidates: [:webp],
              auto: [avif: false, webp: true],
              quality: :default,
-             format_qualities: %{}
+             format_qualities: %{},
+             strip_metadata: true,
+             keep_copyright: true
            ]
 
     assert_received {:cache_get, ^key, adapter_opts}

--- a/test/image_pipe/decode_planner_test.exs
+++ b/test/image_pipe/decode_planner_test.exs
@@ -27,6 +27,16 @@ defmodule ImagePipe.Transform.DecodePlannerTest do
            ]) == [access: :sequential, fail_on: :error]
   end
 
+  test "color-profile normalization is access-neutral" do
+    # Neutral alone collapses to the conservative random default.
+    assert DecodePlanner.open_options([%Operation.NormalizeColorProfile{}]) ==
+             [access: :random, fail_on: :error]
+
+    # Neutral does not downgrade another op's sequential requirement.
+    assert DecodePlanner.open_options([%AutoOrient{}, %Operation.NormalizeColorProfile{}]) ==
+             [access: :sequential, fail_on: :error]
+  end
+
   test "two-dimensional fit resize opens sequentially" do
     assert {:ok, resize} = Operation.resize(:fit, {:px, 120}, {:px, 90})
 

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -60,6 +60,33 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
     end
   end
 
+  defmodule MetadataOriginImage do
+    @moduledoc false
+
+    alias Vix.Vips.Image, as: VixImage
+    alias Vix.Vips.MutableImage, as: VixMutableImage
+
+    # Generates a JPEG carrying EXIF (Copyright + ImageDescription) and XMP so
+    # wire tests can assert that sm/kcr strip or retain them as expected.
+    def call(conn, _opts) do
+      img = Image.new!(100, 100, color: :white)
+
+      {:ok, with_metadata} =
+        VixImage.mutate(img, fn mut ->
+          VixMutableImage.set(mut, "exif-ifd0-Copyright", :gchararray, "(c) ACME")
+          VixMutableImage.set(mut, "exif-ifd0-ImageDescription", :gchararray, "A test image")
+          VixMutableImage.set(mut, "xmp-data", :VipsBlob, "<x:xmpmeta/>")
+          :ok
+        end)
+
+      body = Image.write!(with_metadata, :memory, suffix: ".jpg")
+
+      conn
+      |> Plug.Conn.put_resp_content_type("image/jpeg")
+      |> Plug.Conn.send_resp(200, body)
+    end
+  end
+
   defmodule EffectOriginImage do
     @moduledoc false
 
@@ -983,6 +1010,84 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
     refute_received {:fetch_credentials, "tenant-b", [role: "tenant-b"], _runtime_opts}
   end
 
+  describe "sm/kcr metadata stripping" do
+    # Note on libvips JPEG behavior: libvips always writes a minimal EXIF block
+    # on JPEG encode (with image dimensions, color space, etc.) regardless of
+    # metadata stripping. Therefore "exif-data present" is always true after JPEG
+    # encode and cannot be used to assert stripping. The meaningful assertions are
+    # on specific EXIF field values (e.g. copyright, image_description) and on
+    # xmp-data, which is only present when the source carried it.
+
+    test "sm:0 retains EXIF copyright, ImageDescription, and XMP; default (sm on) strips them" do
+      # Establish the sm:0 baseline first: if the fixture itself lacks metadata,
+      # these assertions will fail loudly rather than letting the default-strips
+      # assertions pass as false negatives.
+      kept_conn =
+        call_imgproxy(
+          "/_/sm:0/scp:0/f:jpeg/plain/images/meta.jpg",
+          metadata_origin_opts()
+        )
+
+      assert kept_conn.status == 200
+
+      {kept_image, kept_fields} = response_metadata(kept_conn)
+      {:ok, kept_exif} = Image.exif(kept_image)
+
+      assert Map.get(kept_exif, :copyright) == "(c) ACME",
+             "sm:0 baseline: copyright must be present; fixture is missing EXIF copyright"
+
+      assert Map.get(kept_exif, :image_description) == "A test image",
+             "sm:0 baseline: ImageDescription must be present; fixture is missing EXIF ImageDescription"
+
+      assert "xmp-data" in kept_fields,
+             "sm:0 baseline: xmp-data must be present; fixture is missing XMP metadata"
+
+      # Default request (sm on, kcr on): XMP and non-copyright EXIF fields must
+      # be stripped. Copyright is preserved by kcr:1 (the default).
+      default_conn =
+        call_imgproxy(
+          "/_/scp:0/f:jpeg/plain/images/meta.jpg",
+          metadata_origin_opts()
+        )
+
+      assert default_conn.status == 200
+
+      {default_image, default_fields} = response_metadata(default_conn)
+      {:ok, default_exif} = Image.exif(default_image)
+
+      refute "xmp-data" in default_fields,
+             "default (sm on): xmp-data must be stripped from the response"
+
+      refute Map.has_key?(default_exif, :image_description),
+             "default (sm on): non-copyright EXIF field (ImageDescription) must be stripped"
+    end
+
+    test "sm:1/kcr:1 keeps EXIF copyright while stripping non-copyright EXIF and XMP" do
+      conn =
+        call_imgproxy(
+          "/_/sm:1/kcr:1/scp:0/f:jpeg/plain/images/meta.jpg",
+          metadata_origin_opts()
+        )
+
+      assert conn.status == 200
+
+      {image, field_names} = response_metadata(conn)
+      {:ok, exif} = Image.exif(image)
+
+      # Copyright must be retained.
+      assert Map.get(exif, :copyright) == "(c) ACME",
+             "kcr:1: copyright must equal the original value"
+
+      # Non-copyright EXIF field (ImageDescription) must be gone.
+      refute Map.has_key?(exif, :image_description),
+             "kcr:1: non-copyright EXIF field (ImageDescription) must be stripped"
+
+      # XMP must be stripped.
+      refute "xmp-data" in field_names,
+             "kcr:1: xmp-data must be stripped"
+    end
+  end
+
   describe "output capability handling" do
     test "automatic negotiation drops avif when the build cannot write it" do
       opts = Keyword.put(@default_opts, :output_capabilities, %{avif: false, webp: true})
@@ -1239,6 +1344,17 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
     ]
   end
 
+  defp metadata_origin_opts do
+    [
+      parser: ImagePipe.Parser.Imgproxy,
+      sources: [
+        path:
+          {RootHTTPAdapter,
+           root_url: "http://origin.test", req_options: [plug: MetadataOriginImage]}
+      ]
+    ]
+  end
+
   defp call_imgproxy(path, opts, accept \\ nil) do
     conn =
       :get
@@ -1272,6 +1388,12 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
 
   defp decoded_image(%Plug.Conn{} = conn) do
     Image.open!(conn.resp_body, access: :random, fail_on: :error)
+  end
+
+  defp response_metadata(%Plug.Conn{} = conn) do
+    image = Image.open!(conn.resp_body, access: :random, fail_on: :error)
+    {:ok, field_names} = VipsImage.header_field_names(image)
+    {image, field_names}
   end
 
   defp sampled_pixels(image) do

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -1063,6 +1063,14 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
     end
 
     test "sm:1/kcr:1 keeps EXIF copyright while stripping non-copyright EXIF and XMP" do
+      # Baseline: confirm the fixture actually carries the non-copyright EXIF
+      # field, so the "stripped" refute below cannot pass vacuously even when
+      # this test runs in isolation.
+      baseline = call_imgproxy("/_/sm:0/scp:0/f:jpeg/plain/images/meta.jpg", metadata_origin_opts())
+      {baseline_image, _baseline_fields} = response_metadata(baseline)
+      {:ok, baseline_exif} = Image.exif(baseline_image)
+      assert Map.get(baseline_exif, :image_description) == "A test image"
+
       conn =
         call_imgproxy(
           "/_/sm:1/kcr:1/scp:0/f:jpeg/plain/images/meta.jpg",

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -87,6 +87,24 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
     end
   end
 
+  defmodule WideGamutOriginImage do
+    @moduledoc false
+
+    # Generates a P3 wide-gamut PNG carrying an embedded ICC profile.
+    # `Image.to_colorspace(_, :p3, [])` attaches a P3 ICC profile to the
+    # in-memory image, and libvips embeds it in the PNG stream on write.
+    # Re-opening the PNG bytes confirms "icc-profile-data" is present.
+    def call(conn, _opts) do
+      {:ok, base} = Image.new(40, 40, color: [200, 50, 50])
+      {:ok, p3_img} = Image.to_colorspace(base, :p3, [])
+      body = Image.write!(p3_img, :memory, suffix: ".png")
+
+      conn
+      |> Plug.Conn.put_resp_content_type("image/png")
+      |> Plug.Conn.send_resp(200, body)
+    end
+  end
+
   defmodule EffectOriginImage do
     @moduledoc false
 
@@ -1096,6 +1114,71 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
     end
   end
 
+  describe "scp color-profile normalization" do
+    # Note: `Image.to_colorspace(img, :p3, [])` attaches a P3 ICC profile to the
+    # in-memory image, which libvips embeds in PNG output. Re-opening the PNG bytes
+    # confirms "icc-profile-data" is present, so the scp:0 baseline assertion will
+    # fail loudly if the source generation ever loses the profile, preventing the
+    # scp:1 "dropped" assertion from passing as a false negative.
+    #
+    # Unlike EXIF (which libvips regenerates minimally on JPEG encode), libvips does
+    # NOT synthesize an ICC profile — it embeds one only when the image carries it.
+    # Therefore "icc-profile-data" presence/absence is a meaningful scp assertion.
+
+    test "scp:0 retains the embedded ICC profile; scp:1 (default) drops it and outputs sRGB" do
+      # Establish the scp:0 baseline first: if the source lost its ICC profile,
+      # these assertions fail loudly and prevent the scp:1 refute from passing
+      # vacuously against a profile-less output.
+      scp0_conn =
+        call_imgproxy(
+          "/_/scp:0/f:png/plain/images/wide.png",
+          wide_gamut_origin_opts()
+        )
+
+      assert scp0_conn.status == 200
+
+      {_scp0_image, scp0_fields} = response_metadata(scp0_conn)
+
+      assert "icc-profile-data" in scp0_fields,
+             "scp:0 baseline: icc-profile-data must be present; source lost its ICC profile"
+
+      # scp:1: the NormalizeColorProfile transform converts pixels to sRGB and the
+      # encoder drops the icc-profile-data header at finalize.
+      scp1_conn =
+        call_imgproxy(
+          "/_/scp:1/f:png/plain/images/wide.png",
+          wide_gamut_origin_opts()
+        )
+
+      assert scp1_conn.status == 200
+
+      {scp1_image, scp1_fields} = response_metadata(scp1_conn)
+
+      refute "icc-profile-data" in scp1_fields,
+             "scp:1: icc-profile-data must be absent from the response"
+
+      assert Image.colorspace(scp1_image) == :srgb,
+             "scp:1: output colorspace must be sRGB (NormalizeColorProfile converted pixels)"
+    end
+
+    test "default request (no scp in URL) drops the ICC profile" do
+      # Same as scp:1 but exercises the default plan: strip_color_profile is true
+      # by default in Plan.Output, so no explicit scp option is needed.
+      default_conn =
+        call_imgproxy(
+          "/_/f:png/plain/images/wide.png",
+          wide_gamut_origin_opts()
+        )
+
+      assert default_conn.status == 200
+
+      {_default_image, default_fields} = response_metadata(default_conn)
+
+      refute "icc-profile-data" in default_fields,
+             "default (scp on): icc-profile-data must be absent from the response"
+    end
+  end
+
   describe "output capability handling" do
     test "automatic negotiation drops avif when the build cannot write it" do
       opts = Keyword.put(@default_opts, :output_capabilities, %{avif: false, webp: true})
@@ -1359,6 +1442,17 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
         path:
           {RootHTTPAdapter,
            root_url: "http://origin.test", req_options: [plug: MetadataOriginImage]}
+      ]
+    ]
+  end
+
+  defp wide_gamut_origin_opts do
+    [
+      parser: ImagePipe.Parser.Imgproxy,
+      sources: [
+        path:
+          {RootHTTPAdapter,
+           root_url: "http://origin.test", req_options: [plug: WideGamutOriginImage]}
       ]
     ]
   end

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -68,7 +68,11 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
 
     # Generates a JPEG carrying EXIF (Copyright + ImageDescription) and XMP so
     # wire tests can assert that sm/kcr strip or retain them as expected.
-    def call(conn, _opts) do
+    def init(opts), do: opts
+
+    def call(conn, opts) do
+      if pid = Keyword.get(List.wrap(opts), :test_pid), do: send(pid, :origin_fetch)
+
       img = Image.new!(100, 100, color: :white)
 
       {:ok, with_metadata} =
@@ -1144,6 +1148,40 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
       # XMP must be stripped.
       refute "xmp-data" in field_names,
              "kcr:1: xmp-data must be stripped"
+    end
+
+    test "sm flag produces an isolated filesystem-cache variant" do
+      {opts, cache_root} =
+        cached_opts(
+          sources: [
+            path:
+              {RootHTTPAdapter,
+               root_url: "http://origin.test",
+               req_options: [plug: {MetadataOriginImage, test_pid: self()}]}
+          ]
+        )
+
+      try do
+        # Default (sm on): cache miss, EXIF stripped.
+        stripped = call_imgproxy("/_/scp:0/f:jpeg/plain/images/meta.jpg", opts)
+        assert stripped.status == 200
+        assert_received :origin_fetch
+
+        # sm:0: distinct cache key -> cache miss, EXIF retained, different bytes.
+        kept = call_imgproxy("/_/sm:0/scp:0/f:jpeg/plain/images/meta.jpg", opts)
+        assert kept.status == 200
+        assert_received :origin_fetch
+        refute kept.resp_body == stripped.resp_body
+
+        # Re-request sm:0: cache hit (no origin fetch), identical bytes — the
+        # variant was cached separately, not cross-served from the default entry.
+        kept_again = call_imgproxy("/_/sm:0/scp:0/f:jpeg/plain/images/meta.jpg", opts)
+        assert kept_again.status == 200
+        refute_received :origin_fetch
+        assert kept_again.resp_body == kept.resp_body
+      after
+        File.rm_rf!(cache_root)
+      end
     end
   end
 

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -1078,6 +1078,37 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
 
       refute Map.has_key?(default_exif, :image_description),
              "default (sm on): non-copyright EXIF field (ImageDescription) must be stripped"
+
+      assert Map.get(default_exif, :copyright) == "(c) ACME",
+             "default (kcr on): copyright must be retained"
+    end
+
+    test "sm:1/kcr:0 strips copyright along with other EXIF and XMP" do
+      # Baseline: the fixture carries copyright, so the refute below is meaningful
+      # even when this test runs in isolation.
+      baseline =
+        call_imgproxy("/_/sm:0/scp:0/f:jpeg/plain/images/meta.jpg", metadata_origin_opts())
+
+      {baseline_image, _baseline_fields} = response_metadata(baseline)
+      {:ok, baseline_exif} = Image.exif(baseline_image)
+      assert Map.get(baseline_exif, :copyright) == "(c) ACME"
+
+      conn =
+        call_imgproxy(
+          "/_/sm:1/kcr:0/scp:0/f:jpeg/plain/images/meta.jpg",
+          metadata_origin_opts()
+        )
+
+      assert conn.status == 200
+
+      {image, field_names} = response_metadata(conn)
+      {:ok, exif} = Image.exif(image)
+
+      refute Map.has_key?(exif, :copyright),
+             "kcr:0: copyright must be stripped along with other metadata"
+
+      refute "xmp-data" in field_names,
+             "kcr:0: xmp-data must be stripped"
     end
 
     test "sm:1/kcr:1 keeps EXIF copyright while stripping non-copyright EXIF and XMP" do

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -1084,7 +1084,9 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
       # Baseline: confirm the fixture actually carries the non-copyright EXIF
       # field, so the "stripped" refute below cannot pass vacuously even when
       # this test runs in isolation.
-      baseline = call_imgproxy("/_/sm:0/scp:0/f:jpeg/plain/images/meta.jpg", metadata_origin_opts())
+      baseline =
+        call_imgproxy("/_/sm:0/scp:0/f:jpeg/plain/images/meta.jpg", metadata_origin_opts())
+
       {baseline_image, _baseline_fields} = response_metadata(baseline)
       {:ok, baseline_exif} = Image.exif(baseline_image)
       assert Map.get(baseline_exif, :image_description) == "A test image"

--- a/test/image_pipe/output_encoder_test.exs
+++ b/test/image_pipe/output_encoder_test.exs
@@ -24,7 +24,10 @@ defmodule ImagePipe.Output.EncoderTest do
     resolved_output = %Resolved{
       format: :webp,
       quality: {:quality, 80},
-      response_headers: []
+      response_headers: [],
+      strip_metadata: false,
+      keep_copyright: true,
+      strip_color_profile: false
     }
 
     assert {:ok, stream, "image/webp"} =
@@ -40,7 +43,14 @@ defmodule ImagePipe.Output.EncoderTest do
     assert {:error, {:encode, %RuntimeError{message: "forced stream failure"}, stacktrace}} =
              Encoder.stream_output(
                image,
-               %Resolved{format: :jpeg, quality: :default, response_headers: []},
+               %Resolved{
+                 format: :jpeg,
+                 quality: :default,
+                 response_headers: [],
+                 strip_metadata: false,
+                 keep_copyright: true,
+                 strip_color_profile: false
+               },
                image_module: RaisingStreamImage
              )
 

--- a/test/image_pipe/output_policy_test.exs
+++ b/test/image_pipe/output_policy_test.exs
@@ -33,7 +33,10 @@ defmodule ImagePipe.Output.PolicyTest do
                  modern_candidates: [],
                  headers: [],
                  quality: :default,
-                 format_qualities: %{}
+                 format_qualities: %{},
+                 strip_metadata: true,
+                 keep_copyright: true,
+                 strip_color_profile: true
                }
     end
 
@@ -49,7 +52,10 @@ defmodule ImagePipe.Output.PolicyTest do
                  modern_candidates: [:avif, :webp],
                  headers: [{"vary", "Accept"}],
                  quality: :default,
-                 format_qualities: %{}
+                 format_qualities: %{},
+                 strip_metadata: true,
+                 keep_copyright: true,
+                 strip_color_profile: true
                }
     end
 
@@ -82,7 +88,10 @@ defmodule ImagePipe.Output.PolicyTest do
         modern_candidates: [],
         headers: [],
         quality: :default,
-        format_qualities: %{}
+        format_qualities: %{},
+        strip_metadata: true,
+        keep_copyright: true,
+        strip_color_profile: true
       }
 
       assert Policy.resolve(policy, nil) ==
@@ -90,7 +99,10 @@ defmodule ImagePipe.Output.PolicyTest do
                 %Resolved{
                   format: :png,
                   quality: :default,
-                  response_headers: []
+                  response_headers: [],
+                  strip_metadata: true,
+                  keep_copyright: true,
+                  strip_color_profile: true
                 }}
     end
 
@@ -100,7 +112,10 @@ defmodule ImagePipe.Output.PolicyTest do
         modern_candidates: [:avif, :webp],
         headers: [{"vary", "Accept"}],
         quality: :default,
-        format_qualities: %{}
+        format_qualities: %{},
+        strip_metadata: true,
+        keep_copyright: true,
+        strip_color_profile: true
       }
 
       assert Policy.resolve(policy, nil) ==
@@ -108,7 +123,10 @@ defmodule ImagePipe.Output.PolicyTest do
                 %Resolved{
                   format: :avif,
                   quality: :default,
-                  response_headers: [{"vary", "Accept"}]
+                  response_headers: [{"vary", "Accept"}],
+                  strip_metadata: true,
+                  keep_copyright: true,
+                  strip_color_profile: true
                 }}
     end
 
@@ -118,7 +136,10 @@ defmodule ImagePipe.Output.PolicyTest do
         modern_candidates: [],
         headers: [{"vary", "Accept"}],
         quality: :default,
-        format_qualities: %{}
+        format_qualities: %{},
+        strip_metadata: true,
+        keep_copyright: true,
+        strip_color_profile: true
       }
 
       assert Policy.resolve(policy, nil) == {:error, :source_format_required}
@@ -130,7 +151,10 @@ defmodule ImagePipe.Output.PolicyTest do
         modern_candidates: [],
         headers: [{"vary", "Accept"}],
         quality: :default,
-        format_qualities: %{}
+        format_qualities: %{},
+        strip_metadata: true,
+        keep_copyright: true,
+        strip_color_profile: true
       }
 
       assert Policy.resolve(policy, :png) ==
@@ -138,7 +162,10 @@ defmodule ImagePipe.Output.PolicyTest do
                 %Resolved{
                   format: :png,
                   quality: :default,
-                  response_headers: [{"vary", "Accept"}]
+                  response_headers: [{"vary", "Accept"}],
+                  strip_metadata: true,
+                  keep_copyright: true,
+                  strip_color_profile: true
                 }}
 
       assert Policy.resolve(policy, :jpeg) ==
@@ -146,7 +173,10 @@ defmodule ImagePipe.Output.PolicyTest do
                 %Resolved{
                   format: :jpeg,
                   quality: :default,
-                  response_headers: [{"vary", "Accept"}]
+                  response_headers: [{"vary", "Accept"}],
+                  strip_metadata: true,
+                  keep_copyright: true,
+                  strip_color_profile: true
                 }}
     end
 
@@ -156,7 +186,10 @@ defmodule ImagePipe.Output.PolicyTest do
         modern_candidates: [],
         headers: [{"vary", "Accept"}],
         quality: :default,
-        format_qualities: %{}
+        format_qualities: %{},
+        strip_metadata: true,
+        keep_copyright: true,
+        strip_color_profile: true
       }
 
       assert Policy.resolve(policy, :webp) == {:needs_final_image_alpha, :source}
@@ -169,7 +202,10 @@ defmodule ImagePipe.Output.PolicyTest do
         modern_candidates: [],
         headers: [{"vary", "Accept"}],
         quality: :default,
-        format_qualities: %{}
+        format_qualities: %{},
+        strip_metadata: true,
+        keep_copyright: true,
+        strip_color_profile: true
       }
 
       assert Policy.resolve(policy, :heif) == {:needs_final_image_alpha, :source}
@@ -189,14 +225,20 @@ defmodule ImagePipe.Output.PolicyTest do
         modern_candidates: [],
         headers: [{"vary", "Accept"}],
         quality: :default,
-        format_qualities: %{}
+        format_qualities: %{},
+        strip_metadata: true,
+        keep_copyright: true,
+        strip_color_profile: true
       }
 
       assert Policy.resolve_final_image_alpha(policy, true) ==
                %Resolved{
                  format: :png,
                  quality: :default,
-                 response_headers: [{"vary", "Accept"}]
+                 response_headers: [{"vary", "Accept"}],
+                 strip_metadata: true,
+                 keep_copyright: true,
+                 strip_color_profile: true
                }
     end
 
@@ -206,14 +248,20 @@ defmodule ImagePipe.Output.PolicyTest do
         modern_candidates: [],
         headers: [{"vary", "Accept"}],
         quality: :default,
-        format_qualities: %{}
+        format_qualities: %{},
+        strip_metadata: true,
+        keep_copyright: true,
+        strip_color_profile: true
       }
 
       assert Policy.resolve_final_image_alpha(policy, false) ==
                %Resolved{
                  format: :jpeg,
                  quality: :default,
-                 response_headers: [{"vary", "Accept"}]
+                 response_headers: [{"vary", "Accept"}],
+                 strip_metadata: true,
+                 keep_copyright: true,
+                 strip_color_profile: true
                }
     end
 
@@ -223,21 +271,30 @@ defmodule ImagePipe.Output.PolicyTest do
         modern_candidates: [],
         headers: [{"vary", "Accept"}],
         quality: :default,
-        format_qualities: %{jpeg: {:quality, 82}, png: {:quality, 70}}
+        format_qualities: %{jpeg: {:quality, 82}, png: {:quality, 70}},
+        strip_metadata: true,
+        keep_copyright: true,
+        strip_color_profile: true
       }
 
       assert Policy.resolve_final_image_alpha(policy, false) ==
                %Resolved{
                  format: :jpeg,
                  quality: {:quality, 82},
-                 response_headers: [{"vary", "Accept"}]
+                 response_headers: [{"vary", "Accept"}],
+                 strip_metadata: true,
+                 keep_copyright: true,
+                 strip_color_profile: true
                }
 
       assert Policy.resolve_final_image_alpha(policy, true) ==
                %Resolved{
                  format: :png,
                  quality: {:quality, 70},
-                 response_headers: [{"vary", "Accept"}]
+                 response_headers: [{"vary", "Accept"}],
+                 strip_metadata: true,
+                 keep_copyright: true,
+                 strip_color_profile: true
                }
     end
   end
@@ -257,7 +314,10 @@ defmodule ImagePipe.Output.PolicyTest do
                 %Resolved{
                   format: :webp,
                   quality: {:quality, 80},
-                  response_headers: []
+                  response_headers: [],
+                  strip_metadata: true,
+                  keep_copyright: true,
+                  strip_color_profile: true
                 }}
     end
 
@@ -275,7 +335,10 @@ defmodule ImagePipe.Output.PolicyTest do
                 %Resolved{
                   format: :webp,
                   quality: {:quality, 70},
-                  response_headers: []
+                  response_headers: [],
+                  strip_metadata: true,
+                  keep_copyright: true,
+                  strip_color_profile: true
                 }}
     end
   end
@@ -287,7 +350,10 @@ defmodule ImagePipe.Output.PolicyTest do
         modern_candidates: [],
         headers: [],
         quality: :default,
-        format_qualities: %{}
+        format_qualities: %{},
+        strip_metadata: true,
+        keep_copyright: true,
+        strip_color_profile: true
       }
 
       assert Policy.ensure_capable(policy, output_capabilities: %{avif: false}) ==
@@ -300,7 +366,10 @@ defmodule ImagePipe.Output.PolicyTest do
         modern_candidates: [],
         headers: [],
         quality: :default,
-        format_qualities: %{}
+        format_qualities: %{},
+        strip_metadata: true,
+        keep_copyright: true,
+        strip_color_profile: true
       }
 
       assert Policy.ensure_capable(policy, output_capabilities: %{avif: true}) == :ok
@@ -312,7 +381,10 @@ defmodule ImagePipe.Output.PolicyTest do
         modern_candidates: [],
         headers: [{"vary", "Accept"}],
         quality: :default,
-        format_qualities: %{}
+        format_qualities: %{},
+        strip_metadata: true,
+        keep_copyright: true,
+        strip_color_profile: true
       }
 
       assert Policy.ensure_capable(policy, output_capabilities: %{avif: false}) == :ok

--- a/test/image_pipe/plan/operation_key_data_test.exs
+++ b/test/image_pipe/plan/operation_key_data_test.exs
@@ -10,6 +10,7 @@ defmodule ImagePipe.Plan.OperationKeyDataTest do
   alias ImagePipe.Plan.Operation.Duotone
   alias ImagePipe.Plan.Operation.Flip
   alias ImagePipe.Plan.Operation.Monochrome
+  alias ImagePipe.Plan.Operation.NormalizeColorProfile
   alias ImagePipe.Plan.Operation.Pixelate
   alias ImagePipe.Plan.Operation.Rotate
   alias ImagePipe.Plan.Operation.Saturation
@@ -207,6 +208,12 @@ defmodule ImagePipe.Plan.OperationKeyDataTest do
       assert KeyData.data(%AutoOrient{}) == [op: :auto_orient]
       assert KeyData.data(%Rotate{angle: 270}) == [op: :rotate, angle: 270]
       assert KeyData.data(%Flip{axis: :both}) == [op: :flip, axis: :both]
+    end
+  end
+
+  describe "color-profile operation data" do
+    test "returns key data for the color-profile normalization operation" do
+      assert KeyData.data(%NormalizeColorProfile{}) == [op: :normalize_color_profile]
     end
   end
 

--- a/test/image_pipe/plug_test.exs
+++ b/test/image_pipe/plug_test.exs
@@ -1132,7 +1132,9 @@ defmodule ImagePipe.PlugTest do
              modern_candidates: [:avif, :webp],
              auto: [avif: true, webp: true],
              quality: :default,
-             format_qualities: %{}
+             format_qualities: %{},
+             strip_metadata: true,
+             keep_copyright: true
            ]
 
     refute inspect(key_a.data) =~ "image/webp"
@@ -1443,7 +1445,9 @@ defmodule ImagePipe.PlugTest do
       modern_candidates: [:avif, :webp],
       auto: [avif: true, webp: true],
       quality: :default,
-      format_qualities: %{}
+      format_qualities: %{},
+      strip_metadata: true,
+      keep_copyright: true
     )
 
     refute_received :origin_was_called
@@ -1471,7 +1475,9 @@ defmodule ImagePipe.PlugTest do
           modern_candidates: [],
           auto: [avif: true, webp: true],
           quality: :default,
-          format_qualities: %{}
+          format_qualities: %{},
+          strip_metadata: true,
+          keep_copyright: true
         ] ->
           {:hit, cached_entry}
 
@@ -1497,7 +1503,9 @@ defmodule ImagePipe.PlugTest do
       modern_candidates: [],
       auto: [avif: true, webp: true],
       quality: :default,
-      format_qualities: %{}
+      format_qualities: %{},
+      strip_metadata: true,
+      keep_copyright: true
     )
 
     refute_received :origin_was_called
@@ -1525,7 +1533,9 @@ defmodule ImagePipe.PlugTest do
           modern_candidates: [],
           auto: [avif: false, webp: false],
           quality: :default,
-          format_qualities: %{}
+          format_qualities: %{},
+          strip_metadata: true,
+          keep_copyright: true
         ] ->
           {:hit, cached_entry}
 
@@ -1553,7 +1563,9 @@ defmodule ImagePipe.PlugTest do
       modern_candidates: [],
       auto: [avif: false, webp: false],
       quality: :default,
-      format_qualities: %{}
+      format_qualities: %{},
+      strip_metadata: true,
+      keep_copyright: true
     )
 
     refute_received :origin_was_called
@@ -1581,7 +1593,9 @@ defmodule ImagePipe.PlugTest do
           modern_candidates: [],
           auto: [avif: false, webp: false],
           quality: :default,
-          format_qualities: %{}
+          format_qualities: %{},
+          strip_metadata: true,
+          keep_copyright: true
         ] ->
           {:hit, cached_entry}
 
@@ -1609,7 +1623,9 @@ defmodule ImagePipe.PlugTest do
       modern_candidates: [],
       auto: [avif: false, webp: false],
       quality: :default,
-      format_qualities: %{}
+      format_qualities: %{},
+      strip_metadata: true,
+      keep_copyright: true
     )
 
     refute_received :origin_was_called

--- a/test/image_pipe/request/source_session_supervisor_test.exs
+++ b/test/image_pipe/request/source_session_supervisor_test.exs
@@ -368,7 +368,10 @@ defmodule ImagePipe.Request.SourceSessionSupervisorTest do
       modern_candidates: [],
       headers: [],
       quality: :default,
-      format_qualities: %{}
+      format_qualities: %{},
+      strip_metadata: true,
+      keep_copyright: true,
+      strip_color_profile: true
     }
   end
 

--- a/test/image_pipe/request/source_session_test.exs
+++ b/test/image_pipe/request/source_session_test.exs
@@ -979,12 +979,22 @@ defmodule ImagePipe.Request.SourceSessionTest do
       modern_candidates: [],
       headers: [],
       quality: :default,
-      format_qualities: %{}
+      format_qualities: %{},
+      strip_metadata: true,
+      keep_copyright: true,
+      strip_color_profile: true
     }
   end
 
   defp resolved_output do
-    %Resolved{format: :jpeg, quality: :default, response_headers: []}
+    %Resolved{
+      format: :jpeg,
+      quality: :default,
+      response_headers: [],
+      strip_metadata: true,
+      keep_copyright: true,
+      strip_color_profile: true
+    }
   end
 
   defp opts(extra_opts \\ []) do

--- a/test/image_pipe/response_sender_test.exs
+++ b/test/image_pipe/response_sender_test.exs
@@ -487,7 +487,14 @@ defmodule ImagePipe.Response.SenderTest do
           headers: [],
           next: fn -> :done end,
           cancel: fn -> :ok end,
-          resolved_output: %Resolved{format: :jpeg, quality: :default, response_headers: []}
+          resolved_output: %Resolved{
+            format: :jpeg,
+            quality: :default,
+            response_headers: [],
+            strip_metadata: true,
+            keep_copyright: true,
+            strip_color_profile: true
+          }
         ],
         overrides
       )

--- a/test/parser/imgproxy/plan_builder_test.exs
+++ b/test/parser/imgproxy/plan_builder_test.exs
@@ -783,7 +783,7 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilderTest do
                  []
                )
 
-      assert automatic_plan.output == %ImagePipe.Plan.Output{mode: :automatic}
+      assert automatic_plan.output.mode == :automatic
       assert [%ImagePipe.Plan.Pipeline{} | _] = automatic_plan.pipelines
 
       for format <- Format.output_formats() do
@@ -796,7 +796,7 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilderTest do
                    []
                  )
 
-        assert explicit_plan.output == %ImagePipe.Plan.Output{mode: {:explicit, format}}
+        assert explicit_plan.output.mode == {:explicit, format}
         assert explicit_plan.pipelines == automatic_plan.pipelines
       end
     end

--- a/test/parser/imgproxy/plan_builder_test.exs
+++ b/test/parser/imgproxy/plan_builder_test.exs
@@ -798,6 +798,11 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilderTest do
 
         assert explicit_plan.output.mode == {:explicit, format}
         assert explicit_plan.pipelines == automatic_plan.pipelines
+
+        # Shared output fields (strip_metadata/keep_copyright/strip_color_profile)
+        # must not diverge between automatic and explicit output modes.
+        assert Map.drop(Map.from_struct(explicit_plan.output), [:mode]) ==
+                 Map.drop(Map.from_struct(automatic_plan.output), [:mode])
       end
     end
   end

--- a/test/parser/imgproxy_property_test.exs
+++ b/test/parser/imgproxy_property_test.exs
@@ -10,7 +10,6 @@ defmodule ImagePipe.Parser.ImgproxyPropertyTest do
   alias ImagePipe.Plan.Pipeline
   alias ImagePipe.Plan.Source
 
-  @no_auto_rotate_opts [imgproxy: [auto_rotate: false]]
   @baseline_opts [imgproxy: [auto_rotate: false, strip_color_profile: false]]
 
   property "parser returns tagged results for arbitrary processing segments" do

--- a/test/parser/imgproxy_property_test.exs
+++ b/test/parser/imgproxy_property_test.exs
@@ -11,6 +11,7 @@ defmodule ImagePipe.Parser.ImgproxyPropertyTest do
   alias ImagePipe.Plan.Source
 
   @no_auto_rotate_opts [imgproxy: [auto_rotate: false]]
+  @baseline_opts [imgproxy: [auto_rotate: false, strip_color_profile: false]]
 
   property "parser returns tagged results for arbitrary processing segments" do
     check all segments <- list_of(processing_segment(), max_length: 5),
@@ -98,7 +99,7 @@ defmodule ImagePipe.Parser.ImgproxyPropertyTest do
     end
   end
 
-  defp parse_path(path), do: Imgproxy.parse(conn(:get, path), @no_auto_rotate_opts)
+  defp parse_path(path), do: Imgproxy.parse(conn(:get, path), @baseline_opts)
 
   defp pixels(value), do: {:px, value}
 

--- a/test/parser/imgproxy_test.exs
+++ b/test/parser/imgproxy_test.exs
@@ -545,7 +545,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
              Imgproxy.parse(
                conn(:get, "/_/rs:fit:300:200:0:1:ce:0:0/plain/images/cat.jpg"),
-               @no_auto_rotate_opts
+               @baseline_opts
              )
 
     assert Enum.any?(operations, &match?(%Operation.Canvas{}, &1))

--- a/test/parser/imgproxy_test.exs
+++ b/test/parser/imgproxy_test.exs
@@ -13,6 +13,8 @@ defmodule ImagePipe.Parser.ImgproxyTest do
   alias ImagePipe.Plan.Response
   alias ImagePipe.Plan.Source
 
+  alias ImagePipe.Cache.Key, as: CacheKey
+
   defmodule FoobarTranslator do
     @behaviour ImagePipe.Parser.Imgproxy.SourceScheme
 
@@ -157,6 +159,21 @@ defmodule ImagePipe.Parser.ImgproxyTest do
                conn(:get, "/_/sm:1/plain/images/cat.jpg"),
                imgproxy: [strip_metadata: false]
              )
+  end
+
+  test "sm/kcr/scp produce distinct cache keys" do
+    source_identity = [kind: :path, adapter: :path, root: "default", path: ["images", "cat.jpg"]]
+
+    key = fn path ->
+      {:ok, plan} = Imgproxy.parse(conn(:get, path), [])
+      CacheKey.build(conn(:get, path), plan, source_identity)
+    end
+
+    base = key.("/_/sm:1/kcr:1/scp:1/plain/images/cat.jpg")
+
+    refute base == key.("/_/sm:0/kcr:1/scp:1/plain/images/cat.jpg")
+    refute base == key.("/_/sm:1/kcr:0/scp:1/plain/images/cat.jpg")
+    refute base == key.("/_/sm:1/kcr:1/scp:0/plain/images/cat.jpg")
   end
 
   test "parse/2 accepts parser options and keeps no-option parse/1 as a delegating helper" do

--- a/test/parser/imgproxy_test.exs
+++ b/test/parser/imgproxy_test.exs
@@ -35,6 +35,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
   end
 
   @no_auto_rotate_opts [imgproxy: [auto_rotate: false]]
+  @baseline_opts [imgproxy: [auto_rotate: false, strip_color_profile: false]]
 
   test "parses a plain source with no processing options" do
     assert {:ok,
@@ -42,7 +43,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
               source: %Source.Path{segments: ["images", "cat.jpg"]},
               pipelines: [%Pipeline{operations: [%AutoOrient{}]}],
               output: %Output{mode: :automatic}
-            }} = Imgproxy.parse(conn(:get, "/_/plain/images/cat.jpg"), [])
+            }} = Imgproxy.parse(conn(:get, "/_/plain/images/cat.jpg"), imgproxy: [strip_color_profile: false])
   end
 
   test "parses escaped embedded s3 query before output suffix handling" do
@@ -96,6 +97,35 @@ defmodule ImagePipe.Parser.ImgproxyTest do
     assert_raise ArgumentError, ~r/invalid imgproxy config/, fn ->
       Imgproxy.validate_options!(auto_rotate: "true")
     end
+  end
+
+  test "strip_color_profile emits NormalizeColorProfile after geometry, before effects" do
+    assert {:ok, %Plan{pipelines: [%Pipeline{operations: ops}]}} =
+             Imgproxy.parse(conn(:get, "/_/plain/images/cat.jpg"), @no_auto_rotate_opts)
+    assert :normalize_color_profile in operation_names(ops)
+
+    assert {:ok, %Plan{pipelines: [%Pipeline{operations: ops0}]}} =
+             Imgproxy.parse(conn(:get, "/_/scp:0/plain/images/cat.jpg"), @no_auto_rotate_opts)
+    refute :normalize_color_profile in operation_names(ops0)
+
+    assert {:ok, %Plan{pipelines: [%Pipeline{operations: ops1}]}} =
+             Imgproxy.parse(
+               conn(:get, "/_/scp:1/plain/images/cat.jpg"),
+               imgproxy: [strip_color_profile: false]
+             )
+    assert :normalize_color_profile in operation_names(ops1)
+
+    assert {:ok, %Plan{pipelines: [%Pipeline{operations: pos_ops}]}} =
+             Imgproxy.parse(
+               conn(:get, "/_/w:10/bl:2/plain/images/cat.jpg"),
+               @no_auto_rotate_opts
+             )
+
+    names = operation_names(pos_ops)
+    assert Enum.find_index(names, &(&1 == :resize)) <
+             Enum.find_index(names, &(&1 == :normalize_color_profile))
+    assert Enum.find_index(names, &(&1 == :normalize_color_profile)) <
+             Enum.find_index(names, &(&1 == :blur))
   end
 
   test "parse/2 accepts parser options and keeps no-option parse/1 as a delegating helper" do
@@ -478,7 +508,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
              Imgproxy.parse(
                conn(:get, "/_/rs::::::ce::/plain/images/cat.jpg"),
-               @no_auto_rotate_opts
+               @baseline_opts
              )
 
     assert [%Operation.Canvas{placement: placement}] = operations
@@ -487,7 +517,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
              Imgproxy.parse(
                conn(:get, "/_/s:::::ce::/plain/images/cat.jpg"),
-               @no_auto_rotate_opts
+               @baseline_opts
              )
 
     assert [%Operation.Canvas{placement: placement}] = operations
@@ -540,7 +570,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
   test "public parse plans supported geometry pipeline semantics" do
     assert {:ok,
             %Plan{pipelines: [%Pipeline{operations: [%Operation.Resize{mode: :fit} = resize]}]}} =
-             Imgproxy.parse(conn(:get, "/_/z:2/plain/images/cat.jpg"), @no_auto_rotate_opts)
+             Imgproxy.parse(conn(:get, "/_/z:2/plain/images/cat.jpg"), @baseline_opts)
 
     assert resize.zoom_x == 2.0
     assert resize.zoom_y == 2.0
@@ -548,7 +578,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: [%Operation.CropGuided{} = crop]}]}} =
              Imgproxy.parse(
                conn(:get, "/_/crop:10:20/plain/images/cat.jpg"),
-               @no_auto_rotate_opts
+               @baseline_opts
              )
 
     assert crop.width == {:px, 10}
@@ -556,22 +586,22 @@ defmodule ImagePipe.Parser.ImgproxyTest do
     assert crop.guide == :center
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: [%AutoOrient{}]}]}} =
-             Imgproxy.parse(conn(:get, "/_/ar:true/plain/images/cat.jpg"), [])
+             Imgproxy.parse(conn(:get, "/_/ar:true/plain/images/cat.jpg"), imgproxy: [strip_color_profile: false])
 
     for segment <- ~w(ar:false rot:0 rot:360 fl:false:false) do
       assert {:ok, %Plan{pipelines: [%Pipeline{operations: []}]}} =
                Imgproxy.parse(
                  conn(:get, "/_/#{segment}/plain/images/cat.jpg"),
-                 @no_auto_rotate_opts
+                 @baseline_opts
                )
     end
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
-             Imgproxy.parse(conn(:get, "/_/crop:10:20/ar:true/plain/images/cat.jpg"), [])
+             Imgproxy.parse(conn(:get, "/_/crop:10:20/ar:true/plain/images/cat.jpg"), imgproxy: [strip_color_profile: false])
 
     assert operation_names(operations) == [:auto_orient, :crop_guided]
 
-    opts = [imgproxy: [auto_rotate: true]]
+    opts = [imgproxy: [auto_rotate: true, strip_color_profile: false]]
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: [%AutoOrient{}]}]}} =
              Imgproxy.parse(conn(:get, "/_/plain/images/cat.jpg"), opts)
@@ -603,7 +633,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
              Imgproxy.parse(conn(:get, "/_/w:100/-/ar:true/plain/images/cat.jpg"),
-               imgproxy: [auto_rotate: false]
+               imgproxy: [auto_rotate: false, strip_color_profile: false]
              )
 
     assert operation_names(operations) == [:auto_orient, :resize]
@@ -618,14 +648,14 @@ defmodule ImagePipe.Parser.ImgproxyTest do
       assert {:ok, %Plan{pipelines: [%Pipeline{operations: []}]}} =
                Imgproxy.parse(
                  conn(:get, "/_/#{segment}/plain/images/cat.jpg"),
-                 @no_auto_rotate_opts
+                 @baseline_opts
                )
     end
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
              Imgproxy.parse(
                conn(:get, "/_/rs:fit:300:200:0:0:ce/plain/images/cat.jpg"),
-               @no_auto_rotate_opts
+               @baseline_opts
              )
 
     refute Enum.any?(operations, &match?(%Operation.Canvas{}, &1))
@@ -633,10 +663,10 @@ defmodule ImagePipe.Parser.ImgproxyTest do
 
   test "parses supported resizing type aliases into plans and rejects unsupported values" do
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: []}]}} =
-             Imgproxy.parse(conn(:get, "/_/rt:fit/plain/images/cat.jpg"), @no_auto_rotate_opts)
+             Imgproxy.parse(conn(:get, "/_/rt:fit/plain/images/cat.jpg"), @baseline_opts)
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: []}]}} =
-             Imgproxy.parse(conn(:get, "/_/rt:force/plain/images/cat.jpg"), @no_auto_rotate_opts)
+             Imgproxy.parse(conn(:get, "/_/rt:force/plain/images/cat.jpg"), @baseline_opts)
 
     assert Imgproxy.parse(conn(:get, "/_/rt:fill/plain/images/cat.jpg"), []) ==
              {:error, {:missing_dimensions, :fill}}
@@ -659,7 +689,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
             }} =
              Imgproxy.parse(
                conn(:get, "/_/rt:fill-down/w:100/h:100/plain/images/cat.jpg"),
-               @no_auto_rotate_opts
+               @baseline_opts
              )
 
     assert resize.enlargement == :deny
@@ -674,7 +704,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
             }} =
              Imgproxy.parse(
                conn(:get, "/_/rt:auto/w:100/h:100/plain/images/cat.jpg"),
-               @no_auto_rotate_opts
+               @baseline_opts
              )
   end
 
@@ -695,7 +725,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
             %Plan{pipelines: [%Pipeline{operations: [%Operation.Resize{mode: :fit} = resize]}]}} =
              Imgproxy.parse(
                conn(:get, "/_/w:0/h:0/mw:300/plain/images/cat.jpg"),
-               @no_auto_rotate_opts
+               @baseline_opts
              )
 
     assert resize.width == auto()
@@ -740,7 +770,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
             }} =
              Imgproxy.parse(
                conn(:get, "/_/g:nowe/rs:fill:300:200/plain/images/cat.jpg"),
-               @no_auto_rotate_opts
+               @baseline_opts
              )
 
     assert anchor(crop.guide) == {:left, :top}
@@ -755,7 +785,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
             }} =
              Imgproxy.parse(
                conn(:get, "/_/gravity:fp:0.5:0.25/rs:fill:300:200/plain/images/cat.jpg"),
-               @no_auto_rotate_opts
+               @baseline_opts
              )
 
     assert focal_point(crop.guide) == {1, 2, 1, 4}
@@ -770,7 +800,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
             } = plan} =
              Imgproxy.parse(
                conn(:get, "/_/g:fp:1:0/rs:fill:300:200/plain/images/cat.jpg"),
-               @no_auto_rotate_opts
+               @baseline_opts
              )
 
     assert focal_point(crop.guide) == {1, 1, 0, 1}
@@ -788,7 +818,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
             }} =
              Imgproxy.parse(
                conn(:get, "/_/g:soea/rt:auto/w:300/h:200/plain/images/cat.jpg"),
-               @no_auto_rotate_opts
+               @baseline_opts
              )
 
     assert anchor(crop.guide) == {:right, :bottom}
@@ -805,7 +835,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
             }} =
              Imgproxy.parse(
                conn(:get, "/_/g:soea:8:-0.5/rt:auto/w:300/h:200/plain/images/cat.jpg"),
-               @no_auto_rotate_opts
+               @baseline_opts
              )
 
     assert anchor(crop.guide) == {:right, :bottom}
@@ -824,7 +854,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
             }} =
              Imgproxy.parse(
                conn(:get, "/_/g:soea:12:-0.25/rs:fill:300:200/plain/images/cat.jpg"),
-               @no_auto_rotate_opts
+               @baseline_opts
              )
 
     assert anchor(crop.guide) == {:right, :bottom}
@@ -863,7 +893,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
     assert_output_mode("/_/w:100/-/f:webp/plain/images/cat.jpg", {:explicit, :webp})
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
-             Imgproxy.parse(conn(:get, "/_/f:webp/-/plain/images/cat.jpg"), @no_auto_rotate_opts)
+             Imgproxy.parse(conn(:get, "/_/f:webp/-/plain/images/cat.jpg"), @baseline_opts)
 
     assert operations == []
   end
@@ -1144,10 +1174,10 @@ defmodule ImagePipe.Parser.ImgproxyTest do
 
   test "global-only and empty groups do not become executable pipelines" do
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: []}]}} =
-             Imgproxy.parse(conn(:get, "/_/f:webp/-/plain/images/cat.jpg"), @no_auto_rotate_opts)
+             Imgproxy.parse(conn(:get, "/_/f:webp/-/plain/images/cat.jpg"), @baseline_opts)
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
-             Imgproxy.parse(conn(:get, "/_/-/w:100/plain/images/cat.jpg"), @no_auto_rotate_opts)
+             Imgproxy.parse(conn(:get, "/_/-/w:100/plain/images/cat.jpg"), @baseline_opts)
 
     assert length(operations) == 1
     assert [%{__struct__: _} = operation] = operations
@@ -1488,7 +1518,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
             }} =
              Imgproxy.parse(
                conn(:get, "/_/w:500/-/h:200/plain/images/cat.jpg"),
-               @no_auto_rotate_opts
+               @baseline_opts
              )
 
     assert [%Operation.Resize{mode: :fit} = first_params] = first_operations
@@ -1502,13 +1532,13 @@ defmodule ImagePipe.Parser.ImgproxyTest do
 
   test "ignores empty groups around chained imgproxy pipeline separators" do
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: leading_operations}]}} =
-             Imgproxy.parse(conn(:get, "/_/-/w:500/plain/images/cat.jpg"), @no_auto_rotate_opts)
+             Imgproxy.parse(conn(:get, "/_/-/w:500/plain/images/cat.jpg"), @baseline_opts)
 
     assert [%Operation.Resize{mode: :fit} = leading_params] = leading_operations
     assert leading_params.width == pixels(500)
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: trailing_operations}]}} =
-             Imgproxy.parse(conn(:get, "/_/w:500/-/plain/images/cat.jpg"), @no_auto_rotate_opts)
+             Imgproxy.parse(conn(:get, "/_/w:500/-/plain/images/cat.jpg"), @baseline_opts)
 
     assert [%Operation.Resize{mode: :fit} = trailing_params] = trailing_operations
     assert trailing_params.width == pixels(500)
@@ -1522,7 +1552,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
             }} =
              Imgproxy.parse(
                conn(:get, "/_/w:500/-/-/h:200/plain/images/cat.jpg"),
-               @no_auto_rotate_opts
+               @baseline_opts
              )
 
     assert [%Operation.Resize{mode: :fit} = first_params] = first_operations
@@ -1534,7 +1564,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
 
   test "preserves no-op single-pipeline behavior" do
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: []}]}} =
-             Imgproxy.parse(conn(:get, "/_/plain/images/cat.jpg"), @no_auto_rotate_opts)
+             Imgproxy.parse(conn(:get, "/_/plain/images/cat.jpg"), @baseline_opts)
   end
 
   test "later field assignments are scoped to each imgproxy pipeline" do
@@ -1547,7 +1577,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
             }} =
              Imgproxy.parse(
                conn(:get, "/_/w:500/w:600/-/h:200/h:300/plain/images/cat.jpg"),
-               @no_auto_rotate_opts
+               @baseline_opts
              )
 
     assert [%Operation.Resize{mode: :fit} = first_params] = first_operations
@@ -1615,7 +1645,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
 
   defp operations_for(path) do
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
-             Imgproxy.parse(conn(:get, path), @no_auto_rotate_opts)
+             Imgproxy.parse(conn(:get, path), @baseline_opts)
 
     operations
   end
@@ -1645,6 +1675,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
     imgproxy_opts =
       [
         auto_rotate: false,
+        strip_color_profile: false,
         signature: [keys: ["746573742d6b6579"], salts: ["746573742d73616c74"]]
       ]
       |> Keyword.merge(overrides)
@@ -1654,7 +1685,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
   end
 
   defp preset_opts(definitions) do
-    [imgproxy: Imgproxy.validate_options!(auto_rotate: false, presets: definitions)]
+    [imgproxy: Imgproxy.validate_options!(auto_rotate: false, strip_color_profile: false, presets: definitions)]
   end
 
   defp assert_error_status(reason, status) do
@@ -1690,6 +1721,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
   defp operation_name(%Operation.Brightness{}), do: :brightness
   defp operation_name(%Operation.Contrast{}), do: :contrast
   defp operation_name(%Operation.Saturation{}), do: :saturation
+  defp operation_name(%Operation.NormalizeColorProfile{}), do: :normalize_color_profile
 
   defp forbidden_parsed_transform_operations(%Plan{} = plan) do
     plan.pipelines

--- a/test/parser/imgproxy_test.exs
+++ b/test/parser/imgproxy_test.exs
@@ -45,7 +45,10 @@ defmodule ImagePipe.Parser.ImgproxyTest do
               source: %Source.Path{segments: ["images", "cat.jpg"]},
               pipelines: [%Pipeline{operations: [%AutoOrient{}]}],
               output: %Output{mode: :automatic}
-            }} = Imgproxy.parse(conn(:get, "/_/plain/images/cat.jpg"), imgproxy: [strip_color_profile: false])
+            }} =
+             Imgproxy.parse(conn(:get, "/_/plain/images/cat.jpg"),
+               imgproxy: [strip_color_profile: false]
+             )
   end
 
   test "parses escaped embedded s3 query before output suffix handling" do
@@ -104,10 +107,12 @@ defmodule ImagePipe.Parser.ImgproxyTest do
   test "strip_color_profile emits NormalizeColorProfile after geometry, before effects" do
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: ops}]}} =
              Imgproxy.parse(conn(:get, "/_/plain/images/cat.jpg"), @no_auto_rotate_opts)
+
     assert :normalize_color_profile in operation_names(ops)
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: ops0}]}} =
              Imgproxy.parse(conn(:get, "/_/scp:0/plain/images/cat.jpg"), @no_auto_rotate_opts)
+
     refute :normalize_color_profile in operation_names(ops0)
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: ops1}]}} =
@@ -115,6 +120,7 @@ defmodule ImagePipe.Parser.ImgproxyTest do
                conn(:get, "/_/scp:1/plain/images/cat.jpg"),
                imgproxy: [strip_color_profile: false]
              )
+
     assert :normalize_color_profile in operation_names(ops1)
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: pos_ops}]}} =
@@ -124,8 +130,10 @@ defmodule ImagePipe.Parser.ImgproxyTest do
              )
 
     names = operation_names(pos_ops)
+
     assert Enum.find_index(names, &(&1 == :resize)) <
              Enum.find_index(names, &(&1 == :normalize_color_profile))
+
     assert Enum.find_index(names, &(&1 == :normalize_color_profile)) <
              Enum.find_index(names, &(&1 == :blur))
   end
@@ -638,7 +646,9 @@ defmodule ImagePipe.Parser.ImgproxyTest do
     assert crop.guide == :center
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: [%AutoOrient{}]}]}} =
-             Imgproxy.parse(conn(:get, "/_/ar:true/plain/images/cat.jpg"), imgproxy: [strip_color_profile: false])
+             Imgproxy.parse(conn(:get, "/_/ar:true/plain/images/cat.jpg"),
+               imgproxy: [strip_color_profile: false]
+             )
 
     for segment <- ~w(ar:false rot:0 rot:360 fl:false:false) do
       assert {:ok, %Plan{pipelines: [%Pipeline{operations: []}]}} =
@@ -649,7 +659,9 @@ defmodule ImagePipe.Parser.ImgproxyTest do
     end
 
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: operations}]}} =
-             Imgproxy.parse(conn(:get, "/_/crop:10:20/ar:true/plain/images/cat.jpg"), imgproxy: [strip_color_profile: false])
+             Imgproxy.parse(conn(:get, "/_/crop:10:20/ar:true/plain/images/cat.jpg"),
+               imgproxy: [strip_color_profile: false]
+             )
 
     assert operation_names(operations) == [:auto_orient, :crop_guided]
 
@@ -1737,7 +1749,14 @@ defmodule ImagePipe.Parser.ImgproxyTest do
   end
 
   defp preset_opts(definitions) do
-    [imgproxy: Imgproxy.validate_options!(auto_rotate: false, strip_color_profile: false, presets: definitions)]
+    [
+      imgproxy:
+        Imgproxy.validate_options!(
+          auto_rotate: false,
+          strip_color_profile: false,
+          presets: definitions
+        )
+    ]
   end
 
   defp assert_error_status(reason, status) do

--- a/test/parser/imgproxy_test.exs
+++ b/test/parser/imgproxy_test.exs
@@ -174,6 +174,10 @@ defmodule ImagePipe.Parser.ImgproxyTest do
     refute base == key.("/_/sm:0/kcr:1/scp:1/plain/images/cat.jpg")
     refute base == key.("/_/sm:1/kcr:0/scp:1/plain/images/cat.jpg")
     refute base == key.("/_/sm:1/kcr:1/scp:0/plain/images/cat.jpg")
+
+    # explicit output format keys through the same output material
+    refute key.("/_/f:jpeg/sm:1/plain/images/cat.jpg") ==
+             key.("/_/f:jpeg/sm:0/plain/images/cat.jpg")
   end
 
   test "parse/2 accepts parser options and keeps no-option parse/1 as a delegating helper" do

--- a/test/parser/imgproxy_test.exs
+++ b/test/parser/imgproxy_test.exs
@@ -128,6 +128,37 @@ defmodule ImagePipe.Parser.ImgproxyTest do
              Enum.find_index(names, &(&1 == :blur))
   end
 
+  test "sm/kcr/scp map to Plan.Output with kcr normalization" do
+    # defaults: all on
+    assert {:ok,
+            %Plan{
+              output: %Output{
+                strip_metadata: true,
+                keep_copyright: true,
+                strip_color_profile: true
+              }
+            }} = Imgproxy.parse(conn(:get, "/_/plain/images/cat.jpg"), [])
+
+    # sm:0 forces keep_copyright to false (normalization)
+    assert {:ok, %Plan{output: %Output{strip_metadata: false, keep_copyright: false}}} =
+             Imgproxy.parse(conn(:get, "/_/sm:0/kcr:1/plain/images/cat.jpg"), [])
+
+    # kcr:0 with stripping on
+    assert {:ok, %Plan{output: %Output{strip_metadata: true, keep_copyright: false}}} =
+             Imgproxy.parse(conn(:get, "/_/kcr:0/plain/images/cat.jpg"), [])
+
+    # scp threads onto Plan.Output
+    assert {:ok, %Plan{output: %Output{strip_color_profile: false}}} =
+             Imgproxy.parse(conn(:get, "/_/scp:0/plain/images/cat.jpg"), [])
+
+    # config default off, URL re-enables
+    assert {:ok, %Plan{output: %Output{strip_metadata: true}}} =
+             Imgproxy.parse(
+               conn(:get, "/_/sm:1/plain/images/cat.jpg"),
+               imgproxy: [strip_metadata: false]
+             )
+  end
+
   test "parse/2 accepts parser options and keeps no-option parse/1 as a delegating helper" do
     conn = conn(:get, "/_/plain/images/cat.jpg")
 


### PR DESCRIPTION
> Supersedes #125 (auto-closed when the branch was renamed).

## Summary

Implements imgproxy's output metadata and color-profile controls, all **default-on**, with defaults owned by the imgproxy parser config (`imgproxy: [strip_metadata: true, keep_copyright: true, strip_color_profile: true]`) and per-request URL overrides (`sm:0` / `kcr:0` / `scp:0`):

- **`strip_metadata` (`sm`)** and **`keep_copyright` (`kcr`)** — encode-time metadata policy on `ImagePipe.Plan.Output`, threaded `Plan.Output → Output.Policy → Output.Resolved → Output.Encoder`. Strips EXIF/XMP/IPTC; `kcr` retains EXIF copyright/artist.
- **`strip_color_profile` (`scp`)** — a product-neutral `NormalizeColorProfile` transform op (ICC-aware sRGB conversion) positioned after geometry and before the effect chain; the embedded ICC profile header is dropped at the encoder finalize.

Closes the privacy gap where ImagePipe previously preserved source EXIF/GPS/XMP into every response.

### Design notes
- **Metadata removal happens at the encoder, after a safe `copy_memory` realize.** `Vix` `mutate` realizes pixels inside a linked GenServer whose failure would crash the producer (500) on corrupt sources; realizing once via `copy_memory` first keeps corrupt inputs degrading to a **415 decode error**. (The transform chain stays lazy.)
- Avoids the libvips blunt `strip` flag (would also drop ICC) and `image` v0.67's `remove_metadata(_, :xmp)` no-op (an upstream `"xmp-dataa"` typo) — uses explicit header field names via `Vix` mutate.
- Cache key: `sm`/`kcr` in `output_plan_data`; `scp` keyed via the `NormalizeColorProfile` op's `KeyData`. `keep_copyright` canonicalized to `false` when `strip_metadata` is false.

### Deliberate divergences from imgproxy (documented in the support matrix)
- `keep_copyright` preserves **EXIF copyright/artist only** (imgproxy also retains full XMP/IPTC blobs) — privacy-conservative.
- No full input/output color management (imgproxy color-manages every image regardless of `scp`) — tracked in #124.

### Scope
- Updated the `demo/` Svelte app (controls + URL state, with backend-matching `kcr` normalization) and the imgproxy support matrix + transform-operations docs.
- Spun off follow-ups: #119 (color_profile/cp), #120 (dpi), #121 (preserve_hdr), #122 (enforce_thumbnail), #123 (page/pages/disable_animation), #124 (full color management).

Closes #30.

## Test Plan
- [x] `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict` (0 issues), `mix test` (1102 tests, 0 failures)
- [x] `mix demo.verify` (85 vitest, svelte-check, oxlint, Vite build)
- [x] Parser: sm/kcr → Plan.Output + normalization; scp emits NormalizeColorProfile at the correct position; config-default + URL-override
- [x] Cache-key distinctness for sm/kcr/scp (incl. explicit-format path)
- [x] Wire-level (`ImagePipe.call/2`, decoded response): default strips EXIF/XMP; `sm:0` retains; `kcr:1` keeps copyright; `scp:1` outputs sRGB with no embedded profile, `scp:0` retains it
- [x] Corrupt-source request still returns 415 (not 500) with default-on stripping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metadata stripping controls: strip metadata and keep copyright options for image processing.
  * Added color profile normalization option to manage embedded ICC profiles in images.
  * Metadata controls now available in demo UI with conditional toggle states.

* **Documentation**
  * Updated support matrix documenting metadata and color profile operation support.
  * Added design specification and implementation plan for metadata/color profile features.
  * Added color profile operation documentation to transform operations guide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hlindset/image_plug/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->