### PR TITLE
test: de-flake cross-process DOWN assertions (assert_receive_timeout)

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,7 @@
-ExUnit.start(capture_log: true)
+# Cross-process `assert_receive {:DOWN, ...}` liveness checks (e.g. the
+# SourceSession.Producer tests) can exceed the default 100ms budget under CI
+# scheduler load (oversubscribed cores plus libvips/NIF work on dirty
+# schedulers), producing flaky timeouts. Give those waits more slack; it does
+# not slow down the passing path, which delivers the message near-instantly.
+ExUnit.start(capture_log: true, assert_receive_timeout: 2_000)
 {:ok, _} = Application.ensure_all_started(:req)


### PR DESCRIPTION
## Problem

CI on #126 failed in `ImagePipe.Request.SourceSession.ProducerTest`:

```
1) test producer can be stopped while a demand is blocked
   test/image_pipe/request/source_session/producer_test.exs:142
   Assertion failed, no matching message after 100ms
   code: assert_receive {:DOWN, ^caller_ref, :process, ^caller, :normal}
```

This is a flake, **unrelated to #126** — that PR is an imgproxy metadata/color-profile change and never touches `producer.ex` or `producer_test.exs`.

## Root cause

The producer is a bare `spawn_link` process; `Producer.next/2` reaches it via `Process.monitor` + a message, with **no link** from the test's caller process. In the failing test, the earlier assertions (producer DOWN `:shutdown`, and the caller's `{:error, {:producer, {:exit, :shutdown}}}` result) had already passed, so the caller had returned from `next` and was microseconds from exiting `:normal`. There is no link path that could make it exit with any other reason — the only variable is whether the monitor `:DOWN` lands within ExUnit's default **100ms** `assert_receive` budget.

Under CI scheduler load (oversubscribed cores + libvips/`vix` NIF work on dirty schedulers + GC of large image binaries) that budget is occasionally exceeded, timing out on a message that is essentially already in flight. The test passes 80/80 in isolation locally; the flake needs the concurrent load.

The same fragile pattern (default-timeout `assert_receive {:DOWN, ...}` liveness checks) appears at multiple sites in that file.

## Fix

Set `assert_receive_timeout: 2_000` suite-wide in `test/test_helper.exs`. The passing path delivers the message near-instantly, so this only adds slack to the failing-under-load case and changes no production behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)