### PR TITLE
Simplify imgproxy option grammar: declarative @special_specs for fixed-arity options

### DIFF
--- a/docs/superpowers/plans/2026-05-31-imgproxy-option-grammar-simplification.md
+++ b/docs/superpowers/plans/2026-05-31-imgproxy-option-grammar-simplification.md
@@ -1,0 +1,344 @@
+# imgproxy Option Grammar Simplification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert the 7 single-required-arg imgproxy pipeline options (`blur`, `sharpen`, `pixelate`, `dpr`, `brightness`, `contrast`, `saturation`) from hand-written `parse_*` clauses to a declarative `@special_specs` table + generic `interpret_special/3`, with zero change to observable behavior.
+
+**Architecture:** This is a behavior-preserving refactor. The production change already exists as an uncommitted working-tree edit (the "spike"). To do it rigorously we (1) move the spike aside into a git stash so the working tree returns to the pre-refactor baseline, (2) add characterization tests that lock the exact behavior the refactor must preserve and prove they pass against the *old* code, then (3) restore the spike and prove the same tests plus the full suite stay green. The conversion routes `@special_specs` aliases through a new `interpret_special/3` that does arity/empty checks (uniform `:invalid_option_segment` on failure) and dispatches each arg through `apply_type/2` to the *existing, unchanged* value parsers (so each type's canonical error tag is preserved).
+
+**Tech Stack:** Elixir, ExUnit, StreamData (ExUnitProperties), Plug. All commands run via `mise exec -- ...`. Spec: [docs/superpowers/specs/2026-05-31-imgproxy-option-grammar-simplification-design.md](../specs/2026-05-31-imgproxy-option-grammar-simplification-design.md).
+
+**Key fact about test phases:** These are *characterization* (regression-locking) tests for a refactor, not red→green TDD for new behavior. Each new test is expected to **pass on the pre-refactor baseline** (Task 2–4) — that is the proof it correctly captures current behavior — and must **still pass after the refactor** (Task 5). There is intentionally no red phase.
+
+**Why git stash (not a patch file):** the spike is the source of truth and lives in the working tree now. `git stash` stores it in git's object store exactly — no hand-transcribed diff to drift, no `/tmp` fragility. The stash persists across tasks/subagents (same repo, same machine). Tasks 2–4 touch only test files, so the stashed `option_grammar.ex` change never conflicts.
+
+---
+
+## Files
+
+- Modify (production): `lib/image_pipe/parser/imgproxy/option_grammar.ex` — the refactor (currently an uncommitted working-tree edit; stashed in Task 1, restored in Task 5). See Appendix for exactly what the change adds/removes.
+- Modify (test): `test/parser/imgproxy/option_grammar_test.exs` — add a `dpr` value-semantics test and an alias-equivalence property.
+- Modify (test): `test/parser/imgproxy_test.exs` — tighten 3 loose adjustment out-of-range assertions to the exact error tag.
+
+---
+
+### Task 1: Stash the spike to reach the pre-refactor baseline
+
+**Files:**
+- Modify: `lib/image_pipe/parser/imgproxy/option_grammar.ex` (stash working-tree edit)
+
+- [ ] **Step 1: Confirm the uncommitted refactor is present and is the only uncommitted change**
+
+Run:
+```bash
+cd /Users/hlindset/src/image_plug/.claude/worktrees/tender-diffie-3e2dbf
+git status --porcelain
+```
+Expected: exactly one line — ` M lib/image_pipe/parser/imgproxy/option_grammar.ex`. If there are other modified files, STOP and reconcile (this plan assumes the spike is the sole working-tree change). If that line is absent, the spike was already committed or lost — STOP and reconcile against the Appendix before continuing.
+
+- [ ] **Step 2: Stash the spike**
+
+Run:
+```bash
+cd /Users/hlindset/src/image_plug/.claude/worktrees/tender-diffie-3e2dbf
+git stash push -m "spike: option grammar @special_specs conversion" -- lib/image_pipe/parser/imgproxy/option_grammar.ex
+git stash list
+```
+Expected: `git status --porcelain` would now be empty; `git stash list` shows `stash@{0}: On <branch>: spike: option grammar @special_specs conversion`.
+
+- [ ] **Step 3: Verify the baseline compiles and the parser suite is green**
+
+Run:
+```bash
+mise exec -- mix test test/parser/imgproxy/option_grammar_test.exs test/parser/imgproxy_test.exs
+```
+Expected: PASS, `0 failures`. (This is the original bespoke code — the behavior the refactor must preserve.)
+
+---
+
+### Task 2: Lock `dpr` value semantics (characterization test)
+
+**Why:** `dpr`'s type is `:positive_float`. No existing test pins `dpr`'s value behavior at the `OptionGrammar.parse/1` boundary (only its arity is covered by `invalid_pipeline_arity_segments/0`). A refactor that mistyped it (e.g. `:non_neg_float`) would let `dpr:0` through silently. This test pins it.
+
+**Files:**
+- Modify: `test/parser/imgproxy/option_grammar_test.exs`
+
+- [ ] **Step 1: Add the test after the existing "basic effect options parse with imgproxy aliases" test**
+
+Locate this existing block (around line 117–129):
+```elixir
+  test "basic effect options parse with imgproxy aliases" do
+    assert OptionGrammar.parse("blur:2.5") == {:ok, {:pipeline, [blur: 2.5]}}
+    assert OptionGrammar.parse("bl:3") == {:ok, {:pipeline, [blur: 3.0]}}
+    assert OptionGrammar.parse("bl:0") == {:ok, {:pipeline, [blur: 0.0]}}
+
+    assert OptionGrammar.parse("sharpen:0.7") == {:ok, {:pipeline, [sharpen: 0.7]}}
+    assert OptionGrammar.parse("sh:1") == {:ok, {:pipeline, [sharpen: 1.0]}}
+    assert OptionGrammar.parse("sh:0") == {:ok, {:pipeline, [sharpen: 0.0]}}
+
+    assert OptionGrammar.parse("pixelate:8") == {:ok, {:pipeline, [pixelate: 8]}}
+    assert OptionGrammar.parse("pix:12") == {:ok, {:pipeline, [pixelate: 12]}}
+    assert OptionGrammar.parse("pix:0") == {:ok, {:pipeline, [pixelate: 0]}}
+  end
+```
+
+Immediately after its closing `end`, insert:
+```elixir
+  test "dpr parses positive floats and rejects non-positive values" do
+    assert OptionGrammar.parse("dpr:1.5") == {:ok, {:pipeline, [dpr: 1.5]}}
+    assert OptionGrammar.parse("dpr:2") == {:ok, {:pipeline, [dpr: 2.0]}}
+    assert OptionGrammar.parse("dpr:0") == {:error, {:invalid_positive_float, "0"}}
+    assert OptionGrammar.parse("dpr:-1") == {:error, {:invalid_positive_float, "-1"}}
+  end
+```
+
+- [ ] **Step 2: Run the test file against the baseline; expect PASS**
+
+Run (`mix test` has no name filter; run the whole file — the new test is included):
+```bash
+mise exec -- mix test test/parser/imgproxy/option_grammar_test.exs
+```
+Expected: PASS, `0 failures`, and the count is one higher than the baseline run in Task 1 Step 3. (Passing on the pre-refactor code proves the test characterizes current behavior.)
+
+---
+
+### Task 3: Tighten the adjustment out-of-range assertions to the exact tag
+
+**Why:** `brightness`/`contrast`/`saturation` out-of-range inputs currently assert only the loose `{:error, _reason}`. Their type is `:adjustment`, which emits `{:invalid_adjustment, value}`; the wire layer (`Imgproxy.parse`) propagates that tag unchanged (verified). Tightening locks the exact tag so a refactor can't silently change it.
+
+**Files:**
+- Modify: `test/parser/imgproxy_test.exs`
+
+- [ ] **Step 1: Replace the loose assertions with exact-tag assertions**
+
+Locate this existing test (around line 1289–1293):
+```elixir
+  test "rejects out-of-range imgproxy brightness contrast and saturation values" do
+    assert {:error, _reason} = Imgproxy.parse(conn(:get, "/_/br:101/plain/images/cat.jpg"), [])
+    assert {:error, _reason} = Imgproxy.parse(conn(:get, "/_/co:-101/plain/images/cat.jpg"), [])
+    assert {:error, _reason} = Imgproxy.parse(conn(:get, "/_/sa:101/plain/images/cat.jpg"), [])
+  end
+```
+
+Replace the whole test with:
+```elixir
+  test "rejects out-of-range imgproxy brightness contrast and saturation values" do
+    assert Imgproxy.parse(conn(:get, "/_/br:101/plain/images/cat.jpg"), []) ==
+             {:error, {:invalid_adjustment, "101"}}
+
+    assert Imgproxy.parse(conn(:get, "/_/co:-101/plain/images/cat.jpg"), []) ==
+             {:error, {:invalid_adjustment, "-101"}}
+
+    assert Imgproxy.parse(conn(:get, "/_/sa:101/plain/images/cat.jpg"), []) ==
+             {:error, {:invalid_adjustment, "101"}}
+  end
+```
+
+- [ ] **Step 2: Run the test file against the baseline; expect PASS**
+
+Run (whole file — `mix test` has no name filter):
+```bash
+mise exec -- mix test test/parser/imgproxy_test.exs
+```
+Expected: PASS, `0 failures` (the tightened "rejects out-of-range imgproxy brightness contrast and saturation values" test passes against the pre-refactor code).
+
+---
+
+### Task 4: Add the alias-equivalence property, then commit the locking tests
+
+**Why:** Each converted option has a long and short alias mapping to one `@special_specs` row. This property guards against an alias accidentally diverging (e.g. a typo'd type on one alias), mirroring the existing `zoom`/`z` property. `dpr` has no short alias, so it is not included. Empty values are excluded because an empty arg yields `{:invalid_option_segment, "<segment>"}` whose segment string legitimately differs between `blur:` and `bl:` (an artifact, not a divergence); every non-empty value produces an alias-independent result (a value-tagged error or an `{:ok, ...}` assignment).
+
+**Files:**
+- Modify: `test/parser/imgproxy/option_grammar_test.exs`
+
+- [ ] **Step 1: Add the property after the existing `zoom` alias property**
+
+Locate this existing block at the top of the file (around line 9–18):
+```elixir
+  property "zoom aliases parse equivalent zoom_x and zoom_y assignments" do
+    check all x_int <- integer(1..2000),
+              y_int <- integer(1..2000),
+              max_runs: 200 do
+      x = decimal_string(x_int)
+      y = decimal_string(y_int)
+
+      assert OptionGrammar.parse("zoom:#{x}:#{y}") == OptionGrammar.parse("z:#{x}:#{y}")
+    end
+  end
+```
+
+Immediately after its closing `end`, insert:
+```elixir
+  property "fixed-arity option aliases parse equivalently to their long forms" do
+    pairs = [
+      {"blur", "bl"},
+      {"sharpen", "sh"},
+      {"pixelate", "pix"},
+      {"brightness", "br"},
+      {"contrast", "co"},
+      {"saturation", "sa"}
+    ]
+
+    # Non-empty values only: an empty arg yields {:invalid_option_segment, segment}
+    # whose segment string differs by alias (e.g. "blur:" vs "bl:") — an expected
+    # artifact, not a divergence. Every non-empty value produces an alias-independent
+    # result (a value-tagged error or an {:ok, ...} assignment).
+    check all {long, short} <- member_of(pairs),
+              value <-
+                one_of([
+                  map(integer(-200..200), &Integer.to_string/1),
+                  string(:alphanumeric, min_length: 1)
+                ]),
+              max_runs: 300 do
+      assert OptionGrammar.parse("#{long}:#{value}") == OptionGrammar.parse("#{short}:#{value}")
+    end
+  end
+```
+
+- [ ] **Step 2: Run the test file against the baseline; expect PASS**
+
+Run (whole file — `mix test` has no name filter):
+```bash
+mise exec -- mix test test/parser/imgproxy/option_grammar_test.exs
+```
+Expected: PASS, `0 failures`; the property-count line now reads `2 properties` (the existing `zoom`/`z` property plus the new one).
+
+- [ ] **Step 3: Run both touched test files in full to confirm nothing regressed**
+
+Run:
+```bash
+mise exec -- mix test test/parser/imgproxy/option_grammar_test.exs test/parser/imgproxy_test.exs
+```
+Expected: PASS, `0 failures`.
+
+- [ ] **Step 4: Commit the locking tests (on the pre-refactor baseline)**
+
+Run:
+```bash
+cd /Users/hlindset/src/image_plug/.claude/worktrees/tender-diffie-3e2dbf
+git add test/parser/imgproxy/option_grammar_test.exs test/parser/imgproxy_test.exs
+git commit -m "test: lock imgproxy fixed-arity option behavior before grammar refactor
+
+Characterization pins added at the parse/1 boundary that the upcoming
+@special_specs conversion must preserve:
+- dpr value semantics (positive_float: dpr:1.5 ok, dpr:0/-1 rejected)
+- exact :invalid_adjustment tag for out-of-range br/co/sa
+- alias-equivalence property over the 6 long/short pairs
+
+Green against the pre-refactor bespoke parsers.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+Expected: commit succeeds.
+
+---
+
+### Task 5: Restore the refactor and prove behavior is preserved
+
+**Files:**
+- Modify: `lib/image_pipe/parser/imgproxy/option_grammar.ex` (restore stashed spike)
+
+- [ ] **Step 1: Restore the stashed refactor**
+
+Run:
+```bash
+cd /Users/hlindset/src/image_plug/.claude/worktrees/tender-diffie-3e2dbf
+git stash list
+git stash pop
+```
+Expected: `git stash list` shows the `spike: option grammar @special_specs conversion` entry at `stash@{0}`; `git stash pop` applies it cleanly (no conflict — it only touches `option_grammar.ex`, which Tasks 2–4 did not) and reports the dropped stash. If `git stash list` shows multiple entries, pop the specific one: `git stash pop stash@{N}` for the matching message.
+
+- [ ] **Step 2: Confirm the restored change matches the intended refactor**
+
+Run:
+```bash
+git -C /Users/hlindset/src/image_plug/.claude/worktrees/tender-diffie-3e2dbf diff --stat -- lib/image_pipe/parser/imgproxy/option_grammar.ex
+```
+Expected: `lib/image_pipe/parser/imgproxy/option_grammar.ex | 134 ++++---...  70 insertions(+), 64 deletions(-)`. The diff introduces `@special_specs`, `parse_pipeline_option/3`, `interpret_special/3`, `interpret_special_args/2`, `apply_type/2`, and removes `parse_effect_float/3`, `parse_pixelate/2`, `parse_adjustment/3`, `parse_dpr/2` and their dispatch clauses (Appendix).
+
+- [ ] **Step 3: Compile with warnings-as-errors**
+
+Run:
+```bash
+mise exec -- mix compile --warnings-as-errors
+```
+Expected: compiles, no warnings.
+
+- [ ] **Step 4: Run the locking tests + the full imgproxy parser and wire suites**
+
+Run:
+```bash
+mise exec -- mix test test/parser/imgproxy/option_grammar_test.exs test/parser/imgproxy_test.exs test/parser/imgproxy_property_test.exs test/image_pipe/imgproxy_wire_conformance_test.exs
+```
+Expected: PASS, `0 failures` (the same locking tests from Tasks 2–4 now pass against the refactored code — behavior preserved).
+
+- [ ] **Step 5: Commit the refactor**
+
+Run:
+```bash
+cd /Users/hlindset/src/image_plug/.claude/worktrees/tender-diffie-3e2dbf
+git add lib/image_pipe/parser/imgproxy/option_grammar.ex
+git commit -m "refactor: convert 7 fixed-arity imgproxy options to @special_specs
+
+blur, sharpen, pixelate, dpr, brightness, contrast, saturation now parse
+via a declarative @special_specs table + interpret_special/3, dispatching
+through apply_type/2 to the existing value parsers. Arity/empty failures
+yield :invalid_option_segment; value failures propagate each type's
+canonical tag. Behavior unchanged (locked by the prior test commit; full
+parser/property/wire suites green). Irregular options (scp, car,
+background_alpha, gravity, padding, etc.) remain bespoke.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+Expected: commit succeeds.
+
+---
+
+### Task 6: Full gate and final check
+
+- [ ] **Step 1: Run the full Elixir gate**
+
+Run:
+```bash
+mise exec -- mix format --check-formatted && \
+mise exec -- mix compile --warnings-as-errors && \
+mise exec -- mix credo --strict && \
+mise exec -- mix test
+```
+Expected: all four pass. `mix test` reports `0 failures`. (Equivalent to `mise run precommit`.)
+
+- [ ] **Step 2: Confirm the branch is clean with the two new commits**
+
+Run:
+```bash
+cd /Users/hlindset/src/image_plug/.claude/worktrees/tender-diffie-3e2dbf
+git status
+git log --oneline -3
+```
+Expected: working tree clean; `git stash list` empty; top two commits are `refactor: convert 7 fixed-arity imgproxy options to @special_specs` and `test: lock imgproxy fixed-arity option behavior before grammar refactor`, on top of the committed design/plan docs.
+
+---
+
+## Appendix: what the refactor changes (prose; the exact change lives in the git stash)
+
+The authoritative change is the stashed working-tree edit restored in Task 5 — do not re-transcribe it by hand. For review/orientation, the refactor to `lib/image_pipe/parser/imgproxy/option_grammar.ex` does exactly this (net `70 insertions(+), 64 deletions(-)`):
+
+**Adds:**
+- `@special_specs` module attribute — a map from each option alias to `[{assignment_key, value_type}]`:
+  - `blur`/`bl` → `[{:blur, :non_neg_float}]`
+  - `sharpen`/`sh` → `[{:sharpen, :non_neg_float}]`
+  - `pixelate`/`pix` → `[{:pixelate, :non_neg_int}]`
+  - `dpr` → `[{:dpr, :positive_float}]`
+  - `brightness`/`br` → `[{:brightness, :adjustment}]`
+  - `contrast`/`co` → `[{:contrast, :adjustment}]`
+  - `saturation`/`sa` → `[{:saturation, :adjustment}]`
+- `parse_pipeline_option/3` — replaces the inline `:error ->` branch in the `@option_specs` lookup; does `@special_specs` lookup → `interpret_special/3`, else falls through to `parse_special_option/3`, then wraps the result as `{:ok, {:pipeline, assignments}}`.
+- `interpret_special/3` — `cond`: `length(args) != length(arg_specs)` → `{:error, {:invalid_option_segment, segment}}`; any empty arg → same; else `interpret_special_args/2`.
+- `interpret_special_args/2` — zips specs with args, `reduce_while` running each through `apply_type/2`, accumulating `{key, parsed}` and halting on the first error (propagating the value parser's tag), reversing on success.
+- `apply_type/2` — 4 clauses mapping `:non_neg_float`/`:positive_float`/`:non_neg_int`/`:adjustment` to the existing `parse_non_negative_float/1`/`parse_positive_float/1`/`parse_non_negative_integer/1`/`parse_adjustment_value/1`. No catch-all (an unknown type raises, by design).
+
+**Removes** (now handled by the table + interpreter):
+- The `parse_special_option/3` dispatch clauses for `"dpr"`, `["blur","bl"]`, `["sharpen","sh"]`, `["pixelate","pix"]`, `["brightness","br"]`, `["contrast","co"]`, `["saturation","sa"]`.
+- The helper functions `parse_effect_float/3`, `parse_pixelate/2`, `parse_adjustment/3`, `parse_dpr/2`.
+
+**Keeps unchanged:** every value parser (`parse_non_negative_float/1`, `parse_positive_float/1`, `parse_non_negative_integer/1`, `parse_adjustment_value/1`, `parse_boolean/1`, …) and all other `parse_special_option/3` clauses (`zoom`, `extend`, `crop`, `gravity`, `padding`, `background`, `background_alpha`, `monochrome`, `duotone`, `strip_color_profile`, `crop_aspect_ratio`, etc.).

--- a/docs/superpowers/specs/2026-05-31-imgproxy-option-grammar-simplification-design.md
+++ b/docs/superpowers/specs/2026-05-31-imgproxy-option-grammar-simplification-design.md
@@ -1,7 +1,7 @@
 # imgproxy option grammar simplification
 
 **Date:** 2026-05-31
-**Status:** Design — awaiting review
+**Status:** Design — reviewed (parallel subagent cycle applied), awaiting user sign-off
 **Scope:** `lib/image_pipe/parser/imgproxy/option_grammar.ex` (internal refactor only)
 
 ## Problem
@@ -32,9 +32,8 @@ dominant future cost is safely adding more options, not reading the file once.
   and **error tag** the parser produces today must be byte-for-byte preserved.
   The existing test suites are the specification.
 - No NimbleParsec / external parser dependency.
-- No cache-key data-version bump (parser output is unchanged; per project
-  guidelines, greenfield cache shape is reshaped in place, and here it is not
-  even changing).
+- No cache-key data-version bump (parser output is unchanged; canonical plan
+  fields and thus cache keys are unaffected — confirmed in review).
 - No demo changes (no options added, removed, or reparameterized).
 - No new public API. `OptionGrammar.parse/1`'s return contract is unchanged, so
   `options.ex`, `plan_builder.ex`, and the wire layer are untouched.
@@ -56,72 +55,101 @@ green, credo `--strict` clean, and `--warnings-as-errors` compile.
   "blur" => [{:blur, :non_neg_float}],
   "bl"   => [{:blur, :non_neg_float}],
   # ...
+  "strip_color_profile" => [{:strip_color_profile, :bool, default: true}],
+  "scp"                 => [{:strip_color_profile, :bool, default: true}],
+  "crop_aspect_ratio" => [{:crop_aspect_ratio, :non_neg_float},
+                          {:crop_aspect_ratio_enlarge, :bool, default: false}],
+  # ...car aliases
 }
 ```
 
 Each alias maps to an ordered list of arg specs. An arg spec is:
 
 - `{key, type}` — required, non-empty; or
-- `{key, type, opts}` where `opts` may carry:
-  - `default:` — value used when this (trailing) arg is absent or empty,
-    making the arg optional;
-  - `error:` — an option-specific error tag substituted when the value parser
-    fails, for options whose diagnostic differs from the type's canonical tag.
+- `{key, type, default: value}` — optional **trailing** arg. `value` is an
+  already-parsed literal (e.g. `true`, `false`), used directly **without** going
+  through `apply_type` (so `default: true`, not `default: "true"`).
 
 `type` is an atom dispatched by `apply_type/2` to an existing value parser
-(`:non_neg_float` → `parse_non_negative_float/1`, etc.). The value parsers are
-unchanged; most already emit their own canonical error tag, so `error:` is only
-needed where the option historically wraps a generic failure into a specific tag
-(e.g. `background_alpha` → `:invalid_background_alpha`).
+(`:non_neg_float` → `parse_non_negative_float/1`, `:bool` → `parse_boolean/1`,
+etc.). The value parsers are unchanged; each already emits its own canonical
+error tag, so there is **no per-option error-tag override** in this design (the
+earlier `error:` idea was dropped — its only candidate, `background_alpha`, is
+not convertible; see bespoke list).
+
+New `apply_type/2` entries required by this change: `:bool` → `parse_boolean/1`.
+(The seven spike options already use `:non_neg_float`, `:positive_float`,
+`:non_neg_int`, `:adjustment`.)
 
 ### Interpreter
 
-`interpret_special/3` (validated by the spike, plus the two extensions above):
+`interpret_special/3`:
 
-1. Split args into required vs optional (trailing-with-`default`).
-2. Arity outside `[required_count, total_count]`, or an empty value in a
-   required position → `{:error, {:invalid_option_segment, segment}}` (the
-   uniform "shape is wrong" tag the bespoke parsers already return).
-3. Fill absent/empty optional args from their `default`.
-4. Run each value through `apply_type/2`; on failure, return the arg's `error:`
-   override if present, else propagate the type parser's tag.
-5. Return `{:ok, keyword_assignments}`; `parse_pipeline_option/3` wraps it as
+1. Let `required` = count of args without `default:`, `total` = all args.
+2. **Arity:** if `length(args)` is outside `[required, total]` →
+   `{:error, {:invalid_option_segment, segment}}`.
+3. **Required positions:** an empty value (`""`) in any *required* position →
+   `{:error, {:invalid_option_segment, segment}}`.
+4. **Optional positions — absent vs. empty are distinct:**
+   - *absent* (position beyond the provided arity) → contribute the spec's
+     pre-parsed `default:` value directly (do **not** call `apply_type`).
+   - *present* (within provided arity), including an explicit empty `""` →
+     treated as a provided value: empty → `{:invalid_option_segment, segment}`;
+     non-empty → run through `apply_type`.
+5. Run each present value through `apply_type/2`; on failure, propagate the value
+   parser's own tag.
+6. Return `{:ok, keyword_assignments}`; `parse_pipeline_option/3` wraps it as
    `{:pipeline, assignments}` exactly as before.
 
-The interpreter does **not** grow alternative-shape (`one_of`), output-nesting,
-post-combination, or fan-out constructs. That boundary is deliberate (see below).
+This absent-vs-empty distinction is load-bearing: it reproduces the bespoke
+behavior where `scp` → `true` but `scp:` → error, and `car:1.5` defaults enlarge
+to `false` but `car:1.5:` → error.
 
-### Options the schema absorbs
+The interpreter introduces no runtime validation of the `@special_specs` shape
+itself (e.g. that defaulted args are trailing). That is a programmer-error
+invariant covered by the green test suite, not a runtime guard — consistent with
+the project's "trust internal producers, reserve raises for programmer error"
+guideline. An unknown `type` atom raises via `apply_type/2`'s missing clause, by
+design.
+
+### Options the schema absorbs (9 total)
 
 - **Spike (done):** `blur`, `sharpen`, `pixelate`, `dpr`, `brightness`,
-  `contrast`, `saturation`.
-- **Per-arg error override:** `background_alpha` (single arg, value failure →
-  `:invalid_background_alpha`). Exercises the `error:` capability.
-- **Optional-trailing-with-default:** `strip_color_profile` (optional bool,
-  default `true`), `crop_aspect_ratio` (required ratio + optional enlarge bool,
-  default `false`).
-
-Target: ~10 of the ~25 special options, plus the once-written interpreter.
+  `contrast`, `saturation` — single required arg, type's canonical error tag.
+- **Optional-trailing-with-default:** `strip_color_profile` (optional `:bool`,
+  default `true`; bare `scp` → `true`, `scp:` → error), `crop_aspect_ratio`
+  (required `:non_neg_float` ratio + optional `:bool` enlarge, default `false`;
+  flat 1:1 mapping to its two output keys).
 
 ### Options that stay bespoke (and why)
 
-Each carries logic a flat key→value schema cannot express without adding a
-construct used by essentially one option — which would be net more complexity,
-not less:
+Each carries logic a flat key→value schema cannot express:
 
-- **Output-shape transforms / nesting / constants:** `extend`,
-  `extend_aspect_ratio` (bool + optional gravity tail + `extend_requested: true`
-  constant), `auto_rotate`, `rotate`, `flip` (assignments nested under
-  `:orientation`; `rotate` mod-90 normalization; `flip` combines two bools).
-- **Nested keyword + optional colors:** `monochrome`, `duotone`.
-- **Alternative shapes / fan-out:** `background` (empty | hex | `r:g:b`), `zoom`
-  (1 arg fans to `zoom_x`+`zoom_y`, or 2 args).
-- **Variadic sub-grammars:** `padding` (1–4 values with `:unset` holes),
-  `gravity`/`crop` (anchor enum vs. focal-point vs. offset tuple),
-  `filename` (percent-encoded vs. base64 variant).
-- **`resize`/`size`** (the `Enum.split` + extend-gravity merge) and
-  `format_quality` (pair into a map) keep their existing `parse_known_option/4`
-  clauses.
+- **`background_alpha`** — *not convertible.* Its arity/empty failures return the
+  option-specific `{:invalid_background_alpha, args}` (pinned by
+  `option_grammar_test.exs`), not the interpreter's uniform
+  `{:invalid_option_segment, segment}`. Preserving that would require a
+  whole-option error override used by exactly one option — net more complexity.
+- **`auto_rotate`, `rotate`, `flip`** — assignments nest under `:orientation`
+  (a shape consumed uniformly downstream in `options.ex`, so the nesting itself
+  is shared by 3 options). They stay bespoke not because nesting is rare but
+  because each also carries logic the flat interpreter lacks: `rotate` does
+  mod-90 validation + `normalize_rotation/1` (a post-parse transform), `flip`
+  collapses two bools into a `:both/:horizontal/:vertical/nil` enum (a
+  post-combine), and all three support a zero-arg form (every arg optional, not
+  trailing-optional). Nesting never travels alone here.
+- **`extend`, `extend_aspect_ratio`** — bool + optional gravity sub-grammar +
+  an injected `extend_requested: true` constant, entangled together.
+- **`monochrome`, `duotone`** — nested keyword output + optional colors with
+  remapped error tags.
+- **`background` (empty | hex | r:g:b), `zoom` (1-arg fan-out | 2-arg)** —
+  alternative arg shapes / fan-out. The two don't share an alternation strategy,
+  so a `one_of` combinator would serve two unrelated cases — deliberately not
+  added.
+- **`padding` (1–4 values with `:unset` holes), `gravity`/`crop` (anchor enum vs.
+  focal-point vs. offset tuple), `filename` (percent vs. base64).**
+- **`resize`/`size`** (`Enum.split` + extend-gravity merge) and `format_quality`
+  (pair into a map) keep their existing `parse_known_option/4` clauses.
 
 ### Dispatch
 
@@ -130,50 +158,101 @@ non-`@option_specs` options: `@special_specs` lookup → `interpret_special/3`,
 else fall through to the remaining `parse_special_option/3` clauses. One path,
 two handler kinds.
 
-The `@option_specs` regulars already run through the declarative
-`parse_known_option` → `parse_field` path and are **out of scope**; unifying that
-table with `@special_specs` is a possible later follow-on, not part of this work.
+### Two spec tables, deliberately
+
+After this change the parser has **two** declarative arg-spec interpreters:
+`@option_specs` + `parse_field/2` (for the resize/format/quality/etc. family),
+and `@special_specs` + `apply_type/2` (this change). They are the same idea in
+two vocabularies (`field` vs `type`, `skip_empty:` vs `default:`) with two error
+models. Unifying them now would force `resize`/`size`'s irregular merge into a
+shared table — over-generalization this design otherwise avoids — so they stay
+separate. To limit drift:
+
+- Align naming where cheap so the two read as dialects of one idea.
+- Unify only when a third regular-option family appears, or when `@option_specs`
+  needs a `default:`-equivalent. Documented here so the divergence is a known,
+  bounded decision rather than silent.
 
 ## Error model
 
 | Failure | Tag |
 | --- | --- |
-| Wrong arity / empty required arg | `{:invalid_option_segment, segment}` |
-| Value parse failure, no `error:` override | the value parser's own tag (e.g. `:invalid_non_negative_float`) |
-| Value parse failure, with `error:` override | `{error_tag, value}` (e.g. `:invalid_background_alpha`) |
+| Wrong arity / empty required arg / empty *present* optional arg | `{:invalid_option_segment, segment}` |
+| Value parse failure | the value parser's own tag (e.g. `:invalid_non_negative_float`, `:invalid_positive_float`, `:invalid_adjustment`) |
 
-This matches current behavior for every converted option exactly.
+This matches current behavior for **the nine converted options** exactly.
+Options whose bespoke parsers use option-specific arity/empty tags (e.g.
+`background_alpha`) are excluded from conversion precisely because they don't fit
+this uniform model.
 
 ## Testing
 
-- TDD against the **existing** specs: `test/parser/imgproxy_test.exs`,
-  `test/parser/imgproxy_property_test.exs`, and
-  `test/image_pipe/imgproxy_wire_conformance_test.exs`. Green-to-green; no test
-  rewrites except deletion of any that become redundant duplicates.
-- Each converted option keeps its existing coverage; if an option's error-tag or
-  arity edge isn't already asserted, add a focused parser-level case before
-  converting it.
-- Gate before finishing: `mix format --check-formatted`,
-  `mix compile --warnings-as-errors`, `mix credo --strict`, `mix test`
-  (via `mise exec --`).
+Treat the existing suites as the spec; convert green-to-green. Primary spec files
+(the design's original list omitted the most important one):
+
+- `test/parser/imgproxy/option_grammar_test.exs` — **primary**: pins exact
+  `{:ok, {:pipeline, [...]}}` tuples and error tags for these options, including
+  the `invalid_pipeline_arity_segments/0` arity table.
+- `test/parser/imgproxy/options_test.exs`, `.../plan_builder_test.exs` — pin
+  `car`, `dpr`, brightness/contrast/saturation at the plan layer.
+- `test/parser/imgproxy_test.exs`, `.../imgproxy_property_test.exs`,
+  `test/image_pipe/imgproxy_wire_conformance_test.exs` — wire/behavior contracts.
+
+**Pins to add at the `OptionGrammar.parse/1` boundary _before_ converting** (each
+closes an un-asserted behavior the refactor could otherwise silently change):
+
+- `dpr`: `dpr:0` → `{:error, {:invalid_positive_float, "0"}}` and a fractional
+  success (`dpr:1.5`). Type semantics are currently unpinned.
+- `crop_aspect_ratio`: both `car:<ratio>` (1-arg, enlarge defaults `false`) and
+  `car:<ratio>:<bool>` (2-arg) → exact `{:pipeline, [...]}` keyword lists; plus
+  ratio failure (`car:nope`) and the empty-trailing edge `car:1.5:` →
+  `{:invalid_option_segment, ...}`.
+- `strip_color_profile`: bare `scp`/`strip_color_profile` (no args) →
+  `{:ok, {:pipeline, [strip_color_profile: true]}}`; plus `scp:` →
+  `{:invalid_option_segment, ...}` and `scp:bad` → error.
+- `brightness`/`contrast`/`saturation`: tighten existing out-of-range assertions
+  from `{:error, _}` to the exact `{:invalid_adjustment, value}` tag.
+
+**One property to add:** alias-equivalence over the converted long/short pairs
+(`blur`/`bl`, `sharpen`/`sh`, `pixelate`/`pix`, `brightness`/`br`, `contrast`/`co`,
+`saturation`/`sa`, `crop_aspect_ratio`/`crop_ar`/`car`) — `parse(long:v) ==
+parse(short:v)` over valid and invalid `v`, mirroring the existing `zoom`/`z`
+property. No arity-fuzz property: the explicit arity table already covers edges.
+
+**Tests not to write / not to delete:**
+
+- New cases are forward contract pins at `parse/1` (tagged tuples are public
+  contract). No old-vs-new parity/characterization harnesses; no `*_characterization_test.exs`.
+- No name-policing: do not assert `function_exported?` on the deleted
+  `parse_blur/2` etc. The `parse/1`-level suites are the sole proof.
+- **Do not delete coverage as "redundant."** The arity table and cases like
+  `bga:0.0 → {:ratio, 0, 10}` are the sole pin for their edge. The only permitted
+  deletions are parity/characterization pins the spike may have introduced, and a
+  redundancy claim must name the specific other test covering the identical
+  input→output.
+- All new pins drive through `parse/1`; never hand-build `%CropRequest{}` or
+  assignment keyword lists as inputs.
+
+Gate before finishing: `mix format --check-formatted`,
+`mix compile --warnings-as-errors`, `mix credo --strict`, `mix test`
+(via `mise exec --`).
 
 ## Boundaries / guideline compliance
 
 - Stays entirely within `ImagePipe.Parser.Imgproxy.*` — no cross-namespace
-  change, no concrete transform modules referenced, no plan-model change.
-- Per CLAUDE.md test guidance: no impossible-internal-misuse tests, no
-  name-policing tests, no post-migration parity pins. The interpreter is trusted
-  internal dispatch; missing/unknown types in `@special_specs` are a programmer
-  error and may raise rather than being guarded.
+  change, no concrete transform modules referenced, no plan-model change. No
+  architecture-test changes needed.
+- The interpreter is trusted internal dispatch; arity/empty checks validate
+  untrusted URL input (a real boundary), not impossible internal misuse.
 
 ## Risks / trade-offs
 
 - **Indirection vs. greppability.** `grep parse_blur` no longer lands on the
-  logic; you read the `@special_specs` row + the interpreter. Real cost,
-  accepted because the marginal cost of the next regular option drops to ~one
-  table row. Mitigated by keeping the interpreter small and the bespoke set
-  explicit.
-- **Scope honesty.** The spike showed the clean-fit set is ~10 options, not
-  "most of them" — the rest have output-shape logic that does not belong in a
-  flat schema. The design caps the interpreter's capabilities deliberately
-  rather than chasing every option.
+  logic; you read the `@special_specs` row + the interpreter. Accepted because
+  the marginal cost of the next regular option drops to ~one table row.
+- **Modest absorbed set.** After review, the clean-fit set is 9 options (7 spike
+  + `scp` + `crop_aspect_ratio`); `background_alpha` and all output-shape /
+  sub-grammar / fan-out options stay bespoke. The interpreter's capabilities are
+  capped at fixed-required + optional-trailing-with-default deliberately.
+- **Dual interpreters.** Two declarative tables coexist (see "Two spec tables").
+  Bounded by the documented unify-trigger.

--- a/docs/superpowers/specs/2026-05-31-imgproxy-option-grammar-simplification-design.md
+++ b/docs/superpowers/specs/2026-05-31-imgproxy-option-grammar-simplification-design.md
@@ -133,6 +133,17 @@ exactly that pre-wired, pipeline-scoped, existing-type set.
   `*_options`, …) get prioritized, or (b) `trim` — the lone non-Pro, commonly-used
   member — is requested. `trim` is heterogeneously typed (float threshold, color,
   two booleans), so even then a general facility needs per-arg type+default specs.
+- **Gravity sub-grammar consolidation.** `parse_gravity` (the `g:` path) and
+  `parse_crop_gravity` (the crop path) are two parallel implementations of the
+  same gravity grammar (both handle `sm`, `fp`, anchor separately, with different
+  output shapes) — the exact "two parallel implementations of one grammar" this
+  change collapses for fixed-arity options. Consolidating them into one shared
+  gravity-tail parser is a natural follow-on. Trigger: a feature that touches
+  gravity in both paths — notably smart object cropping (`obj`/object-detection
+  gravity), which applies to both `g:obj:…` and crop's gravity argument and would
+  otherwise be implemented (and drift) twice. Not in scope here (gravity isn't one
+  of the converted options); flagged so the obj work has a consolidation target on
+  record rather than rediscovering the duplication.
 
 ## Error model
 

--- a/docs/superpowers/specs/2026-05-31-imgproxy-option-grammar-simplification-design.md
+++ b/docs/superpowers/specs/2026-05-31-imgproxy-option-grammar-simplification-design.md
@@ -1,7 +1,7 @@
 # imgproxy option grammar simplification
 
 **Date:** 2026-05-31
-**Status:** Design — reviewed (parallel subagent cycle applied), awaiting user sign-off
+**Status:** Design — reviewed (two parallel subagent cycles + catalog analysis), scope finalized
 **Scope:** `lib/image_pipe/parser/imgproxy/option_grammar.ex` (internal refactor only)
 
 ## Problem
@@ -17,14 +17,14 @@ args, run each arg through a value parser, fall back to
 The grammar itself is trivial (`String.split(segment, ":")`); a parser-combinator
 library such as NimbleParsec would not help, because there is no character-level
 or recursive structure to parse. The cost is **semantic interpretation per
-option**, and it is paid again by hand for every option.
+option**, paid again by hand for every option.
 
 ## Goal
 
 Make adding a regular imgproxy option a small, low-risk, data-shaped change, and
 centralize arity/empty-arg/error handling so it is implemented once. This is a
 compatibility parser tracking an external product's option catalog, so the
-dominant future cost is safely adding more options, not reading the file once.
+dominant future cost is safely adding more options.
 
 ## Non-goals
 
@@ -32,206 +32,197 @@ dominant future cost is safely adding more options, not reading the file once.
   and **error tag** the parser produces today must be byte-for-byte preserved.
   The existing test suites are the specification.
 - No NimbleParsec / external parser dependency.
-- No cache-key data-version bump (parser output is unchanged; canonical plan
-  fields and thus cache keys are unaffected — confirmed in review).
+- No cache-key data-version bump (parser output unchanged; canonical plan fields
+  and thus cache keys are unaffected — confirmed in review).
 - No demo changes (no options added, removed, or reparameterized).
 - No new public API. `OptionGrammar.parse/1`'s return contract is unchanged, so
   `options.ex`, `plan_builder.ex`, and the wire layer are untouched.
 
+## Scope (finalized: 8 options)
+
+Two earlier review cycles plus an analysis of imgproxy's full unimplemented
+option catalog (below) settled the scope:
+
+- **Convert the 7 single-required-arg pipeline options** — `blur`, `sharpen`,
+  `pixelate`, `dpr`, `brightness`, `contrast`, `saturation` — via a declarative
+  `@special_specs` table + `interpret_special/3`. (Already done in a working-tree
+  spike: 174 parser/property/wire tests green, credo `--strict` clean,
+  `--warnings-as-errors` compile.)
+- **Convert `strip_color_profile`/`scp`** via a separate minimal
+  single-optional-boolean facility (`@optional_boolean_specs` +
+  `interpret_optional_boolean/3`), shaped so the future boolean cluster
+  (`raw`, `enforce_thumbnail`, `preserve_hdr`) is a one-row addition each.
+- **`crop_aspect_ratio`/`car` is NOT converted.** Its leading-required +
+  optional-trailing shape is the only thing that would force absent-vs-empty
+  range logic into a shared interpreter; for a single option that is not worth
+  the complexity. It stays bespoke unchanged.
+- **`background_alpha` stays bespoke** — its arity/empty failures use the
+  option-specific `{:invalid_background_alpha, args}` tag (pinned by tests), not
+  the uniform `{:invalid_option_segment}`.
+
+## Catalog-informed rationale
+
+Why this scope, from imgproxy's documented processing-option catalog (sources:
+docs.imgproxy.net/usage/processing, /generating_the_url). Of the **unimplemented**
+options, bucketed by the parsing mechanism each needs:
+
+| Bucket | Mechanism needed | Count | Non-Pro |
+| --- | --- | --- | --- |
+| A. Fixed-arity (`max_bytes`, `dpi`, `page`, `watermark_size`, …) | none — a `@special_specs` row | 15 | 5 |
+| B. Single optional-boolean (`raw`, `enforce_thumbnail`, `preserve_hdr`, `disable_animation`) | `@optional_boolean_specs` row | 4 | 3 |
+| C. Multi optional-trailing (`adjust`, `trim`, `unsharp_masking`, `gradient`, `*_options`) | a general multi-optional interpreter | 9 | 1 (`trim`) |
+| D. Irregular (`watermark`, `style`, `skip_processing`, detections) | bespoke | ~14 | 3 |
+
+This is the justification for the design:
+
+- **Bucket A (15 options) is the real payoff of the schema** and needs no new
+  mechanism — each is a future one-line `@special_specs` row. This is why the
+  table approach is worth adopting at all.
+- **Bucket B is a genuine but small non-Pro cluster (3 future + `scp` now).** A
+  *minimal* single-optional-boolean facility serves it cheaply; a general
+  `default:`/range interpreter would be overkill. Hence the dedicated tiny table
+  rather than extending `interpret_special/3`.
+- **Bucket C is overwhelmingly Pro (8 of 9)** and its one non-Pro member
+  (`trim`) is heterogeneously typed. A general multi-optional interpreter is
+  deferred until/unless the Pro encoding/color options are prioritized — added
+  then, with real data points, per the project's "add it when the caller
+  appears" discipline.
+
 ## Approach
 
-A declarative spec table plus one generic interpreter for the options that fit a
-flat shape, with genuinely irregular options left as explicit bespoke parsers.
-
-This was validated by a spike (already in the working tree) that converted the
-seven single-arg pipeline options — `blur`, `sharpen`, `pixelate`, `dpr`,
-`brightness`, `contrast`, `saturation` — with all 174 parser/property/wire tests
-green, credo `--strict` clean, and `--warnings-as-errors` compile.
-
-### Data model
+### `@special_specs` — fixed-arity options (spike, done)
 
 ```elixir
 @special_specs %{
   "blur" => [{:blur, :non_neg_float}],
   "bl"   => [{:blur, :non_neg_float}],
-  # ...
-  "strip_color_profile" => [{:strip_color_profile, :bool, default: true}],
-  "scp"                 => [{:strip_color_profile, :bool, default: true}],
-  "crop_aspect_ratio" => [{:crop_aspect_ratio, :non_neg_float},
-                          {:crop_aspect_ratio_enlarge, :bool, default: false}],
-  # ...car aliases
+  # sharpen, pixelate, dpr, brightness, contrast, saturation
 }
 ```
 
-Each alias maps to an ordered list of arg specs. An arg spec is:
+Each alias maps to an ordered list of `{key, type}` required, non-empty args.
+`type` is dispatched by `apply_type/2` to an existing value parser
+(`:non_neg_float`, `:positive_float`, `:non_neg_int`, `:adjustment`). The value
+parsers are unchanged and each emits its own canonical error tag, so no
+per-option error override is needed.
 
-- `{key, type}` — required, non-empty; or
-- `{key, type, default: value}` — optional **trailing** arg. `value` is an
-  already-parsed literal (e.g. `true`, `false`), used directly **without** going
-  through `apply_type` (so `default: true`, not `default: "true"`).
+`interpret_special/3`: arity mismatch or empty value →
+`{:error, {:invalid_option_segment, segment}}`; otherwise run each value through
+`apply_type/2`, propagating the parser's own error tag on failure; return
+`{:ok, keyword_assignments}`. An unknown `type` atom raises via `apply_type/2`'s
+missing clause, by design (trusted internal dispatch).
 
-`type` is an atom dispatched by `apply_type/2` to an existing value parser
-(`:non_neg_float` → `parse_non_negative_float/1`, `:bool` → `parse_boolean/1`,
-etc.). The value parsers are unchanged; each already emits its own canonical
-error tag, so there is **no per-option error-tag override** in this design (the
-earlier `error:` idea was dropped — its only candidate, `background_alpha`, is
-not convertible; see bespoke list).
+### `@optional_boolean_specs` — single optional booleans (new, minimal)
 
-New `apply_type/2` entries required by this change: `:bool` → `parse_boolean/1`.
-(The seven spike options already use `:non_neg_float`, `:positive_float`,
-`:non_neg_int`, `:adjustment`.)
+```elixir
+@optional_boolean_specs %{
+  "strip_color_profile" => {:strip_color_profile, true},
+  "scp"                 => {:strip_color_profile, true},
+  # future one-liners: "raw" => {:raw, false},
+  #   "enforce_thumbnail" => {:enforce_thumbnail, false},
+  #   "preserve_hdr" => {:preserve_hdr, true}
+}
+```
 
-### Interpreter
+`interpret_optional_boolean({key, default}, args, segment)` — exactly three cases,
+reproducing the current `parse_strip_color_profile/2` behavior:
 
-`interpret_special/3`:
+- `[]` (option present, no value) → `{:ok, [{key, default}]}`.
+- `[value]` with `value != ""` → `parse_boolean(value)`, propagating
+  `{:invalid_boolean, value}` on failure.
+- anything else (`[""]`, `[_, _ | _]`) → `{:error, {:invalid_option_segment, segment}}`.
 
-1. Let `required` = count of args without `default:`, `total` = all args.
-2. **Arity:** if `length(args)` is outside `[required, total]` →
-   `{:error, {:invalid_option_segment, segment}}`.
-3. **Required positions:** an empty value (`""`) in any *required* position →
-   `{:error, {:invalid_option_segment, segment}}`.
-4. **Optional positions — absent vs. empty are distinct:**
-   - *absent* (position beyond the provided arity) → contribute the spec's
-     pre-parsed `default:` value directly (do **not** call `apply_type`).
-   - *present* (within provided arity), including an explicit empty `""` →
-     treated as a provided value: empty → `{:invalid_option_segment, segment}`;
-     non-empty → run through `apply_type`.
-5. Run each present value through `apply_type/2`; on failure, propagate the value
-   parser's own tag.
-6. Return `{:ok, keyword_assignments}`; `parse_pipeline_option/3` wraps it as
-   `{:pipeline, assignments}` exactly as before.
-
-This absent-vs-empty distinction is load-bearing: it reproduces the bespoke
-behavior where `scp` → `true` but `scp:` → error, and `car:1.5` defaults enlarge
-to `false` but `car:1.5:` → error.
-
-The interpreter introduces no runtime validation of the `@special_specs` shape
-itself (e.g. that defaulted args are trailing). That is a programmer-error
-invariant covered by the green test suite, not a runtime guard — consistent with
-the project's "trust internal producers, reserve raises for programmer error"
-guideline. An unknown `type` atom raises via `apply_type/2`'s missing clause, by
-design.
-
-### Options the schema absorbs (9 total)
-
-- **Spike (done):** `blur`, `sharpen`, `pixelate`, `dpr`, `brightness`,
-  `contrast`, `saturation` — single required arg, type's canonical error tag.
-- **Optional-trailing-with-default:** `strip_color_profile` (optional `:bool`,
-  default `true`; bare `scp` → `true`, `scp:` → error), `crop_aspect_ratio`
-  (required `:non_neg_float` ratio + optional `:bool` enlarge, default `false`;
-  flat 1:1 mapping to its two output keys).
-
-### Options that stay bespoke (and why)
-
-Each carries logic a flat key→value schema cannot express:
-
-- **`background_alpha`** — *not convertible.* Its arity/empty failures return the
-  option-specific `{:invalid_background_alpha, args}` (pinned by
-  `option_grammar_test.exs`), not the interpreter's uniform
-  `{:invalid_option_segment, segment}`. Preserving that would require a
-  whole-option error override used by exactly one option — net more complexity.
-- **`auto_rotate`, `rotate`, `flip`** — assignments nest under `:orientation`
-  (a shape consumed uniformly downstream in `options.ex`, so the nesting itself
-  is shared by 3 options). They stay bespoke not because nesting is rare but
-  because each also carries logic the flat interpreter lacks: `rotate` does
-  mod-90 validation + `normalize_rotation/1` (a post-parse transform), `flip`
-  collapses two bools into a `:both/:horizontal/:vertical/nil` enum (a
-  post-combine), and all three support a zero-arg form (every arg optional, not
-  trailing-optional). Nesting never travels alone here.
-- **`extend`, `extend_aspect_ratio`** — bool + optional gravity sub-grammar +
-  an injected `extend_requested: true` constant, entangled together.
-- **`monochrome`, `duotone`** — nested keyword output + optional colors with
-  remapped error tags.
-- **`background` (empty | hex | r:g:b), `zoom` (1-arg fan-out | 2-arg)** —
-  alternative arg shapes / fan-out. The two don't share an alternation strategy,
-  so a `one_of` combinator would serve two unrelated cases — deliberately not
-  added.
-- **`padding` (1–4 values with `:unset` holes), `gravity`/`crop` (anchor enum vs.
-  focal-point vs. offset tuple), `filename` (percent vs. base64).**
-- **`resize`/`size`** (`Enum.split` + extend-gravity merge) and `format_quality`
-  (pair into a map) keep their existing `parse_known_option/4` clauses.
+No arity range arithmetic, no absent-vs-empty distinction beyond these three
+clauses. Adding a future boolean option is one table row; its default is a
+pre-parsed literal. `apply_type` is not involved (the handler calls
+`parse_boolean/1` directly).
 
 ### Dispatch
 
 `parse_pipeline_option/3` (introduced in the spike) is the single entry for
-non-`@option_specs` options: `@special_specs` lookup → `interpret_special/3`,
-else fall through to the remaining `parse_special_option/3` clauses. One path,
-two handler kinds.
+non-`@option_specs` options. Lookup order:
 
-### Two spec tables, deliberately
+1. `@special_specs` → `interpret_special/3`
+2. `@optional_boolean_specs` → `interpret_optional_boolean/3`
+3. fall through to the remaining bespoke `parse_special_option/3` clauses
 
-After this change the parser has **two** declarative arg-spec interpreters:
-`@option_specs` + `parse_field/2` (for the resize/format/quality/etc. family),
-and `@special_specs` + `apply_type/2` (this change). They are the same idea in
-two vocabularies (`field` vs `type`, `skip_empty:` vs `default:`) with two error
-models. Unifying them now would force `resize`/`size`'s irregular merge into a
-shared table — over-generalization this design otherwise avoids — so they stay
-separate. To limit drift:
+One dispatch path, three handler kinds. Each table is small and single-purpose.
 
-- Align naming where cheap so the two read as dialects of one idea.
-- Unify only when a third regular-option family appears, or when `@option_specs`
-  needs a `default:`-equivalent. Documented here so the divergence is a known,
-  bounded decision rather than silent.
+### Options that stay bespoke (and why)
+
+`background_alpha` (option-specific arity tag), `crop_aspect_ratio` (leading-req +
+optional, would force range logic for one option), `auto_rotate`/`rotate`/`flip`
+(nest under `:orientation`; `rotate` mod-90 transform; `flip` two-bool collapse;
+all have zero-arg forms), `extend`/`extend_aspect_ratio` (bool + gravity
+sub-grammar + injected constant), `monochrome`/`duotone` (nested keyword +
+optional colors), `background`/`zoom` (alternative shapes / fan-out),
+`padding`/`gravity`/`crop`/`filename` (variadic sub-grammars), and `resize`/`size`
++ `format_quality` (existing `parse_known_option/4` clauses).
+
+### Spec-table divergence, deliberately
+
+After this change the parser has small declarative tables —
+`@option_specs`/`parse_field` (resize/format/quality family),
+`@special_specs`/`apply_type` (fixed-arity specials), and
+`@optional_boolean_specs` (optional booleans) — each purpose-clear. They are not
+unified now: forcing `resize`/`size`'s irregular merge into a shared table would
+be over-generalization. Unify only if a third regular-option family appears or a
+table needs another's capability. Documented so the divergence is a bounded,
+known decision, not silent drift.
 
 ## Error model
 
 | Failure | Tag |
 | --- | --- |
-| Wrong arity / empty required arg / empty *present* optional arg | `{:invalid_option_segment, segment}` |
-| Value parse failure | the value parser's own tag (e.g. `:invalid_non_negative_float`, `:invalid_positive_float`, `:invalid_adjustment`) |
+| Fixed-arity: wrong arity / empty arg | `{:invalid_option_segment, segment}` |
+| Fixed-arity: value parse failure | value parser's own tag (`:invalid_non_negative_float`, `:invalid_positive_float`, `:invalid_adjustment`, …) |
+| Optional-boolean: `scp` / `scp:1` / `scp:0` | success (`true` / parsed bool) |
+| Optional-boolean: `scp:` / `scp:1:2` | `{:invalid_option_segment, segment}` |
+| Optional-boolean: `scp:bad` | `{:invalid_boolean, "bad"}` (from `parse_boolean/1`) |
 
-This matches current behavior for **the nine converted options** exactly.
-Options whose bespoke parsers use option-specific arity/empty tags (e.g.
-`background_alpha`) are excluded from conversion precisely because they don't fit
-this uniform model.
+Matches current behavior for all 8 converted options exactly.
 
 ## Testing
 
-Treat the existing suites as the spec; convert green-to-green. Primary spec files
-(the design's original list omitted the most important one):
+Treat the existing suites as the spec; convert green-to-green. Primary spec files:
 
-- `test/parser/imgproxy/option_grammar_test.exs` — **primary**: pins exact
-  `{:ok, {:pipeline, [...]}}` tuples and error tags for these options, including
-  the `invalid_pipeline_arity_segments/0` arity table.
-- `test/parser/imgproxy/options_test.exs`, `.../plan_builder_test.exs` — pin
-  `car`, `dpr`, brightness/contrast/saturation at the plan layer.
+- `test/parser/imgproxy/option_grammar_test.exs` — **primary**: exact
+  `{:ok, {:pipeline, [...]}}` tuples + error tags, incl. the
+  `invalid_pipeline_arity_segments/0` arity table.
+- `test/parser/imgproxy/options_test.exs`, `.../plan_builder_test.exs` — plan-layer
+  pins (e.g. brightness/contrast/saturation, dpr).
 - `test/parser/imgproxy_test.exs`, `.../imgproxy_property_test.exs`,
   `test/image_pipe/imgproxy_wire_conformance_test.exs` — wire/behavior contracts.
 
 **Pins to add at the `OptionGrammar.parse/1` boundary _before_ converting** (each
-closes an un-asserted behavior the refactor could otherwise silently change):
+confirmed genuinely missing at that boundary in review):
 
 - `dpr`: `dpr:0` → `{:error, {:invalid_positive_float, "0"}}` and a fractional
-  success (`dpr:1.5`). Type semantics are currently unpinned.
-- `crop_aspect_ratio`: both `car:<ratio>` (1-arg, enlarge defaults `false`) and
-  `car:<ratio>:<bool>` (2-arg) → exact `{:pipeline, [...]}` keyword lists; plus
-  ratio failure (`car:nope`) and the empty-trailing edge `car:1.5:` →
-  `{:invalid_option_segment, ...}`.
-- `strip_color_profile`: bare `scp`/`strip_color_profile` (no args) →
-  `{:ok, {:pipeline, [strip_color_profile: true]}}`; plus `scp:` →
-  `{:invalid_option_segment, ...}` and `scp:bad` → error.
+  success (`dpr:1.5`). Type semantics currently unpinned.
+- `strip_color_profile`/`scp`: bare `scp` → `{:ok, {:pipeline, [strip_color_profile: true]}}`;
+  `scp:0`/`scp:1` → flat bool; `scp:` → `{:invalid_option_segment, ...}`;
+  `scp:bad` → `{:invalid_boolean, "bad"}`. (Wire tests exercise `scp:0`/`scp:1`
+  only; the bare/default-true and empty/invalid edges are unpinned at `parse/1`.)
 - `brightness`/`contrast`/`saturation`: tighten existing out-of-range assertions
-  from `{:error, _}` to the exact `{:invalid_adjustment, value}` tag.
+  from loose `{:error, _}` to the exact `{:invalid_adjustment, value}` tag.
 
 **One property to add:** alias-equivalence over the converted long/short pairs
 (`blur`/`bl`, `sharpen`/`sh`, `pixelate`/`pix`, `brightness`/`br`, `contrast`/`co`,
-`saturation`/`sa`, `crop_aspect_ratio`/`crop_ar`/`car`) — `parse(long:v) ==
-parse(short:v)` over valid and invalid `v`, mirroring the existing `zoom`/`z`
-property. No arity-fuzz property: the explicit arity table already covers edges.
+`saturation`/`sa`, `strip_color_profile`/`scp`) — `parse(long:v) == parse(short:v)`
+over valid and invalid `v`, mirroring the existing `zoom`/`z` property. No
+arity-fuzz property: the explicit arity table covers edges.
 
 **Tests not to write / not to delete:**
 
 - New cases are forward contract pins at `parse/1` (tagged tuples are public
-  contract). No old-vs-new parity/characterization harnesses; no `*_characterization_test.exs`.
-- No name-policing: do not assert `function_exported?` on the deleted
-  `parse_blur/2` etc. The `parse/1`-level suites are the sole proof.
-- **Do not delete coverage as "redundant."** The arity table and cases like
-  `bga:0.0 → {:ratio, 0, 10}` are the sole pin for their edge. The only permitted
-  deletions are parity/characterization pins the spike may have introduced, and a
-  redundancy claim must name the specific other test covering the identical
-  input→output.
-- All new pins drive through `parse/1`; never hand-build `%CropRequest{}` or
-  assignment keyword lists as inputs.
+  contract). No old-vs-new parity/characterization harnesses.
+- No name-policing: do not assert `function_exported?` on deleted `parse_blur/2`
+  etc. The `parse/1`-level suites are the sole proof.
+- Do not delete coverage as "redundant"; only permitted deletions are
+  parity/characterization pins the spike may have introduced, and a redundancy
+  claim must name the specific other test covering the identical input→output.
+- All new pins drive through `parse/1`; never hand-build internal structs as
+  inputs.
 
 Gate before finishing: `mix format --check-formatted`,
 `mix compile --warnings-as-errors`, `mix credo --strict`, `mix test`
@@ -242,17 +233,18 @@ Gate before finishing: `mix format --check-formatted`,
 - Stays entirely within `ImagePipe.Parser.Imgproxy.*` — no cross-namespace
   change, no concrete transform modules referenced, no plan-model change. No
   architecture-test changes needed.
-- The interpreter is trusted internal dispatch; arity/empty checks validate
+- Interpreters are trusted internal dispatch; arity/empty checks validate
   untrusted URL input (a real boundary), not impossible internal misuse.
 
 ## Risks / trade-offs
 
 - **Indirection vs. greppability.** `grep parse_blur` no longer lands on the
-  logic; you read the `@special_specs` row + the interpreter. Accepted because
-  the marginal cost of the next regular option drops to ~one table row.
-- **Modest absorbed set.** After review, the clean-fit set is 9 options (7 spike
-  + `scp` + `crop_aspect_ratio`); `background_alpha` and all output-shape /
-  sub-grammar / fan-out options stay bespoke. The interpreter's capabilities are
-  capped at fixed-required + optional-trailing-with-default deliberately.
-- **Dual interpreters.** Two declarative tables coexist (see "Two spec tables").
-  Bounded by the documented unify-trigger.
+  logic; you read the table row + the interpreter. Accepted: the marginal cost of
+  the next fixed-arity option (15 of them in the catalog) drops to one table row.
+- **Three small tables.** Each is single-purpose and tiny; bounded by the
+  documented unify-trigger. Preferred over one mixed table or over deepening
+  `interpret_special/3` with optional-range logic.
+- **Deferred mechanisms.** `crop_aspect_ratio`'s leading-req+optional shape and
+  bucket C's multi-optional-trailing options are intentionally not built now;
+  the catalog shows bucket C is Pro-heavy, so the trigger to build a general
+  multi-optional interpreter is "the Pro encoding/color options get prioritized."

--- a/docs/superpowers/specs/2026-05-31-imgproxy-option-grammar-simplification-design.md
+++ b/docs/superpowers/specs/2026-05-31-imgproxy-option-grammar-simplification-design.md
@@ -1,7 +1,7 @@
 # imgproxy option grammar simplification
 
 **Date:** 2026-05-31
-**Status:** Design — reviewed (two parallel subagent cycles + catalog analysis), scope finalized
+**Status:** Design — reviewed (three parallel subagent cycles + catalog analysis), scope finalized
 **Scope:** `lib/image_pipe/parser/imgproxy/option_grammar.ex` (internal refactor only)
 
 ## Problem
@@ -21,10 +21,10 @@ option**, paid again by hand for every option.
 
 ## Goal
 
-Make adding a regular imgproxy option a small, low-risk, data-shaped change, and
-centralize arity/empty-arg/error handling so it is implemented once. This is a
-compatibility parser tracking an external product's option catalog, so the
-dominant future cost is safely adding more options.
+Collapse the repeated per-option skeleton for the options that share it, so the
+parsing rule lives as data in one place and the arity/empty/error handling is
+implemented once. This is a compatibility parser tracking an external product's
+option catalog, so reducing the per-option boilerplate has compounding value.
 
 ## Non-goals
 
@@ -38,59 +38,35 @@ dominant future cost is safely adding more options.
 - No new public API. `OptionGrammar.parse/1`'s return contract is unchanged, so
   `options.ex`, `plan_builder.ex`, and the wire layer are untouched.
 
-## Scope (finalized: 8 options)
+## Scope (finalized: 7 options)
 
-Two earlier review cycles plus an analysis of imgproxy's full unimplemented
-option catalog (below) settled the scope:
+Three review cycles plus an analysis of imgproxy's unimplemented option catalog
+settled the scope deliberately narrow:
 
 - **Convert the 7 single-required-arg pipeline options** — `blur`, `sharpen`,
-  `pixelate`, `dpr`, `brightness`, `contrast`, `saturation` — via a declarative
-  `@special_specs` table + `interpret_special/3`. (Already done in a working-tree
-  spike: 174 parser/property/wire tests green, credo `--strict` clean,
-  `--warnings-as-errors` compile.)
-- **Convert `strip_color_profile`/`scp`** via a separate minimal
-  single-optional-boolean facility (`@optional_boolean_specs` +
-  `interpret_optional_boolean/3`), shaped so the future boolean cluster
-  (`raw`, `enforce_thumbnail`, `preserve_hdr`) is a one-row addition each.
-- **`crop_aspect_ratio`/`car` is NOT converted.** Its leading-required +
-  optional-trailing shape is the only thing that would force absent-vs-empty
-  range logic into a shared interpreter; for a single option that is not worth
-  the complexity. It stays bespoke unchanged.
-- **`background_alpha` stays bespoke** — its arity/empty failures use the
-  option-specific `{:invalid_background_alpha, args}` tag (pinned by tests), not
-  the uniform `{:invalid_option_segment}`.
+  `pixelate`, `dpr`, `brightness`, `contrast`, `saturation` — to a declarative
+  `@special_specs` table + `interpret_special/3`. These share the exact same
+  skeleton and all reuse value parsers that already exist, so the conversion is
+  pure deduplication of proven-identical code.
+- **Everything else stays bespoke**, including options that *look* close but
+  aren't pure-fit:
+  - `strip_color_profile`/`scp` — a single *optional* boolean. Converting it
+    would mean building a new optional-boolean facility (table + interpreter +
+    dispatch branch) whose only current consumer is `scp`, justified by future
+    options that don't exist yet. Its existing bespoke clause is already minimal
+    and correct; it stays until a real second caller appears (see Deferred work).
+  - `crop_aspect_ratio`/`car` — leading-required + optional-trailing; the only
+    shape that would force absent-vs-empty range logic into a shared interpreter.
+  - `background_alpha` — arity/empty failures use the option-specific
+    `{:invalid_background_alpha, args}` tag (pinned by tests), not the uniform
+    `{:invalid_option_segment}`.
 
-## Catalog-informed rationale
+The 7-option conversion already exists in the working tree (the spike): 174
+parser/property/wire tests green, credo `--strict` clean, `--warnings-as-errors`
+compile. The remaining work in this change is **locking tests** (below), not new
+production logic.
 
-Why this scope, from imgproxy's documented processing-option catalog (sources:
-docs.imgproxy.net/usage/processing, /generating_the_url). Of the **unimplemented**
-options, bucketed by the parsing mechanism each needs:
-
-| Bucket | Mechanism needed | Count | Non-Pro |
-| --- | --- | --- | --- |
-| A. Fixed-arity (`max_bytes`, `dpi`, `page`, `watermark_size`, …) | none — a `@special_specs` row | 15 | 5 |
-| B. Single optional-boolean (`raw`, `enforce_thumbnail`, `preserve_hdr`, `disable_animation`) | `@optional_boolean_specs` row | 4 | 3 |
-| C. Multi optional-trailing (`adjust`, `trim`, `unsharp_masking`, `gradient`, `*_options`) | a general multi-optional interpreter | 9 | 1 (`trim`) |
-| D. Irregular (`watermark`, `style`, `skip_processing`, detections) | bespoke | ~14 | 3 |
-
-This is the justification for the design:
-
-- **Bucket A (15 options) is the real payoff of the schema** and needs no new
-  mechanism — each is a future one-line `@special_specs` row. This is why the
-  table approach is worth adopting at all.
-- **Bucket B is a genuine but small non-Pro cluster (3 future + `scp` now).** A
-  *minimal* single-optional-boolean facility serves it cheaply; a general
-  `default:`/range interpreter would be overkill. Hence the dedicated tiny table
-  rather than extending `interpret_special/3`.
-- **Bucket C is overwhelmingly Pro (8 of 9)** and its one non-Pro member
-  (`trim`) is heterogeneously typed. A general multi-optional interpreter is
-  deferred until/unless the Pro encoding/color options are prioritized — added
-  then, with real data points, per the project's "add it when the caller
-  appears" discipline.
-
-## Approach
-
-### `@special_specs` — fixed-arity options (spike, done)
+## Approach (the spike, already implemented)
 
 ```elixir
 @special_specs %{
@@ -109,115 +85,101 @@ per-option error override is needed.
 `interpret_special/3`: arity mismatch or empty value →
 `{:error, {:invalid_option_segment, segment}}`; otherwise run each value through
 `apply_type/2`, propagating the parser's own error tag on failure; return
-`{:ok, keyword_assignments}`. An unknown `type` atom raises via `apply_type/2`'s
-missing clause, by design (trusted internal dispatch).
+`{:ok, keyword_assignments}`, which `parse_pipeline_option/3` wraps as
+`{:ok, {:pipeline, assignments}}`. An unknown `type` atom raises via
+`apply_type/2`'s missing clause, by design (trusted internal dispatch).
 
-### `@optional_boolean_specs` — single optional booleans (new, minimal)
+Dispatch via `parse_pipeline_option/3`: `@special_specs` lookup →
+`interpret_special/3`, else fall through to the existing bespoke
+`parse_special_option/3` clauses. One path, two handler kinds.
 
-```elixir
-@optional_boolean_specs %{
-  "strip_color_profile" => {:strip_color_profile, true},
-  "scp"                 => {:strip_color_profile, true},
-  # future one-liners: "raw" => {:raw, false},
-  #   "enforce_thumbnail" => {:enforce_thumbnail, false},
-  #   "preserve_hdr" => {:preserve_hdr, true}
-}
-```
+## Catalog-informed rationale (and an honest bound on the payoff)
 
-`interpret_optional_boolean({key, default}, args, segment)` — exactly three cases,
-reproducing the current `parse_strip_color_profile/2` behavior:
+Of imgproxy's **unimplemented** processing options (sources:
+docs.imgproxy.net/usage/processing, /generating_the_url), bucketed by the parsing
+mechanism each would need:
 
-- `[]` (option present, no value) → `{:ok, [{key, default}]}`.
-- `[value]` with `value != ""` → `parse_boolean(value)`, propagating
-  `{:invalid_boolean, value}` on failure.
-- anything else (`[""]`, `[_, _ | _]`) → `{:error, {:invalid_option_segment, segment}}`.
+| Bucket | Mechanism | Count | Non-Pro |
+| --- | --- | --- | --- |
+| A. Fixed-arity (`max_bytes`, `dpi`, `page`, `watermark_size`, …) | a `@special_specs` row + whatever else the option needs | 15 | 5 |
+| B. Single optional-boolean (`raw`, `enforce_thumbnail`, `preserve_hdr`, `disable_animation`) | an optional-boolean facility | 4 | 3 |
+| C. Multi optional-trailing (`adjust`, `trim`, `unsharp_masking`, `gradient`, `*_options`) | a general multi-optional interpreter | 9 | 1 (`trim`) |
+| D. Irregular (`watermark`, `style`, `skip_processing`, detections) | bespoke | ~14 | 3 |
 
-No arity range arithmetic, no absent-vs-empty distinction beyond these three
-clauses. Adding a future boolean option is one table row; its default is a
-pre-parsed literal. `apply_type` is not involved (the handler calls
-`parse_boolean/1` directly).
+**Honest bound (review correction):** the `@special_specs` table collapses only
+the *grammar-parsing* step. A genuinely new bucket-A option may still need a new
+`apply_type` clause + value parser (e.g. an enum like `resizing_algorithm`), a
+struct field on `PipelineRequest`/`Effects`, and a `plan_builder` operation — and
+`interpret_special/3` currently only emits pipeline-scoped assignments, so a
+non-pipeline option (`max_bytes`, `page`) can't use it without first adding scope
+routing (the `@option_specs` path has `scoped_assignments/2` for this;
+`@special_specs` does not). So the schema is worth adopting for the recurring
+grammar-skeleton dedup it provides on pipeline options with existing value types
+— not because 15 options become free one-liners. The 7 converted options are
+exactly that pre-wired, pipeline-scoped, existing-type set.
 
-### Dispatch
+## Deferred work (documented, not built)
 
-`parse_pipeline_option/3` (introduced in the spike) is the single entry for
-non-`@option_specs` options. Lookup order:
-
-1. `@special_specs` → `interpret_special/3`
-2. `@optional_boolean_specs` → `interpret_optional_boolean/3`
-3. fall through to the remaining bespoke `parse_special_option/3` clauses
-
-One dispatch path, three handler kinds. Each table is small and single-purpose.
-
-### Options that stay bespoke (and why)
-
-`background_alpha` (option-specific arity tag), `crop_aspect_ratio` (leading-req +
-optional, would force range logic for one option), `auto_rotate`/`rotate`/`flip`
-(nest under `:orientation`; `rotate` mod-90 transform; `flip` two-bool collapse;
-all have zero-arg forms), `extend`/`extend_aspect_ratio` (bool + gravity
-sub-grammar + injected constant), `monochrome`/`duotone` (nested keyword +
-optional colors), `background`/`zoom` (alternative shapes / fan-out),
-`padding`/`gravity`/`crop`/`filename` (variadic sub-grammars), and `resize`/`size`
-+ `format_quality` (existing `parse_known_option/4` clauses).
-
-### Spec-table divergence, deliberately
-
-After this change the parser has small declarative tables —
-`@option_specs`/`parse_field` (resize/format/quality family),
-`@special_specs`/`apply_type` (fixed-arity specials), and
-`@optional_boolean_specs` (optional booleans) — each purpose-clear. They are not
-unified now: forcing `resize`/`size`'s irregular merge into a shared table would
-be over-generalization. Unify only if a third regular-option family appears or a
-table needs another's capability. Documented so the divergence is a bounded,
-known decision, not silent drift.
+- **Optional-boolean facility (bucket B).** When the first real future boolean
+  option (`enforce_thumbnail` / `preserve_hdr`; `disable_animation` is Pro) is
+  prioritized, add a minimal single-optional-boolean handler and migrate `scp`
+  into it in the same change. `raw` is *not* a clean member — in imgproxy it
+  switches response mode (serve source bytes), so its parse-grammar surface
+  understates the planner/output work it needs; classify it then, with its real
+  shape in hand. Building this now for `scp` alone is premature (per the same
+  "add it when the caller appears" discipline used to defer bucket C).
+- **Multi-optional interpreter (bucket C).** Deferred. Two independent triggers,
+  not one: (a) the Pro encoding/color options (`adjust`, `unsharp_masking`,
+  `*_options`, …) get prioritized, or (b) `trim` — the lone non-Pro, commonly-used
+  member — is requested. `trim` is heterogeneously typed (float threshold, color,
+  two booleans), so even then a general facility needs per-arg type+default specs.
 
 ## Error model
 
 | Failure | Tag |
 | --- | --- |
-| Fixed-arity: wrong arity / empty arg | `{:invalid_option_segment, segment}` |
-| Fixed-arity: value parse failure | value parser's own tag (`:invalid_non_negative_float`, `:invalid_positive_float`, `:invalid_adjustment`, …) |
-| Optional-boolean: `scp` / `scp:1` / `scp:0` | success (`true` / parsed bool) |
-| Optional-boolean: `scp:` / `scp:1:2` | `{:invalid_option_segment, segment}` |
-| Optional-boolean: `scp:bad` | `{:invalid_boolean, "bad"}` (from `parse_boolean/1`) |
+| Wrong arity / empty arg | `{:invalid_option_segment, segment}` |
+| Value parse failure | value parser's own tag (`:invalid_non_negative_float`, `:invalid_positive_float`, `:invalid_non_negative_integer`, `:invalid_adjustment`) |
 
-Matches current behavior for all 8 converted options exactly.
+Matches current behavior for all 7 converted options exactly. (Verified case-by-
+case in review across every arity/emptiness shape.)
 
 ## Testing
 
-Treat the existing suites as the spec; convert green-to-green. Primary spec files:
+The 7-option conversion is already green against the existing suites. This change
+adds **locking pins** at the `OptionGrammar.parse/1` boundary that were found
+missing — they pin behavior the conversion relies on but that no test currently
+asserts at the grammar boundary:
 
-- `test/parser/imgproxy/option_grammar_test.exs` — **primary**: exact
-  `{:ok, {:pipeline, [...]}}` tuples + error tags, incl. the
-  `invalid_pipeline_arity_segments/0` arity table.
-- `test/parser/imgproxy/options_test.exs`, `.../plan_builder_test.exs` — plan-layer
-  pins (e.g. brightness/contrast/saturation, dpr).
-- `test/parser/imgproxy_test.exs`, `.../imgproxy_property_test.exs`,
-  `test/image_pipe/imgproxy_wire_conformance_test.exs` — wire/behavior contracts.
+Primary spec files: `test/parser/imgproxy/option_grammar_test.exs` (exact
+`{:ok, {:pipeline, [...]}}` tuples + error tags, incl. the
+`invalid_pipeline_arity_segments/0` arity table); `.../options_test.exs`,
+`.../plan_builder_test.exs` (plan-layer pins); the wire suites for behavior.
 
-**Pins to add at the `OptionGrammar.parse/1` boundary _before_ converting** (each
-confirmed genuinely missing at that boundary in review):
+Pins to add (each confirmed genuinely absent at `parse/1` in review):
 
 - `dpr`: `dpr:0` → `{:error, {:invalid_positive_float, "0"}}` and a fractional
-  success (`dpr:1.5`). Type semantics currently unpinned.
-- `strip_color_profile`/`scp`: bare `scp` → `{:ok, {:pipeline, [strip_color_profile: true]}}`;
-  `scp:0`/`scp:1` → flat bool; `scp:` → `{:invalid_option_segment, ...}`;
-  `scp:bad` → `{:invalid_boolean, "bad"}`. (Wire tests exercise `scp:0`/`scp:1`
-  only; the bare/default-true and empty/invalid edges are unpinned at `parse/1`.)
-- `brightness`/`contrast`/`saturation`: tighten existing out-of-range assertions
-  from loose `{:error, _}` to the exact `{:invalid_adjustment, value}` tag.
+  success `dpr:1.5`. Type semantics are pinned nowhere today (only the arity
+  table covers `dpr`/`dpr:`/`dpr:1:2`); a mis-typed `:non_neg_float` would slip
+  through.
+- `brightness`/`contrast`/`saturation`: **tighten** the existing out-of-range
+  assertions (`imgproxy_test.exs` ~1290, `request_safety_test.exs` ~194) from the
+  loose `{:error, _}` to the exact `{:invalid_adjustment, value}` tag. This is a
+  tightening of existing loose coverage, not net-new coverage.
 
-**One property to add:** alias-equivalence over the converted long/short pairs
+One property to add: alias-equivalence over the 7 converted long/short pairs
 (`blur`/`bl`, `sharpen`/`sh`, `pixelate`/`pix`, `brightness`/`br`, `contrast`/`co`,
-`saturation`/`sa`, `strip_color_profile`/`scp`) — `parse(long:v) == parse(short:v)`
-over valid and invalid `v`, mirroring the existing `zoom`/`z` property. No
-arity-fuzz property: the explicit arity table covers edges.
+`saturation`/`sa`) — `parse(long:v) == parse(short:v)` over valid and invalid `v`,
+mirroring the existing `zoom`/`z` property. No arity-fuzz property: the explicit
+arity table covers edges. (No `scp` pair — `scp` is unchanged.)
 
-**Tests not to write / not to delete:**
+Tests not to write / not to delete:
 
 - New cases are forward contract pins at `parse/1` (tagged tuples are public
   contract). No old-vs-new parity/characterization harnesses.
-- No name-policing: do not assert `function_exported?` on deleted `parse_blur/2`
-  etc. The `parse/1`-level suites are the sole proof.
+- No name-policing: do not assert `function_exported?` on the deleted
+  `parse_effect_float/3` / `parse_dpr/2` / `parse_adjustment/3` / `parse_pixelate/2`.
+  The `parse/1`-level suites are the sole proof.
 - Do not delete coverage as "redundant"; only permitted deletions are
   parity/characterization pins the spike may have introduced, and a redundancy
   claim must name the specific other test covering the identical input→output.
@@ -232,19 +194,18 @@ Gate before finishing: `mix format --check-formatted`,
 
 - Stays entirely within `ImagePipe.Parser.Imgproxy.*` — no cross-namespace
   change, no concrete transform modules referenced, no plan-model change. No
-  architecture-test changes needed.
-- Interpreters are trusted internal dispatch; arity/empty checks validate
+  architecture-test changes needed. (Product-neutrality/namespace compliance
+  confirmed in review.)
+- The interpreter is trusted internal dispatch; arity/empty checks validate
   untrusted URL input (a real boundary), not impossible internal misuse.
 
 ## Risks / trade-offs
 
 - **Indirection vs. greppability.** `grep parse_blur` no longer lands on the
-  logic; you read the table row + the interpreter. Accepted: the marginal cost of
-  the next fixed-arity option (15 of them in the catalog) drops to one table row.
-- **Three small tables.** Each is single-purpose and tiny; bounded by the
-  documented unify-trigger. Preferred over one mixed table or over deepening
-  `interpret_special/3` with optional-range logic.
-- **Deferred mechanisms.** `crop_aspect_ratio`'s leading-req+optional shape and
-  bucket C's multi-optional-trailing options are intentionally not built now;
-  the catalog shows bucket C is Pro-heavy, so the trigger to build a general
-  multi-optional interpreter is "the Pro encoding/color options get prioritized."
+  logic; you read the `@special_specs` row + the interpreter. Accepted for the
+  recurring grammar-skeleton dedup; the bound above keeps the claimed payoff
+  honest.
+- **Deliberately narrow.** Only the 7 pure-fit options convert. `scp`, `car`,
+  `background_alpha`, and all bucket B/C/D options stay bespoke, with documented
+  triggers for when the optional-boolean and multi-optional facilities should be
+  built. This is the conservative reading the review cycles converged on.

--- a/docs/superpowers/specs/2026-05-31-imgproxy-option-grammar-simplification-design.md
+++ b/docs/superpowers/specs/2026-05-31-imgproxy-option-grammar-simplification-design.md
@@ -1,0 +1,179 @@
+# imgproxy option grammar simplification
+
+**Date:** 2026-05-31
+**Status:** Design — awaiting review
+**Scope:** `lib/image_pipe/parser/imgproxy/option_grammar.ex` (internal refactor only)
+
+## Problem
+
+`OptionGrammar` parses imgproxy processing-option segments (`rs:fill:300:200`,
+`bl:5`, `br:20`, …). The largest concentration of duplication is in the
+`parse_special_option/3` family: ~25 dispatch clauses, most of the form
+`when name in [...] -> parse_xxx(args, segment)`, each delegating to a bespoke
+`parse_xxx/2` that re-implements the same skeleton — match arity, reject empty
+args, run each arg through a value parser, fall back to
+`{:error, {:invalid_option_segment, segment}}`.
+
+The grammar itself is trivial (`String.split(segment, ":")`); a parser-combinator
+library such as NimbleParsec would not help, because there is no character-level
+or recursive structure to parse. The cost is **semantic interpretation per
+option**, and it is paid again by hand for every option.
+
+## Goal
+
+Make adding a regular imgproxy option a small, low-risk, data-shaped change, and
+centralize arity/empty-arg/error handling so it is implemented once. This is a
+compatibility parser tracking an external product's option catalog, so the
+dominant future cost is safely adding more options, not reading the file once.
+
+## Non-goals
+
+- No change to observable behavior. Every status, header, decoded pixel result,
+  and **error tag** the parser produces today must be byte-for-byte preserved.
+  The existing test suites are the specification.
+- No NimbleParsec / external parser dependency.
+- No cache-key data-version bump (parser output is unchanged; per project
+  guidelines, greenfield cache shape is reshaped in place, and here it is not
+  even changing).
+- No demo changes (no options added, removed, or reparameterized).
+- No new public API. `OptionGrammar.parse/1`'s return contract is unchanged, so
+  `options.ex`, `plan_builder.ex`, and the wire layer are untouched.
+
+## Approach
+
+A declarative spec table plus one generic interpreter for the options that fit a
+flat shape, with genuinely irregular options left as explicit bespoke parsers.
+
+This was validated by a spike (already in the working tree) that converted the
+seven single-arg pipeline options — `blur`, `sharpen`, `pixelate`, `dpr`,
+`brightness`, `contrast`, `saturation` — with all 174 parser/property/wire tests
+green, credo `--strict` clean, and `--warnings-as-errors` compile.
+
+### Data model
+
+```elixir
+@special_specs %{
+  "blur" => [{:blur, :non_neg_float}],
+  "bl"   => [{:blur, :non_neg_float}],
+  # ...
+}
+```
+
+Each alias maps to an ordered list of arg specs. An arg spec is:
+
+- `{key, type}` — required, non-empty; or
+- `{key, type, opts}` where `opts` may carry:
+  - `default:` — value used when this (trailing) arg is absent or empty,
+    making the arg optional;
+  - `error:` — an option-specific error tag substituted when the value parser
+    fails, for options whose diagnostic differs from the type's canonical tag.
+
+`type` is an atom dispatched by `apply_type/2` to an existing value parser
+(`:non_neg_float` → `parse_non_negative_float/1`, etc.). The value parsers are
+unchanged; most already emit their own canonical error tag, so `error:` is only
+needed where the option historically wraps a generic failure into a specific tag
+(e.g. `background_alpha` → `:invalid_background_alpha`).
+
+### Interpreter
+
+`interpret_special/3` (validated by the spike, plus the two extensions above):
+
+1. Split args into required vs optional (trailing-with-`default`).
+2. Arity outside `[required_count, total_count]`, or an empty value in a
+   required position → `{:error, {:invalid_option_segment, segment}}` (the
+   uniform "shape is wrong" tag the bespoke parsers already return).
+3. Fill absent/empty optional args from their `default`.
+4. Run each value through `apply_type/2`; on failure, return the arg's `error:`
+   override if present, else propagate the type parser's tag.
+5. Return `{:ok, keyword_assignments}`; `parse_pipeline_option/3` wraps it as
+   `{:pipeline, assignments}` exactly as before.
+
+The interpreter does **not** grow alternative-shape (`one_of`), output-nesting,
+post-combination, or fan-out constructs. That boundary is deliberate (see below).
+
+### Options the schema absorbs
+
+- **Spike (done):** `blur`, `sharpen`, `pixelate`, `dpr`, `brightness`,
+  `contrast`, `saturation`.
+- **Per-arg error override:** `background_alpha` (single arg, value failure →
+  `:invalid_background_alpha`). Exercises the `error:` capability.
+- **Optional-trailing-with-default:** `strip_color_profile` (optional bool,
+  default `true`), `crop_aspect_ratio` (required ratio + optional enlarge bool,
+  default `false`).
+
+Target: ~10 of the ~25 special options, plus the once-written interpreter.
+
+### Options that stay bespoke (and why)
+
+Each carries logic a flat key→value schema cannot express without adding a
+construct used by essentially one option — which would be net more complexity,
+not less:
+
+- **Output-shape transforms / nesting / constants:** `extend`,
+  `extend_aspect_ratio` (bool + optional gravity tail + `extend_requested: true`
+  constant), `auto_rotate`, `rotate`, `flip` (assignments nested under
+  `:orientation`; `rotate` mod-90 normalization; `flip` combines two bools).
+- **Nested keyword + optional colors:** `monochrome`, `duotone`.
+- **Alternative shapes / fan-out:** `background` (empty | hex | `r:g:b`), `zoom`
+  (1 arg fans to `zoom_x`+`zoom_y`, or 2 args).
+- **Variadic sub-grammars:** `padding` (1–4 values with `:unset` holes),
+  `gravity`/`crop` (anchor enum vs. focal-point vs. offset tuple),
+  `filename` (percent-encoded vs. base64 variant).
+- **`resize`/`size`** (the `Enum.split` + extend-gravity merge) and
+  `format_quality` (pair into a map) keep their existing `parse_known_option/4`
+  clauses.
+
+### Dispatch
+
+`parse_pipeline_option/3` (introduced in the spike) is the single entry for
+non-`@option_specs` options: `@special_specs` lookup → `interpret_special/3`,
+else fall through to the remaining `parse_special_option/3` clauses. One path,
+two handler kinds.
+
+The `@option_specs` regulars already run through the declarative
+`parse_known_option` → `parse_field` path and are **out of scope**; unifying that
+table with `@special_specs` is a possible later follow-on, not part of this work.
+
+## Error model
+
+| Failure | Tag |
+| --- | --- |
+| Wrong arity / empty required arg | `{:invalid_option_segment, segment}` |
+| Value parse failure, no `error:` override | the value parser's own tag (e.g. `:invalid_non_negative_float`) |
+| Value parse failure, with `error:` override | `{error_tag, value}` (e.g. `:invalid_background_alpha`) |
+
+This matches current behavior for every converted option exactly.
+
+## Testing
+
+- TDD against the **existing** specs: `test/parser/imgproxy_test.exs`,
+  `test/parser/imgproxy_property_test.exs`, and
+  `test/image_pipe/imgproxy_wire_conformance_test.exs`. Green-to-green; no test
+  rewrites except deletion of any that become redundant duplicates.
+- Each converted option keeps its existing coverage; if an option's error-tag or
+  arity edge isn't already asserted, add a focused parser-level case before
+  converting it.
+- Gate before finishing: `mix format --check-formatted`,
+  `mix compile --warnings-as-errors`, `mix credo --strict`, `mix test`
+  (via `mise exec --`).
+
+## Boundaries / guideline compliance
+
+- Stays entirely within `ImagePipe.Parser.Imgproxy.*` — no cross-namespace
+  change, no concrete transform modules referenced, no plan-model change.
+- Per CLAUDE.md test guidance: no impossible-internal-misuse tests, no
+  name-policing tests, no post-migration parity pins. The interpreter is trusted
+  internal dispatch; missing/unknown types in `@special_specs` are a programmer
+  error and may raise rather than being guarded.
+
+## Risks / trade-offs
+
+- **Indirection vs. greppability.** `grep parse_blur` no longer lands on the
+  logic; you read the `@special_specs` row + the interpreter. Real cost,
+  accepted because the marginal cost of the next regular option drops to ~one
+  table row. Mitigated by keeping the interpreter small and the bespoke set
+  explicit.
+- **Scope honesty.** The spike showed the clean-fit set is ~10 options, not
+  "most of them" — the rest have output-shape logic that does not belong in a
+  flat schema. The design caps the interpreter's capabilities deliberately
+  rather than chasing every option.

--- a/lib/image_pipe/parser/imgproxy/option_grammar.ex
+++ b/lib/image_pipe/parser/imgproxy/option_grammar.ex
@@ -56,6 +56,27 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammar do
     "kcr" => {:keep_copyright, [:keep_copyright]}
   }
 
