### PR TITLE
test: de-flake source-session encode and slow-origin timeouts under CI load

### DIFF
--- a/lib/image_pipe/request/source_session.ex
+++ b/lib/image_pipe/request/source_session.ex
@@ -8,7 +8,13 @@ defmodule ImagePipe.Request.SourceSession do
   alias ImagePipe.Request.SourceSession.Producer
   alias ImagePipe.Request.SourceSession.Request
 
-  @call_timeout 15_000
+  # Backstop for a wedged producer, not an input-safety bound (real liveness is
+  # bounded by origin_receive_timeout and the decoded-pixel limit). `prepare`/`next`
+  # block on the producer, which for non-streamable codecs (AVIF, WebP) means a full
+  # synchronous encode. Under oversubscribed CI cores, libvips/NIF encode work on
+  # dirty schedulers can take many seconds wall-clock, so keep this comfortably above
+  # a realistic worst-case encode to avoid spurious :timeout failures.
+  @call_timeout 30_000
   @cancel_timeout 2_000
   @shutdown_timeout 2_000
 

--- a/test/image_pipe/plug_test.exs
+++ b/test/image_pipe/plug_test.exs
@@ -520,7 +520,10 @@ defmodule ImagePipe.PlugTest do
 
     assert_receive {^ref, :first_chunk_sent, ^server}, @slow_origin_first_chunk_timeout
 
-    Task.await(task, 2_000)
+    # The behavior under test is the request's own `origin_receive_timeout` (~1s);
+    # this is just the harness waiting for that to surface. Keep the upper bound
+    # generous so CI scheduler load can't trip it before the request completes.
+    Task.await(task, 10_000)
   end
 
   defp chunked_body_chunk(body) do


### PR DESCRIPTION
## Summary

Fixes two intermittent CI failures (seen on [#130](https://github.com/hlindset/image_plug/pull/130)) that are pre-existing flakes on `main`, not introduced by that PR. Both trace to the same cause: **oversubscribed CI cores + libvips/NIF encode work on dirty schedulers** inflating wall-clock time past fixed timeouts.

### Job 1 — two `500` vs `200` failures on AVIF/WebP negotiation tests
`prepare`/`next` block on the producer, and AVIF/WebP aren't streamable, so the call waits for a **full synchronous encode** of the full-res 10MP `beach.jpg` fixture (~1–2s uncontended). On `ubuntu-latest` (4 vCPU) ExUnit runs `max_cases=8` and libvips spawns ~4 threads/op → ~8× core oversubscription, ballooning an encode past the **15s `@call_timeout`** → `source session failed: :timeout` → 500.

Raise the backstop to **30s**. It guards a *wedged producer*, not input safety — real liveness is still bounded by `origin_receive_timeout` and the decoded-pixel limit.

### Job 2 — `Task.await` EXIT timeout
The slow-origin test helper awaited only `2_000`ms while the behavior under test is a ~1s `origin_receive_timeout`, leaving just 1s of slack that CI scheduler load can exhaust. The await is only the harness waiting for the request to surface; widen it to **10s** without changing the tested timing.

## Evidence
- `beach.jpg` is 4000×2667 (10.7 MP); a full-res AVIF encode is ~980ms even on a fast 12-core machine vs ~17ms resized.
- The negotiation tests request `/_/plain/images/beach.jpg` with no resize → full 10MP encode.
- Simulated 16 concurrent full-res AVIF encodes under 2 schedulers → 12s max, on a fast box.
- Reproduced the exact CI signature (`source session failed: :timeout` → 500) by temporarily lowering `@call_timeout` under constrained schedulers, then reverted.

## Verification
- Previously-failing tests pass.
- Full `mise run precommit` green: `format --check-formatted`, `compile --warnings-as-errors`, `credo --strict` (no issues), all 1108 tests + 35 properties + 1 doctest.

## Follow-up
~10+ tests do real full-res modern-format encodes. If this class reappears despite the 30s backstop, the next lever is reducing that encode cost (small resize in the negotiation tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)