### PR TITLE
fix: include strip_color_profile in cache key data

### DIFF
--- a/lib/image_pipe/cache/key.ex
+++ b/lib/image_pipe/cache/key.ex
@@ -109,6 +109,7 @@ defmodule ImagePipe.Cache.Key do
        quality: output.quality,
        format_qualities: output.format_qualities,
        strip_metadata: output.strip_metadata,
+       strip_color_profile: output.strip_color_profile,
        keep_copyright: output.keep_copyright
      ]}
   end
@@ -121,6 +122,7 @@ defmodule ImagePipe.Cache.Key do
        quality: output.quality,
        format_qualities: output.format_qualities,
        strip_metadata: output.strip_metadata,
+       strip_color_profile: output.strip_color_profile,
        keep_copyright: output.keep_copyright
      ]}
   end
@@ -141,6 +143,7 @@ defmodule ImagePipe.Cache.Key do
        quality: output.quality,
        format_qualities: output.format_qualities,
        strip_metadata: output.strip_metadata,
+       strip_color_profile: output.strip_color_profile,
        keep_copyright: output.keep_copyright
      ]}
   end

--- a/test/image_pipe/cache/key_test.exs
+++ b/test/image_pipe/cache/key_test.exs
@@ -182,6 +182,7 @@ defmodule ImagePipe.Cache.KeyTest do
                quality: :default,
                format_qualities: %{},
                strip_metadata: true,
+               strip_color_profile: true,
                keep_copyright: true
              ],
              representation: [version: 1],
@@ -835,6 +836,7 @@ defmodule ImagePipe.Cache.KeyTest do
              quality: :default,
              format_qualities: %{},
              strip_metadata: true,
+             strip_color_profile: true,
              keep_copyright: true
            ]
 
@@ -867,6 +869,7 @@ defmodule ImagePipe.Cache.KeyTest do
                quality: :default,
                format_qualities: %{},
                strip_metadata: true,
+               strip_color_profile: true,
                keep_copyright: true
              ]
 
@@ -915,8 +918,24 @@ defmodule ImagePipe.Cache.KeyTest do
              quality: :default,
              format_qualities: %{},
              strip_metadata: true,
+             strip_color_profile: true,
              keep_copyright: true
            ]
+  end
+
+  test "different output metadata flags change cache key" do
+    conn = conn(:get, "/_/f:webp/plain/images/cat.jpg")
+
+    for flag <- [:strip_metadata, :keep_copyright, :strip_color_profile] do
+      on_plan = plan(output: %Output{mode: {:explicit, :webp}} |> Map.put(flag, true))
+      off_plan = plan(output: %Output{mode: {:explicit, :webp}} |> Map.put(flag, false))
+
+      on_key = build_key!(conn, on_plan, source_identity())
+      off_key = build_key!(conn, off_plan, source_identity())
+
+      refute on_key.hash == off_key.hash,
+             "expected differing #{flag} to change the cache key"
+    end
   end
 
   test "explicit formats do not include Accept key data or automatic marker" do
@@ -933,6 +952,7 @@ defmodule ImagePipe.Cache.KeyTest do
              quality: :default,
              format_qualities: %{},
              strip_metadata: true,
+             strip_color_profile: true,
              keep_copyright: true
            ]
 

--- a/test/image_pipe/cache_test.exs
+++ b/test/image_pipe/cache_test.exs
@@ -388,6 +388,7 @@ defmodule ImagePipe.CacheTest do
              quality: :default,
              format_qualities: %{},
              strip_metadata: true,
+             strip_color_profile: true,
              keep_copyright: true
            ]
 

--- a/test/image_pipe/plug_test.exs
+++ b/test/image_pipe/plug_test.exs
@@ -1134,6 +1134,7 @@ defmodule ImagePipe.PlugTest do
              quality: :default,
              format_qualities: %{},
              strip_metadata: true,
+             strip_color_profile: true,
              keep_copyright: true
            ]
 
@@ -1447,6 +1448,7 @@ defmodule ImagePipe.PlugTest do
       quality: :default,
       format_qualities: %{},
       strip_metadata: true,
+      strip_color_profile: true,
       keep_copyright: true
     )
 
@@ -1477,6 +1479,7 @@ defmodule ImagePipe.PlugTest do
           quality: :default,
           format_qualities: %{},
           strip_metadata: true,
+          strip_color_profile: true,
           keep_copyright: true
         ] ->
           {:hit, cached_entry}
@@ -1505,6 +1508,7 @@ defmodule ImagePipe.PlugTest do
       quality: :default,
       format_qualities: %{},
       strip_metadata: true,
+      strip_color_profile: true,
       keep_copyright: true
     )
 
@@ -1535,6 +1539,7 @@ defmodule ImagePipe.PlugTest do
           quality: :default,
           format_qualities: %{},
           strip_metadata: true,
+          strip_color_profile: true,
           keep_copyright: true
         ] ->
           {:hit, cached_entry}
@@ -1565,6 +1570,7 @@ defmodule ImagePipe.PlugTest do
       quality: :default,
       format_qualities: %{},
       strip_metadata: true,
+      strip_color_profile: true,
       keep_copyright: true
     )
 
@@ -1595,6 +1601,7 @@ defmodule ImagePipe.PlugTest do
           quality: :default,
           format_qualities: %{},
           strip_metadata: true,
+          strip_color_profile: true,
           keep_copyright: true
         ] ->
           {:hit, cached_entry}
@@ -1625,6 +1632,7 @@ defmodule ImagePipe.PlugTest do
       quality: :default,
       format_qualities: %{},
       strip_metadata: true,
+      strip_color_profile: true,
       keep_copyright: true
     )
 


### PR DESCRIPTION
## Problem

`strip_color_profile` from `ImagePipe.Plan.Output` was **not** included in the cache key data, even though the sibling metadata flags `strip_metadata` and `keep_copyright` were. As a result, two requests that differ only in `strip_color_profile` — one stripping the embedded ICC profile, the other preserving it — produced the **same** cache key and would serve each other's cached bytes.

## Fix

`lib/image_pipe/cache/key.ex`: add `strip_color_profile: output.strip_color_profile` alongside `strip_metadata` / `keep_copyright` in all three output key-data blocks:

- `output_plan_data/2` — automatic mode
- `output_plan_data/2` — explicit format mode
- `output_data/3` — automatic negotiated lookup

This is response-identity material (it changes the successful encoded bytes), so it belongs in the key per the cache guidelines.

## Tests

- Updated the existing cache-key shape assertions in `cache/key_test.exs`, `cache_test.exs`, and `plug_test.exs`.
- Added a regression test (*"different output metadata flags change cache key"*) asserting that differing `strip_metadata`, `keep_copyright`, **and** `strip_color_profile` each change the cache key hash. This test fails on the `strip_color_profile` case without the fix.

Per project guidelines (greenfield, unreleased) the cache key data version is **not** bumped; the key data is reshaped in place.

## Verification

- `mix test` — 1 doctest, 34 properties, 1106 tests, 0 failures
- `mix compile --warnings-as-errors` — clean
- `mix credo --strict` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)