+  # Declarative specs for regular fixed-arity pipeline options. Each entry maps
+  # an option alias to an ordered list of {assignment_key, value_type} args. The
+  # value_type names a parser in apply_type/2, which already emits that type's
+  # canonical error tag, so per-option diagnostics are preserved without a
+  # per-option error override. Irregular options stay in parse_special_option/3.
+  @special_specs %{
+    "blur" => [{:blur, :non_neg_float}],
+    "bl" => [{:blur, :non_neg_float}],
+    "sharpen" => [{:sharpen, :non_neg_float}],
+    "sh" => [{:sharpen, :non_neg_float}],
+    "pixelate" => [{:pixelate, :non_neg_int}],
+    "pix" => [{:pixelate, :non_neg_int}],
+    "dpr" => [{:dpr, :positive_float}],
+    "brightness" => [{:brightness, :adjustment}],
+    "br" => [{:brightness, :adjustment}],
+    "contrast" => [{:contrast, :adjustment}],
+    "co" => [{:contrast, :adjustment}],
+    "saturation" => [{:saturation, :adjustment}],
+    "sa" => [{:saturation, :adjustment}]
+  }
+
   @gravity_anchors %{
     "no" => {:anchor, :center, :top},
     "so" => {:anchor, :center, :bottom},
@@ -100,9 +121,23 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammar do
         end
 
       :error ->
-        with {:ok, assignments} <- parse_special_option(name, args, segment) do
-          {:ok, {:pipeline, assignments}}
-        end
+        parse_pipeline_option(name, args, segment)
+    end
+  end
+
+  # Pipeline-scoped options. Regular fixed-arity options are described
+  # declaratively in @special_specs and run through interpret_special/3; the
+  # remaining options with irregular arities/sub-grammars stay as bespoke
+  # parse_special_option/3 clauses.
+  defp parse_pipeline_option(name, args, segment) do
+    result =
+      case Map.fetch(@special_specs, name) do
+        {:ok, arg_specs} -> interpret_special(arg_specs, args, segment)
+        :error -> parse_special_option(name, args, segment)
+      end
+
+    with {:ok, assignments} <- result do
+      {:ok, {:pipeline, assignments}}
     end
   end
 
@@ -376,12 +411,40 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammar do
   defp parse_boolean(value) when value in ["0", "f", "false"], do: {:ok, false}
   defp parse_boolean(value), do: {:error, {:invalid_boolean, value}}
 
-  defp parse_special_option(name, args, segment) when name in ["zoom", "z"] do
-    parse_zoom(args, segment)
+  # Generic interpreter for @special_specs entries: each spec is a fixed list of
+  # required, non-empty args. Arity/empty-arg failures yield the uniform
+  # :invalid_option_segment tag (matching the bespoke parsers); value failures
+  # propagate the type parser's own tag.
+  defp interpret_special(arg_specs, args, segment) do
+    cond do
+      length(args) != length(arg_specs) -> {:error, {:invalid_option_segment, segment}}
+      Enum.any?(args, &(&1 == "")) -> {:error, {:invalid_option_segment, segment}}
+      true -> interpret_special_args(arg_specs, args)
+    end
   end
 
-  defp parse_special_option("dpr", args, segment) do
-    parse_dpr(args, segment)
+  defp interpret_special_args(arg_specs, args) do
+    arg_specs
+    |> Enum.zip(args)
+    |> Enum.reduce_while({:ok, []}, fn {{key, type}, value}, {:ok, acc} ->
+      case apply_type(type, value) do
+        {:ok, parsed} -> {:cont, {:ok, [{key, parsed} | acc]}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, acc} -> {:ok, Enum.reverse(acc)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp apply_type(:non_neg_float, value), do: parse_non_negative_float(value)
+  defp apply_type(:positive_float, value), do: parse_positive_float(value)
+  defp apply_type(:non_neg_int, value), do: parse_non_negative_integer(value)
+  defp apply_type(:adjustment, value), do: parse_adjustment_value(value)
+
+  defp parse_special_option(name, args, segment) when name in ["zoom", "z"] do
+    parse_zoom(args, segment)
   end
 
   defp parse_special_option(name, args, segment) when name in ["extend", "ex"] do
@@ -435,18 +498,6 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammar do
     parse_background_alpha(args, segment)
   end
 
-  defp parse_special_option(name, args, segment) when name in ["blur", "bl"] do
-    parse_effect_float(:blur, args, segment)
-  end
-
-  defp parse_special_option(name, args, segment) when name in ["sharpen", "sh"] do
-    parse_effect_float(:sharpen, args, segment)
-  end
-
-  defp parse_special_option(name, args, segment) when name in ["pixelate", "pix"] do
-    parse_pixelate(args, segment)
-  end
-
   defp parse_special_option(name, args, segment) when name in ["monochrome", "mc"] do
     parse_monochrome(args, segment)
   end
@@ -455,36 +506,7 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammar do
     parse_duotone(args, segment)
   end
 
-  defp parse_special_option(name, args, segment) when name in ["brightness", "br"] do
-    parse_adjustment(:brightness, args, segment)
-  end
-
-  defp parse_special_option(name, args, segment) when name in ["contrast", "co"] do
-    parse_adjustment(:contrast, args, segment)
-  end
-
-  defp parse_special_option(name, args, segment) when name in ["saturation", "sa"] do
-    parse_adjustment(:saturation, args, segment)
-  end
-
   defp parse_special_option(name, _args, _segment), do: {:error, {:unknown_option, name}}
-
-  defp parse_effect_float(key, [value], _segment) when value != "" do
-    with {:ok, value} <- parse_non_negative_float(value) do
-      {:ok, [{key, value}]}
-    end
-  end
-
-  defp parse_effect_float(_key, _args, segment),
-    do: {:error, {:invalid_option_segment, segment}}
-
-  defp parse_pixelate([value], _segment) when value != "" do
-    with {:ok, value} <- parse_non_negative_integer(value) do
-      {:ok, [pixelate: value]}
-    end
-  end
-
-  defp parse_pixelate(_args, segment), do: {:error, {:invalid_option_segment, segment}}
 
   defp parse_monochrome([intensity], _segment) when intensity != "" do
     with {:ok, intensity} <- parse_intensity(intensity) do
@@ -552,14 +574,6 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammar do
       {:ok, [{field, color}]}
     end
   end
-
-  defp parse_adjustment(key, [value], _segment) when value != "" do
-    with {:ok, value} <- parse_adjustment_value(value) do
-      {:ok, [{key, value}]}
-    end
-  end
-
-  defp parse_adjustment(_key, _args, segment), do: {:error, {:invalid_option_segment, segment}}
 
   defp parse_adjustment_value(value) do
     case parse_number(value) do
@@ -680,14 +694,6 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammar do
   end
 
   defp parse_zoom(_args, segment), do: {:error, {:invalid_option_segment, segment}}
-
-  defp parse_dpr([value], _segment) when value != "" do
-    with {:ok, dpr} <- parse_positive_float(value) do
-      {:ok, [dpr: dpr]}
-    end
-  end
-
-  defp parse_dpr(_args, segment), do: {:error, {:invalid_option_segment, segment}}
 
   defp parse_extend([value], _segment) when value != "" do
     with {:ok, extend?} <- parse_boolean(value) do

--- a/test/parser/imgproxy/option_grammar_test.exs
+++ b/test/parser/imgproxy/option_grammar_test.exs
@@ -17,6 +17,31 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammarTest do
     end
   end
 
+  property "fixed-arity option aliases parse equivalently to their long forms" do
+    pairs = [
+      {"blur", "bl"},
+      {"sharpen", "sh"},
+      {"pixelate", "pix"},
+      {"brightness", "br"},
+      {"contrast", "co"},
+      {"saturation", "sa"}
+    ]
+
+    # Non-empty values only: an empty arg yields {:invalid_option_segment, segment}
+    # whose segment string differs by alias (e.g. "blur:" vs "bl:") — an expected
+    # artifact, not a divergence. Every non-empty value produces an alias-independent
+    # result (a value-tagged error or an {:ok, ...} assignment).
+    check all {long, short} <- member_of(pairs),
+              value <-
+                one_of([
+                  map(integer(-200..200), &Integer.to_string/1),
+                  string(:alphanumeric, min_length: 1)
+                ]),
+              max_runs: 300 do
+      assert OptionGrammar.parse("#{long}:#{value}") == OptionGrammar.parse("#{short}:#{value}")
+    end
+  end
+
   test "resize full grammar preserves explicit extend_requested assignment" do
     assert OptionGrammar.parse("resize:fill:300:200:1:0") ==
              {:ok,
@@ -126,6 +151,13 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammarTest do
     assert OptionGrammar.parse("pixelate:8") == {:ok, {:pipeline, [pixelate: 8]}}
     assert OptionGrammar.parse("pix:12") == {:ok, {:pipeline, [pixelate: 12]}}
     assert OptionGrammar.parse("pix:0") == {:ok, {:pipeline, [pixelate: 0]}}
+  end
+
+  test "dpr parses positive floats and rejects non-positive values" do
+    assert OptionGrammar.parse("dpr:1.5") == {:ok, {:pipeline, [dpr: 1.5]}}
+    assert OptionGrammar.parse("dpr:2") == {:ok, {:pipeline, [dpr: 2.0]}}
+    assert OptionGrammar.parse("dpr:0") == {:error, {:invalid_positive_float, "0"}}
+    assert OptionGrammar.parse("dpr:-1") == {:error, {:invalid_positive_float, "-1"}}
   end
 
   test "tone effect options parse with imgproxy aliases" do

--- a/test/parser/imgproxy/option_grammar_test.exs
+++ b/test/parser/imgproxy/option_grammar_test.exs
@@ -35,6 +35,7 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammarTest do
               value <-
                 one_of([
                   map(integer(-200..200), &Integer.to_string/1),
+                  map(float(min: -200.0, max: 200.0), &Float.to_string/1),
                   string(:alphanumeric, min_length: 1)
                 ]),
               max_runs: 300 do

--- a/test/parser/imgproxy/option_grammar_test.exs
+++ b/test/parser/imgproxy/option_grammar_test.exs
@@ -161,6 +161,13 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammarTest do
     assert OptionGrammar.parse("dpr:-1") == {:error, {:invalid_positive_float, "-1"}}
   end
 
+  test "blur, sharpen, and pixelate reject invalid values with type-specific tags" do
+    assert OptionGrammar.parse("blur:-1") == {:error, {:invalid_non_negative_float, "-1"}}
+    assert OptionGrammar.parse("sharpen:abc") == {:error, {:invalid_non_negative_float, "abc"}}
+    assert OptionGrammar.parse("pixelate:-1") == {:error, {:invalid_non_negative_integer, "-1"}}
+    assert OptionGrammar.parse("pixelate:1.5") == {:error, {:invalid_non_negative_integer, "1.5"}}
+  end
+
   test "tone effect options parse with imgproxy aliases" do
     assert OptionGrammar.parse("monochrome:0.5") ==
              {:ok, {:pipeline, [monochrome: [intensity: {:ratio, 5, 10}]]}}

--- a/test/parser/imgproxy_test.exs
+++ b/test/parser/imgproxy_test.exs
@@ -1287,9 +1287,14 @@ defmodule ImagePipe.Parser.ImgproxyTest do
   end
 
   test "rejects out-of-range imgproxy brightness contrast and saturation values" do
-    assert {:error, _reason} = Imgproxy.parse(conn(:get, "/_/br:101/plain/images/cat.jpg"), [])
-    assert {:error, _reason} = Imgproxy.parse(conn(:get, "/_/co:-101/plain/images/cat.jpg"), [])
-    assert {:error, _reason} = Imgproxy.parse(conn(:get, "/_/sa:101/plain/images/cat.jpg"), [])
+    assert Imgproxy.parse(conn(:get, "/_/br:101/plain/images/cat.jpg"), []) ==
+             {:error, {:invalid_adjustment, "101"}}
+
+    assert Imgproxy.parse(conn(:get, "/_/co:-101/plain/images/cat.jpg"), []) ==
+             {:error, {:invalid_adjustment, "-101"}}
+
+    assert Imgproxy.parse(conn(:get, "/_/sa:101/plain/images/cat.jpg"), []) ==
+             {:error, {:invalid_adjustment, "101"}}
   end
 
   test "parses processing options before validating output extension" do


### PR DESCRIPTION
## Summary

Refactors the imgproxy `OptionGrammar` parser to collapse the repeated per-option skeleton for the options that share it. The 7 single-required-arg pipeline options — `blur`, `sharpen`, `pixelate`, `dpr`, `brightness`, `contrast`, `saturation` — now parse via a declarative `@special_specs` table + a generic `interpret_special/3`, dispatching each arg through `apply_type/2` to the existing, unchanged value parsers. This removes ~4 near-identical hand-written `parse_*` helpers and their dispatch clauses.

**Behavior-preserving:** every parse result and error tag is byte-identical to before (arity/empty failures → `:invalid_option_segment`; value failures → each type's canonical tag). Irregular options (`scp`, `crop_aspect_ratio`, `background_alpha`, `gravity`, `padding`, `crop`, etc.) intentionally remain bespoke.

Scope was deliberately kept narrow (7 options) after three review cycles + a catalog analysis — see the design doc for why `scp`/`car`/`background_alpha` and the optional-boolean / multi-optional facilities were left out (and documented as deferred work, including the `parse_gravity`/`parse_crop_gravity` consolidation that smart object cropping will motivate).

## Changes

- `lib/image_pipe/parser/imgproxy/option_grammar.ex` — `@special_specs` table, `parse_pipeline_option/3`, `interpret_special/3`, `interpret_special_args/2`, `apply_type/2`; removed `parse_effect_float/3`, `parse_pixelate/2`, `parse_adjustment/3`, `parse_dpr/2`.
- Tests — added characterization pins at the `parse/1` boundary (committed first, green against the pre-refactor code): `dpr` value semantics, exact `:invalid_adjustment` tag for out-of-range `br`/`co`/`sa`, and an alias-equivalence property over the 6 long/short pairs.
- `docs/superpowers/specs/…` and `docs/superpowers/plans/…` — design (with full review history) and implementation plan.

## Test Plan

- [x] `mix test` — full suite green (1107 tests, 35 properties, 1 doctest, 0 failures)
- [x] `mix compile --warnings-as-errors`
- [x] `mix credo --strict` — no issues
- [x] `mix format --check-formatted`
- [x] Characterization tests pass against both pre- and post-refactor code (behavior preserved)
- [x] Final code review confirmed byte-identical behavior across success/arity/empty/value-error paths for all 7 options

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added implementation plan and design specifications for internal option parsing improvements.

* **Refactor**
  * Streamlined image processing option parsing logic for improved maintainability.

* **Tests**
  * Added property-based tests for option alias equivalence.
  * Enhanced validation tests for effect options including positive float handling and range checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->