### PR TITLE
General object gravity (Slice 1): multi-class g:obj via a Composite detector

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,10 @@
 ## Telemetry guidelines
 
 - Treat telemetry as part of the runtime observability contract. Use `:telemetry.span/3`-style `:start`, `:stop`, and `:exception` event naming for request and meaningful stage spans.
-- Keep telemetry metadata safe by default. The real constraint is *sensitivity*, not cardinality: metadata fans out to every attached handler (including third-party exporters), so high-cardinality, product-neutral data (transform operation structs, decoded dimensions) is fine, but genuinely sensitive data must not be emitted unless an explicit opt-in is designed and documented. Parser-internal/dialect structs and cache-internal shapes still stay isolated per the namespace guidelines — they should not leak into events. Never emit by default:
-  - Full request paths or source URLs
-  - Signatures, tokens, credentials
-  - Filenames or other path-derived identifiers (including filesystem/storage paths and cache keys)
+- Keep telemetry metadata safe by default. The real constraint is *sensitivity* — not cardinality, and not whether a string looks path-shaped. Metadata fans out to every attached handler (including third-party exporters), so high-cardinality, product-neutral data is fine to emit: transform operation structs, decoded dimensions, class names, and identifiers like a detector's model-artifact name (e.g. a model filename) or a cache key. A value is not sensitive merely because it is a filename or path-derived — judge by whether the *specific* value carries a secret or reveals private end-user content, not by its shape. (Separately, and for *boundary* reasons rather than sensitivity: parser-internal/dialect structs and cache-internal shapes should not leak into events — see the namespace guidelines.) What is *actually* sensitive must not be emitted unless an explicit opt-in is designed and documented:
+  - Secrets — signatures, tokens, credentials, API keys, or anything else that grants access.
+  - Strings that routinely *embed* such secrets — above all full source URLs and request paths, which commonly carry signed-URL query params, signature segments, or presigned credentials. Emit these only behind a documented opt-in, or after stripping the secret-bearing parts.
+  - Private end-user content or PII the host would not want fanned out to exporters.
 - Cardinality is a consumer concern, not an emission concern: `Telemetry.Metrics` requires the metrics author to choose tags, and nothing forwards the raw metadata map to storage. Emit the data; let handlers project it.
 - Keep third-party backend integrations out of the library: hosts attach AppSignal, OpenTelemetry, and metrics handlers themselves. ImagePipe may ship an opt-in default handler that uses only the stdlib `Logger` (`ImagePipe.Telemetry.attach_default_logger/1`); it is never attached automatically.
 - Prefer shared telemetry helpers over ad hoc event emission so naming, measurements, metadata merging, and exception behavior stay consistent.

--- a/demo/src/App.svelte
+++ b/demo/src/App.svelte
@@ -885,16 +885,7 @@
 
           {#if state.gravityMode === "objClasses"}
             <div class="field">
-              <span>
-                <span>Classes</span>
-                <span class="field-hint">
-                  {state.gravityObjClasses.length === 0
-                    ? "g:obj"
-                    : state.gravityObjClasses.length === 1
-                      ? "1 class"
-                      : `${state.gravityObjClasses.length} classes`}
-                </span>
-              </span>
+              <span>Classes</span>
               <!-- Multi-select for COCO-80 classes. Matches the underscore spelling
                    in ImagePipe.Transform.Detector.ImageVision.Objects (@coco_classes).
                    Empty selection = bare g:obj (all objects). -->
@@ -2139,12 +2130,6 @@
     color: var(--accent);
     font-size: 12px;
     line-height: 1;
-  }
-
-  .field-hint {
-    color: var(--text-muted);
-    font-family: var(--font-mono);
-    font-size: 12px;
   }
 
   .text-input {

--- a/demo/src/App.svelte
+++ b/demo/src/App.svelte
@@ -21,7 +21,6 @@
     defaultDemoState,
     focalPointFromBounds,
     gravitySegment,
-    objGravitySegment,
     processedSizeLabel,
     resizeOptionSegment,
     resetCropPixelsToSource,
@@ -883,66 +882,52 @@
           {#if state.gravityMode === "objClasses"}
             <div class="field">
               <span>
-                <span>Object scope</span>
-                <span class="field-hint"
-                  >{objGravitySegment(state.gravityObjClasses, state.gravityObjAll)}</span
-                >
-              </span>
-              <select bind:value={state.gravityObjAll}>
-                <option value={false}>specific classes</option>
-                <option value={true}>all (g:obj:all)</option>
-              </select>
-            </div>
-
-            {#if !state.gravityObjAll}
-              <div class="field">
-                <span>
-                  <span>Classes</span>
-                  <span class="field-hint">
-                    {state.gravityObjClasses.length === 0
-                      ? "bare obj (all)"
-                      : state.gravityObjClasses.length === 1
-                        ? "1 class"
-                        : `${state.gravityObjClasses.length} classes`}
-                  </span>
+                <span>Classes</span>
+                <span class="field-hint">
+                  {state.gravityObjClasses.length === 0
+                    ? "g:obj"
+                    : state.gravityObjClasses.length === 1
+                      ? "1 class"
+                      : `${state.gravityObjClasses.length} classes`}
                 </span>
-                <!-- Multi-select for COCO-80 classes. Matches the underscore spelling
-                     in ImagePipe.Transform.Detector.ImageVision.Objects (@coco_classes). -->
-                <Select.Root type="multiple" bind:value={state.gravityObjClasses}>
-                  <Select.Trigger class="obj-class-trigger" aria-label="Select object classes">
-                    <span class="obj-class-trigger-label">
-                      {state.gravityObjClasses.length === 0
-                        ? "Choose classes…"
-                        : state.gravityObjClasses.length === 1
-                          ? state.gravityObjClasses[0]
-                          : `${state.gravityObjClasses.length} classes selected`}
-                    </span>
-                    <span class="obj-class-trigger-chevron" aria-hidden="true"></span>
-                  </Select.Trigger>
-                  <Select.Portal>
-                    <Select.Content class="obj-class-content" sideOffset={4}>
-                      <Select.Viewport class="obj-class-viewport">
-                        {#each cocoClasses as cls}
-                          <Select.Item class="obj-class-item" value={cls} label={cls}>
-                            {#snippet children({ selected })}
-                              <span class="obj-class-item-check" aria-hidden="true">
-                                {#if selected}✓{/if}
-                              </span>
-                              {cls}
-                            {/snippet}
-                          </Select.Item>
-                        {/each}
-                      </Select.Viewport>
-                    </Select.Content>
-                  </Select.Portal>
-                </Select.Root>
-                {#if state.gravityObjClasses.length === 0}
-                  <p class="field-hint-text">
-                    No classes selected — emits bare <code>g:obj</code> (all objects)
-                  </p>
-                {/if}
-              </div>
-            {/if}
+              </span>
+              <!-- Multi-select for COCO-80 classes. Matches the underscore spelling
+                   in ImagePipe.Transform.Detector.ImageVision.Objects (@coco_classes).
+                   Empty selection = bare g:obj (all objects). -->
+              <Select.Root type="multiple" bind:value={state.gravityObjClasses}>
+                <Select.Trigger class="obj-class-trigger" aria-label="Select object classes">
+                  <span class="obj-class-trigger-label">
+                    {state.gravityObjClasses.length === 0
+                      ? "All objects"
+                      : state.gravityObjClasses.length === 1
+                        ? state.gravityObjClasses[0]
+                        : `${state.gravityObjClasses.length} classes selected`}
+                  </span>
+                  <span class="obj-class-trigger-chevron" aria-hidden="true"></span>
+                </Select.Trigger>
+                <Select.Portal>
+                  <Select.Content class="obj-class-content" sideOffset={4}>
+                    <Select.Viewport class="obj-class-viewport">
+                      {#each cocoClasses as cls}
+                        <Select.Item class="obj-class-item" value={cls} label={cls}>
+                          {#snippet children({ selected })}
+                            <span class="obj-class-item-check" aria-hidden="true">
+                              {#if selected}✓{/if}
+                            </span>
+                            {cls}
+                          {/snippet}
+                        </Select.Item>
+                      {/each}
+                    </Select.Viewport>
+                  </Select.Content>
+                </Select.Portal>
+              </Select.Root>
+              {#if state.gravityObjClasses.length === 0}
+                <p class="field-hint-text">
+                  No classes selected — emits bare <code>g:obj</code> (all objects)
+                </p>
+              {/if}
+            </div>
           {/if}
         {/if}
       </section>

--- a/demo/src/App.svelte
+++ b/demo/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { Collapsible, RadioGroup, Switch } from "bits-ui";
+  import { Collapsible, RadioGroup, Select, Switch } from "bits-ui";
   import CropDimensionControl from "./CropDimensionControl.svelte";
   import RangeNumber from "./RangeNumber.svelte";
   import ResizeDimensionControl from "./ResizeDimensionControl.svelte";
@@ -908,24 +908,34 @@
                 </span>
                 <!-- Multi-select for COCO-80 classes. Matches the underscore spelling
                      in ImagePipe.Transform.Detector.ImageVision.Objects (@coco_classes). -->
-                <select
-                  class="obj-class-select"
-                  multiple
-                  size={8}
-                  value={state.gravityObjClasses}
-                  onchange={(e) => {
-                    const select = e.currentTarget;
-                    state.gravityObjClasses = Array.from(select.selectedOptions).map(
-                      (opt) => opt.value,
-                    );
-                  }}
-                >
-                  {#each cocoClasses as cls}
-                    <option value={cls} selected={state.gravityObjClasses.includes(cls)}
-                      >{cls}</option
-                    >
-                  {/each}
-                </select>
+                <Select.Root type="multiple" bind:value={state.gravityObjClasses}>
+                  <Select.Trigger class="obj-class-trigger" aria-label="Select object classes">
+                    <span class="obj-class-trigger-label">
+                      {state.gravityObjClasses.length === 0
+                        ? "Choose classes…"
+                        : state.gravityObjClasses.length === 1
+                          ? state.gravityObjClasses[0]
+                          : `${state.gravityObjClasses.length} classes selected`}
+                    </span>
+                    <span class="obj-class-trigger-chevron" aria-hidden="true"></span>
+                  </Select.Trigger>
+                  <Select.Portal>
+                    <Select.Content class="obj-class-content" sideOffset={4}>
+                      <Select.Viewport class="obj-class-viewport">
+                        {#each cocoClasses as cls}
+                          <Select.Item class="obj-class-item" value={cls} label={cls}>
+                            {#snippet children({ selected })}
+                              <span class="obj-class-item-check" aria-hidden="true">
+                                {#if selected}✓{/if}
+                              </span>
+                              {cls}
+                            {/snippet}
+                          </Select.Item>
+                        {/each}
+                      </Select.Viewport>
+                    </Select.Content>
+                  </Select.Portal>
+                </Select.Root>
                 {#if state.gravityObjClasses.length === 0}
                   <p class="field-hint-text">
                     No classes selected — emits bare <code>g:obj</code> (all objects)
@@ -2051,10 +2061,100 @@
     background-repeat: no-repeat;
   }
 
-  .obj-class-select {
-    height: auto;
-    padding-inline: 8px;
-    background-image: none;
+  :global(.obj-class-trigger) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    width: 100%;
+    min-height: 38px;
+    padding-inline: 12px;
+    border: 1px solid var(--border-strong);
+    border-radius: 7px;
+    background: var(--surface-control);
+    color: var(--text-primary);
+    font: inherit;
+    font-size: 14px;
+    line-height: 18px;
+    text-align: left;
+    cursor: default;
+
+    &:focus-visible {
+      outline: 2px solid var(--focus-ring);
+      outline-offset: 2px;
+    }
+  }
+
+  .obj-class-trigger-label {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .obj-class-trigger-chevron {
+    flex-shrink: 0;
+    width: 10px;
+    height: 10px;
+    background-image:
+      linear-gradient(45deg, transparent 50%, var(--text-muted) 50%),
+      linear-gradient(135deg, var(--text-muted) 50%, transparent 50%);
+    background-position:
+      0% 0%,
+      100% 0%;
+    background-size: 5px 5px;
+    background-repeat: no-repeat;
+  }
+
+  :global(.obj-class-content) {
+    z-index: 50;
+    min-width: var(--bits-select-anchor-width);
+    border: 1px solid var(--border-strong);
+    border-radius: 7px;
+    background: var(--surface-sidebar);
+    box-shadow: 0 8px 24px rgb(0 0 0 / 28%);
+    overflow: hidden;
+  }
+
+  :global(.obj-class-viewport) {
+    max-height: 220px;
+    overflow-y: auto;
+    padding: 4px;
+    scrollbar-width: thin;
+    scrollbar-color: var(--border-strong) transparent;
+  }
+
+  :global(.obj-class-item) {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 8px;
+    border-radius: 5px;
+    color: var(--text-primary);
+    font-size: 13px;
+    line-height: 18px;
+    cursor: default;
+    user-select: none;
+
+    &[data-highlighted] {
+      background: var(--surface-control);
+      outline: none;
+    }
+
+    &[data-selected] {
+      color: var(--text-primary);
+    }
+  }
+
+  .obj-class-item-check {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    flex-shrink: 0;
+    color: var(--accent);
+    font-size: 12px;
+    line-height: 1;
   }
 
   .field-hint {

--- a/demo/src/App.svelte
+++ b/demo/src/App.svelte
@@ -40,6 +40,10 @@
     type ThemeMode,
   } from "./theme";
 
+  // COCO-80 classes shown alphabetically in the picker. `cocoClasses` keeps its
+  // canonical (adapter) order as the source of truth; this is display-only.
+  const sortedCocoClasses = [...cocoClasses].sort((a, b) => a.localeCompare(b));
+
   let copyLabel = "Copy URL";
   let drawerOpen = false;
   let mobileTools = false;
@@ -908,7 +912,7 @@
                 <Select.Portal>
                   <Select.Content class="obj-class-content" sideOffset={4}>
                     <Select.Viewport class="obj-class-viewport">
-                      {#each cocoClasses as cls}
+                      {#each sortedCocoClasses as cls}
                         <Select.Item class="obj-class-item" value={cls} label={cls}>
                           {#snippet children({ selected })}
                             <span class="obj-class-item-check" aria-hidden="true">
@@ -922,11 +926,6 @@
                   </Select.Content>
                 </Select.Portal>
               </Select.Root>
-              {#if state.gravityObjClasses.length === 0}
-                <p class="field-hint-text">
-                  No classes selected — emits bare <code>g:obj</code> (all objects)
-                </p>
-              {/if}
             </div>
           {/if}
         {/if}
@@ -2146,17 +2145,6 @@
     color: var(--text-muted);
     font-family: var(--font-mono);
     font-size: 12px;
-  }
-
-  .field-hint-text {
-    margin: 0;
-    color: var(--text-muted);
-    font-size: 12px;
-    line-height: 16px;
-  }
-
-  .field-hint-text code {
-    font-family: var(--font-mono);
   }
 
   .text-input {

--- a/demo/src/App.svelte
+++ b/demo/src/App.svelte
@@ -2062,6 +2062,9 @@
 
   .obj-class-trigger-label {
     flex: 1;
+    /* min-width: 0 lets the flex item shrink below its content width so the
+       ellipsis engages instead of overflowing and pushing the chevron out. */
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/demo/src/App.svelte
+++ b/demo/src/App.svelte
@@ -13,6 +13,7 @@
   } from "./demo-url-state";
   import {
     buildProcessingPath,
+    cocoClasses,
     controlLimits,
     cropOptionSegment,
     cropPixelLimit,
@@ -20,6 +21,7 @@
     defaultDemoState,
     focalPointFromBounds,
     gravitySegment,
+    objGravitySegment,
     processedSizeLabel,
     resizeOptionSegment,
     resetCropPixelsToSource,
@@ -755,6 +757,8 @@
               <option value="sowe">south west</option>
               <option value="sm">smart</option>
               <option value="obj:face">object (face)</option>
+              <option value="obj">object (all, bare)</option>
+              <option value="obj:all">object (all, explicit)</option>
             </select>
           </label>
         {/if}
@@ -800,6 +804,7 @@
               <option value="offset">anchor + offset</option>
               <option value="smart">smart</option>
               <option value="objFace">object (face)</option>
+              <option value="objClasses">object (classes)</option>
             </select>
           </label>
 
@@ -873,6 +878,61 @@
               max={controlLimits.gravityOffset.max}
               step={controlLimits.gravityOffset.step}
             />
+          {/if}
+
+          {#if state.gravityMode === "objClasses"}
+            <div class="field">
+              <span>
+                <span>Object scope</span>
+                <span class="field-hint"
+                  >{objGravitySegment(state.gravityObjClasses, state.gravityObjAll)}</span
+                >
+              </span>
+              <select bind:value={state.gravityObjAll}>
+                <option value={false}>specific classes</option>
+                <option value={true}>all (g:obj:all)</option>
+              </select>
+            </div>
+
+            {#if !state.gravityObjAll}
+              <div class="field">
+                <span>
+                  <span>Classes</span>
+                  <span class="field-hint">
+                    {state.gravityObjClasses.length === 0
+                      ? "bare obj (all)"
+                      : state.gravityObjClasses.length === 1
+                        ? "1 class"
+                        : `${state.gravityObjClasses.length} classes`}
+                  </span>
+                </span>
+                <!-- Multi-select for COCO-80 classes. Matches the underscore spelling
+                     in ImagePipe.Transform.Detector.ImageVision.Objects (@coco_classes). -->
+                <select
+                  class="obj-class-select"
+                  multiple
+                  size={8}
+                  value={state.gravityObjClasses}
+                  onchange={(e) => {
+                    const select = e.currentTarget;
+                    state.gravityObjClasses = Array.from(select.selectedOptions).map(
+                      (opt) => opt.value,
+                    );
+                  }}
+                >
+                  {#each cocoClasses as cls}
+                    <option value={cls} selected={state.gravityObjClasses.includes(cls)}
+                      >{cls}</option
+                    >
+                  {/each}
+                </select>
+                {#if state.gravityObjClasses.length === 0}
+                  <p class="field-hint-text">
+                    No classes selected — emits bare <code>g:obj</code> (all objects)
+                  </p>
+                {/if}
+              </div>
+            {/if}
           {/if}
         {/if}
       </section>
@@ -1989,6 +2049,29 @@
       calc(100% - 12px) 16px;
     background-size: 5px 5px;
     background-repeat: no-repeat;
+  }
+
+  .obj-class-select {
+    height: auto;
+    padding-inline: 8px;
+    background-image: none;
+  }
+
+  .field-hint {
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 12px;
+  }
+
+  .field-hint-text {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 12px;
+    line-height: 16px;
+  }
+
+  .field-hint-text code {
+    font-family: var(--font-mono);
   }
 
   .text-input {

--- a/demo/src/ToolToggleHeader.svelte
+++ b/demo/src/ToolToggleHeader.svelte
@@ -20,7 +20,7 @@
   aria-label={`${checked ? "Disable" : "Enable"} ${title.toLowerCase()}`}
   onclick={toggleChecked}
 >
-  <span>
+  <span class="tool-toggle-text">
     <h2>{title}</h2>
     <p>{summary}</p>
   </span>
@@ -62,6 +62,11 @@
       font-family: var(--font-mono);
       font-size: 12px;
       line-height: 16px;
+      /* Long summaries (e.g. g:obj:car:dog:… with many classes) must truncate
+         rather than push the toggle switch out of bounds. */
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     &:focus-visible {
@@ -69,6 +74,13 @@
       outline: 2px solid var(--focus-ring);
       outline-offset: 4px;
     }
+  }
+
+  .tool-toggle-text {
+    /* min-width: 0 lets this flex item shrink so the summary `p` can ellipsize
+       instead of forcing width and pushing the switch out of bounds. */
+    min-width: 0;
+    flex: 1;
   }
 
   .switch-root {

--- a/demo/src/demo-url-state.ts
+++ b/demo/src/demo-url-state.ts
@@ -701,7 +701,6 @@ function parseGravity(currentState: DemoState, args: string[]): DemoState | null
       gravityEnabled: true,
       gravityMode: "objClasses",
       gravityObjClasses: [],
-      gravityObjAll: false,
     };
   }
 
@@ -717,26 +716,22 @@ function parseGravity(currentState: DemoState, args: string[]): DemoState | null
       };
     }
 
-    // g:obj:all — explicit all pseudo-class
-    if (classes.length === 1 && classes[0] === "all") {
+    // g:obj:all or g:obj:%c…:all — "all" anywhere means all objects; normalize to empty selection
+    if (classes.includes("all")) {
       return {
         ...currentState,
         gravityEnabled: true,
         gravityMode: "objClasses",
         gravityObjClasses: [],
-        gravityObjAll: true,
       };
     }
 
-    // g:obj:%c1:…:%cN — explicit class list (may contain "all" which collapses to :all)
-    const hasAll = classes.includes("all");
-
+    // g:obj:%c1:…:%cN — explicit class list
     return {
       ...currentState,
       gravityEnabled: true,
       gravityMode: "objClasses",
-      gravityObjClasses: hasAll ? [] : classes,
-      gravityObjAll: hasAll,
+      gravityObjClasses: classes,
     };
   }
 

--- a/demo/src/demo-url-state.ts
+++ b/demo/src/demo-url-state.ts
@@ -1,4 +1,5 @@
 import {
+  cocoClasses,
   defaultDemoState,
   resetCropPixelsToSource,
   sampleImages,
@@ -14,6 +15,8 @@ import {
   type Rotate,
   type SourceImage,
 } from "./processing-path";
+
+const cocoClassSet = new Set<string>(cocoClasses);
 
 export type ExpandedToolboxes = {
   effectsOpen: boolean;
@@ -726,12 +729,21 @@ function parseGravity(currentState: DemoState, args: string[]): DemoState | null
       };
     }
 
-    // g:obj:%c1:…:%cN — explicit class list
+    // g:obj:%c1:…:%cN — explicit class list. The backend best-effort-drops
+    // classes no detector knows, so mirror that: keep only known COCO-80 classes
+    // (deduped). If every token is unknown the picker can't represent it (empty
+    // would read as "all objects"), so leave gravity unchanged.
+    const knownClasses = [...new Set(classes.filter((cls) => cocoClassSet.has(cls)))];
+
+    if (knownClasses.length === 0) {
+      return currentState;
+    }
+
     return {
       ...currentState,
       gravityEnabled: true,
       gravityMode: "objClasses",
-      gravityObjClasses: classes,
+      gravityObjClasses: knownClasses,
     };
   }
 

--- a/demo/src/demo-url-state.ts
+++ b/demo/src/demo-url-state.ts
@@ -694,11 +694,49 @@ function parseGravity(currentState: DemoState, args: string[]): DemoState | null
     };
   }
 
-  if (args.length === 2 && modeOrGravity === "obj" && xArg === "face") {
+  if (args.length === 1 && modeOrGravity === "obj") {
+    // g:obj — bare object gravity (all classes)
     return {
       ...currentState,
       gravityEnabled: true,
-      gravityMode: "objFace",
+      gravityMode: "objClasses",
+      gravityObjClasses: [],
+      gravityObjAll: false,
+    };
+  }
+
+  if (args.length >= 2 && modeOrGravity === "obj") {
+    const classes = args.slice(1);
+
+    // g:obj:face is preserved as the legacy objFace mode for UI clarity
+    if (classes.length === 1 && classes[0] === "face") {
+      return {
+        ...currentState,
+        gravityEnabled: true,
+        gravityMode: "objFace",
+      };
+    }
+
+    // g:obj:all — explicit all pseudo-class
+    if (classes.length === 1 && classes[0] === "all") {
+      return {
+        ...currentState,
+        gravityEnabled: true,
+        gravityMode: "objClasses",
+        gravityObjClasses: [],
+        gravityObjAll: true,
+      };
+    }
+
+    // g:obj:%c1:…:%cN — explicit class list (may contain "all" which collapses to :all)
+    const hasAll = classes.includes("all");
+
+    return {
+      ...currentState,
+      gravityEnabled: true,
+      gravityMode: "objClasses",
+      gravityObjClasses: hasAll ? [] : classes,
+      gravityObjAll: hasAll,
     };
   }
 
@@ -862,11 +900,20 @@ function cropGravityFromArgs(args: string[]): CropGravity | null {
       return value;
     }
 
+    // bare obj gravity: c:W:H:obj
+    if (value === "obj") {
+      return "obj";
+    }
+
     return null;
   }
 
   if (args.length === 2 && args[0] === "obj" && args[1] === "face") {
     return "obj:face";
+  }
+
+  if (args.length === 2 && args[0] === "obj" && args[1] === "all") {
+    return "obj:all";
   }
 
   return null;

--- a/demo/src/processing-path.test.ts
+++ b/demo/src/processing-path.test.ts
@@ -564,7 +564,7 @@ describe("processing path generation", () => {
     expect(optionSegments(state)).toEqual(["g:obj:car:dog"]);
   });
 
-  it("rounds trips bare g:obj through the demo path", () => {
+  it("round-trips bare g:obj through the demo path", () => {
     const parsed = parseDemoPath("/demo/g:obj/plain/local:///images/dog.jpg");
 
     expect(parsed).toMatchObject({
@@ -599,6 +599,26 @@ describe("processing path generation", () => {
     });
 
     expect(demoPathForState(parsed)).toBe("/demo/g:obj:car:dog/plain/local:///images/dog.jpg");
+  });
+
+  it("drops unknown class tokens, keeping only known COCO-80 classes", () => {
+    const parsed = parseDemoPath("/demo/g:obj:car:spaceship/plain/local:///images/dog.jpg");
+
+    expect(parsed).toMatchObject({
+      gravityEnabled: true,
+      gravityMode: "objClasses",
+      gravityObjClasses: ["car"],
+    });
+
+    expect(demoPathForState(parsed)).toBe("/demo/g:obj:car/plain/local:///images/dog.jpg");
+  });
+
+  it("leaves gravity unchanged for an all-unknown g:obj segment", () => {
+    const parsed = parseDemoPath("/demo/g:obj:spaceship/plain/local:///images/dog.jpg");
+
+    // every token unknown -> the picker can't represent it, so the segment is
+    // ignored and gravity is not switched to object-classes mode
+    expect(parsed.gravityMode).not.toBe("objClasses");
   });
 
   it("normalizes g:obj:car:all (all mixed with classes) to empty selection (all objects)", () => {

--- a/demo/src/processing-path.test.ts
+++ b/demo/src/processing-path.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   buildProcessingPath,
+  cocoClasses,
   controlLimits,
   cropDimensionSegment,
   cropOptionSegment,
@@ -11,6 +12,7 @@ import {
   debounce,
   focalPointFromBounds,
   imageRequestBytesFromPerformance,
+  objGravitySegment,
   resetCropPixelsToSource,
   processedSizeLabel,
   optionSegments,
@@ -538,6 +540,151 @@ describe("processing path generation", () => {
       cropEnabled: true,
       cropGravity: "obj:face",
     });
+  });
+
+  it("emits bare g:obj for object-class gravity with no classes selected", () => {
+    const state = {
+      ...defaultDemoState,
+      gravityEnabled: true,
+      gravityMode: "objClasses" as const,
+      gravityObjClasses: [],
+      gravityObjAll: false,
+    };
+
+    expect(optionSegments(state)).toEqual(["g:obj"]);
+  });
+
+  it("emits g:obj:all when gravityObjAll is true", () => {
+    const state = {
+      ...defaultDemoState,
+      gravityEnabled: true,
+      gravityMode: "objClasses" as const,
+      gravityObjClasses: [],
+      gravityObjAll: true,
+    };
+
+    expect(optionSegments(state)).toEqual(["g:obj:all"]);
+  });
+
+  it("emits g:obj:%c1:…:%cN for an explicit class list", () => {
+    const state = {
+      ...defaultDemoState,
+      gravityEnabled: true,
+      gravityMode: "objClasses" as const,
+      gravityObjClasses: ["car", "dog"],
+      gravityObjAll: false,
+    };
+
+    expect(optionSegments(state)).toEqual(["g:obj:car:dog"]);
+  });
+
+  it("rounds trips bare g:obj through the demo path", () => {
+    const parsed = parseDemoPath("/demo/g:obj/plain/local:///images/dog.jpg");
+
+    expect(parsed).toMatchObject({
+      gravityEnabled: true,
+      gravityMode: "objClasses",
+      gravityObjClasses: [],
+      gravityObjAll: false,
+    });
+
+    expect(demoPathForState(parsed)).toBe("/demo/g:obj/plain/local:///images/dog.jpg");
+  });
+
+  it("round-trips g:obj:all through the demo path", () => {
+    const parsed = parseDemoPath("/demo/g:obj:all/plain/local:///images/dog.jpg");
+
+    expect(parsed).toMatchObject({
+      gravityEnabled: true,
+      gravityMode: "objClasses",
+      gravityObjClasses: [],
+      gravityObjAll: true,
+    });
+
+    expect(demoPathForState(parsed)).toBe("/demo/g:obj:all/plain/local:///images/dog.jpg");
+  });
+
+  it("round-trips g:obj with explicit classes through the demo path", () => {
+    const parsed = parseDemoPath("/demo/g:obj:car:dog/plain/local:///images/dog.jpg");
+
+    expect(parsed).toMatchObject({
+      gravityEnabled: true,
+      gravityMode: "objClasses",
+      gravityObjClasses: ["car", "dog"],
+      gravityObjAll: false,
+    });
+
+    expect(demoPathForState(parsed)).toBe("/demo/g:obj:car:dog/plain/local:///images/dog.jpg");
+  });
+
+  it("collapses g:obj:all mixed with classes to gravityObjAll=true", () => {
+    const parsed = parseDemoPath("/demo/g:obj:car:all/plain/local:///images/dog.jpg");
+
+    expect(parsed).toMatchObject({
+      gravityEnabled: true,
+      gravityMode: "objClasses",
+      gravityObjClasses: [],
+      gravityObjAll: true,
+    });
+  });
+
+  it("preserves g:obj:face as the legacy objFace mode", () => {
+    const parsed = parseDemoPath("/demo/g:obj:face/plain/local:///images/dog.jpg");
+
+    expect(parsed).toMatchObject({
+      gravityEnabled: true,
+      gravityMode: "objFace",
+    });
+  });
+
+  it("round-trips bare crop obj gravity through the demo path", () => {
+    const state = {
+      ...activeDemoState,
+      cropEnabled: true,
+      cropGravity: "obj" as const,
+    };
+
+    const segments = optionSegments(state);
+    expect(segments).toContain("c:5011:7516:obj");
+
+    const parsed = parseDemoPath(demoPathForState(state));
+    expect(parsed).toMatchObject({
+      cropEnabled: true,
+      cropGravity: "obj",
+    });
+  });
+
+  it("round-trips explicit obj:all crop gravity through the demo path", () => {
+    const state = {
+      ...activeDemoState,
+      cropEnabled: true,
+      cropGravity: "obj:all" as const,
+    };
+
+    const segments = optionSegments(state);
+    expect(segments).toContain("c:5011:7516:obj:all");
+
+    const parsed = parseDemoPath(demoPathForState(state));
+    expect(parsed).toMatchObject({
+      cropEnabled: true,
+      cropGravity: "obj:all",
+    });
+  });
+
+  it("objGravitySegment helper produces correct URL segments", () => {
+    expect(objGravitySegment([], false)).toBe("g:obj");
+    expect(objGravitySegment([], true)).toBe("g:obj:all");
+    expect(objGravitySegment(["car"], false)).toBe("g:obj:car");
+    expect(objGravitySegment(["car", "dog"], false)).toBe("g:obj:car:dog");
+  });
+
+  it("COCO-80 class list has exactly 80 entries in underscore spelling", () => {
+    expect(cocoClasses).toHaveLength(80);
+    expect(cocoClasses).toContain("person");
+    expect(cocoClasses).toContain("traffic_light");
+    expect(cocoClasses).toContain("toothbrush");
+    // No space-spelled entries
+    expect(cocoClasses.every((c) => !c.includes(" "))).toBe(true);
   });
 
   it("normalizes focal point coordinates from a picker rectangle", () => {

--- a/demo/src/processing-path.test.ts
+++ b/demo/src/processing-path.test.ts
@@ -548,22 +548,9 @@ describe("processing path generation", () => {
       gravityEnabled: true,
       gravityMode: "objClasses" as const,
       gravityObjClasses: [],
-      gravityObjAll: false,
     };
 
     expect(optionSegments(state)).toEqual(["g:obj"]);
-  });
-
-  it("emits g:obj:all when gravityObjAll is true", () => {
-    const state = {
-      ...defaultDemoState,
-      gravityEnabled: true,
-      gravityMode: "objClasses" as const,
-      gravityObjClasses: [],
-      gravityObjAll: true,
-    };
-
-    expect(optionSegments(state)).toEqual(["g:obj:all"]);
   });
 
   it("emits g:obj:%c1:…:%cN for an explicit class list", () => {
@@ -572,7 +559,6 @@ describe("processing path generation", () => {
       gravityEnabled: true,
       gravityMode: "objClasses" as const,
       gravityObjClasses: ["car", "dog"],
-      gravityObjAll: false,
     };
 
     expect(optionSegments(state)).toEqual(["g:obj:car:dog"]);
@@ -585,23 +571,22 @@ describe("processing path generation", () => {
       gravityEnabled: true,
       gravityMode: "objClasses",
       gravityObjClasses: [],
-      gravityObjAll: false,
     });
 
     expect(demoPathForState(parsed)).toBe("/demo/g:obj/plain/local:///images/dog.jpg");
   });
 
-  it("round-trips g:obj:all through the demo path", () => {
+  it("normalizes g:obj:all to bare g:obj (empty selection = all objects)", () => {
     const parsed = parseDemoPath("/demo/g:obj:all/plain/local:///images/dog.jpg");
 
     expect(parsed).toMatchObject({
       gravityEnabled: true,
       gravityMode: "objClasses",
       gravityObjClasses: [],
-      gravityObjAll: true,
     });
 
-    expect(demoPathForState(parsed)).toBe("/demo/g:obj:all/plain/local:///images/dog.jpg");
+    // g:obj:all normalizes to bare g:obj on serialize (they are semantically equivalent)
+    expect(demoPathForState(parsed)).toBe("/demo/g:obj/plain/local:///images/dog.jpg");
   });
 
   it("round-trips g:obj with explicit classes through the demo path", () => {
@@ -611,21 +596,22 @@ describe("processing path generation", () => {
       gravityEnabled: true,
       gravityMode: "objClasses",
       gravityObjClasses: ["car", "dog"],
-      gravityObjAll: false,
     });
 
     expect(demoPathForState(parsed)).toBe("/demo/g:obj:car:dog/plain/local:///images/dog.jpg");
   });
 
-  it("collapses g:obj:all mixed with classes to gravityObjAll=true", () => {
+  it("normalizes g:obj:car:all (all mixed with classes) to empty selection (all objects)", () => {
     const parsed = parseDemoPath("/demo/g:obj:car:all/plain/local:///images/dog.jpg");
 
     expect(parsed).toMatchObject({
       gravityEnabled: true,
       gravityMode: "objClasses",
       gravityObjClasses: [],
-      gravityObjAll: true,
     });
+
+    // Serializes to bare g:obj (canonical form for all objects)
+    expect(demoPathForState(parsed)).toBe("/demo/g:obj/plain/local:///images/dog.jpg");
   });
 
   it("preserves g:obj:face as the legacy objFace mode", () => {
@@ -672,10 +658,9 @@ describe("processing path generation", () => {
   });
 
   it("objGravitySegment helper produces correct URL segments", () => {
-    expect(objGravitySegment([], false)).toBe("g:obj");
-    expect(objGravitySegment([], true)).toBe("g:obj:all");
-    expect(objGravitySegment(["car"], false)).toBe("g:obj:car");
-    expect(objGravitySegment(["car", "dog"], false)).toBe("g:obj:car:dog");
+    expect(objGravitySegment([])).toBe("g:obj");
+    expect(objGravitySegment(["car"])).toBe("g:obj:car");
+    expect(objGravitySegment(["car", "dog"])).toBe("g:obj:car:dog");
   });
 
   it("COCO-80 class list has exactly 80 entries in underscore spelling", () => {

--- a/demo/src/processing-path.ts
+++ b/demo/src/processing-path.ts
@@ -158,11 +158,8 @@ export type DemoState = {
   gravityFocalY: number;
   gravityOffsetX: number;
   gravityOffsetY: number;
-  // Object-class gravity: empty array = bare obj (all), explicit class list otherwise.
-  // The "all" pseudo-class is stored as an empty array; use gravityObjAll to pick the
-  // explicit g:obj:all form.
+  // Object-class gravity: empty array = bare obj (all classes); explicit class list otherwise.
   gravityObjClasses: string[];
-  gravityObjAll: boolean;
   enlarge: boolean;
   cropEnabled: boolean;
   cropWidthUnit: CropDimensionUnit;
@@ -351,7 +348,6 @@ export const defaultDemoState: DemoState = {
   gravityOffsetX: 0,
   gravityOffsetY: 0,
   gravityObjClasses: [],
-  gravityObjAll: false,
   enlarge: false,
   cropEnabled: false,
   cropWidthUnit: "px",
@@ -608,7 +604,7 @@ export function gravitySegment(currentState: DemoState): string {
   }
 
   if (currentState.gravityMode === "objClasses") {
-    return objGravitySegment(currentState.gravityObjClasses, currentState.gravityObjAll);
+    return objGravitySegment(currentState.gravityObjClasses);
   }
 
   if (currentState.gravityMode === "focalPoint") {
@@ -622,11 +618,7 @@ export function gravitySegment(currentState: DemoState): string {
   return `g:${currentState.gravity}`;
 }
 
-export function objGravitySegment(classes: string[], objAll: boolean): string {
-  if (objAll) {
-    return "g:obj:all";
-  }
-
+export function objGravitySegment(classes: string[]): string {
   if (classes.length === 0) {
     return "g:obj";
   }

--- a/demo/src/processing-path.ts
+++ b/demo/src/processing-path.ts
@@ -2,8 +2,8 @@ import { sampleImages } from "virtual:sample-images";
 
 export type ResizeMode = "fit" | "fill" | "fill-down" | "force" | "auto";
 export type Gravity = "ce" | "no" | "so" | "ea" | "we" | "noea" | "nowe" | "soea" | "sowe";
-export type GravityMode = "anchor" | "focalPoint" | "offset" | "smart" | "objFace";
-export type CropGravity = "inherit" | Gravity | "sm" | "obj:face";
+export type GravityMode = "anchor" | "focalPoint" | "offset" | "smart" | "objFace" | "objClasses";
+export type CropGravity = "inherit" | Gravity | "sm" | "obj:face" | "obj" | "obj:all";
 export type CropDimensionUnit = "px" | "percent" | "full";
 export type ResizeDimensionUnit = "px" | "auto";
 export type OutputFormat = "webp" | "avif" | "jpeg" | "png";
@@ -11,6 +11,93 @@ export type Flip = "none" | "horizontal" | "vertical" | "both";
 export type Rotate = 0 | 90 | 180 | 270;
 export type SignatureMode = "unsigned" | "signed";
 export type SourceImage = (typeof sampleImages)[number]["path"];
+
+// COCO-80 object classes in underscore spelling, matching the hardcoded list in
+// ImagePipe.Transform.Detector.ImageVision.Objects (@coco_classes).
+export const cocoClasses = [
+  "person",
+  "bicycle",
+  "car",
+  "motorcycle",
+  "airplane",
+  "bus",
+  "train",
+  "truck",
+  "boat",
+  "traffic_light",
+  "fire_hydrant",
+  "stop_sign",
+  "parking_meter",
+  "bench",
+  "bird",
+  "cat",
+  "dog",
+  "horse",
+  "sheep",
+  "cow",
+  "elephant",
+  "bear",
+  "zebra",
+  "giraffe",
+  "backpack",
+  "umbrella",
+  "handbag",
+  "tie",
+  "suitcase",
+  "frisbee",
+  "skis",
+  "snowboard",
+  "sports_ball",
+  "kite",
+  "baseball_bat",
+  "baseball_glove",
+  "skateboard",
+  "surfboard",
+  "tennis_racket",
+  "bottle",
+  "wine_glass",
+  "cup",
+  "fork",
+  "knife",
+  "spoon",
+  "bowl",
+  "banana",
+  "apple",
+  "sandwich",
+  "orange",
+  "broccoli",
+  "carrot",
+  "hot_dog",
+  "pizza",
+  "donut",
+  "cake",
+  "chair",
+  "couch",
+  "potted_plant",
+  "bed",
+  "dining_table",
+  "toilet",
+  "tv",
+  "laptop",
+  "mouse",
+  "remote",
+  "keyboard",
+  "cell_phone",
+  "microwave",
+  "oven",
+  "toaster",
+  "sink",
+  "refrigerator",
+  "book",
+  "clock",
+  "vase",
+  "scissors",
+  "teddy_bear",
+  "hair_drier",
+  "toothbrush",
+] as const;
+
+export type CocoClass = (typeof cocoClasses)[number];
 
 export type DemoState = {
   signatureMode: SignatureMode;
@@ -71,6 +158,11 @@ export type DemoState = {
   gravityFocalY: number;
   gravityOffsetX: number;
   gravityOffsetY: number;
+  // Object-class gravity: empty array = bare obj (all), explicit class list otherwise.
+  // The "all" pseudo-class is stored as an empty array; use gravityObjAll to pick the
+  // explicit g:obj:all form.
+  gravityObjClasses: string[];
+  gravityObjAll: boolean;
   enlarge: boolean;
   cropEnabled: boolean;
   cropWidthUnit: CropDimensionUnit;
@@ -258,6 +350,8 @@ export const defaultDemoState: DemoState = {
   gravityFocalY: 0.5,
   gravityOffsetX: 0,
   gravityOffsetY: 0,
+  gravityObjClasses: [],
+  gravityObjAll: false,
   enlarge: false,
   cropEnabled: false,
   cropWidthUnit: "px",
@@ -513,6 +607,10 @@ export function gravitySegment(currentState: DemoState): string {
     return "g:obj:face";
   }
 
+  if (currentState.gravityMode === "objClasses") {
+    return objGravitySegment(currentState.gravityObjClasses, currentState.gravityObjAll);
+  }
+
   if (currentState.gravityMode === "focalPoint") {
     return `g:fp:${currentState.gravityFocalX}:${currentState.gravityFocalY}`;
   }
@@ -522,6 +620,18 @@ export function gravitySegment(currentState: DemoState): string {
   }
 
   return `g:${currentState.gravity}`;
+}
+
+export function objGravitySegment(classes: string[], objAll: boolean): string {
+  if (objAll) {
+    return "g:obj:all";
+  }
+
+  if (classes.length === 0) {
+    return "g:obj";
+  }
+
+  return `g:obj:${classes.join(":")}`;
 }
 
 export function focalPointFromBounds(

--- a/docs/content-aware-gravity.md
+++ b/docs/content-aware-gravity.md
@@ -43,7 +43,7 @@ Practical requirements:
 
 Once both deps compile, face detection **activates automatically** — you don't
 have to configure anything. ImagePipe's default detector
-(`ImagePipe.Transform.Detector.ImageVision`) checks at runtime whether
+(`ImagePipe.Transform.Detector.ImageVision.Face`) checks at runtime whether
 `Image.FaceDetection` is loadable and uses it when it is.
 
 ## What happens without it
@@ -70,7 +70,7 @@ plug ImagePipe,
 ```
 
 - **`detector`** — which detector backs the face-aware paths.
-  - `:default` *(default)* — the bundled `ImagePipe.Transform.Detector.ImageVision`
+  - `:default` *(default)* — the bundled `ImagePipe.Transform.Detector.ImageVision.Face`
     adapter. Activates automatically when `image_vision` + `ortex` are loaded;
     reports unavailable (→ attention fallback) otherwise.
   - `nil` — detection disabled. Face-aware requests always fall back to attention.

--- a/docs/content-aware-gravity.md
+++ b/docs/content-aware-gravity.md
@@ -185,7 +185,11 @@ Class names use the **underscore spelling** matching the COCO-80 vocabulary:
 child detector — both the face (YuNet) and object (RT-DETR) adapters run, and
 their regions are merged before computing the crop focus. A class list routes
 only to the detector(s) that own the requested classes; e.g. `g:obj:face` routes
-only to YuNet, `g:obj:car` routes only to RT-DETR.
+only to YuNet, `g:obj:car` routes only to RT-DETR. Detection runs on the decoded
+image inside the bounded transform pipeline (subject to `max_input_pixels`), and
+successful responses are cached — but note that `g:obj`/`g:obj:all` runs *two*
+models per cache miss, so size `max_input_pixels`/concurrency limits with the
+heavier RT-DETR path in mind.
 
 **Unknown classes degrade, never error.** If a requested class isn't claimed by
 any configured detector, it is silently dropped. `g:obj:unicorn` produces the

--- a/docs/content-aware-gravity.md
+++ b/docs/content-aware-gravity.md
@@ -1,22 +1,24 @@
 # Content-aware gravity (smart crop & face detection)
 
-ImagePipe supports three content-aware ways to choose *where* a cover/crop is
+ImagePipe supports several content-aware ways to choose *where* a cover/crop is
 anchored, on top of the usual fixed anchors and focal points:
 
 | URL | What it does | Needs ML? |
 | --- | --- | --- |
 | `g:sm` | libvips **attention** smart crop — picks the most salient region | No |
 | `g:obj:face` (and `c:W:H:obj:face`) | anchors the crop on **detected faces** | **Yes** |
+| `g:obj` / `g:obj:all` | anchors on **all detected objects** (faces + COCO-80) | **Yes** |
+| `g:obj:%c1:…:%cN` | anchors on specific object classes, e.g. `g:obj:car:dog` | **Yes** |
 | `g:sm` + `smart_crop_face_detection` config | **blends** the attention point with detected faces | **Yes** |
 
 `g:sm` works out of the box — it's pure libvips and needs no extra dependencies.
-The face-aware paths need an optional ML detector, which this guide explains how
-to enable.
+The face-aware and object-aware paths need an optional ML detector, which this
+guide explains how to enable.
 
-## Enabling face detection
+## Enabling face and object detection
 
-Face detection is **off by default**. ImagePipe pulls no ML runtime in a normal
-build; a host opts in by adding two dependencies:
+Face and object detection are **off by default**. ImagePipe pulls no ML runtime
+in a normal build; a host opts in by adding two dependencies:
 
 ```elixir
 # mix.exs — in YOUR application's deps
@@ -26,25 +28,33 @@ build; a host opts in by adding two dependencies:
 
 Both are required:
 
-- **`image_vision`** provides `Image.FaceDetection` (the YuNet face model).
-- **`ortex`** is the ONNX runtime `image_vision` runs the model through.
-  `image_vision` compiles `Image.FaceDetection` **only** when Ortex is present
+- **`image_vision`** provides `Image.FaceDetection` (YuNet) and
+  `Image.Detection` (RT-DETR, COCO-80).
+- **`ortex`** is the ONNX runtime `image_vision` runs models through.
+  `image_vision` compiles the detection modules **only** when Ortex is present
   (`if ImageVision.ortex_configured?()`), so `image_vision` *without* `ortex`
-  silently provides no face detection. This is the single most common setup
-  mistake.
+  silently provides no detection. This is the single most common setup mistake.
 
 Practical requirements:
 
 - **A Rust toolchain** — `ortex` builds a native NIF (it needs `cargo`/`rustc`).
-- **A one-time model download** — the YuNet model (~340 KB) is fetched from
-  HuggingFace on the **first** detection request and cached on disk. The first
-  cold request therefore appears to "hang" while it downloads (see
+- **A one-time model download** — the YuNet face model (~340 KB) is fetched from
+  HuggingFace on the **first** face detection request and cached on disk. The
+  RT-DETR object model (~175 MB) must be pre-fetched explicitly (see
+  [Warming up](#warming-up-avoiding-first-request-latency)); use
+  `mix image_vision.download_models --detect` at build/deploy time to avoid
+  first-request cold-start latency for object detection.
+  The first cold face request therefore appears to "hang" while it downloads
+  unless the warmup worker is used (see
   [Warming up](#warming-up-avoiding-first-request-latency)).
 
-Once both deps compile, face detection **activates automatically** — you don't
-have to configure anything. ImagePipe's default detector
-(`ImagePipe.Transform.Detector.ImageVision.Face`) checks at runtime whether
-`Image.FaceDetection` is loadable and uses it when it is.
+Once both deps compile, face and object detection **activates automatically** —
+you don't have to configure anything. ImagePipe's default detector is a
+`Composite` that routes `face` requests to the YuNet adapter
+(`ImagePipe.Transform.Detector.ImageVision.Face`) and COCO-80 object requests to
+the RT-DETR adapter (`ImagePipe.Transform.Detector.ImageVision.Objects`). Each
+checks at runtime whether its `image_vision` module is loadable and uses it when
+it is.
 
 ## What happens without it
 
@@ -94,18 +104,21 @@ warmup worker to **your** supervision tree:
 
 ```elixir
 # in your application.ex children
-{ImagePipe.Transform.Detector.Warmup, detector: :default, classes: ["face"]}
+{ImagePipe.Transform.Detector.Warmup, detector: :default}
 ```
 
-It runs once, off the boot path (it does not block your supervisor's startup),
-triggers the model load, and then terminates normally (it is `restart:
-:transient`, so it is not restarted). If the detector is unavailable it is a
-clean no-op. The `:detector` option mirrors the plug's — pass the same value you
-gave the plug (`:default`, a custom module, or `nil` to disable).
+The default `classes: :all` warms both the face (YuNet) and object (RT-DETR)
+models. If you only use face detection, you can pass `classes: ["face"]` to skip
+the larger RT-DETR model. It runs once, off the boot path (it does not block your
+supervisor's startup), triggers the model load, and then terminates normally (it
+is `restart: :transient`, so it is not restarted). If the detector is unavailable
+it is a clean no-op. The `:detector` option mirrors the plug's — pass the same
+value you gave the plug (`:default`, a custom module, or `nil` to disable).
 
-There is also a build/deploy-time option: `mix image_vision.download_models`
-pre-fetches some models — but note it does **not** include the YuNet face model;
-use the warmup worker (or just accept the first-request download) for faces.
+There is also a build/deploy-time option: `mix image_vision.download_models
+--detect` pre-fetches the RT-DETR object model (~175 MB). The YuNet face model
+(~340 KB) is downloaded on first use regardless; use the warmup worker (or just
+accept the first-request download) for face detection.
 
 ## Custom detectors
 
@@ -117,9 +130,12 @@ defmodule MyApp.MyDetector do
   @behaviour ImagePipe.Transform.Detector
 
   @impl true
+  def supported_classes(_opts), do: ["face", "car"]
+
+  @impl true
   def detect(image, opts) do
-    classes = Keyword.get(opts, :classes, [])
-    # ... return product-neutral regions ...
+    classes = Keyword.get(opts, :classes, :all)
+    # ... return product-neutral regions for the requested classes ...
     {:ok, [%{label: "face", score: 0.97, box: {x, y, width, height}}]}
     # box is {x, y, width, height} in absolute top-left pixels
   end
@@ -138,21 +154,77 @@ end
 
 Then `detector: MyApp.MyDetector`. The `identity/1` return participates in the
 cache key, so a model/version change you encode there correctly invalidates
-cached results.
+cached results. Keep `identity/1` free of secrets — it appears in per-model
+telemetry spans that fan out to all attached handlers. `supported_classes/1`
+must be answerable even when the optional dep is absent; it is used for class
+routing and availability checks before any model is loaded.
+
+## General object gravity
+
+Beyond face detection, ImagePipe supports the full `g:obj` object gravity
+surface: specific COCO-80 classes, bare `obj` (all objects), and the `all`
+pseudo-class.
+
+**Class syntax.** Append one or more class names as colon-separated tokens:
+
+```
+g:obj:car               # anchor on detected cars
+g:obj:car:dog           # anchor on cars and dogs (class union)
+g:obj                   # all detected objects — faces + all COCO-80 classes
+g:obj:all               # explicit all-objects form, same as bare g:obj
+c:W:H:obj:car           # crop form with specific class
+```
+
+Class names use the **underscore spelling** matching the COCO-80 vocabulary:
+`traffic_light`, `sports_ball`, `hot_dog`, etc. The full 80-class list is in
+`ImagePipe.Transform.Detector.ImageVision.Objects`.
+
+**Union of detectors.** `g:obj` and `g:obj:all` route to *every* configured
+child detector — both the face (YuNet) and object (RT-DETR) adapters run, and
+their regions are merged before computing the crop focus. A class list routes
+only to the detector(s) that own the requested classes; e.g. `g:obj:face` routes
+only to YuNet, `g:obj:car` routes only to RT-DETR.
+
+**Unknown classes degrade, never error.** If a requested class isn't claimed by
+any configured detector, it is silently dropped. `g:obj:unicorn` produces the
+same result as `g:obj` with no unicorn regions — the request succeeds and falls
+back to attention saliency. Only classes that route to at least one child
+contribute to the crop.
+
+**Equal-weight area centroid.** The crop focus is the area-weighted centroid of
+all detected regions, without per-class weights. With many mixed-size objects
+the result naturally biases toward larger ones. If you want a face-centric crop
+on a busy scene, use `g:obj:face` directly — or, in a future slice, use `objw`
+per-class weights once that surface ships.
+
+**Class-aware cache identity.** The cache key includes only the child detector
+identities that the requested class set routes to. An object-only request
+(`g:obj:car`) is unaffected by a face model version change, and vice versa.
+
+**Model size and cold-start.** The RT-DETR model is approximately 175 MB. Unlike
+the small YuNet face model, it is not downloaded on first use automatically — use
+`mix image_vision.download_models --detect` at build/deploy time to pre-fetch
+it, and add the warmup worker so it loads into memory before the first request
+(see [Warming up](#warming-up-avoiding-first-request-latency)).
 
 ## How requests, the detector, and the cache interact
 
-- `g:obj:face` resolves the detected faces' **area-weighted centroid** to a focal
-  point and reuses the normal focal-point crop. Multiple faces are combined by
-  area; out-of-image or malformed boxes are dropped.
-- The detector's `identity/1` is folded into the **cache key** for face-aware
-  requests, so swapping the detector/model (or running with vs. without the dep)
-  never serves stale bytes.
+- `g:obj:face` and `g:obj:car:dog` (etc.) resolve the detected regions'
+  **area-weighted centroid** to a focal point and reuse the normal focal-point
+  crop. Multiple regions are combined by area; out-of-image or malformed boxes
+  are dropped.
+- The detector's **class-aware** `identity/1` is folded into the **cache key**
+  for detection-aware requests. Only the child detectors that the requested class
+  set routes to contribute to the key — so swapping the face model doesn't
+  invalidate object-only cached results, and vice versa.
 - When a detector runs, detection emits a `[:image_pipe, :transform, :detect]`
   telemetry span with honest duration (the model inference is real, eager work)
   — useful for spotting cold-start cost. Its `:result` metadata distinguishes a
-  real detection (`:detected`), a normal no-face frame (`:no_regions`), and a
+  real detection (`:detected`), a normal no-object frame (`:no_regions`), and a
   configured detector that produced nothing usable (`:unavailable`, `:error`).
+  The Composite also emits a nested `[:image_pipe, :transform, :detect, :model]`
+  span per child detector that ran — see [telemetry.md](telemetry.md) for the
+  full schema.
   When no detector is configured, nothing runs, so instead of a span ImagePipe
   emits a one-shot `[:image_pipe, :transform, :detect, :skipped]` marker
   (`result: :no_detector`). The opt-in default Logger escalates `:unavailable`,
@@ -162,11 +234,13 @@ cached results.
 
 ## imgproxy compatibility & divergences
 
-`g:obj:face` / `c:W:H:obj:face` are a faithful single-class (`face`) subset of
-imgproxy's object gravity; the broader object-detection surface (general classes,
-`objw`, `objects_position`) is out of scope. ImagePipe uses `image_vision`'s
-YuNet face model rather than imgproxy's configurable YOLO models, so detected
-boxes — and the resulting crops — are compatible in intent but not bit-identical.
-The face-assist blend weight is ImagePipe's own approximation. The full row-by-row
+`g:obj:face` / `c:W:H:obj:face` and multi-class `g:obj:%c1:…:%cN` / `g:obj` /
+`g:obj:all` are now supported. The remaining out-of-scope parts of imgproxy's
+object gravity surface are `objw` (per-class detection weights) and
+`objects_position` — these are deferred to a future slice. ImagePipe uses
+`image_vision`'s YuNet face model (not imgproxy's configurable YOLO models) and
+RT-DETR for COCO-80 objects (not YOLO), so detected boxes — and the resulting
+crops — are compatible in intent but not bit-identical to imgproxy. The
+face-assist blend weight is ImagePipe's own approximation. The full row-by-row
 mapping and divergence notes are in
 [imgproxy_support_matrix.md](imgproxy_support_matrix.md#smart-crop-object-detection-classification-and-best-format-models).

--- a/docs/content-aware-gravity.md
+++ b/docs/content-aware-gravity.md
@@ -79,10 +79,12 @@ plug ImagePipe,
   detector_required: false   # default
 ```
 
-- **`detector`** — which detector backs the face-aware paths.
-  - `:default` *(default)* — the bundled `ImagePipe.Transform.Detector.ImageVision.Face`
-    adapter. Activates automatically when `image_vision` + `ortex` are loaded;
-    reports unavailable (→ attention fallback) otherwise.
+- **`detector`** — which detector backs the face- and object-aware paths.
+  - `:default` *(default)* — the bundled `ImagePipe.Transform.Detector.Composite`,
+    which routes faces to `ImageVision.Face` (YuNet) and objects to
+    `ImageVision.Objects` (RT-DETR/COCO-80). Activates automatically when
+    `image_vision` + `ortex` are loaded; reports unavailable (→ attention
+    fallback) otherwise.
   - `nil` — detection disabled. Face-aware requests always fall back to attention.
   - a module implementing `ImagePipe.Transform.Detector` — a
     [custom detector](#custom-detectors).
@@ -167,7 +169,7 @@ pseudo-class.
 
 **Class syntax.** Append one or more class names as colon-separated tokens:
 
-```
+```text
 g:obj:car               # anchor on detected cars
 g:obj:car:dog           # anchor on cars and dogs (class union)
 g:obj                   # all detected objects — faces + all COCO-80 classes

--- a/docs/imgproxy_support_matrix.md
+++ b/docs/imgproxy_support_matrix.md
@@ -392,43 +392,47 @@ source support.
 
 ### Smart crop, object detection, classification, and best-format models
 
-ImagePipe ships a narrow slice of object-detection gravity: `g:obj:face` (and
-the crop form `c:W:H:obj:face`) selects a single `face` class through an optional
-ML detector, falling back to libvips attention smart crop when the detector is
-unavailable. This graceful fallback is the default; a host can instead opt into
-strict mode (`detector_required: true`), which **rejects** a `g:obj:face` request
-with a 422 (before any source fetch or cache access) when the detector is
+ImagePipe supports object-detection gravity: `g:obj:face` / `c:W:H:obj:face`
+(single `face` class), multi-class `g:obj:%c1:…:%cN`, and bare `g:obj` /
+`g:obj:all` (all detected objects). All forms fall back to libvips attention
+smart crop when the detector is unavailable. This graceful fallback is the
+default; a host can instead opt into strict mode (`detector_required: true`),
+which **rejects** a `g:obj:face` (or `g:obj:car`, etc.) request with a 422
+(before any source fetch or cache access) when the relevant detector child is
 unavailable rather than falling back — see
-[content-aware-gravity.md](content-aware-gravity.md). Face-assist `g:sm` is never
-hard-rejected. Enabling it requires the host to add **both** `image_vision` **and**
-its ONNX backend `ortex` (a Rust runtime; the YuNet model downloads on first
-use) — see [content-aware-gravity.md](content-aware-gravity.md) for the full host
-setup, the `detector` / `detector_required` options, warmup, and custom
-detectors. None of imgproxy's object-detection or smart-crop
-*configuration* knobs are read; they are not blanket-missing now that part of the
-surface ships, so the relevant variables are broken out below.
+[content-aware-gravity.md](content-aware-gravity.md). Unknown classes are
+dropped silently (best-effort). Face-assist `g:sm` is never hard-rejected.
+Enabling ML gravity requires the host to add **both** `image_vision` **and** its
+ONNX backend `ortex` (a Rust runtime) — see
+[content-aware-gravity.md](content-aware-gravity.md) for the full host setup,
+the `detector` / `detector_required` options, warmup, and custom detectors. None
+of imgproxy's object-detection or smart-crop *configuration* knobs are read; they
+are not blanket-missing now that part of the surface ships, so the relevant
+variables are broken out below.
 
 **Model and threshold divergence.** imgproxy uses host-configured YOLO models
-with tunable confidence/NMS thresholds and a configurable gravity mode.
-ImagePipe uses `image_vision`'s YuNet face model with fixed thresholds. Detected
-boxes and resulting crops are compatible in intent but are not bit-identical to
-imgproxy.
+with tunable confidence/NMS thresholds and a configurable gravity mode. ImagePipe
+uses `image_vision`'s YuNet face model (fixed thresholds, ~340 KB) for face
+detection and RT-DETR (~175 MB) for COCO-80 object detection. Detected boxes and
+resulting crops are compatible in intent but are not bit-identical to imgproxy.
+The RT-DETR model must be pre-fetched with `mix image_vision.download_models
+--detect` (unlike YuNet, it does not auto-download on first use).
 
 - ⭕ `IMGPROXY_OBJECT_DETECTION_GRAVITY_MODE` — imgproxy defaults to
-  `max_score_area` (highest-scoring detected region). ImagePipe instead
-  approximates object gravity with an area-weighted centroid of detected face
-  boxes, so the chosen focus point diverges from imgproxy's gravity mode.
+  `max_score_area` (highest-scoring detected region). ImagePipe instead uses an
+  area-weighted centroid of all detected regions, so the chosen focus point
+  diverges from imgproxy's gravity mode.
 - ⭕ `IMGPROXY_OBJECT_DETECTION_FALLBACK_TO_SMART_CROP` — by default ImagePipe
-  falls back to libvips attention smart crop when no face is detected or the
+  falls back to libvips attention smart crop when no object is detected or the
   detector is unavailable. The imgproxy variable isn't read, but the fallback is
   not unconditional: a host can opt into strict mode (`detector_required: true`),
-  which **rejects** a `g:obj:face` request with a 422 (before any source fetch or
-  cache access) when the detector is unavailable instead of falling back — see
-  [content-aware-gravity.md](content-aware-gravity.md). Face-assist `g:sm` always
-  falls back and is never hard-rejected.
+  which **rejects** a `g:obj:…` request with a 422 (before any source fetch or
+  cache access) when the relevant detector is unavailable instead of falling back
+  — see [content-aware-gravity.md](content-aware-gravity.md). Face-assist `g:sm`
+  always falls back and is never hard-rejected.
 - ⭕ `IMGPROXY_OBJECT_DETECTION_*` confidence and NMS thresholds — ImagePipe uses
-  the YuNet face model's fixed detection-confidence and non-max-suppression
-  thresholds; they are not exposed as configuration.
+  fixed detection-confidence and non-max-suppression thresholds for both the YuNet
+  and RT-DETR models; they are not exposed as configuration.
 - ✅ `IMGPROXY_SMART_CROP_FACE_DETECTION` — Modeled as the imgproxy-parser option
   `smart_crop_face_detection`; when enabled, `g:sm` blends the libvips attention
   point with detected faces (weight ~0.7). The attention⊕face combination is
@@ -527,11 +531,12 @@ transforms or output encoding.
 | `gravity` anchors | `g` | Supported | `ce`, `no`, `so`, `ea`, `we`, `noea`, `nowe`, `soea`, `sowe`. |
 | `gravity:fp` | `g:fp` | Supported | Focal point coordinates from `0.0` to `1.0`. |
 | `gravity:sm` | `g:sm` | Supported | Smart gravity via libvips attention smart crop (`VIPS_INTERESTING_ATTENTION`). |
-| `gravity:obj:face` | `g:obj:face` | Supported | Single `face` class via optional `image_vision` face detection; falls back to libvips attention when the detector is unavailable. |
-| `gravity:obj` | | Partial | Only the single `face` class is supported (`g:obj:face`); bare `g:obj` (all), `g:obj:all`, multi-class, and `g:objw` are rejected. |
-| `gravity:objw` | | Missing | Pro object-detection gravity with weights. |
+| `gravity:obj:face` | `g:obj:face` | Supported | Single `face` class via optional `image_vision` YuNet face detection; falls back to libvips attention when the detector is unavailable. |
+| `gravity:obj` / `g:obj:all` | | Supported | All detected objects — union of face (YuNet) and COCO-80 object (RT-DETR) detectors; falls back to libvips attention when the detector is unavailable. |
+| `gravity:obj:%c1:…:%cN` | | Supported | Multi-class object gravity using the COCO-80 vocabulary (underscore spelling, e.g. `g:obj:car:traffic_light`). Unknown classes are silently dropped (best-effort). Class-aware cache identity: only the detector children routed by the requested class set contribute to the cache key. |
+| `gravity:objw` | | Missing | Pro object-detection gravity with per-class weights (`objw`). Deferred to a future slice. |
 | `objects_position` | `obj_pos`, `op` | Missing | Pro object-detection positioning. |
-| `crop` | `c` | Supported | Absolute, relative, or full-axis dimensions. Supports anchor, focal-point, smart gravity (`c:W:H:sm`), and object-face gravity (`c:W:H:obj:face`); smart gravity runs libvips attention smart crop, and object-face gravity uses optional `image_vision` face detection with attention fallback. |
+| `crop` | `c` | Supported | Absolute, relative, or full-axis dimensions. Supports anchor, focal-point, smart gravity (`c:W:H:sm`), and object gravity (`c:W:H:obj:face`, `c:W:H:obj:car:dog`, `c:W:H:obj`, `c:W:H:obj:all`); smart gravity runs libvips attention smart crop, and object gravity uses optional `image_vision` detection with attention fallback. |
 | `crop_aspect_ratio` | `crop_ar`, `car` | Supported | Pro crop-area aspect-ratio correction. `aspect_ratio` zero is a no-op. `enlarge` grows the area then clamps to image bounds; default reduces. Corrects size only, not gravity. Wired through gravity crops. |
 | `trim` | `t` | Missing | Requires full-image memory behavior and trim operation. |
 | `padding` | `pd` | Supported | CSS-style shorthand, sparse repeated options, effective DPR scaling, and `padding:` no-op compatibility. |

--- a/docs/superpowers/plans/2026-05-31-object-gravity-slice1.md
+++ b/docs/superpowers/plans/2026-05-31-object-gravity-slice1.md
@@ -41,31 +41,45 @@
 - `docs/content-aware-gravity.md`, `docs/imgproxy_support_matrix.md`, `docs/telemetry.md` — docs.
 - `demo/` — object-class controls + URL state.
 
-**Test files (created/extended):**
+**Test files (created/extended) — exact paths:**
 - `test/image_pipe/transform/detector/composite_test.exs` (new)
-- `test/image_pipe/transform/detector/image_vision_test.exs` (rename refs; tagged smoke)
-- `test/image_pipe/parser/imgproxy/plan_builder_test.exs` (flip rejection → acceptance)
-- `test/image_pipe/parser/imgproxy/option_grammar_test.exs` (multi-class/`all` grammar; if present)
-- `test/image_pipe/cache/key_test.exs` (class-aware identity)
+- `test/image_pipe/transform/detector/image_vision_test.exs` (rename refs; tagged Objects smoke/drift)
+- `test/parser/imgproxy/plan_builder_test.exs` (flip rejection → acceptance) — note `test/parser/…`, **not** `test/image_pipe/parser/…`
+- `test/image_pipe/cache/key_test.exs` (class-aware key material via `build_key!/4`)
 - `test/image_pipe/imgproxy_wire_conformance_test.exs` (pixel + gate triad)
-- `test/image_pipe/transform/operation/crop_operation_test.exs` (FakeDetector `supported_classes`)
-- `test/image_pipe/plan_data_test.exs` or wherever `key_data` guide encoding is tested (`:all`)
+- `test/image_pipe/transform/crop_operation_test.exs` (FakeDetector `supported_classes`) — note: `transform/`, **not** `transform/operation/`
+- `test/image_pipe/plan/operation_key_data_test.exs` (`{:detect, :all}` guide encoding)
+- `test/support/fake_detector.ex`, `test/image_pipe/transform/detector_test.exs`, `test/image_pipe/transform/detector/warmup_test.exs` (add `supported_classes/1` to their fakes — see Task 1)
+
+### Test harness reference (READ BEFORE WRITING ANY TEST)
+
+The plan's test snippets are illustrative; **bind them to the harness that actually exists** (verified in plan review). Do not invent helpers:
+
+- **Wire tests** (`imgproxy_wire_conformance_test.exs`): drive with `call_imgproxy(path, opts, accept \\ nil)` (returns a `conn`); read `conn.status` / `conn.resp_body`; decode dimensions with `dimensions(conn)` (which uses `decoded_image/1`). Source is the hardcoded `"plain/images/beach.jpg"` (there is **no** `source_url/0`/`request/2`/`wire_opts/1`/`decoded_dimensions/1`). Inject a detector via `Keyword.merge(@default_opts, detector: SomeModule, detector_required: …)`. Assert "no source fetch" with the existing `OriginShouldNotFetch` plug + inline `refute_received :origin_fetch` (plus the telemetry/cache `refute_received` it already uses) — there is **no** `assert_no_source_fetch/1`. The existing test `"detector_required + unavailable detector rejects before source AND cache access"` (~line 541) is the template for the 422 pre-fetch leg; the `g:sm` pixel test is the template for decode-and-compare.
+- **Parser tests** (`test/parser/imgproxy/plan_builder_test.exs`): drive the planner with `plan_pipeline(keyword_attrs, opts)` over `%ParsedRequest{}`/`%PipelineRequest{}`/`%CropRequest{}` and read `resize.guide` / `crop.guide` directly. There is **no** `build/1` or `detect_guide/1` URL-string helper.
+- **Cache-key tests** (`cache/key_test.exs`): call `build_key!(conn, plan, source_identity(), detector_identity: {Detector, :v1})` — the identity tuple is passed **literally**; `Cache.Key.build` does **not** resolve a detector (forbidden by the architecture test). Build plans via the planner / `Operation.crop_guided/4`, not hand-built structs.
+- **Key-data tests** (`plan/operation_key_data_test.exs`): `KeyData.data(%CropGuided{…})` on struct literals (sanctioned in this file).
+- **Telemetry tests**: attach with `:telemetry_test.attach_event_handlers(self(), [[:image_pipe, :transform, :detect, :model, :stop]])` (note the `:image_pipe` prefix). Runtime `telemetry_opts` is `[telemetry_prefix: [:image_pipe]]` (the key is `:telemetry_prefix`, not `:prefix`); `Telemetry.span/4` is `(telemetry_opts, stage, start_meta, fun)` with `fun` returning `{value, stop_meta}`.
+- **FakeDetector**: the shared `ImagePipe.Test.FakeDetector` (`test/support/fake_detector.ex`) is the canonical injected fake (used across `crop_operation_test.exs`); extend it rather than hand-rolling where it fits.
 
 ---
 
 ## Task 1: Add `supported_classes/1` to the Detector behaviour
 
-**Files:**
-- Modify: `lib/image_pipe/transform/detector.ex`
-- Modify: `lib/image_pipe/transform/detector/image_vision.ex` (temporary — implements the new callback so the tree keeps compiling; renamed in Task 2)
-- Modify: every in-repo `@behaviour ImagePipe.Transform.Detector` implementation, including test fakes (search first)
+**Files (verified in plan review — every implementer must gain the callback in THIS commit or `--warnings-as-errors` fails):**
+- Modify: `lib/image_pipe/transform/detector.ex` (add the callback)
+- Modify: `lib/image_pipe/transform/detector/image_vision.ex` (prod adapter → `["face"]`; renamed in Task 2)
+- Modify: `test/support/fake_detector.ex` — `ImagePipe.Test.FakeDetector` (the shared fake; note it may not use `@impl`)
+- Modify: `test/image_pipe/transform/detector_test.exs` — fakes `WithWarmup` **and** `NoWarmup`
+- Modify: `test/image_pipe/transform/detector/warmup_test.exs` — fakes `SignalDetector` **and** `UnavailableDetector`
+- Modify: `test/image_pipe/imgproxy_wire_conformance_test.exs` — fake `UnavailableDetector`
 
-`mix compile --warnings-as-errors` treats a missing required callback as a failure, so every implementer must gain the callback in this same task.
+That is **6 fake modules across 5 files** plus the prod adapter. `mix compile --warnings-as-errors` treats a missing required callback as a failure.
 
-- [ ] **Step 1: Find every detector implementation that must gain the callback**
+- [ ] **Step 1: Confirm the full implementer list**
 
-Run: `mise exec -- grep -rl "@behaviour ImagePipe.Transform.Detector" lib test`
-Expected: at least `lib/image_pipe/transform/detector/image_vision.ex` and one or more test fakes (e.g. in `test/support/` or inline in `crop_operation_test.exs` / `image_vision_test.exs`). Note each path — all of them get a `supported_classes/1` in this task.
+Run: `grep -rl "@behaviour ImagePipe.Transform.Detector" lib test`
+Expected: the 5 files above. Open each and note that `detector_test.exs` and `warmup_test.exs` define **two** fakes each — every module gets `supported_classes/1`, not just one per file.
 
 - [ ] **Step 2: Add the callback to the behaviour**
 
@@ -120,7 +134,7 @@ git commit -m "feat(detector): add supported_classes/1 behaviour callback"
 
 ## Task 2: Rename the face adapter to `ImageVision.Face`
 
-A mechanical move so the bundled adapters are symmetric siblings (`ImageVision.Face` / `ImageVision.Objects`) under the Composite. No behavior change to the face path.
+Mostly a mechanical move so the bundled adapters are symmetric siblings (`ImageVision.Face` / `ImageVision.Objects`) under the Composite. It also makes one deliberate behavior change to `detect/2` (called out below and tested): it accepts `classes == :all` (returns faces) and returns `{:ok, []}` for any other routed class instead of the old `{:error, {:detector, {:unsupported_classes, …}}}` — because the Composite never routes non-face classes here, and `:all` legitimately asks this child for faces. The face *detection* behavior (`["face"]` → faces) is unchanged.
 
 **Files:**
 - Create: `lib/image_pipe/transform/detector/image_vision/face.ex`
@@ -219,16 +233,46 @@ In `test/image_pipe/transform/detector/image_vision_test.exs` and any cache-key 
 
 Run: `mise exec -- grep -rn "Detector.ImageVision\b" lib test docs` and fix any remaining bare `ImageVision` references that should be `ImageVision.Face`.
 
-- [ ] **Step 5: Compile + run the face/detector tests**
+- [ ] **Step 5: Add tests for the new `detect/2` arms**
+
+In `test/image_pipe/transform/detector/image_vision_test.exs`, add (default lane — no dep needed, since both assertions hit the `available?` short-circuit when the dep is absent):
+
+```elixir
+  alias ImagePipe.Transform.Detector.ImageVision.Face
+
+  test "Face.detect with :all short-circuits to unavailable when the dep is absent" do
+    # In the default (no image_vision) lane, available? is false, so any classes
+    # value returns the unavailable error rather than crashing.
+    assert {:error, {:detector, :unavailable}} = Face.detect(:image, classes: :all)
+    assert {:error, {:detector, :unavailable}} = Face.detect(:image, classes: ["car"])
+  end
+```
+
+And a tagged assertion (dep present) that `:all` returns faces and a non-face routed class returns `{:ok, []}`:
+
+```elixir
+  describe "Face.detect routing (real model)" do
+    @describetag :image_vision
+
+    test "classes: :all returns faces; a non-face routed class returns no regions" do
+      {:ok, image} = Image.new(64, 64, color: :black)
+      assert {:ok, regions} = Face.detect(image, classes: :all)
+      assert is_list(regions)
+      assert {:ok, []} = Face.detect(image, classes: ["car"])
+    end
+  end
+```
+
+- [ ] **Step 6: Compile + run the face/detector tests**
 
 Run: `mise exec -- mix compile --warnings-as-errors && mise exec -- mix test test/image_pipe/transform/detector/`
-Expected: PASS (face behavior unchanged).
+Expected: PASS (face detection behavior unchanged; new `detect/2` arms covered).
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add -A lib/image_pipe/transform lib/image_pipe/transform.ex test docs
-git commit -m "refactor(detector): rename ImageVision -> ImageVision.Face"
+git commit -m "feat(detector): rename ImageVision -> ImageVision.Face; detect/2 accepts :all"
 ```
 
 ---
@@ -246,9 +290,10 @@ Add to `test/image_pipe/transform/detector/image_vision_test.exs`:
 ```elixir
   alias ImagePipe.Transform.Detector.ImageVision.Objects
 
-  describe "Objects adapter (real model)" do
-    @describetag :image_vision
-
+  # supported_classes is a hardcoded static list (dep-independent), so this runs
+  # in the DEFAULT lane — it is the deterministic coverage for the underscore
+  # spelling that the normalization depends on.
+  describe "Objects vocabulary (no dependency required)" do
     test "supported_classes is the static COCO-80 vocabulary in underscore spelling" do
       classes = Objects.supported_classes([])
       assert "person" in classes
@@ -256,6 +301,10 @@ Add to `test/image_pipe/transform/detector/image_vision_test.exs`:
       refute "traffic light" in classes
       assert length(classes) == 80
     end
+  end
+
+  describe "Objects adapter (real model)" do
+    @describetag :image_vision
 
     test "supported_classes matches the model's labels (drift guard)" do
       model_labels =
@@ -277,7 +326,8 @@ Add to `test/image_pipe/transform/detector/image_vision_test.exs`:
 
 - [ ] **Step 2: Run it to verify it fails**
 
-Run: `IMAGE_VISION=1 mise exec -- mix test test/image_pipe/transform/detector/image_vision_test.exs --only image_vision`
+Default lane (runs the non-tagged vocabulary test):
+Run: `mise exec -- mix test test/image_pipe/transform/detector/image_vision_test.exs`
 Expected: FAIL — `Objects` is undefined.
 
 - [ ] **Step 3: Implement the Objects adapter**
@@ -374,10 +424,11 @@ defmodule ImagePipe.Transform.Detector.ImageVision.Objects do
 end
 ```
 
-- [ ] **Step 4: Run the tagged tests to verify they pass**
+- [ ] **Step 4: Run both lanes to verify they pass**
 
-Run: `IMAGE_VISION=1 mise exec -- mix test test/image_pipe/transform/detector/image_vision_test.exs --only image_vision`
-Expected: PASS (drift, smoke, vocabulary).
+Default lane (vocabulary): `mise exec -- mix test test/image_pipe/transform/detector/image_vision_test.exs`
+Tagged lane (drift + smoke, needs the dep + model download): `IMAGE_VISION=1 mise exec -- mix test test/image_pipe/transform/detector/image_vision_test.exs --include image_vision`
+Expected: PASS in both.
 
 - [ ] **Step 5: Compile with warnings-as-errors**
 
@@ -669,10 +720,14 @@ In `lib/image_pipe/transform/detector/warmup.ex`, change the default classes in 
 
 Update the moduledoc example to `{ImagePipe.Transform.Detector.Warmup, detector: :default}` (no explicit `classes:` needed; `:all` warms everything).
 
-- [ ] **Step 3: Compile + run the full detector + transform suites**
+- [ ] **Step 3: Compile + run the suites that prove the unchanged paths**
 
 Run: `mise exec -- mix compile --warnings-as-errors && mise exec -- mix test test/image_pipe/transform/`
-Expected: PASS. Existing `{:smart, :face_assist}` and `{:detect, ["face"]}` behavior is unchanged because the Composite routes `["face"]` to the Face child only.
+Expected: PASS — and specifically these existing tests must stay green to *prove* the Composite-as-default didn't perturb the shipped paths (they inject `FakeDetector`, but `warmup_test` resolves `:default` which is now the Composite warming two unavailable children → must degrade cleanly):
+- `crop_operation_test.exs` — `"face_assist blends attention with the face centroid"` (face-assist unchanged), the `{:detect, ["face"]}` crop test, and `"anchors on the area-weighted centroid of detected boxes"` (equal-weight `area` centroid unchanged).
+- `detector/warmup_test.exs` — the `:default`-path warmup expectations (now warms both children; unavailable → clean no-op/degraded path, not a crash).
+
+If any of these regress, the Composite default broke a shipped contract — fix the production code, not the test.
 
 - [ ] **Step 4: Commit**
 
@@ -686,37 +741,52 @@ git commit -m "feat(detector): default detector is the Composite (face + objects
 ## Task 6: Plan `{:detect, :all}` sentinel end-to-end (types, detect_classes, key_data)
 
 **Files:**
+- Modify: `lib/image_pipe/plan/operation.ex` — **`smart_guide/1` validation gate** (the actual producer that rejects `:all`)
+- Modify: `lib/image_pipe/plan/operation/resize.ex` — `guide` type (the fill path builds a `Resize`)
 - Modify: `lib/image_pipe/plan/operation/crop_guided.ex` (guide type)
 - Modify: `lib/image_pipe/transform/operation/crop.ex` (gravity type)
 - Modify: `lib/image_pipe/plan.ex:88-99` (`detect_classes/1` `@spec`)
 - Modify: `lib/image_pipe/plan/key_data.ex:198` (`guide_data`)
-- Test: the existing key-data/plan-data test file (find with grep below)
+- Test: `test/image_pipe/plan/operation_key_data_test.exs` (the `describe "guide_data via CropGuided cache data"` block builds `%CropGuided{}` literals — mirror it for `:all`)
+
+**Critical (caught in plan review):** `{:detect, :all}` is rejected at *operation construction* by `lib/image_pipe/plan/operation.ex`'s `smart_guide/1` (its clause is `smart_guide({:detect, classes}) when is_list(classes) and classes != []`, falling through to `{:error, :guide}`). This gate is hit by **both** `Operation.crop_guided/4` (crop path) **and** `Operation.resize/4` (fill path), so without this edit `rs:fill:100:100/g:obj` — the most common form — fails before any downstream code runs. Both `operation.ex` (the gate) and `resize.ex` (its `guide` type) must accept the sentinel.
 
 - [ ] **Step 1: Write the failing key-data test for `:all`**
 
-Find the key-data test file:
-
-Run: `mise exec -- grep -rln "type: :detect" test`
-Expected: a test asserting `guide_data`/key material for `{:detect, ["face"]}` (e.g. `test/image_pipe/cache/key_test.exs` or a plan-data test). Add, next to it:
+The key-data guide test lives in `test/image_pipe/plan/operation_key_data_test.exs`, in `describe "guide_data via CropGuided cache data"` (~line 261), which calls `KeyData.data(%CropGuided{…, guide: {:detect, ["face"]}})` on `%CropGuided{}` literals (the file already builds these structs, so it is sanctioned here). Add, mirroring the neighboring `{:detect, ["face"]}` case exactly (copy its `%CropGuided{}` construction and the way it extracts the `guide:` key data):
 
 ```elixir
-  test "detect-all guide encodes as classes: :all" do
-    guide = {:detect, :all}
-    # Build the smallest real plan/operation a producer makes with this guide and
-    # assert the cache-key material distinguishes :all from a class list. Use the
-    # same helper the neighboring {:detect, ["face"]} test uses to extract guide
-    # key data; assert it contains `classes: :all`.
-  end
+    test "detect :all guide encodes as classes: :all" do
+      data = KeyData.data(%CropGuided{width: {:px, 100}, height: {:px, 100}, guide: {:detect, :all}})
+      # extract the guide key-data the same way the {:detect, ["face"]} test does:
+      assert Keyword.get(guide_key_data(data), :classes) == :all
+    end
 ```
 
-Replace the comment with the same extraction the neighboring `{:detect, …}` test uses (mirror its setup exactly — do not hand-build internal structs the test file does not already build).
+Match the file's real `%CropGuided{}` field shape and its existing guide-extraction (the helper/inline match the neighboring test uses) — do not invent a `guide_key_data/1` if the file extracts differently.
 
 - [ ] **Step 2: Run to verify failure**
 
-Run: `mise exec -- mix test <that file> -k "detect-all"` (or run the file).
-Expected: FAIL — `guide_data({:detect, :all})` has no clause (`FunctionClauseError`) or the assertion fails.
+Run: `mise exec -- mix test test/image_pipe/plan/operation_key_data_test.exs`
+Expected: FAIL — `guide_data({:detect, :all})` has no clause (`FunctionClauseError`, since the existing clause is guarded `when is_list(classes)`).
 
 - [ ] **Step 3: Add the type and the key-data clause**
+
+In `lib/image_pipe/plan/operation.ex`, add a `smart_guide/1` clause for the sentinel **before** the existing `{:detect, classes}` clause (line 679):
+
+```elixir
+  defp smart_guide({:detect, :all} = guide), do: {:ok, guide}
+
+  defp smart_guide({:detect, classes} = guide)
+       when is_list(classes) and classes != [] do
+```
+
+In `lib/image_pipe/plan/operation/resize.ex`, extend the `guide` type (line 28):
+
+```elixir
+          | {:detect, :all}
+          | {:detect, nonempty_list(String.t())}
+```
 
 In `lib/image_pipe/plan/operation/crop_guided.ex`, extend the `guide` type (line 33):
 
@@ -749,7 +819,7 @@ In `lib/image_pipe/plan.ex`, widen the `detect_classes/1` `@spec` (line 89). The
 
 - [ ] **Step 4: Run the test to verify it passes**
 
-Run: `mise exec -- mix test <that file> -k "detect-all"`
+Run: `mise exec -- mix test test/image_pipe/plan/operation_key_data_test.exs`
 Expected: PASS.
 
 - [ ] **Step 5: Compile with warnings-as-errors**
@@ -776,54 +846,69 @@ The grammar (`option_grammar.ex`) already parses `g:obj…` / `c:W:H:obj…` int
 
 **Critical:** `{:obj, …}` is mapped in **two** functions — `resize_guide/2` (used for `rs:fill` + `g:obj`, line 558) and `tagged_gravity/2` (used for `c:W:H:obj`, line 252). Both currently special-case `["face"]` and reject other classes. **Both must change identically** — update them via one shared helper so they can't diverge. (`canvas_placement/2` has no `{:obj,…}` clause and object gravity is not valid for extend/canvas, so leave it untouched.)
 
-- [ ] **Step 1: Update the failing tests (flip rejection → acceptance)**
+- [ ] **Step 1: Flip the existing rejection tests to acceptance**
 
-In `test/image_pipe/parser/imgproxy/plan_builder_test.exs`, find the existing tests asserting bare/all/multi-class object gravity is rejected (they assert `{:error, {:unsupported_gravity, _}}`). Replace them with acceptance assertions:
+`test/parser/imgproxy/plan_builder_test.exs` drives the planner with `plan_pipeline(keyword_attrs, opts)` over request structs and reads `resize.guide` / `crop.guide` (there is no `build/1`/`detect_guide/1`). The existing rejection tests to **replace** are named:
+- `"rejects bare object gravity (all detected objects)"` (~line 844)
+- `"rejects the all pseudo-class object gravity"` (~line 854)
+- `"rejects multi-class object gravity"` (~line 864)
+- `"rejects object gravity with trailing class tokens treated as offsets"` (~line 874)
+
+Rewrite them in the file's real idiom (mirror a neighboring `{:obj, ["face"]}`/guide test for the exact `plan_pipeline` attrs and the resize/crop struct shapes). Fill path exercises `resize_guide/2`; crop path exercises `tagged_gravity/2` — cover both:
 
 ```elixir
+  # fill path (resize_guide)
   test "g:obj with explicit classes maps to a detect guide with those classes" do
-    assert {:ok, plan} = build("rs:fill:100:100/g:obj:car:dog/plain/http://e/x.jpg")
-    assert detect_guide(plan) == {:detect, ["car", "dog"]}
+    {:ok, [%{resize: resize}]} = plan_pipeline(resizing_type: :fill, width: {:pixels, 100},
+      height: {:pixels, 100}, gravity: {:obj, ["car", "dog"]})
+    assert resize.guide == {:detect, ["car", "dog"]}
   end
 
-  test "bare g:obj maps to detect :all" do
-    assert {:ok, plan} = build("rs:fill:100:100/g:obj/plain/http://e/x.jpg")
-    assert detect_guide(plan) == {:detect, :all}
+  test "bare object gravity maps to detect :all" do
+    {:ok, [%{resize: resize}]} = plan_pipeline(resizing_type: :fill, width: {:pixels, 100},
+      height: {:pixels, 100}, gravity: {:obj, []})
+    assert resize.guide == {:detect, :all}
   end
 
-  test "g:obj:all maps to detect :all" do
-    assert {:ok, plan} = build("rs:fill:100:100/g:obj:all/plain/http://e/x.jpg")
-    assert detect_guide(plan) == {:detect, :all}
+  test "the all pseudo-class maps to detect :all" do
+    {:ok, [%{resize: resize}]} = plan_pipeline(resizing_type: :fill, width: {:pixels, 100},
+      height: {:pixels, 100}, gravity: {:obj, ["all"]})
+    assert resize.guide == {:detect, :all}
   end
 
   test "all appearing among classes collapses to detect :all" do
-    assert {:ok, plan} = build("rs:fill:100:100/g:obj:car:all/plain/http://e/x.jpg")
-    assert detect_guide(plan) == {:detect, :all}
+    {:ok, [%{resize: resize}]} = plan_pipeline(resizing_type: :fill, width: {:pixels, 100},
+      height: {:pixels, 100}, gravity: {:obj, ["car", "all"]})
+    assert resize.guide == {:detect, :all}
   end
 
   test "g:obj:face still maps to a face detect guide" do
-    assert {:ok, plan} = build("rs:fill:100:100/g:obj:face/plain/http://e/x.jpg")
-    assert detect_guide(plan) == {:detect, ["face"]}
+    {:ok, [%{resize: resize}]} = plan_pipeline(resizing_type: :fill, width: {:pixels, 100},
+      height: {:pixels, 100}, gravity: {:obj, ["face"]})
+    assert resize.guide == {:detect, ["face"]}
   end
 
-  test "crop form c:W:H:obj:classes maps to a detect guide (tagged_gravity path)" do
-    assert {:ok, plan} = build("c:200:200:obj:car:dog/plain/http://e/x.jpg")
-    assert detect_guide(plan) == {:detect, ["car", "dog"]}
+  # crop path (tagged_gravity)
+  test "crop object gravity maps to a detect guide" do
+    {:ok, [%{crop: crop}]} = plan_pipeline(crop: %CropRequest{width: {:pixels, 200},
+      height: {:pixels, 200}, gravity: {:obj, ["car", "dog"]}})
+    assert crop.guide == {:detect, ["car", "dog"]}
   end
 
-  test "crop form bare c:W:H:obj maps to detect :all" do
-    assert {:ok, plan} = build("c:200:200:obj/plain/http://e/x.jpg")
-    assert detect_guide(plan) == {:detect, :all}
+  # behavior change: numeric trailing tokens are now unknown classes (dropped at
+  # routing), NOT an error. This REPLACES "rejects ... trailing class tokens".
+  test "object gravity with numeric tokens treats them as (unknown) classes, not an error" do
+    {:ok, [%{resize: resize}]} = plan_pipeline(resizing_type: :fill, width: {:pixels, 100},
+      height: {:pixels, 100}, gravity: {:obj, ["face", "5", "5"]})
+    assert resize.guide == {:detect, ["face", "5", "5"]}
   end
 ```
 
-These two crop-form cases exercise `tagged_gravity/2`; the `rs:fill` cases above exercise `resize_guide/2`. Both mappers must pass.
-
-Use the file's existing request-building and guide-extraction helpers (mirror a neighboring test). If a `detect_guide/1` helper does not exist, extract the guide the same way the neighboring `{:detect, ["face"]}` test does — do not hand-build plan structs.
+Match the real `plan_pipeline/2` attribute names and the `resize`/`crop` accessor shape from the neighboring tests (the snippet's struct shapes are illustrative). **Explicit decision:** the old `"rejects … trailing class tokens treated as offsets"` test is *deleted and replaced* by the last test above — under best-effort dropping, `g:obj:face:5:5` is `{:detect, ["face", "5", "5"]}` where `"5"` is an unknown class dropped at routing (object gravity has no offset args). This is an intentional behavior change, not an oversight.
 
 - [ ] **Step 2: Run to verify failure**
 
-Run: `mise exec -- mix test test/image_pipe/parser/imgproxy/plan_builder_test.exs`
+Run: `mise exec -- mix test test/parser/imgproxy/plan_builder_test.exs`
 Expected: FAIL — current code returns `{:error, {:unsupported_gravity, …}}` for non-`["face"]` object gravity.
 
 - [ ] **Step 3: Add a shared object-guide helper and call it from both mappers**
@@ -860,33 +945,32 @@ And replace the `{:obj, …}` clauses in **`tagged_gravity/2`** (lines 664-667) 
 
 - [ ] **Step 4: Run the parser tests to verify they pass**
 
-Run: `mise exec -- mix test test/image_pipe/parser/imgproxy/plan_builder_test.exs`
+Run: `mise exec -- mix test test/parser/imgproxy/plan_builder_test.exs`
 Expected: PASS.
 
-- [ ] **Step 5: Add an order-insensitivity property test**
+- [ ] **Step 5: Add an order-insensitivity property test at the key-data level**
 
-In the same file (or the parser property test file if one exists), add:
+The class list is sorted in `guide_data` (`Enum.sort(classes)`), so order-insensitivity is a key-data property. Add to `test/image_pipe/plan/operation_key_data_test.exs` (self-contained, uses the file's `KeyData.data/1` + `%CropGuided{}` idiom and the project's `StreamData` import):
 
 ```elixir
-  property "object class order does not change the detect guide's key material" do
+  property "detect-guide class order does not change the guide key data" do
     check all classes <- uniq_list_of(member_of(["car", "dog", "cat", "person"]), min_length: 1, max_length: 4) do
-      shuffled = Enum.shuffle(classes)
-      {:ok, a} = build("rs:fill:100:100/g:obj:" <> Enum.join(classes, ":") <> "/plain/http://e/x.jpg")
-      {:ok, b} = build("rs:fill:100:100/g:obj:" <> Enum.join(shuffled, ":") <> "/plain/http://e/x.jpg")
-      assert ImagePipe.Cache.Key.build(conn(), a, "sid") == ImagePipe.Cache.Key.build(conn(), b, "sid")
+      a = KeyData.data(%CropGuided{width: {:px, 100}, height: {:px, 100}, guide: {:detect, classes}})
+      b = KeyData.data(%CropGuided{width: {:px, 100}, height: {:px, 100}, guide: {:detect, Enum.shuffle(classes)}})
+      assert a == b
     end
   end
 ```
 
-Use the project's actual `StreamData` import and the real `Cache.Key.build/3-4` signature and a test `conn`/source-identity helper (mirror `key_test.exs`). If property-test infra for parser+cache-key isn't readily wired, place this in `key_test.exs` instead, where the conn/source-identity helpers already exist.
+Match the file's real `StreamData`/`ExUnitProperties` import and `%CropGuided{}` field shape.
 
 - [ ] **Step 6: Run + commit**
 
-Run: `mise exec -- mix test test/image_pipe/parser/imgproxy/plan_builder_test.exs`
+Run: `mise exec -- mix test test/parser/imgproxy/plan_builder_test.exs test/image_pipe/plan/operation_key_data_test.exs`
 Expected: PASS.
 
 ```bash
-git add lib/image_pipe/parser/imgproxy/plan_builder.ex test/image_pipe/parser/imgproxy/plan_builder_test.exs
+git add lib/image_pipe/parser/imgproxy/plan_builder.ex test/parser/imgproxy/plan_builder_test.exs test/image_pipe/plan/operation_key_data_test.exs
 git commit -m "feat(imgproxy): parse multi-class object gravity and all/bare obj -> detect"
 ```
 
@@ -897,13 +981,13 @@ git commit -m "feat(imgproxy): parse multi-class object gravity and all/bare obj
 **Files:**
 - Modify: `lib/image_pipe/request/runner.ex:238-247`
 - Modify: `lib/image_pipe/plug.ex:143-151`
-- Test: `test/image_pipe/cache/key_test.exs` (class-aware identity invariants)
+- Test: `test/image_pipe/imgproxy_wire_conformance_test.exs` (observe the cache key via `CacheProbe`)
 
-- [ ] **Step 1: Write the failing class-aware identity tests**
+The class-aware *identity routing* is already unit-proven in Task 4 (`Composite.identity/2`). What Task 8 adds is the *wiring*: the runner threads the plan's detect classes into `detector_identity`, and the plug threads them into the availability gate. The runner wiring's observable effect is the **cache key**, which the wire test's `CacheProbe` reports via `{:cache_lookup, key}` — so verify at the wire level (no fictional `key_for`; `Cache.Key.build` takes `detector_identity` literally and never resolves a detector). The plug wiring is verified by Task 10's gate triad.
 
-`detector:` must resolve via `Transform.resolve_detector/1`, which accepts a **module atom** (not a `%Composite{}` struct). So define one named test detector module that delegates to the explicit `Composite` helpers (`Composite.new/1` + `detect/3`/`identity/2`/`available?/2`/`supported_classes/1`) with fake children, and make the fake children read their identity *version* from `opts` — that way a single module covers the version-bump independence checks without defining many modules.
+- [ ] **Step 1: Write the failing class-aware key tests (wire-level, via CacheProbe)**
 
-In `test/image_pipe/cache/key_test.exs` (mirror the file's existing detector-identity test setup for `key_for`/conn/source-identity):
+`detector:` resolves a **module atom**. Define one named detector module that delegates to `Composite.new(...)` with fake children whose identity *version* is read from `opts` — so a single module covers the version-bump independence checks. Put these in the wire test file (alongside its existing `UnavailableDetector`/`CacheProbe`):
 
 ```elixir
   defmodule FaceVerFake do
@@ -930,11 +1014,10 @@ In `test/image_pipe/cache/key_test.exs` (mirror the file's existing detector-ide
     def detect(_, _), do: {:ok, []}
   end
 
-  defmodule TestComposite do
+  defmodule VerComposite do
     @behaviour ImagePipe.Transform.Detector
     alias ImagePipe.Transform.Detector.Composite
-    @children [FaceVerFake, ObjectVerFake]
-    defp c, do: Composite.new(@children)
+    defp c, do: Composite.new([FaceVerFake, ObjectVerFake])
     @impl true
     def supported_classes(_o), do: Composite.supported_classes(c())
     @impl true
@@ -945,33 +1028,45 @@ In `test/image_pipe/cache/key_test.exs` (mirror the file's existing detector-ide
     def identity(o), do: Composite.identity(c(), o)
   end
 
-  test "an object-only request's key is independent of the face model identity" do
-    a = key_for("rs:fill:100:100/g:obj:car/...", detector: TestComposite, face_ver: :v1)
-    b = key_for("rs:fill:100:100/g:obj:car/...", detector: TestComposite, face_ver: :v2)
-    assert a == b
+  # Capture the cache key the plug looked up for one request. Uses the file's
+  # existing CacheProbe (it sends {:cache_lookup, key}) and call_imgproxy/2.
+  defp lookup_key(path, opts) do
+    call_imgproxy(path, opts)
+    assert_received {:cache_lookup, key}
+    key
   end
 
-  test "a face-only request's key is independent of the object model identity" do
-    a = key_for("rs:fill:100:100/g:obj:face/...", detector: TestComposite, object_ver: :v1)
-    b = key_for("rs:fill:100:100/g:obj:face/...", detector: TestComposite, object_ver: :v2)
-    assert a == b
+  defp ver_opts(extra) do
+    # Merge into the file's CacheProbe-backed opts (see the existing cache tests),
+    # adding the detector and the version knobs that flow through to identity/1.
+    Keyword.merge(probe_opts(), [detector: VerComposite] ++ extra)
   end
 
-  test "a mixed request's key changes when either model identity changes" do
-    base = key_for("rs:fill:100:100/g:obj:face:car/...", detector: TestComposite, face_ver: :v1, object_ver: :v1)
-    diff_face = key_for("rs:fill:100:100/g:obj:face:car/...", detector: TestComposite, face_ver: :v2, object_ver: :v1)
-    diff_obj = key_for("rs:fill:100:100/g:obj:face:car/...", detector: TestComposite, face_ver: :v1, object_ver: :v2)
+  test "object-only request key is independent of the face model identity" do
+    assert lookup_key("rs:fill:50:50/g:obj:car/plain/images/beach.jpg", ver_opts(face_ver: :v1)) ==
+             lookup_key("rs:fill:50:50/g:obj:car/plain/images/beach.jpg", ver_opts(face_ver: :v2))
+  end
+
+  test "face-only request key is independent of the object model identity" do
+    assert lookup_key("rs:fill:50:50/g:obj:face/plain/images/beach.jpg", ver_opts(object_ver: :v1)) ==
+             lookup_key("rs:fill:50:50/g:obj:face/plain/images/beach.jpg", ver_opts(object_ver: :v2))
+  end
+
+  test "mixed request key changes when either model identity changes" do
+    base = lookup_key("rs:fill:50:50/g:obj:face:car/plain/images/beach.jpg", ver_opts(face_ver: :v1, object_ver: :v1))
+    diff_face = lookup_key("rs:fill:50:50/g:obj:face:car/plain/images/beach.jpg", ver_opts(face_ver: :v2, object_ver: :v1))
+    diff_obj = lookup_key("rs:fill:50:50/g:obj:face:car/plain/images/beach.jpg", ver_opts(face_ver: :v1, object_ver: :v2))
     assert base != diff_face
     assert base != diff_obj
   end
 ```
 
-`key_for/2` must pass the extra opts (`face_ver`/`object_ver`/`detector`) through to the request opts that reach `Cache.Key.build`/`put_detector_identity` (so they land in the `opts` handed to `identity/1`). Mirror the file's existing detector test for how `detector:` is threaded; pass `face_ver`/`object_ver` the same way. The independence works because `put_detector_identity` threads `:classes` into those opts, and `TestComposite.identity/1` routes to only the relevant child, whose identity reads its `*_ver` from the same opts.
+Bind `probe_opts/0` to the file's real CacheProbe-backed opts (mirror the existing `"equivalent imgproxy option order shares filesystem cache"` / `cached_opts/0` test, or the `cache: {CacheProbe, []}` setup the safety tests use). The `face_ver`/`object_ver` reach `identity/1` because `put_detector_identity` (Step 3) passes the request `opts` (with `:classes` added) to `Transform.detector_identity/2`.
 
 - [ ] **Step 2: Run to verify failure**
 
-Run: `mise exec -- mix test test/image_pipe/cache/key_test.exs`
-Expected: FAIL — `detector_identity` currently ignores classes, so all three requests fold in the same (class-agnostic) identity, breaking the independence invariants.
+Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs`
+Expected: FAIL — `put_detector_identity` currently calls `detector_identity(detector, opts)` with no `:classes`, so `Composite.identity` defaults to `:all` and folds **both** children into every key. The object-only key then changes with `face_ver`, breaking the independence assertion.
 
 - [ ] **Step 3: Thread classes into the cache-key identity**
 
@@ -1017,9 +1112,9 @@ In `lib/image_pipe/plug.ex`, update `validate_detector_capability/2` (lines 143-
 
 `Transform.detector_available?/2` passes `opts` to `module.available?/1`, so the Composite evaluates availability for the routed class set.
 
-- [ ] **Step 5: Run the cache-key tests to verify they pass**
+- [ ] **Step 5: Run the wire cache-key tests to verify they pass**
 
-Run: `mise exec -- mix test test/image_pipe/cache/key_test.exs`
+Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs`
 Expected: PASS.
 
 - [ ] **Step 6: Compile + commit**
@@ -1028,7 +1123,7 @@ Run: `mise exec -- mix compile --warnings-as-errors`
 Expected: PASS.
 
 ```bash
-git add lib/image_pipe/request/runner.ex lib/image_pipe/plug.ex test/image_pipe/cache/key_test.exs
+git add lib/image_pipe/request/runner.ex lib/image_pipe/plug.ex test/image_pipe/imgproxy_wire_conformance_test.exs
 git commit -m "feat: class-aware detector identity and strict gate"
 ```
 
@@ -1050,25 +1145,25 @@ Add to `composite_test.exs` (it already has fake children with `identity/1`):
 ```elixir
   test "emits a per-model span per routed child with detector, model identity, and classes" do
     ref =
-      :telemetry_test.attach_event_handlers(self(), [[:transform, :detect, :model, :stop]])
+      :telemetry_test.attach_event_handlers(self(), [[:image_pipe, :transform, :detect, :model, :stop]])
 
     on_exit(fn -> :telemetry.detach(ref) end)
 
     {:ok, _} =
       Composite.detect(composite(), :image,
         classes: ["face", "car"],
-        telemetry_opts: [prefix: [:image_pipe], metadata: %{}]
+        telemetry_opts: [telemetry_prefix: [:image_pipe]]
       )
 
-    assert_received {[:transform, :detect, :model, :stop], ^ref, _measurements,
+    assert_received {[:image_pipe, :transform, :detect, :model, :stop], ^ref, _measurements,
                      %{detector: FaceChild, model: {FaceChild, :face_v1}, classes: ["face"], regions: 1}}
 
-    assert_received {[:transform, :detect, :model, :stop], ^ref, _measurements,
+    assert_received {[:image_pipe, :transform, :detect, :model, :stop], ^ref, _measurements,
                      %{detector: ObjectChild, model: {ObjectChild, :obj_v1}, classes: ["car"], regions: 1}}
   end
 ```
 
-Match the real `telemetry_opts` shape the codebase uses — inspect how `crop.ex` builds `state.telemetry_opts` and how `ImagePipe.Telemetry.span/4` reads it, and mirror that exact structure here.
+The event prefix is `[:image_pipe]` (the default `Telemetry.span/4` prefix) and the opts key is `:telemetry_prefix` (NOT `:prefix`) — `Telemetry.span/4` reads `Keyword.get(telemetry_opts, :telemetry_prefix, [:image_pipe])`. Confirm against `crop_operation_test.exs`'s existing `[:image_pipe, :transform, :detect, :stop]` attachment.
 
 - [ ] **Step 2: Run to verify failure**
 
@@ -1182,27 +1277,27 @@ In `test/image_pipe/imgproxy_wire_conformance_test.exs` (or its support module),
 - [ ] **Step 2: Write the failing pixel-divergence test for a non-face class**
 
 ```elixir
-  test "g:obj:car crop is biased toward the detected object and differs from center and attention" do
-    opts = wire_opts(detector: CornerObjectDetector)
+  test "g:obj:car crop biases toward the detected object, differing from center and attention" do
+    opts = Keyword.merge(@default_opts, detector: CornerObjectDetector)
 
-    obj = request("rs:fill:50:50/g:obj:car/plain/" <> source_url(), opts)
-    centered = request("rs:fill:50:50/g:ce/plain/" <> source_url(), opts)
-    attention = request("rs:fill:50:50/g:sm/plain/" <> source_url(), opts)
+    obj = call_imgproxy("rs:fill:50:50/g:obj:car/plain/images/beach.jpg", opts)
+    centered = call_imgproxy("rs:fill:50:50/g:ce/plain/images/beach.jpg", opts)
+    attention = call_imgproxy("rs:fill:50:50/g:sm/plain/images/beach.jpg", opts)
 
     assert obj.status == 200
-    assert decoded_dimensions(obj) == {50, 50}
+    assert dimensions(obj) == {50, 50}
     refute obj.resp_body == centered.resp_body
     refute obj.resp_body == attention.resp_body
   end
 
   test "no-geometry g:obj:car still detects without a resize/crop" do
-    opts = wire_opts(detector: CornerObjectDetector)
-    resp = request("g:obj:car/plain/" <> source_url(), opts)
+    opts = Keyword.merge(@default_opts, detector: CornerObjectDetector)
+    resp = call_imgproxy("g:obj:car/plain/images/beach.jpg", opts)
     assert resp.status == 200
   end
 ```
 
-Use the file's real request/response helpers (`request/2`, `wire_opts/1`, `source_url/0`, `decoded_dimensions/1`) — mirror the existing `g:sm` pixel test. If those helper names differ, match the file's actual conventions. The `detector:` option must be plumbed into the plug opts the test builds (the existing 422 `g:obj:face` test at the strict-gate already injects an unavailable detector — copy how it passes `detector:`).
+Use the file's real helpers: `call_imgproxy(path, opts)` (returns a `conn`), `dimensions(conn)` (decodes), the hardcoded `plain/images/beach.jpg` source, and `@default_opts` (merge to override `detector:`). Mirror the existing `g:sm` decode-and-compare pixel test for exact conventions.
 
 - [ ] **Step 3: Run to verify failure, then implement**
 
@@ -1212,21 +1307,27 @@ Expected: initially FAIL only if something is wrong — by this task the product
 - [ ] **Step 4: Write the gate-triad test**
 
 ```elixir
-  test "detector_required gate: supported+available 200, supported+unavailable 422 pre-fetch, unknown degrades" do
-    # A composite-style detector where the object child is unavailable but face is available.
-    opts = wire_opts(detector: PartialDetector, detector_required: true)
+  test "detector_required gate: available->200, unavailable->422 pre-fetch, unknown->degrade" do
+    opts = Keyword.merge(@default_opts, detector: PartialDetector, detector_required: true)
 
-    assert request("rs:fill:50:50/g:obj:face/plain/" <> source_url(), opts).status == 200
-    assert request("rs:fill:50:50/g:obj:car/plain/" <> source_url(), opts).status == 422
-    assert request("rs:fill:50:50/g:obj:unicorn/plain/" <> source_url(), opts).status == 200
-    # And the 422 happened before any source fetch/cache access:
-    assert_no_source_fetch(fn ->
-      request("rs:fill:50:50/g:obj:car/plain/" <> source_url(), opts)
-    end)
+    # face child available -> routes and succeeds
+    assert call_imgproxy("rs:fill:50:50/g:obj:face/plain/images/beach.jpg", opts).status == 200
+    # unknown class routes to no child -> available? vacuously true -> degrades
+    assert call_imgproxy("rs:fill:50:50/g:obj:unicorn/plain/images/beach.jpg", opts).status == 200
+
+    # object child unavailable -> 422 BEFORE any source fetch or cache access.
+    # Reuse the exact OriginShouldNotFetch source + CacheProbe cache from the
+    # existing "detector_required + unavailable detector rejects before source AND
+    # cache access" test (~line 541), then assert status + refute the side effects.
+    gate_opts = Keyword.merge(opts, source: <OriginShouldNotFetch from the ~line-541 test>, cache: {CacheProbe, []})
+    conn = call_imgproxy("rs:fill:50:50/g:obj:car/plain/images/beach.jpg", gate_opts)
+    assert conn.status == 422
+    refute_received :origin_fetch
+    refute_received {:cache_lookup, _key}
   end
 ```
 
-`detector:` resolves a **module atom**, so define `PartialDetector` as a named module that delegates to `Composite.new([FaceFake, UnavailableObjectFake])` (same delegation shape as `TestComposite` in Task 8). `FaceFake` is available and owns `["face"]` (its `detect/2` returns a region so `g:obj:face` succeeds → 200); `UnavailableObjectFake` owns `["car"]` with `available?/1 -> false`. Then: `g:obj:face` routes to the available face child → 200; `g:obj:car` routes to the unavailable object child → `available?` false → 422 pre-fetch; `g:obj:unicorn` routes to no child → `available?` vacuously true → degrades to 200. Use the file's existing "no source fetch" assertion helper (the strict-gate `g:obj:face` 422 test already demonstrates asserting the source was not hit).
+`PartialDetector` is a named module delegating to `Composite.new([FaceFake, UnavailableObjectFake])` (same delegation shape as `VerComposite` in Task 8). `FaceFake` is available, owns `["face"]`, and its `detect/2` returns a region so `g:obj:face` → 200. `UnavailableObjectFake` owns `["car"]` with `available?/1 -> false`, so `g:obj:car` routes to it → `available?` false → 422 pre-fetch; `g:obj:unicorn` routes to no child → `available?` vacuously true → degrades to 200. The 422 leg must copy the line-541 test's `OriginShouldNotFetch` + `CacheProbe` opts and its `refute_received :origin_fetch` / `refute_received {:cache_lookup, _}` assertions verbatim.
 
 - [ ] **Step 5: Run the wire tests**
 
@@ -1249,10 +1350,12 @@ git commit -m "test(wire): obj:car pixel divergence, no-geometry, and detector_r
 
 - [ ] **Step 1: Extend the detector-reference scan to parser + plan**
 
-Find the `detector_forbidden_files/0` helper (used by the test at line 329) and add the parser and plan source files to its list, so the existing `concrete_detector_references/1` AST scan also forbids parser/planner code from naming `ImagePipe.Transform.Detector.*` modules. Do NOT add a COCO-label denylist — only the detector-module scan (a label denylist would itself leak vocabulary into the test).
+The detector scan (test at line 329) reads the `@detector_forbidden_globs` **module attribute** (line 13), currently covering plug/request/source/response/cache. Add `lib/image_pipe/parser/**/*.ex` and `lib/image_pipe/plan/**/*.ex` to **that attribute** (NOT to `@parser_forbidden_globs` at line 24, which drives a different parser-struct scan — keep the two glob sets separate). The existing `concrete_detector_references/1` AST scan then forbids parser/plan code from naming `ImagePipe.Transform.Detector.*`. Do NOT add a COCO-label denylist — only the detector-module scan (a label denylist would itself leak vocabulary into the test).
 
-Run: `mise exec -- grep -n "detector_forbidden_files" test/image_pipe/architecture_boundary_test.exs`
-Then extend that file-glob list to include `lib/image_pipe/parser/**/*.ex` and `lib/image_pipe/plan/**/*.ex` (match the helper's existing glob style).
+First confirm no plan/parser file already names a detector module:
+
+Run: `grep -rn "Transform.Detector" lib/image_pipe/parser lib/image_pipe/plan`
+Expected: no matches (parser emits `{:detect, …}` atoms; plan/key_data name no detector). If a match exists, that's a real boundary violation to fix before this test will pass.
 
 - [ ] **Step 2: Run the architecture test**
 

--- a/docs/superpowers/plans/2026-05-31-object-gravity-slice1.md
+++ b/docs/superpowers/plans/2026-05-31-object-gravity-slice1.md
@@ -1,0 +1,1367 @@
+# General Object Gravity (Slice 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend ImagePipe's content-aware gravity from the single-class `face` subset to imgproxy's general object gravity (`g:obj`, `g:obj:all`, `g:obj:%c1:…:%cN` and the `c:W:H:obj…` crop forms), backed by a product-neutral Composite detector that routes face classes to YuNet and COCO classes to RT-DETR and merges the regions.
+
+**Architecture:** A new `Detector.Composite` holds an ordered child list `[ImageVision.Face, ImageVision.Objects]`, routes a requested class set per child via a new `supported_classes/1` behaviour callback, fans out, and merges regions. The plan carries a product-neutral `{:detect, :all} | {:detect, [classes]}` guide; the imgproxy parser normalizes `all`/bare-`obj` to `:all` and stays vocabulary-free. Cache identity and the strict gate become class-aware by threading the plan's detect classes into the detector opts. The equal-weight `area` centroid is unchanged (per-class weights are Slice 2).
+
+**Tech Stack:** Elixir, `image_vision 0.4.0` (`Image.FaceDetection` YuNet + `Image.Detection` RT-DETR/COCO-80, via `ortex`), `Vix`/`Image` (libvips), `:telemetry`, `NimbleOptions`, ExUnit + StreamData.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-31-object-gravity-slice1-design.md`
+
+**Run everything via `mise exec -- …`** (e.g. `mise exec -- mix test path`). The Elixir gate is `mise run precommit`; the demo gate is `mise run precommit:demo`.
+
+**ML-dependency lane:** the real models require `image_vision`/`ortex` + a model download. Tests that exercise the real model are tagged `@tag :image_vision` and excluded by default; all deterministic tests inject a fake detector. Run tagged tests with `IMAGE_VISION=1 mise exec -- mix test --only image_vision` only when explicitly verifying the live adapters.
+
+---
+
+## File structure
+
+**New files:**
+- `lib/image_pipe/transform/detector/image_vision/face.ex` — YuNet face adapter (moved from the current `image_vision.ex`, + `supported_classes/1`).
+- `lib/image_pipe/transform/detector/image_vision/objects.ex` — RT-DETR/COCO-80 object adapter.
+- `lib/image_pipe/transform/detector/composite.ex` — ordered-child router/merger; emits per-model spans.
+
+**Deleted:**
+- `lib/image_pipe/transform/detector/image_vision.ex` — replaced by `image_vision/face.ex`.
+
+**Modified:**
+- `lib/image_pipe/transform/detector.ex` — add `@callback supported_classes/1`.
+- `lib/image_pipe/transform.ex:76` — `@default_detector` → `Composite`.
+- `lib/image_pipe/plan/operation/crop_guided.ex` — guide type `+ {:detect, :all}`.
+- `lib/image_pipe/transform/operation/crop.ex` — gravity type `+ {:detect, :all}`; `run_detect` threads `:telemetry_opts`.
+- `lib/image_pipe/plan.ex:88-99` — `detect_classes/1` `@spec` widened to `:all | nonempty_list | nil`.
+- `lib/image_pipe/plan/key_data.ex:198` — add `guide_data({:detect, :all})`.
+- `lib/image_pipe/parser/imgproxy/plan_builder.ex:664-667` — `tagged_gravity/2` multi-class/`:all` mapping.
+- `lib/image_pipe/request/runner.ex:238-247` — thread classes into `detector_identity`.
+- `lib/image_pipe/plug.ex:143-151` — thread classes into the strict gate.
+- `lib/image_pipe/transform/detector/warmup.ex` — default `classes: :all`; moduledoc.
+- `test/image_pipe/architecture_boundary_test.exs` — extend detector-reference scan to parser/plan.
+- `docs/content-aware-gravity.md`, `docs/imgproxy_support_matrix.md`, `docs/telemetry.md` — docs.
+- `demo/` — object-class controls + URL state.
+
+**Test files (created/extended):**
+- `test/image_pipe/transform/detector/composite_test.exs` (new)
+- `test/image_pipe/transform/detector/image_vision_test.exs` (rename refs; tagged smoke)
+- `test/image_pipe/parser/imgproxy/plan_builder_test.exs` (flip rejection → acceptance)
+- `test/image_pipe/parser/imgproxy/option_grammar_test.exs` (multi-class/`all` grammar; if present)
+- `test/image_pipe/cache/key_test.exs` (class-aware identity)
+- `test/image_pipe/imgproxy_wire_conformance_test.exs` (pixel + gate triad)
+- `test/image_pipe/transform/operation/crop_operation_test.exs` (FakeDetector `supported_classes`)
+- `test/image_pipe/plan_data_test.exs` or wherever `key_data` guide encoding is tested (`:all`)
+
+---
+
+## Task 1: Add `supported_classes/1` to the Detector behaviour
+
+**Files:**
+- Modify: `lib/image_pipe/transform/detector.ex`
+- Modify: `lib/image_pipe/transform/detector/image_vision.ex` (temporary — implements the new callback so the tree keeps compiling; renamed in Task 2)
+- Modify: every in-repo `@behaviour ImagePipe.Transform.Detector` implementation, including test fakes (search first)
+
+`mix compile --warnings-as-errors` treats a missing required callback as a failure, so every implementer must gain the callback in this same task.
+
+- [ ] **Step 1: Find every detector implementation that must gain the callback**
+
+Run: `mise exec -- grep -rl "@behaviour ImagePipe.Transform.Detector" lib test`
+Expected: at least `lib/image_pipe/transform/detector/image_vision.ex` and one or more test fakes (e.g. in `test/support/` or inline in `crop_operation_test.exs` / `image_vision_test.exs`). Note each path — all of them get a `supported_classes/1` in this task.
+
+- [ ] **Step 2: Add the callback to the behaviour**
+
+In `lib/image_pipe/transform/detector.ex`, after the `detect/2` callback block (around line 26), add:
+
+```elixir
+  @doc """
+  The class names this detector can produce, in the URL-facing spelling.
+
+  Static metadata used to route a requested class set to detectors and to gate
+  availability — it MUST NOT load a model and MUST be answerable even when the
+  detector's optional dependency is absent (so a routing/availability decision
+  can be made without the dep). `available?/1` may be `false` while this still
+  returns the full vocabulary.
+  """
+  @callback supported_classes(opts :: keyword()) :: [String.t()]
+```
+
+- [ ] **Step 3: Implement it in the current `ImageVision` adapter**
+
+In `lib/image_pipe/transform/detector/image_vision.ex`, add after `available?/1`:
+
+```elixir
+  @impl true
+  def supported_classes(_opts), do: ["face"]
+```
+
+- [ ] **Step 4: Implement it in every test fake found in Step 1**
+
+For each fake, add a `supported_classes/1` returning the classes that fake claims (a face fake returns `["face"]`; a generic fake returns whatever labels its canned regions use). Example for a fake that returns `face` regions:
+
+```elixir
+  @impl true
+  def supported_classes(_opts), do: ["face"]
+```
+
+If a fake is parameterized (returns configurable regions), make `supported_classes/1` return the labels it is configured to emit, or a fixed superset the test controls.
+
+- [ ] **Step 5: Compile with warnings-as-errors**
+
+Run: `mise exec -- mix compile --warnings-as-errors`
+Expected: PASS, no "function supported_classes/1 required by behaviour … is not implemented" warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/image_pipe/transform/detector.ex lib/image_pipe/transform/detector/image_vision.ex test
+git commit -m "feat(detector): add supported_classes/1 behaviour callback"
+```
+
+---
+
+## Task 2: Rename the face adapter to `ImageVision.Face`
+
+A mechanical move so the bundled adapters are symmetric siblings (`ImageVision.Face` / `ImageVision.Objects`) under the Composite. No behavior change to the face path.
+
+**Files:**
+- Create: `lib/image_pipe/transform/detector/image_vision/face.ex`
+- Delete: `lib/image_pipe/transform/detector/image_vision.ex`
+- Modify: `lib/image_pipe/transform.ex:76` (`@default_detector`)
+- Modify: references in `test/image_pipe/transform/detector/image_vision_test.exs`, `lib/image_pipe/transform/detector/warmup.ex` moduledoc, and any cache-key test naming the identity tuple
+
+- [ ] **Step 1: Create the renamed module**
+
+Create `lib/image_pipe/transform/detector/image_vision/face.ex` as the current `image_vision.ex` content with the module renamed to `ImagePipe.Transform.Detector.ImageVision.Face`. Keep the YuNet logic, `@repo`/`@model_file`, `detect/2`, `available?/1`, `warmup/1`, and `supported_classes(_) -> ["face"]`. Update `identity/1` to fold `min_score` into the tuple for forward-consistency with the Objects adapter (min_score is a fixed default here):
+
+```elixir
+defmodule ImagePipe.Transform.Detector.ImageVision.Face do
+  @moduledoc """
+  `ImagePipe.Transform.Detector` for faces, backed by the optional `image_vision`
+  dependency (`Image.FaceDetection`, YuNet). The dependency is not declared by
+  ImagePipe — hosts opt in. When absent, `available?/1` is false and callers fall
+  back gracefully.
+  """
+  @behaviour ImagePipe.Transform.Detector
+
+  @compile {:no_warn_undefined, Image.FaceDetection}
+
+  @repo "opencv/face_detection_yunet"
+  @model_file "face_detection_yunet_2023mar.onnx"
+
+  @impl true
+  def supported_classes(_opts), do: ["face"]
+
+  @impl true
+  def available?(_opts), do: Code.ensure_loaded?(Image.FaceDetection)
+
+  @impl true
+  def identity(_opts) do
+    if available?([]),
+      do: {__MODULE__, {@repo, @model_file}},
+      else: {__MODULE__, :unavailable}
+  end
+
+  @impl true
+  def detect(image, opts) do
+    classes = Keyword.get(opts, :classes, [])
+
+    cond do
+      not available?(opts) -> {:error, {:detector, :unavailable}}
+      classes == :all or classes == ["face"] -> detect_faces(image)
+      true -> {:ok, []}
+    end
+  end
+
+  @impl true
+  def warmup(opts) do
+    if available?(opts) do
+      {:ok, blank} = Image.new(64, 64, color: :black)
+      _ = detect_faces(blank)
+      :ok
+    else
+      {:error, {:detector, :unavailable}}
+    end
+  end
+
+  defp detect_faces(image) do
+    regions =
+      image
+      |> Image.FaceDetection.detect()
+      |> Enum.map(fn %{box: box, score: score} -> %{label: "face", score: score, box: box} end)
+
+    {:ok, regions}
+  rescue
+    error -> {:error, {:detector, error}}
+  end
+end
+```
+
+Note two changes vs the old module: `detect/2` now accepts `classes == :all` (returns faces) and returns `{:ok, []}` for any other routed class instead of an `{:unsupported_classes, …}` error (the Composite never routes non-face classes here, and `:all` legitimately asks for faces).
+
+- [ ] **Step 2: Delete the old module**
+
+```bash
+git rm lib/image_pipe/transform/detector/image_vision.ex
+```
+
+- [ ] **Step 3: Repoint `@default_detector`**
+
+In `lib/image_pipe/transform.ex:76`:
+
+```elixir
+  @default_detector ImagePipe.Transform.Detector.ImageVision.Face
+```
+
+(This is temporary — Task 5 repoints it to the Composite. Pointing at `.Face` now keeps the face path working between tasks.)
+
+- [ ] **Step 4: Update references in tests and docs**
+
+In `test/image_pipe/transform/detector/image_vision_test.exs` and any cache-key test, replace `ImagePipe.Transform.Detector.ImageVision` with `…ImageVision.Face`. Update the `warmup.ex` moduledoc example's `classes: ["face"]` is still valid; no code change required there yet.
+
+Run: `mise exec -- grep -rn "Detector.ImageVision\b" lib test docs` and fix any remaining bare `ImageVision` references that should be `ImageVision.Face`.
+
+- [ ] **Step 5: Compile + run the face/detector tests**
+
+Run: `mise exec -- mix compile --warnings-as-errors && mise exec -- mix test test/image_pipe/transform/detector/`
+Expected: PASS (face behavior unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A lib/image_pipe/transform lib/image_pipe/transform.ex test docs
+git commit -m "refactor(detector): rename ImageVision -> ImageVision.Face"
+```
+
+---
+
+## Task 3: `ImageVision.Objects` adapter (RT-DETR / COCO-80)
+
+**Files:**
+- Create: `lib/image_pipe/transform/detector/image_vision/objects.ex`
+- Test: `test/image_pipe/transform/detector/image_vision_test.exs` (add a tagged smoke + drift test)
+
+- [ ] **Step 1: Write the failing drift + smoke test (tagged)**
+
+Add to `test/image_pipe/transform/detector/image_vision_test.exs`:
+
+```elixir
+  alias ImagePipe.Transform.Detector.ImageVision.Objects
+
+  describe "Objects adapter (real model)" do
+    @describetag :image_vision
+
+    test "supported_classes is the static COCO-80 vocabulary in underscore spelling" do
+      classes = Objects.supported_classes([])
+      assert "person" in classes
+      assert "traffic_light" in classes
+      refute "traffic light" in classes
+      assert length(classes) == 80
+    end
+
+    test "supported_classes matches the model's labels (drift guard)" do
+      model_labels =
+        Image.Detection.classes()
+        |> Enum.map(&String.replace(&1, " ", "_"))
+        |> Enum.sort()
+
+      assert Enum.sort(Objects.supported_classes([])) == model_labels
+    end
+
+    test "detect returns product-neutral regions on a synthetic image" do
+      {:ok, image} = Image.new(320, 240, color: :black)
+      assert {:ok, regions} = Objects.detect(image, classes: :all)
+      assert is_list(regions)
+      assert Enum.all?(regions, &match?(%{label: l, score: _, box: {_, _, _, _}} when is_binary(l), &1))
+    end
+  end
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `IMAGE_VISION=1 mise exec -- mix test test/image_pipe/transform/detector/image_vision_test.exs --only image_vision`
+Expected: FAIL — `Objects` is undefined.
+
+- [ ] **Step 3: Implement the Objects adapter**
+
+Create `lib/image_pipe/transform/detector/image_vision/objects.ex`. The COCO-80 list is hardcoded in underscore spelling (dep-independent). `detect/2` calls `Image.Detection.detect/2` with `min_score`, normalizes the model's space-spelled labels to underscores, and filters to the routed classes (or returns all for `:all`).
+
+```elixir
+defmodule ImagePipe.Transform.Detector.ImageVision.Objects do
+  @moduledoc """
+  `ImagePipe.Transform.Detector` for general objects, backed by the optional
+  `image_vision` dependency (`Image.Detection`, RT-DETR, COCO-80). The dependency
+  is not declared by ImagePipe — hosts opt in. When absent, `available?/1` is
+  false and callers fall back gracefully.
+
+  Class names use the URL-facing underscore spelling (`traffic_light`); the model
+  emits spaces (`"traffic light"`), which this adapter normalizes on both sides.
+  """
+  @behaviour ImagePipe.Transform.Detector
+
+  @compile {:no_warn_undefined, Image.Detection}
+
+  @repo "onnx-community/rtdetr_r50vd"
+  @filename "onnx/model.onnx"
+  @min_score 0.5
+
+  # COCO-80, underscore spelling. Hardcoded (not derived from Image.Detection)
+  # so routing/availability work when the dependency is absent. A tagged drift
+  # test asserts this matches the model's labels.
+  @coco_classes ~w(
+    person bicycle car motorcycle airplane bus train truck boat traffic_light
+    fire_hydrant stop_sign parking_meter bench bird cat dog horse sheep cow
+    elephant bear zebra giraffe backpack umbrella handbag tie suitcase frisbee
+    skis snowboard sports_ball kite baseball_bat baseball_glove skateboard
+    surfboard tennis_racket bottle wine_glass cup fork knife spoon bowl banana
+    apple sandwich orange broccoli carrot hot_dog pizza donut cake chair couch
+    potted_plant bed dining_table toilet tv laptop mouse remote keyboard
+    cell_phone microwave oven toaster sink refrigerator book clock vase scissors
+    teddy_bear hair_drier toothbrush
+  )
+
+  @impl true
+  def supported_classes(_opts), do: @coco_classes
+
+  @impl true
+  def available?(_opts), do: Code.ensure_loaded?(Image.Detection)
+
+  @impl true
+  def identity(_opts) do
+    if available?([]),
+      do: {__MODULE__, {@repo, @filename, @min_score}},
+      else: {__MODULE__, :unavailable}
+  end
+
+  @impl true
+  def detect(image, opts) do
+    classes = Keyword.get(opts, :classes, :all)
+
+    if available?(opts),
+      do: detect_objects(image, classes),
+      else: {:error, {:detector, :unavailable}}
+  end
+
+  @impl true
+  def warmup(opts) do
+    if available?(opts) do
+      {:ok, blank} = Image.new(64, 64, color: :black)
+      _ = detect_objects(blank, :all)
+      :ok
+    else
+      {:error, {:detector, :unavailable}}
+    end
+  end
+
+  defp detect_objects(image, classes) do
+    regions =
+      image
+      |> Image.Detection.detect(min_score: @min_score, repo: @repo, filename: @filename)
+      |> Enum.map(fn %{label: label, score: score, box: box} ->
+        %{label: String.replace(label, " ", "_"), score: score, box: box}
+      end)
+      |> filter_classes(classes)
+
+    {:ok, regions}
+  rescue
+    error -> {:error, {:detector, error}}
+  end
+
+  defp filter_classes(regions, :all), do: regions
+
+  defp filter_classes(regions, classes) when is_list(classes) do
+    wanted = MapSet.new(classes)
+    Enum.filter(regions, fn %{label: label} -> MapSet.member?(wanted, label) end)
+  end
+end
+```
+
+- [ ] **Step 4: Run the tagged tests to verify they pass**
+
+Run: `IMAGE_VISION=1 mise exec -- mix test test/image_pipe/transform/detector/image_vision_test.exs --only image_vision`
+Expected: PASS (drift, smoke, vocabulary).
+
+- [ ] **Step 5: Compile with warnings-as-errors**
+
+Run: `mise exec -- mix compile --warnings-as-errors`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/image_pipe/transform/detector/image_vision/objects.ex test/image_pipe/transform/detector/image_vision_test.exs
+git commit -m "feat(detector): add ImageVision.Objects RT-DETR/COCO-80 adapter"
+```
+
+---
+
+## Task 4: `Detector.Composite` — routing, merge, identity, availability
+
+The Composite is a plain `Detector` module with a fixed child list. Routing, merge, class-aware identity, and class-aware availability all derive from the children's `supported_classes/1`. Per-model telemetry spans are added in Task 9 — keep `detect/2` free of telemetry for now.
+
+**Files:**
+- Create: `lib/image_pipe/transform/detector/composite.ex`
+- Test: `test/image_pipe/transform/detector/composite_test.exs` (new) — driven by **fake child detectors**, not hand-built region lists.
+
+- [ ] **Step 1: Write the failing Composite tests with fake children**
+
+Create `test/image_pipe/transform/detector/composite_test.exs`:
+
+```elixir
+defmodule ImagePipe.Transform.Detector.CompositeTest do
+  use ExUnit.Case, async: true
+
+  alias ImagePipe.Transform.Detector.Composite
+
+  # Fake children: each owns a vocabulary and returns one canned region per
+  # routed class (label = class). Real @behaviour producers, so this is not an
+  # impossible-internal-misuse test.
+  defmodule FaceChild do
+    @behaviour ImagePipe.Transform.Detector
+    @impl true
+    def supported_classes(_), do: ["face"]
+    @impl true
+    def available?(opts), do: Keyword.get(opts, :face_available?, true)
+    @impl true
+    def identity(_), do: {__MODULE__, :face_v1}
+    @impl true
+    def detect(_image, opts), do: {:ok, regions_for(opts)}
+    defp regions_for(opts) do
+      requested(opts, ["face"])
+      |> Enum.map(&%{label: &1, score: 0.9, box: {0, 0, 10, 10}})
+    end
+    defp requested(opts, owned) do
+      case Keyword.get(opts, :classes, :all) do
+        :all -> owned
+        list -> Enum.filter(list, &(&1 in owned))
+      end
+    end
+  end
+
+  defmodule ObjectChild do
+    @behaviour ImagePipe.Transform.Detector
+    @owned ["car", "dog"]
+    @impl true
+    def supported_classes(_), do: @owned
+    @impl true
+    def available?(opts), do: Keyword.get(opts, :object_available?, true)
+    @impl true
+    def identity(_), do: {__MODULE__, :obj_v1}
+    @impl true
+    def detect(_image, opts), do: {:ok, regions_for(opts)}
+    defp regions_for(opts) do
+      case Keyword.get(opts, :classes, :all) do
+        :all -> @owned
+        list -> Enum.filter(list, &(&1 in @owned))
+      end
+      |> Enum.map(&%{label: &1, score: 0.8, box: {50, 50, 10, 10}})
+    end
+  end
+
+  defp composite, do: Composite.new([FaceChild, ObjectChild])
+
+  test "supported_classes is the union of children" do
+    assert Enum.sort(Composite.supported_classes(composite())) == ["car", "dog", "face"]
+  end
+
+  test ":all runs every child and merges all regions" do
+    {:ok, regions} = Composite.detect(composite(), :image, classes: :all)
+    assert Enum.map(regions, & &1.label) |> Enum.sort() == ["car", "dog", "face"]
+  end
+
+  test "a class list routes only to the owning children" do
+    {:ok, regions} = Composite.detect(composite(), :image, classes: ["face", "car"])
+    assert Enum.map(regions, & &1.label) |> Enum.sort() == ["car", "face"]
+  end
+
+  test "unknown classes are dropped (best-effort)" do
+    {:ok, regions} = Composite.detect(composite(), :image, classes: ["face", "unicorn"])
+    assert Enum.map(regions, & &1.label) == ["face"]
+  end
+
+  test "all-unknown yields no regions and is available? = true (degrade, not fail)" do
+    {:ok, regions} = Composite.detect(composite(), :image, classes: ["unicorn"])
+    assert regions == []
+    assert Composite.available?(composite(), classes: ["unicorn"]) == true
+  end
+
+  test "identity reflects only routed children, ordered by child order" do
+    assert Composite.identity(composite(), classes: ["face"]) ==
+             {Composite, [{FaceChild, :face_v1}]}
+
+    assert Composite.identity(composite(), classes: ["car"]) ==
+             {Composite, [{ObjectChild, :obj_v1}]}
+
+    # URL order invariance: face:dog vs dog:face produce the same identity list
+    assert Composite.identity(composite(), classes: ["face", "dog"]) ==
+             Composite.identity(composite(), classes: ["dog", "face"])
+
+    assert Composite.identity(composite(), classes: :all) ==
+             {Composite, [{FaceChild, :face_v1}, {ObjectChild, :obj_v1}]}
+  end
+
+  test "available? requires every routed child to be available" do
+    c = composite()
+    assert Composite.available?(c, classes: ["face"], object_available?: false) == true
+    assert Composite.available?(c, classes: ["car"], object_available?: false) == false
+    assert Composite.available?(c, classes: :all, object_available?: false) == false
+  end
+end
+```
+
+Note the test calls `Composite.detect/3`, `Composite.identity/2`, `Composite.available?/2`, `Composite.supported_classes/1` taking an explicit composite value built by `Composite.new/1`. The behaviour callbacks (`detect/2`, `identity/1`, `available?/1`, `supported_classes/1`) wrap these by reading the default child list — see Step 3.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `mise exec -- mix test test/image_pipe/transform/detector/composite_test.exs`
+Expected: FAIL — `Composite` is undefined.
+
+- [ ] **Step 3: Implement the Composite**
+
+Create `lib/image_pipe/transform/detector/composite.ex`. It implements the `Detector` behaviour using a built-in default child list, and also exposes arity-`+1` helpers that take an explicit child list (used by tests and internally). Routing filters the **fixed ordered child list** by `supported_classes`.
+
+```elixir
+defmodule ImagePipe.Transform.Detector.Composite do
+  @moduledoc """
+  A `ImagePipe.Transform.Detector` that fans a requested class set out across an
+  ordered list of child detectors and merges their regions.
+
+  Each requested class routes to the child(ren) whose `supported_classes/1` claim
+  it (`:all` routes to every child); classes no child claims are dropped
+  (best-effort). Identity and availability are class-aware: they reflect only the
+  children a given request routes to, so e.g. an object-only request is unaffected
+  by a face-model change. The bundled default composes the face (YuNet) and object
+  (RT-DETR) adapters.
+  """
+  @behaviour ImagePipe.Transform.Detector
+
+  alias ImagePipe.Transform.Detector.ImageVision
+
+  @default_children [ImageVision.Face, ImageVision.Objects]
+
+  @type t :: %__MODULE__{children: [module()]}
+  defstruct children: @default_children
+
+  @spec new([module()]) :: t()
+  def new(children) when is_list(children), do: %__MODULE__{children: children}
+
+  @spec default() :: t()
+  def default, do: %__MODULE__{children: @default_children}
+
+  # --- Detector behaviour (uses the default child list) ---
+
+  @impl true
+  def supported_classes(_opts), do: supported_classes(default())
+
+  @impl true
+  def detect(image, opts), do: detect(default(), image, opts)
+
+  @impl true
+  def available?(opts), do: available?(default(), opts)
+
+  @impl true
+  def identity(opts), do: identity(default(), opts)
+
+  @impl true
+  def warmup(opts) do
+    Enum.reduce_while(default().children, :ok, fn child, _ ->
+      case ImagePipe.Transform.Detector.warmup(child, opts) do
+        :ok -> {:cont, :ok}
+        {:error, _} = err -> {:halt, err}
+      end
+    end)
+  end
+
+  # --- Explicit-composite helpers ---
+
+  @spec supported_classes(t()) :: [String.t()]
+  def supported_classes(%__MODULE__{children: children}) do
+    children |> Enum.flat_map(& &1.supported_classes([])) |> Enum.uniq()
+  end
+
+  @spec detect(t(), term(), keyword()) :: {:ok, [map()]}
+  def detect(%__MODULE__{} = composite, image, opts) do
+    classes = Keyword.get(opts, :classes, :all)
+
+    regions =
+      composite
+      |> routed(classes)
+      |> Enum.flat_map(fn {child, child_classes} ->
+        case child.detect(image, Keyword.put(opts, :classes, child_classes)) do
+          {:ok, regions} -> regions
+          {:error, _} -> []
+        end
+      end)
+
+    {:ok, regions}
+  end
+
+  @spec available?(t(), keyword()) :: boolean()
+  def available?(%__MODULE__{} = composite, opts) do
+    classes = Keyword.get(opts, :classes, :all)
+
+    composite
+    |> routed(classes)
+    |> Enum.all?(fn {child, _} -> child.available?(opts) end)
+  end
+
+  @spec identity(t(), keyword()) :: {module(), [term()]}
+  def identity(%__MODULE__{} = composite, opts) do
+    classes = Keyword.get(opts, :classes, :all)
+    ids = composite |> routed(classes) |> Enum.map(fn {child, _} -> child.identity(opts) end)
+    {__MODULE__, ids}
+  end
+
+  # Returns [{child_module, child_classes}] for the children that the requested
+  # class set routes to, preserving the fixed child order. `:all` -> every child
+  # gets `:all`. A class list -> each child gets the intersection with its
+  # supported set, and children with an empty intersection are dropped.
+  defp routed(%__MODULE__{children: children}, :all) do
+    Enum.map(children, &{&1, :all})
+  end
+
+  defp routed(%__MODULE__{children: children}, classes) when is_list(classes) do
+    requested = MapSet.new(classes)
+
+    children
+    |> Enum.map(fn child ->
+      child_classes = Enum.filter(child.supported_classes([]), &MapSet.member?(requested, &1))
+      {child, child_classes}
+    end)
+    |> Enum.reject(fn {_child, child_classes} -> child_classes == [] end)
+  end
+end
+```
+
+- [ ] **Step 4: Run the Composite tests to verify they pass**
+
+Run: `mise exec -- mix test test/image_pipe/transform/detector/composite_test.exs`
+Expected: PASS (all 7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/transform/detector/composite.ex test/image_pipe/transform/detector/composite_test.exs
+git commit -m "feat(detector): add Composite router with class-aware identity/availability"
+```
+
+---
+
+## Task 5: Make `:default` resolve to the Composite
+
+**Files:**
+- Modify: `lib/image_pipe/transform.ex:76`
+- Modify: `lib/image_pipe/transform/detector/warmup.ex` (default `classes: :all`)
+
+- [ ] **Step 1: Repoint the default detector**
+
+In `lib/image_pipe/transform.ex:76`:
+
+```elixir
+  @default_detector ImagePipe.Transform.Detector.Composite
+```
+
+- [ ] **Step 2: Warm both models by default**
+
+In `lib/image_pipe/transform/detector/warmup.ex`, change the default classes in `init/1` from `["face"]` to `:all` so the bundled Composite warms both children:
+
+```elixir
+      classes: Keyword.get(opts, :classes, :all),
+```
+
+Update the moduledoc example to `{ImagePipe.Transform.Detector.Warmup, detector: :default}` (no explicit `classes:` needed; `:all` warms everything).
+
+- [ ] **Step 3: Compile + run the full detector + transform suites**
+
+Run: `mise exec -- mix compile --warnings-as-errors && mise exec -- mix test test/image_pipe/transform/`
+Expected: PASS. Existing `{:smart, :face_assist}` and `{:detect, ["face"]}` behavior is unchanged because the Composite routes `["face"]` to the Face child only.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/image_pipe/transform.ex lib/image_pipe/transform/detector/warmup.ex
+git commit -m "feat(detector): default detector is the Composite (face + objects)"
+```
+
+---
+
+## Task 6: Plan `{:detect, :all}` sentinel end-to-end (types, detect_classes, key_data)
+
+**Files:**
+- Modify: `lib/image_pipe/plan/operation/crop_guided.ex` (guide type)
+- Modify: `lib/image_pipe/transform/operation/crop.ex` (gravity type)
+- Modify: `lib/image_pipe/plan.ex:88-99` (`detect_classes/1` `@spec`)
+- Modify: `lib/image_pipe/plan/key_data.ex:198` (`guide_data`)
+- Test: the existing key-data/plan-data test file (find with grep below)
+
+- [ ] **Step 1: Write the failing key-data test for `:all`**
+
+Find the key-data test file:
+
+Run: `mise exec -- grep -rln "type: :detect" test`
+Expected: a test asserting `guide_data`/key material for `{:detect, ["face"]}` (e.g. `test/image_pipe/cache/key_test.exs` or a plan-data test). Add, next to it:
+
+```elixir
+  test "detect-all guide encodes as classes: :all" do
+    guide = {:detect, :all}
+    # Build the smallest real plan/operation a producer makes with this guide and
+    # assert the cache-key material distinguishes :all from a class list. Use the
+    # same helper the neighboring {:detect, ["face"]} test uses to extract guide
+    # key data; assert it contains `classes: :all`.
+  end
+```
+
+Replace the comment with the same extraction the neighboring `{:detect, …}` test uses (mirror its setup exactly — do not hand-build internal structs the test file does not already build).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `mise exec -- mix test <that file> -k "detect-all"` (or run the file).
+Expected: FAIL — `guide_data({:detect, :all})` has no clause (`FunctionClauseError`) or the assertion fails.
+
+- [ ] **Step 3: Add the type and the key-data clause**
+
+In `lib/image_pipe/plan/operation/crop_guided.ex`, extend the `guide` type (line 33):
+
+```elixir
+          | {:detect, :all}
+          | {:detect, nonempty_list(String.t())}
+```
+
+In `lib/image_pipe/transform/operation/crop.ex`, extend the `gravity` type (line 132):
+
+```elixir
+            | {:detect, :all}
+            | {:detect, [String.t()]}
+```
+
+In `lib/image_pipe/plan/key_data.ex`, add a clause **before** the existing `is_list` clause (line 198):
+
+```elixir
+  defp guide_data({:detect, :all}), do: [type: :detect, classes: :all]
+
+  defp guide_data({:detect, classes}) when is_list(classes),
+    do: [type: :detect, classes: Enum.sort(classes)]
+```
+
+In `lib/image_pipe/plan.ex`, widen the `detect_classes/1` `@spec` (line 89). The body already returns whatever `classes` is bound to in `{:detect, classes}`, so `:all` flows through unchanged:
+
+```elixir
+  @spec detect_classes(t()) :: :all | nonempty_list(String.t()) | nil
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mise exec -- mix test <that file> -k "detect-all"`
+Expected: PASS.
+
+- [ ] **Step 5: Compile with warnings-as-errors**
+
+Run: `mise exec -- mix compile --warnings-as-errors`
+Expected: PASS (no missing-clause or type warnings).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/image_pipe/plan lib/image_pipe/transform/operation/crop.ex
+git commit -m "feat(plan): add {:detect, :all} sentinel through types, detect_classes, key_data"
+```
+
+---
+
+## Task 7: imgproxy parser — multi-class object gravity and `:all`
+
+**Files:**
+- Modify: `lib/image_pipe/parser/imgproxy/plan_builder.ex` — **both** `resize_guide/2` (lines 645-650, the fill path) **and** `tagged_gravity/2` (lines 662-667, the crop path)
+- Test: `test/image_pipe/parser/imgproxy/plan_builder_test.exs` (flip the existing rejection cases to acceptance)
+
+The grammar (`option_grammar.ex`) already parses `g:obj…` / `c:W:H:obj…` into `{:obj, classes}` with `classes == []` for bare `obj`, so only the plan-builder mapping changes.
+
+**Critical:** `{:obj, …}` is mapped in **two** functions — `resize_guide/2` (used for `rs:fill` + `g:obj`, line 558) and `tagged_gravity/2` (used for `c:W:H:obj`, line 252). Both currently special-case `["face"]` and reject other classes. **Both must change identically** — update them via one shared helper so they can't diverge. (`canvas_placement/2` has no `{:obj,…}` clause and object gravity is not valid for extend/canvas, so leave it untouched.)
+
+- [ ] **Step 1: Update the failing tests (flip rejection → acceptance)**
+
+In `test/image_pipe/parser/imgproxy/plan_builder_test.exs`, find the existing tests asserting bare/all/multi-class object gravity is rejected (they assert `{:error, {:unsupported_gravity, _}}`). Replace them with acceptance assertions:
+
+```elixir
+  test "g:obj with explicit classes maps to a detect guide with those classes" do
+    assert {:ok, plan} = build("rs:fill:100:100/g:obj:car:dog/plain/http://e/x.jpg")
+    assert detect_guide(plan) == {:detect, ["car", "dog"]}
+  end
+
+  test "bare g:obj maps to detect :all" do
+    assert {:ok, plan} = build("rs:fill:100:100/g:obj/plain/http://e/x.jpg")
+    assert detect_guide(plan) == {:detect, :all}
+  end
+
+  test "g:obj:all maps to detect :all" do
+    assert {:ok, plan} = build("rs:fill:100:100/g:obj:all/plain/http://e/x.jpg")
+    assert detect_guide(plan) == {:detect, :all}
+  end
+
+  test "all appearing among classes collapses to detect :all" do
+    assert {:ok, plan} = build("rs:fill:100:100/g:obj:car:all/plain/http://e/x.jpg")
+    assert detect_guide(plan) == {:detect, :all}
+  end
+
+  test "g:obj:face still maps to a face detect guide" do
+    assert {:ok, plan} = build("rs:fill:100:100/g:obj:face/plain/http://e/x.jpg")
+    assert detect_guide(plan) == {:detect, ["face"]}
+  end
+
+  test "crop form c:W:H:obj:classes maps to a detect guide (tagged_gravity path)" do
+    assert {:ok, plan} = build("c:200:200:obj:car:dog/plain/http://e/x.jpg")
+    assert detect_guide(plan) == {:detect, ["car", "dog"]}
+  end
+
+  test "crop form bare c:W:H:obj maps to detect :all" do
+    assert {:ok, plan} = build("c:200:200:obj/plain/http://e/x.jpg")
+    assert detect_guide(plan) == {:detect, :all}
+  end
+```
+
+These two crop-form cases exercise `tagged_gravity/2`; the `rs:fill` cases above exercise `resize_guide/2`. Both mappers must pass.
+
+Use the file's existing request-building and guide-extraction helpers (mirror a neighboring test). If a `detect_guide/1` helper does not exist, extract the guide the same way the neighboring `{:detect, ["face"]}` test does — do not hand-build plan structs.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `mise exec -- mix test test/image_pipe/parser/imgproxy/plan_builder_test.exs`
+Expected: FAIL — current code returns `{:error, {:unsupported_gravity, …}}` for non-`["face"]` object gravity.
+
+- [ ] **Step 3: Add a shared object-guide helper and call it from both mappers**
+
+In `lib/image_pipe/parser/imgproxy/plan_builder.ex`, add a private helper (place it near the other guide helpers, e.g. just above `crop_anchor_guide/2`):
+
+```elixir
+  # Maps imgproxy object gravity classes to a product-neutral detect guide.
+  # Bare `obj` (empty classes) or `all` anywhere collapses to the :all sentinel;
+  # otherwise the explicit class list is carried through. Shared by the fill
+  # (resize_guide) and crop (tagged_gravity) paths so they cannot diverge.
+  defp object_detect_guide(classes) do
+    if classes == [] or "all" in classes do
+      {:detect, :all}
+    else
+      {:detect, classes}
+    end
+  end
+```
+
+Then replace the `{:obj, …}` clauses in **`resize_guide/2`** (lines 647-650 — the `{:obj, ["face"]}` clause and the `{:obj, classes}` error clause) with a single clause:
+
+```elixir
+  defp resize_guide({:obj, classes}, _face_assist), do: {:ok, object_detect_guide(classes)}
+```
+
+And replace the `{:obj, …}` clauses in **`tagged_gravity/2`** (lines 664-667) with a single clause:
+
+```elixir
+  defp tagged_gravity({:obj, classes}, _face_assist), do: {:ok, object_detect_guide(classes)}
+```
+
+(`g:obj:face` now flows through `object_detect_guide(["face"])` → `{:detect, ["face"]}` — the dedicated `["face"]` clauses are removed because the general helper covers them.)
+
+- [ ] **Step 4: Run the parser tests to verify they pass**
+
+Run: `mise exec -- mix test test/image_pipe/parser/imgproxy/plan_builder_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Add an order-insensitivity property test**
+
+In the same file (or the parser property test file if one exists), add:
+
+```elixir
+  property "object class order does not change the detect guide's key material" do
+    check all classes <- uniq_list_of(member_of(["car", "dog", "cat", "person"]), min_length: 1, max_length: 4) do
+      shuffled = Enum.shuffle(classes)
+      {:ok, a} = build("rs:fill:100:100/g:obj:" <> Enum.join(classes, ":") <> "/plain/http://e/x.jpg")
+      {:ok, b} = build("rs:fill:100:100/g:obj:" <> Enum.join(shuffled, ":") <> "/plain/http://e/x.jpg")
+      assert ImagePipe.Cache.Key.build(conn(), a, "sid") == ImagePipe.Cache.Key.build(conn(), b, "sid")
+    end
+  end
+```
+
+Use the project's actual `StreamData` import and the real `Cache.Key.build/3-4` signature and a test `conn`/source-identity helper (mirror `key_test.exs`). If property-test infra for parser+cache-key isn't readily wired, place this in `key_test.exs` instead, where the conn/source-identity helpers already exist.
+
+- [ ] **Step 6: Run + commit**
+
+Run: `mise exec -- mix test test/image_pipe/parser/imgproxy/plan_builder_test.exs`
+Expected: PASS.
+
+```bash
+git add lib/image_pipe/parser/imgproxy/plan_builder.ex test/image_pipe/parser/imgproxy/plan_builder_test.exs
+git commit -m "feat(imgproxy): parse multi-class object gravity and all/bare obj -> detect"
+```
+
+---
+
+## Task 8: Class-aware cache identity and strict gate
+
+**Files:**
+- Modify: `lib/image_pipe/request/runner.ex:238-247`
+- Modify: `lib/image_pipe/plug.ex:143-151`
+- Test: `test/image_pipe/cache/key_test.exs` (class-aware identity invariants)
+
+- [ ] **Step 1: Write the failing class-aware identity tests**
+
+`detector:` must resolve via `Transform.resolve_detector/1`, which accepts a **module atom** (not a `%Composite{}` struct). So define one named test detector module that delegates to the explicit `Composite` helpers (`Composite.new/1` + `detect/3`/`identity/2`/`available?/2`/`supported_classes/1`) with fake children, and make the fake children read their identity *version* from `opts` — that way a single module covers the version-bump independence checks without defining many modules.
+
+In `test/image_pipe/cache/key_test.exs` (mirror the file's existing detector-identity test setup for `key_for`/conn/source-identity):
+
+```elixir
+  defmodule FaceVerFake do
+    @behaviour ImagePipe.Transform.Detector
+    @impl true
+    def supported_classes(_), do: ["face"]
+    @impl true
+    def available?(_), do: true
+    @impl true
+    def identity(opts), do: {__MODULE__, Keyword.get(opts, :face_ver, :v1)}
+    @impl true
+    def detect(_, _), do: {:ok, []}
+  end
+
+  defmodule ObjectVerFake do
+    @behaviour ImagePipe.Transform.Detector
+    @impl true
+    def supported_classes(_), do: ["car", "dog"]
+    @impl true
+    def available?(_), do: true
+    @impl true
+    def identity(opts), do: {__MODULE__, Keyword.get(opts, :object_ver, :v1)}
+    @impl true
+    def detect(_, _), do: {:ok, []}
+  end
+
+  defmodule TestComposite do
+    @behaviour ImagePipe.Transform.Detector
+    alias ImagePipe.Transform.Detector.Composite
+    @children [FaceVerFake, ObjectVerFake]
+    defp c, do: Composite.new(@children)
+    @impl true
+    def supported_classes(_o), do: Composite.supported_classes(c())
+    @impl true
+    def detect(i, o), do: Composite.detect(c(), i, o)
+    @impl true
+    def available?(o), do: Composite.available?(c(), o)
+    @impl true
+    def identity(o), do: Composite.identity(c(), o)
+  end
+
+  test "an object-only request's key is independent of the face model identity" do
+    a = key_for("rs:fill:100:100/g:obj:car/...", detector: TestComposite, face_ver: :v1)
+    b = key_for("rs:fill:100:100/g:obj:car/...", detector: TestComposite, face_ver: :v2)
+    assert a == b
+  end
+
+  test "a face-only request's key is independent of the object model identity" do
+    a = key_for("rs:fill:100:100/g:obj:face/...", detector: TestComposite, object_ver: :v1)
+    b = key_for("rs:fill:100:100/g:obj:face/...", detector: TestComposite, object_ver: :v2)
+    assert a == b
+  end
+
+  test "a mixed request's key changes when either model identity changes" do
+    base = key_for("rs:fill:100:100/g:obj:face:car/...", detector: TestComposite, face_ver: :v1, object_ver: :v1)
+    diff_face = key_for("rs:fill:100:100/g:obj:face:car/...", detector: TestComposite, face_ver: :v2, object_ver: :v1)
+    diff_obj = key_for("rs:fill:100:100/g:obj:face:car/...", detector: TestComposite, face_ver: :v1, object_ver: :v2)
+    assert base != diff_face
+    assert base != diff_obj
+  end
+```
+
+`key_for/2` must pass the extra opts (`face_ver`/`object_ver`/`detector`) through to the request opts that reach `Cache.Key.build`/`put_detector_identity` (so they land in the `opts` handed to `identity/1`). Mirror the file's existing detector test for how `detector:` is threaded; pass `face_ver`/`object_ver` the same way. The independence works because `put_detector_identity` threads `:classes` into those opts, and `TestComposite.identity/1` routes to only the relevant child, whose identity reads its `*_ver` from the same opts.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `mise exec -- mix test test/image_pipe/cache/key_test.exs`
+Expected: FAIL — `detector_identity` currently ignores classes, so all three requests fold in the same (class-agnostic) identity, breaking the independence invariants.
+
+- [ ] **Step 3: Thread classes into the cache-key identity**
+
+In `lib/image_pipe/request/runner.ex`, update `put_detector_identity/2` (lines 238-247) to pass the plan's detect classes (defaulting to `["face"]` for the face-assist-only case, which routes to the Face child):
+
+```elixir
+  defp put_detector_identity(opts, plan) do
+    if Plan.detect_classes(plan) != nil or Plan.face_assist?(plan) do
+      classes = Plan.detect_classes(plan) || ["face"]
+      opts_with_classes = Keyword.put(opts, :classes, classes)
+
+      case Transform.detector_identity(Keyword.get(opts, :detector, :default), opts_with_classes) do
+        nil -> opts
+        identity -> Keyword.put(opts, :detector_identity, identity)
+      end
+    else
+      opts
+    end
+  end
+```
+
+`Transform.detector_identity/2` passes `opts` straight to `module.identity/1`, so the Composite reads `opts[:classes]` — no change needed in `transform.ex`.
+
+- [ ] **Step 4: Thread classes into the strict gate**
+
+In `lib/image_pipe/plug.ex`, update `validate_detector_capability/2` (lines 143-151):
+
+```elixir
+  defp validate_detector_capability(%Plan{} = plan, opts) do
+    classes = Plan.detect_classes(plan)
+
+    if Keyword.get(opts, :detector_required, false) and classes != nil do
+      opts_with_classes = Keyword.put(opts, :classes, classes)
+
+      if Transform.detector_available?(Keyword.get(opts, :detector, :default), opts_with_classes),
+        do: :ok,
+        else: {:error, {:detector, :unavailable}}
+    else
+      :ok
+    end
+  end
+```
+
+`Transform.detector_available?/2` passes `opts` to `module.available?/1`, so the Composite evaluates availability for the routed class set.
+
+- [ ] **Step 5: Run the cache-key tests to verify they pass**
+
+Run: `mise exec -- mix test test/image_pipe/cache/key_test.exs`
+Expected: PASS.
+
+- [ ] **Step 6: Compile + commit**
+
+Run: `mise exec -- mix compile --warnings-as-errors`
+Expected: PASS.
+
+```bash
+git add lib/image_pipe/request/runner.ex lib/image_pipe/plug.ex test/image_pipe/cache/key_test.exs
+git commit -m "feat: class-aware detector identity and strict gate"
+```
+
+---
+
+## Task 9: Per-model telemetry spans from the Composite
+
+The aggregate `[:transform, :detect]` span in `crop.ex` is unchanged except for threading `:telemetry_opts` into the detector opts. The Composite emits a nested `[:transform, :detect, :model]` span per child that runs.
+
+**Files:**
+- Modify: `lib/image_pipe/transform/operation/crop.ex` (`run_detect` threads `:telemetry_opts`)
+- Modify: `lib/image_pipe/transform/detector/composite.ex` (emit per-model spans)
+- Test: `test/image_pipe/transform/detector/composite_test.exs` (telemetry assertions)
+
+- [ ] **Step 1: Write the failing per-model telemetry test**
+
+Add to `composite_test.exs` (it already has fake children with `identity/1`):
+
+```elixir
+  test "emits a per-model span per routed child with detector, model identity, and classes" do
+    ref =
+      :telemetry_test.attach_event_handlers(self(), [[:transform, :detect, :model, :stop]])
+
+    on_exit(fn -> :telemetry.detach(ref) end)
+
+    {:ok, _} =
+      Composite.detect(composite(), :image,
+        classes: ["face", "car"],
+        telemetry_opts: [prefix: [:image_pipe], metadata: %{}]
+      )
+
+    assert_received {[:transform, :detect, :model, :stop], ^ref, _measurements,
+                     %{detector: FaceChild, model: {FaceChild, :face_v1}, classes: ["face"], regions: 1}}
+
+    assert_received {[:transform, :detect, :model, :stop], ^ref, _measurements,
+                     %{detector: ObjectChild, model: {ObjectChild, :obj_v1}, classes: ["car"], regions: 1}}
+  end
+```
+
+Match the real `telemetry_opts` shape the codebase uses — inspect how `crop.ex` builds `state.telemetry_opts` and how `ImagePipe.Telemetry.span/4` reads it, and mirror that exact structure here.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `mise exec -- mix test test/image_pipe/transform/detector/composite_test.exs -k "per-model span"`
+Expected: FAIL — no such event emitted.
+
+- [ ] **Step 3: Emit per-model spans in the Composite**
+
+In `lib/image_pipe/transform/detector/composite.ex`, alias the telemetry helper (`alias ImagePipe.Telemetry`) and wrap each child invocation in a span when `telemetry_opts` is present. Replace the `detect/3` fan-out:
+
+```elixir
+  def detect(%__MODULE__{} = composite, image, opts) do
+    classes = Keyword.get(opts, :classes, :all)
+    telemetry_opts = Keyword.get(opts, :telemetry_opts)
+
+    regions =
+      composite
+      |> routed(classes)
+      |> Enum.flat_map(fn {child, child_classes} ->
+        run_child(child, child_classes, image, opts, telemetry_opts)
+      end)
+
+    {:ok, regions}
+  end
+
+  defp run_child(child, child_classes, image, opts, nil) do
+    detect_child(child, child_classes, image, opts)
+  end
+
+  defp run_child(child, child_classes, image, opts, telemetry_opts) do
+    start_meta = %{detector: child, model: child.identity(opts), classes: child_classes}
+
+    Telemetry.span(telemetry_opts, [:transform, :detect, :model], start_meta, fn ->
+      regions = detect_child(child, child_classes, image, opts)
+      {regions, %{regions: length(regions)}}
+    end)
+  end
+
+  defp detect_child(child, child_classes, image, opts) do
+    case child.detect(image, Keyword.put(opts, :classes, child_classes)) do
+      {:ok, regions} -> regions
+      {:error, _} -> []
+    end
+  end
+```
+
+Confirm `ImagePipe.Telemetry.span/4`'s arity/return contract against `crop.ex`'s usage and adjust the call to match exactly (the fn must return `{value, stop_metadata}`).
+
+- [ ] **Step 4: Thread `:telemetry_opts` from `run_detect`**
+
+In `lib/image_pipe/transform/operation/crop.ex`, update `run_detect/5` (line 346) to pass `telemetry_opts` into the detector opts so the Composite can emit nested spans:
+
+```elixir
+  defp run_detect(module, opts, image, classes, telemetry_opts) do
+    Telemetry.span(telemetry_opts, [:transform, :detect], %{classes: classes}, fn ->
+      detect_opts = opts |> Keyword.put(:classes, classes) |> Keyword.put(:telemetry_opts, telemetry_opts)
+      result = validate_detect_result(module.detect(image, detect_opts))
+      {result, %{regions: region_count(result), result: detect_reason(result)}}
+    end)
+  end
+```
+
+- [ ] **Step 5: Run the telemetry test to verify it passes**
+
+Run: `mise exec -- mix test test/image_pipe/transform/detector/composite_test.exs`
+Expected: PASS.
+
+- [ ] **Step 6: Compile + commit**
+
+Run: `mise exec -- mix compile --warnings-as-errors`
+Expected: PASS.
+
+```bash
+git add lib/image_pipe/transform/detector/composite.ex lib/image_pipe/transform/operation/crop.ex test/image_pipe/transform/detector/composite_test.exs
+git commit -m "feat(telemetry): per-model [:transform, :detect, :model] spans from Composite"
+```
+
+---
+
+## Task 10: Wire-level pixel + gate-triad tests (FakeDetector-injected)
+
+These assert the user-visible contract with a deterministic injected detector — no real model. They are the most important behavioral tests in the slice.
+
+**Files:**
+- Test: `test/image_pipe/imgproxy_wire_conformance_test.exs`
+
+- [ ] **Step 1: Add a corner-box FakeDetector to the wire test support**
+
+In `test/image_pipe/imgproxy_wire_conformance_test.exs` (or its support module), define a fake that places a single region in a known corner so the resulting crop is unambiguous:
+
+```elixir
+  defmodule CornerObjectDetector do
+    @behaviour ImagePipe.Transform.Detector
+    @impl true
+    def supported_classes(_), do: ["car", "dog", "face", "person"]
+    @impl true
+    def available?(opts), do: Keyword.get(opts, :available?, true)
+    @impl true
+    def identity(_), do: {__MODULE__, :v1}
+    @impl true
+    def detect(_image, opts) do
+      # A small box near the top-left so a fill-crop biases up-left, distinct
+      # from center and from attention saliency.
+      classes = Keyword.get(opts, :classes, :all)
+      label = if classes == :all, do: "car", else: List.first(List.wrap(classes))
+      {:ok, [%{label: label, score: 0.95, box: {2, 2, 20, 20}}]}
+    end
+  end
+```
+
+- [ ] **Step 2: Write the failing pixel-divergence test for a non-face class**
+
+```elixir
+  test "g:obj:car crop is biased toward the detected object and differs from center and attention" do
+    opts = wire_opts(detector: CornerObjectDetector)
+
+    obj = request("rs:fill:50:50/g:obj:car/plain/" <> source_url(), opts)
+    centered = request("rs:fill:50:50/g:ce/plain/" <> source_url(), opts)
+    attention = request("rs:fill:50:50/g:sm/plain/" <> source_url(), opts)
+
+    assert obj.status == 200
+    assert decoded_dimensions(obj) == {50, 50}
+    refute obj.resp_body == centered.resp_body
+    refute obj.resp_body == attention.resp_body
+  end
+
+  test "no-geometry g:obj:car still detects without a resize/crop" do
+    opts = wire_opts(detector: CornerObjectDetector)
+    resp = request("g:obj:car/plain/" <> source_url(), opts)
+    assert resp.status == 200
+  end
+```
+
+Use the file's real request/response helpers (`request/2`, `wire_opts/1`, `source_url/0`, `decoded_dimensions/1`) — mirror the existing `g:sm` pixel test. If those helper names differ, match the file's actual conventions. The `detector:` option must be plumbed into the plug opts the test builds (the existing 422 `g:obj:face` test at the strict-gate already injects an unavailable detector — copy how it passes `detector:`).
+
+- [ ] **Step 3: Run to verify failure, then implement**
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs -k "g:obj:car"`
+Expected: initially FAIL only if something is wrong — by this task the production code already supports `obj:car`, so these tests should **pass once written** (they validate Tasks 4–8 end-to-end). If they fail, debug the wiring (most likely the `detector:` injection or the crop divergence). Treat a genuine failure here as a real bug to fix in the production code, not the test.
+
+- [ ] **Step 4: Write the gate-triad test**
+
+```elixir
+  test "detector_required gate: supported+available 200, supported+unavailable 422 pre-fetch, unknown degrades" do
+    # A composite-style detector where the object child is unavailable but face is available.
+    opts = wire_opts(detector: PartialDetector, detector_required: true)
+
+    assert request("rs:fill:50:50/g:obj:face/plain/" <> source_url(), opts).status == 200
+    assert request("rs:fill:50:50/g:obj:car/plain/" <> source_url(), opts).status == 422
+    assert request("rs:fill:50:50/g:obj:unicorn/plain/" <> source_url(), opts).status == 200
+    # And the 422 happened before any source fetch/cache access:
+    assert_no_source_fetch(fn ->
+      request("rs:fill:50:50/g:obj:car/plain/" <> source_url(), opts)
+    end)
+  end
+```
+
+`detector:` resolves a **module atom**, so define `PartialDetector` as a named module that delegates to `Composite.new([FaceFake, UnavailableObjectFake])` (same delegation shape as `TestComposite` in Task 8). `FaceFake` is available and owns `["face"]` (its `detect/2` returns a region so `g:obj:face` succeeds → 200); `UnavailableObjectFake` owns `["car"]` with `available?/1 -> false`. Then: `g:obj:face` routes to the available face child → 200; `g:obj:car` routes to the unavailable object child → `available?` false → 422 pre-fetch; `g:obj:unicorn` routes to no child → `available?` vacuously true → degrades to 200. Use the file's existing "no source fetch" assertion helper (the strict-gate `g:obj:face` 422 test already demonstrates asserting the source was not hit).
+
+- [ ] **Step 5: Run the wire tests**
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add test/image_pipe/imgproxy_wire_conformance_test.exs
+git commit -m "test(wire): obj:car pixel divergence, no-geometry, and detector_required gate triad"
+```
+
+---
+
+## Task 11: Architecture boundary — parser/plan must not name detectors
+
+**Files:**
+- Modify: `test/image_pipe/architecture_boundary_test.exs`
+
+- [ ] **Step 1: Extend the detector-reference scan to parser + plan**
+
+Find the `detector_forbidden_files/0` helper (used by the test at line 329) and add the parser and plan source files to its list, so the existing `concrete_detector_references/1` AST scan also forbids parser/planner code from naming `ImagePipe.Transform.Detector.*` modules. Do NOT add a COCO-label denylist — only the detector-module scan (a label denylist would itself leak vocabulary into the test).
+
+Run: `mise exec -- grep -n "detector_forbidden_files" test/image_pipe/architecture_boundary_test.exs`
+Then extend that file-glob list to include `lib/image_pipe/parser/**/*.ex` and `lib/image_pipe/plan/**/*.ex` (match the helper's existing glob style).
+
+- [ ] **Step 2: Run the architecture test**
+
+Run: `mise exec -- mix test test/image_pipe/architecture_boundary_test.exs`
+Expected: PASS — the parser maps to product-neutral `{:detect, …}` guides and never names a detector module, so no violations.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/image_pipe/architecture_boundary_test.exs
+git commit -m "test(arch): forbid parser/plan code from naming concrete detectors"
+```
+
+---
+
+## Task 12: Demo controls + URL state
+
+**Files:**
+- Modify: `demo/` Svelte app (controls + URL state for object gravity)
+
+- [ ] **Step 1: Locate the gravity controls in the demo**
+
+Run: `mise exec -- grep -rln "g:obj\|smart_crop\|gravity" demo/src`
+Expected: the control component(s) and URL-state module that already handle `g:sm` / `g:obj:face`.
+
+- [ ] **Step 2: Add object-class gravity controls**
+
+Add a control that lets the user pick object gravity: a mode (`none` / `sm` / `obj`), and when `obj`, a multi-select of the COCO-80 classes (underscore spelling) plus an explicit `all` option and a bare-`obj` (empty) option. Wire the selection into the URL builder so it emits `g:obj`, `g:obj:all`, or `g:obj:%c1:…:%cN`. Keep `detector: :default` wiring.
+
+Follow the existing control/URL-state pattern exactly (mirror how `g:obj:face` is built today). The COCO-80 underscore list is the same one hardcoded in `ImageVision.Objects` — keep them consistent (a short comment in the demo pointing at the adapter is enough; do not import server code into the demo).
+
+- [ ] **Step 3: Run the demo verify suite**
+
+Run: `mise run precommit:demo`
+Expected: PASS (Elixir gate + `mix demo.verify`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add demo
+git commit -m "feat(demo): object-class gravity controls and URL state"
+```
+
+---
+
+## Task 13: Documentation
+
+**Files:**
+- Modify: `docs/content-aware-gravity.md`, `docs/imgproxy_support_matrix.md`, `docs/telemetry.md`
+
+- [ ] **Step 1: `content-aware-gravity.md`**
+
+Add a "General object gravity" section: `g:obj:%classN`, `g:obj`/`g:obj:all` include faces (the union of detectors), best-effort drop of unknown classes (degrades, never errors), class-aware cache identity, the underscore class spelling, and that the equal-weight default biases toward larger objects (face-centric crops use `g:obj:face` or, later, `objw`). Note RT-DETR cold-start/model size (~175 MB) and `mix image_vision.download_models --detect`. Update the existing "imgproxy compatibility & divergences" paragraph (it currently says general object classes/`objw` are out of scope) to say multi-class + `all` are now supported and only `objw`/`objects_position` remain out (Slice 2 / out of scope).
+
+- [ ] **Step 2: `imgproxy_support_matrix.md`**
+
+Update the object-gravity row: multi-class and `all` supported; `objw`/`objects_position` still out. Keep the YuNet-vs-imgproxy-YOLO divergence note and add the RT-DETR/COCO-80 object model.
+
+- [ ] **Step 3: `telemetry.md`**
+
+Document the per-model `[:transform, :detect, :model]` span (`detector` module name + `model` = the child's `identity/1`; the union of per-model `classes` is the effective set, so a dropped class is a requested class missing from every per-model span) and add the one-line "keep custom `identity/1` free of secrets" note for custom-detector authors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/content-aware-gravity.md docs/imgproxy_support_matrix.md docs/telemetry.md
+git commit -m "docs: general object gravity, support matrix, per-model telemetry"
+```
+
+---
+
+## Task 14: Full gate + final verification
+
+- [ ] **Step 1: Run the Elixir gate**
+
+Run: `mise run precommit`
+Expected: PASS — `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix test` all green.
+
+- [ ] **Step 2: Run the demo gate**
+
+Run: `mise run precommit:demo`
+Expected: PASS.
+
+- [ ] **Step 3: Run the ML-tagged lane once to verify the live adapters**
+
+Run: `IMAGE_VISION=1 mise exec -- mix test --only image_vision`
+Expected: PASS (Objects drift/smoke/vocabulary; any existing face-model tagged tests). If the model download is slow on a cold machine, this is the expected one-time cost.
+
+- [ ] **Step 4: Final review against the spec**
+
+Re-read `docs/superpowers/specs/2026-05-31-object-gravity-slice1-design.md` and confirm each section maps to a landed task. Note any gap for follow-up.
+
+- [ ] **Step 5: No commit needed** if everything was committed per-task. Otherwise commit any docs/cleanup.
+
+---
+
+## Spec coverage map
+
+- Detector `supported_classes/1` → Task 1
+- Split Face / new Objects adapter → Tasks 2, 3
+- Composite (routing, merge, class-aware identity/availability) → Task 4
+- `:default` = Composite, warmup both → Task 5
+- Plan `{:detect, :all}` (types, `detect_classes`, `key_data`) → Task 6
+- Parser multi-class / `all` / bare-`obj`, vocabulary-free → Task 7
+- Class-aware cache identity + strict gate threading → Task 8
+- Per-model telemetry spans → Task 9
+- Wire pixel (non-face) + no-geometry + gate triad → Task 10
+- Architecture boundary (parser/plan ⊬ detectors) → Task 11
+- Demo controls → Task 12
+- Docs (gravity, support matrix, telemetry) → Task 13
+- Real-model tagged smoke + drift + full gate → Tasks 3, 14
+- Equal-weight `area` centroid unchanged (Slice 2 = `objw`) → no task (explicitly untouched; covered by existing focal tests staying green in Tasks 5, 14)

--- a/docs/superpowers/specs/2026-05-31-object-gravity-slice1-design.md
+++ b/docs/superpowers/specs/2026-05-31-object-gravity-slice1-design.md
@@ -1,0 +1,355 @@
+# Object-oriented gravity — Slice 1: general object gravity (equal-weight)
+
+**Status:** approved design, pre-implementation
+**Date:** 2026-05-31
+**Builds on:** the smart-gravity / ML-detection seam landed in #130 (`g:sm`,
+`g:obj:face`, face-assist, the `ImagePipe.Transform.Detector` behaviour, the
+bundled `ImageVision` YuNet adapter, `focal_from_regions`, detector identity in
+the cache key, the `detector_required` gate, `[:transform, :detect]` telemetry,
+`Detector.Warmup`).
+
+## Goal
+
+Extend ImagePipe's content-aware gravity from the single-class `face` subset to
+imgproxy's general object gravity:
+
+- `gravity:obj:%class1:…:%classN` — multi-class object gravity.
+- `gravity:obj` with classes omitted — use **all** detected objects.
+- The `all` pseudo-class.
+- The `c:W:H:obj…` crop forms, same class grammar.
+
+**Out of scope for this slice (deferred to Slice 2):** `gravity:objw` per-class
+weights and the weighted-centroid formula. They are purely additive on top of
+the Composite this slice builds, so deferring them requires no rework. Slice 1
+keeps the existing equal-weight area centroid (`focal_from_regions`) unchanged.
+
+Existing behavior — `g:obj:face`, face-assisted `g:sm`
+(`smart_crop_face_detection`), plain `g:sm`, and every non-detection path — is
+preserved unchanged. `g:obj:face`'s cache keys remain byte-identical (see
+§ Cache identity).
+
+## Why these choices (decision record)
+
+The design was brainstormed decision-by-decision. The settled answers:
+
+1. **Model strategy — composite/routing detector.** COCO-80 (RT-DETR) has
+   `person` but **no `face`**; the shipped `obj:face` is backed by YuNet. A mixed
+   request (`obj:face:dog`) genuinely needs both models. A product-neutral
+   Composite routes each requested class to the detector that owns it, fans out
+   to only the needed models, and merges regions. This keeps `obj:face` on YuNet
+   exactly as today, and a COCO-only alternative (remap `face`→`person`/drop) was
+   rejected because it would silently change already-shipped `obj:face` and
+   face-assist semantics.
+2. **`all` / bare `obj` includes faces.** To the end user, a face is one of the
+   objects the system can detect; excluding it from "all" would be a surprising
+   special case. `all` = the union of every configured child detector's classes,
+   so `obj` / `obj:all` runs both models. This also makes Slice 2's
+   `objw:all:N:face:M` a clean override model (face ∈ all). Honest cost: both
+   models run for `all` requests, and on a person photo RT-DETR `person` and
+   YuNet `face` can both fire — Slice 2 weights are what favor the face; Slice 1's
+   equal-weight default biases toward the larger `person` box, which is the
+   faithful imgproxy equal-weight default.
+3. **Weighted-centroid formula — deferred to Slice 2.** The formula choice only
+   bites once weights exist. Slice 1 keeps the existing `area` centroid. Slice 2
+   will settle `weight·area` vs `weight·√area` vs `weight`-only via dev-loop
+   experimentation behind a **dev/test-only** toggle removed before merge (never a
+   public/plug option).
+4. **Cache identity is class-aware.** Per-request detector identity reflects only
+   the models that actually run for that request's class set (see § Cache
+   identity).
+5. **Unknown classes are best-effort dropped, never an error.** imgproxy's docs do
+   not specify unknown-class behavior (its class vocabulary is host-configured via
+   a classes file), so there is no compatibility contract to honor. A class no
+   configured child claims is simply dropped during routing; if nothing usable
+   remains the request behaves like "no detection" (graceful attention fallback,
+   or 422 under `detector_required` only when a *real, supported* class has no
+   available detector). Dropped classes are observable via telemetry
+   (`effective_classes`). No new config knob.
+6. **Telemetry — aggregate span + per-model nested spans.** Keeps honest total
+   timing and restores per-model cold-start visibility that today's single face
+   span has.
+7. **Config — minimal.** Keep `detector` / `detector_required`. `:default` becomes
+   the Composite with baked-in default models and per-child default `min_score`.
+   Hosts tune via the existing custom-detector extension point. Model
+   `repo`/`filename`/`min_score` are *not* new plug options.
+8. **Scope — two slices.** This is Slice 1 (general object gravity). `objw` is
+   Slice 2.
+
+## Architecture
+
+### Detector behaviour: add `supported_classes/1`
+
+`ImagePipe.Transform.Detector` gains one callback:
+
+```elixir
+@callback supported_classes(opts :: keyword()) :: [String.t()]
+```
+
+- Returns the class set the detector owns. **Static and cheap** — it must not
+  load a model. A detector may return its full vocabulary even when
+  `available?/1` is `false` (deps missing), because the vocabulary is metadata,
+  not a runtime capability.
+- The Composite uses it to route a requested class set to children and to
+  evaluate per-request availability.
+- `detect/2`'s `classes` opt is now `:all | [String.t()]`. `:all` means "every
+  region this detector can produce" (no class filter).
+
+This is a real `@impl` behaviour callback, not a duck-typing probe — consistent
+with the repo's "call the callback, let missing callbacks raise" stance.
+
+### Adapters: split the bundled `ImageVision` into Face + Objects
+
+The current single `ImagePipe.Transform.Detector.ImageVision` (YuNet face) is
+split into two product-neutral adapter modules under the same namespace:
+
+- **`ImagePipe.Transform.Detector.ImageVision.Face`**
+  - Wraps `Image.FaceDetection.detect/1` (YuNet), as today.
+  - `supported_classes(_) → ["face"]`.
+  - `detect/2`: returns face regions for `classes == ["face"]` or `:all`; an empty
+    routed subset returns `{:ok, []}`.
+  - `available?/1`: `Code.ensure_loaded?(Image.FaceDetection)`, as today.
+  - `identity/1`: `{__MODULE__, {repo, model_file, min_score}}`.
+  - `warmup/1`: blank-image detect to trigger model load, as today.
+
+- **`ImagePipe.Transform.Detector.ImageVision.Objects`** (new)
+  - Wraps `Image.Detection.detect/2` (RT-DETR, COCO-80). **Verify the exact
+    function/option names and the COCO-80 label list against the installed
+    `image_vision` before wiring** (assumed: returns `%{label, score, box:
+    {x,y,width,height}}` abs pixels sorted by score; opts `min_score:`, `repo:`,
+    `filename:`).
+  - `supported_classes(_) → <COCO-80 labels>` (owned by this adapter — the
+    parser/planner must never enumerate them).
+  - `detect/2`: runs detection, filters results to the routed classes (or returns
+    all for `:all`), applies `min_score`.
+  - `available?/1`: presence check for `Image.Detection`.
+  - `identity/1`: `{__MODULE__, {repo, filename, min_score}}`.
+  - `warmup/1`: blank-image detect to trigger model load.
+
+### `ImagePipe.Transform.Detector.Composite` (new)
+
+A product-neutral router holding an **ordered list of child detectors**.
+
+- **Construction:** `:default` resolves to `Composite[Face, Objects]` (in that
+  order, so face wins ties in ordered merges if any). Children carry their own
+  default opts (models, `min_score`).
+- **`detect(image, opts)`** where `opts[:classes]` is `:all | [String.t()]`:
+  - `:all` → run **every** child with `classes: :all`; merge all regions.
+  - list → for each child, compute `routed = requested ∩ child.supported_classes`;
+    run only children with a non-empty `routed` (passing `classes: routed`); merge
+    regions. Classes claimed by no child are **dropped** (best-effort).
+  - Merge is region-list concatenation (order-independent for the equal-weight
+    area centroid). De-duplication of overlapping `person`/`face` is **not**
+    performed — both contribute by area; Slice 2 weights arbitrate.
+- **`supported_classes(opts)`** → union of children's `supported_classes`.
+- **`available?(opts)`** → evaluated for the request's class set
+  (`opts[:classes]`): the children that the class set routes to must be available.
+  `:all` routes to all children → all must be available. Used by the strict gate.
+- **`identity(opts)`** → the identities of only the children the request's class
+  set routes to, as an ordered list (see § Cache identity). Class-aware.
+
+### Plan representation
+
+`ImagePipe.Plan.Operation.CropGuided`'s `guide` type gains the `:all` sentinel
+alongside the existing class-list form:
+
+```elixir
+{:detect, :all} | {:detect, nonempty_list(String.t())}
+```
+
+- `:all` stays a **sentinel** resolved inside the Composite at detection time. It
+  is never expanded to a concrete class list at parse/plan time — doing so would
+  force the parser/planner to know the detector's vocabulary, violating the
+  namespace boundary (parser owns syntax, detector owns vocabulary).
+- `ImagePipe.Plan.detect_classes/1` returns `:all | nonempty_list(String.t()) |
+  nil`.
+- `key_data` guide encoding:
+  - `{:detect, :all}` → `[type: :detect, classes: :all]`
+  - `{:detect, classes}` → `[type: :detect, classes: Enum.sort(classes)]`
+
+### Parser (imgproxy) — stays vocabulary-free
+
+In `lib/image_pipe/parser/imgproxy/`:
+
+- `option_grammar.ex` already parses `g:obj:…` and `c:W:H:obj:…` into
+  `{:obj, classes}` with no parse-time validation. Confirm it accepts the empty
+  class list (bare `g:obj`) and multi-class lists; both `g:` and `c:W:H:` forms.
+- `plan_builder.ex` — replace the hard `["face"]`-only gate in `tagged_gravity/2`:
+  - `{:obj, classes}` where `classes == []` or `"all" ∈ classes` → `{:detect, :all}`
+  - `{:obj, classes}` (non-empty, no `all`) → `{:detect, classes}`
+  - (the previous `{:obj, ["face"]}` special case and the
+    `{:unsupported_gravity, …}` rejection for other classes are removed)
+- The parser/planner must not enumerate COCO classes or import any detector
+  module — it only restructures syntax into a product-neutral `{:detect, …}`
+  guide. `all`-normalization is an imgproxy dialect quirk and stays isolated here.
+- `objw` is **not** parsed this slice; it remains an unknown option (errors as
+  today). Slice 2 adds it.
+
+### Transform / crop execution
+
+In `lib/image_pipe/transform/operation/crop.ex`:
+
+- `detect_crop` handles `{:detect, :all}` in addition to the class-list form,
+  threading `classes` (`:all` or list) into the detector opts.
+- `focal_from_regions` is **unchanged** — equal-weight area centroid. (Slice 2
+  introduces the weighted formula.)
+- Detector resolution: `:default` resolves to the Composite via
+  `Transform.resolve_detector/1`. Request/source/response code continues to
+  dispatch only through generic `ImagePipe.Transform` functions and must not name
+  `Composite`, `ImageVision.Face`, or `ImageVision.Objects` directly (Boundary).
+- **Face-assist is unchanged:** `{:smart, :face_assist}` still calls detection
+  with `classes: ["face"]`, which routes to the Face child only. Its blend math,
+  weight, and `[:transform, :detect, :blend]` event are untouched.
+
+### Cache identity (class-aware)
+
+`ImagePipe.Transform.detector_identity/2` becomes class-aware: the cache-key
+build site (`Request.Runner`) threads the plan's detect classes
+(`Plan.detect_classes/1`) into it, and the Composite returns the identities of
+only the children that class set routes to.
+
+Resulting identities:
+
+| Request        | Children that run | Identity material        |
+| -------------- | ----------------- | ------------------------ |
+| `obj:face`     | Face              | `[Face id]` — **= today's key, continuity** |
+| `obj:car`      | Objects           | `[Objects id]`           |
+| `obj:face:dog` | Face + Objects    | `[Face id, Objects id]`  |
+| `obj` / `obj:all` | Face + Objects | `[Face id, Objects id]`  |
+
+Consequences this guarantees:
+
+- Bumping the face model **does not** invalidate `obj:car` results (the face
+  model can't change a car crop) — the key reflects response identity, per the
+  cache guidelines.
+- Each child identity folds in `(repo, model_file/filename, min_score)`, since
+  `min_score` changes which regions survive → changes the crop → changes the
+  bytes.
+- Cache key carries the canonical *requested* class set (sorted); unknown classes
+  that get dropped at runtime stay in the key (harmless over-keying — never
+  serves wrong bytes). No new cache-key data version bump (greenfield; reshape in
+  place).
+
+### Strict gate (`detector_required`)
+
+`validate_detector_capability/2` (plug, pre-fetch) generalizes from face-only:
+
+- Fires only when `detector_required: true` **and** the plan requests detection.
+- Availability is evaluated for the request's class set (threaded into the
+  Composite's `available?`). A 422-before-fetch is returned when a **real,
+  supported, requested** class has no available detector.
+- **Unknown classes never trigger the gate** — they are dropped (not an
+  availability failure). If a request's classes all drop to nothing, it degrades
+  to attention like any other no-detection case (it is not a 422).
+- Graceful default (`detector_required: false`) unchanged: no available detector →
+  attention fallback. Face-assist is never hard-rejected.
+
+### Telemetry
+
+- **`[:transform, :detect]`** stays the aggregate span (honest total detect
+  duration). Metadata gains `requested_classes` and `effective_classes` (the
+  post-routing set actually detected) so best-effort drops are observable. `result`
+  aggregates across children: `:detected` if any child returned regions,
+  `:no_regions` if all ran empty, `:unavailable`/`:error` on child failure.
+- **`[:transform, :detect, :model]`** (new) — a nested span per child detector
+  that runs, with metadata: `detector` (child identity), `classes` (the routed
+  subset, `:all` or list), `regions` (count), and honest inference duration (model
+  inference is real eager work — legitimate compute timing).
+- **`[:transform, :detect, :skipped]`** unchanged (no detector configured),
+  carrying `classes`.
+- Metadata stays product-neutral and non-sensitive: module names, class strings,
+  counts. No paths, URLs, signatures, or filenames.
+- The opt-in default Logger and `telemetry.md` are updated for the new model span
+  and the requested/effective metadata.
+
+### Config & wiring
+
+- Plug options unchanged: `detector` (`:default | nil | module`) and
+  `detector_required` (boolean). No new model-tuning options.
+- `:default` = `Composite[Face, Objects]` with image_vision default models and a
+  per-child default `min_score`.
+- **Warmup:** the warmup worker warms both children (face + objects). Update the
+  default wiring/docs so a single warmup pre-loads both models (e.g. warm with
+  `classes: :all`, or warm each child).
+- Custom detectors and the Composite remain the host's tuning path.
+
+### Demo
+
+Per the repo convention to keep the demo in sync with transform changes
+(`demo/`):
+
+- Add object-class gravity controls: a class multi-select (COCO-80 + an `all`
+  option) plus the bare-`obj` form, wired into URL state alongside the existing
+  face and smart-crop controls.
+- Keep `detector: :default` wiring.
+
+### Docs
+
+- `docs/content-aware-gravity.md` — add the general object gravity section
+  (multi-class, `all`/bare-`obj` includes faces, best-effort unknown-class drop,
+  class-aware cache identity), and note `objw` is Slice 2.
+- `docs/imgproxy_support_matrix.md` — update the obj-gravity row: multi-class and
+  `all` now supported; `objw` / `objects_position` still out (Slice 2 / out of
+  scope). Keep the YuNet-vs-imgproxy-YOLO divergence notes; add the RT-DETR/COCO-80
+  object model.
+- `docs/telemetry.md` — document the per-model span and the
+  requested/effective-classes metadata.
+
+## Testing
+
+Following the repo test guidelines (assert at boundaries the caller doesn't
+control; no impossible-internal-misuse, name-policing, or parity-pin tests):
+
+- **Parser** (`option_grammar`/`plan_builder` tests): `obj:%c1:…:%cN`, bare
+  `obj` → `:all`, `obj:all` → `:all`, `all` among classes → `:all`; both `g:` and
+  `c:W:H:` forms; order-insensitivity of the class list; the former `["face"]`
+  gate no longer rejects other classes.
+- **Planner mapping:** `tagged_gravity` emits `{:detect, :all}` / `{:detect,
+  classes}`; parser remains vocabulary-free (no COCO import — assert via the
+  architecture boundary test, the only place source-scanning is allowed).
+- **Composite unit tests:** routing/partition by `supported_classes`, merge,
+  union `supported_classes`, best-effort drop of unclaimed classes, `:all` runs
+  all children, class-aware `identity/1` (face-only vs objects-only vs both),
+  class-aware `available?/1`.
+- **Wire-level Plug tests** (real `ImagePipe.call/2`, decode the body): `obj:car`,
+  `obj:face:dog`, and `obj:all` produce expected geometry vs a plain/attention
+  baseline; `detector_required` returns 422 **before** source fetch/cache access
+  when a supported class has no available detector; cache reuse for
+  order-equivalent class lists; `Vary: Accept` unaffected.
+- **Cache-key tests:** `obj:face` key equals the pre-change face key (continuity);
+  `obj:car` key differs and is unaffected by a face-model identity bump;
+  `obj:face:car` includes both; class-list canonicalization (sorted) yields a
+  stable key regardless of URL order.
+- **Telemetry tests:** aggregate `[:transform, :detect]` carries
+  `requested_classes`/`effective_classes`; a per-model `[:transform, :detect,
+  :model]` span is emitted per child that runs; `:skipped` still fires with no
+  detector.
+- **Property tests:** parser order-insensitivity for class lists; cache-key
+  canonicalization across class orderings.
+
+## Boundary / namespace compliance
+
+- New modules live under `ImagePipe.Transform.Detector.*` (transform boundary);
+  `Composite`, `ImageVision.Face`, `ImageVision.Objects`.
+- The `Detector` behaviour and the generic `ImagePipe.Transform` entry points are
+  the only detector surface exported; concrete adapter/Composite modules are not
+  named by request/source/response code.
+- Parser emits only product-neutral `{:detect, …}` guides; `all`-normalization is
+  isolated in the imgproxy parser.
+- No detector vocabulary leaks into `parser`, `request`, `cache`, or `plan`.
+
+## Risks / assumptions to verify during implementation
+
+1. **`Image.Detection.detect/2` API** — confirm exact function name, option names
+   (`min_score`/`repo`/`filename`), return shape, and the COCO-80 label list
+   against the installed `image_vision` before wiring the Objects adapter. The
+   region shape is assumed identical to the existing `Detector.region`
+   (`%{label, score, box: {x, y, width, height}}`, abs pixels, sorted by score).
+2. **`ortex`/model download** — RT-DETR pulls a model on first use, like YuNet.
+   The warmup worker must cover it; the first cold object request otherwise pays
+   the download. Document alongside the existing face warmup guidance.
+3. **Both-models cost for `:all`** — `obj`/`obj:all` runs two models. Acceptable
+   and intended; the per-model telemetry span surfaces the cost.
+4. **Equal-weight default bias** — plain `obj:all` on a person photo biases toward
+   the larger `person` box, not the face. This is the faithful imgproxy
+   equal-weight default; face-centric crops use `obj:face` (Slice 1) or `objw`
+   (Slice 2). Documented, not a bug.

--- a/docs/superpowers/specs/2026-05-31-object-gravity-slice1-design.md
+++ b/docs/superpowers/specs/2026-05-31-object-gravity-slice1-design.md
@@ -231,14 +231,23 @@ alongside the existing class-list form:
 **Required producer edits for the `:all` shape** (each is a real code path a wire
 `obj`/`obj:all` request hits — missing any one crashes or silently misbehaves):
 
-1. `ImagePipe.Plan.Operation.CropGuided` — `guide` type gains `{:detect, :all}`.
-2. `lib/image_pipe/transform/operation/crop.ex` — the operation `gravity`
+1. **`lib/image_pipe/plan/operation.ex` — `smart_guide/1`** (the construction-time
+   validation gate, reached by **both** `crop_guided/4` and `resize/4`). Its
+   existing clause is `smart_guide({:detect, classes}) when is_list(classes) and
+   classes != []`, which **rejects** `:all` (falls through to `{:error, :guide}`).
+   Add a `smart_guide({:detect, :all}) → {:ok, …}` clause before it. *Missing this
+   is a hard failure on the most common form `rs:fill/g:obj` — it fails at operation
+   construction before anything downstream runs.*
+2. `ImagePipe.Plan.Operation.CropGuided` — `guide` type gains `{:detect, :all}`.
+3. `lib/image_pipe/plan/operation/resize.ex` — `guide` type gains `{:detect, :all}`
+   (the fill path builds a `Resize`).
+4. `lib/image_pipe/transform/operation/crop.ex` — the operation `gravity`
    typespec and the `execute/2` detect arm accept `{:detect, :all}` (the existing
    `gravity: {:detect, classes}` head matches with `classes = :all`; confirm
    `run_detect`/telemetry carry `classes` as `:all | list`).
-3. `ImagePipe.Plan.detect_classes/1` — `@spec` and body widen to
+5. `ImagePipe.Plan.detect_classes/1` — `@spec` and body widen to
    `:all | nonempty_list(String.t()) | nil`.
-4. `lib/image_pipe/plan/key_data.ex` — add a `guide_data({:detect, :all})` clause
+6. `lib/image_pipe/plan/key_data.ex` — add a `guide_data({:detect, :all})` clause
    returning `[type: :detect, classes: :all]` (today's clause is guarded
    `when is_list(classes)` and would `FunctionClauseError` on `:all`). The list
    clause keeps `classes: Enum.sort(classes)`.

--- a/docs/superpowers/specs/2026-05-31-object-gravity-slice1-design.md
+++ b/docs/superpowers/specs/2026-05-31-object-gravity-slice1-design.md
@@ -352,7 +352,9 @@ Consequences this guarantees:
     intent.
   - the routed `classes` subset (`:all` or list), `regions` (count), and honest
     inference duration (model inference is real eager work — legitimate compute
-    timing, unlike libvips-lazy per-operation spans).
+    timing, unlike libvips-lazy per-operation spans). A model-artifact name carries
+    no secret and reveals no private content, so it is fine to emit under the
+    telemetry sensitivity rule (which targets secrets/PII, not path-shaped strings).
   - **Documented contract (no guard code):** a detector's `identity/1` appears in
     this span, so custom-detector authors should keep it free of secrets. We don't
     add machinery to defend against a detector that both encodes a secret in its

--- a/docs/superpowers/specs/2026-05-31-object-gravity-slice1-design.md
+++ b/docs/superpowers/specs/2026-05-31-object-gravity-slice1-design.md
@@ -84,8 +84,9 @@ The design was brainstormed decision-by-decision. The settled answers:
    configured child claims is simply dropped during routing; if nothing usable
    remains the request behaves like "no detection" (graceful attention fallback,
    or 422 under `detector_required` only when a *real, supported* class has no
-   available detector). Dropped classes are observable via telemetry
-   (`effective_classes`). No new config knob.
+   available detector). Dropped classes are observable via telemetry (a requested
+   class that appears in no per-model `[:transform, :detect, :model]` span was
+   dropped). No new config knob.
 6. **Telemetry — aggregate span + per-model nested spans.** Keeps honest total
    timing and restores per-model cold-start visibility that today's single face
    span has. The per-model span identifies the child by **module name** plus its
@@ -152,9 +153,14 @@ split into two product-neutral adapter modules under the same namespace.
 
 - **`ImagePipe.Transform.Detector.ImageVision.Objects`** (new)
   - Wraps `Image.Detection.detect/2` (RT-DETR, COCO-80).
-  - `supported_classes(_)` **derives from the public `Image.Detection.classes/0`**
-    (the 80 COCO labels image_vision exposes) rather than hardcoding a second,
-    drift-prone copy. Cheap, static, no model load.
+  - `supported_classes(_)` returns a **hardcoded static COCO-80 list** (in the
+    URL-facing underscore spelling). It must NOT derive from
+    `Image.Detection.classes/0` at runtime: routing and the availability gate call
+    `supported_classes` precisely when the dep may be **absent**, and
+    `Image.Detection.classes/0` requires the dep loaded — deriving it would crash
+    the gate. A `@tag :image_vision` drift test asserts the hardcoded list matches
+    the model's labels (normalized), catching upstream COCO changes. Cheap, static,
+    no model load, dep-independent.
   - `detect/2`: runs detection (option `min_score`), filters results to the routed
     classes (or returns all for `:all`).
   - `available?/1`: `Code.ensure_loaded?(Image.Detection)` (mirrors Face).
@@ -293,12 +299,20 @@ boundary edge — request code touches only `Plan` + the generic `Transform`):
 The Composite then returns the identities of only the children that class set
 routes to. Resulting identities:
 
-| Request        | Children that run | Identity material        |
-| -------------- | ----------------- | ------------------------ |
-| `obj:face`     | Face              | `[Face id]` — **= today's key, continuity** |
-| `obj:car`      | Objects           | `[Objects id]`           |
-| `obj:face:dog` | Face + Objects    | `[Face id, Objects id]`  |
-| `obj` / `obj:all` | Face + Objects | `[Face id, Objects id]`  |
+The Composite's `identity/1` returns `{Composite, [child identities…]}` for the
+routed children only (built by filtering the fixed child order):
+
+| Request        | Children that run | Identity material              |
+| -------------- | ----------------- | ------------------------------ |
+| `obj:face`     | Face              | `{Composite, [Face id]}` — **independent of the object model** |
+| `obj:car`      | Objects           | `{Composite, [Objects id]}`    |
+| `obj:face:dog` | Face + Objects    | `{Composite, [Face id, Objects id]}` |
+| `obj` / `obj:all` | Face + Objects | `{Composite, [Face id, Objects id]}` |
+
+(The `obj:face` key is *not* byte-identical to the pre-Composite `{ImageVision,
+…}` key — the Composite wrapper and the `.Face` rename change its shape. Greenfield,
+so that is fine; the cache guideline is reshape-in-place. What matters is the
+*invariant* below, which the reviewer asked be asserted structurally.)
 
 Consequences this guarantees:
 
@@ -336,10 +350,15 @@ Consequences this guarantees:
 ### Telemetry
 
 - **`[:transform, :detect]`** stays the aggregate span (honest total detect
-  duration). Metadata gains `requested_classes` and `effective_classes` (the
-  post-routing set actually detected) so best-effort drops are observable. `result`
-  aggregates across children: `:detected` if any child returned regions,
-  `:no_regions` if all ran empty, `:unavailable`/`:error` on child failure.
+  duration), emitted by `crop.ex`'s `run_detect` exactly as today. Its `classes`
+  metadata is the **requested** set (`:all` or the class list). `result` reflects
+  the merged outcome (`:detected` if any region, `:no_regions` otherwise). The
+  **effective** (post-routing) set is observable as the **union of the per-model
+  spans' `classes`** — so best-effort drops show up as the gap between the
+  aggregate's requested `classes` and the per-model spans. (We deliberately do not
+  add `effective_classes` to the aggregate: the Composite can't return it through
+  the host-facing `detect/2` contract without changing that contract, and the
+  per-model spans already carry it.)
 - **`[:transform, :detect, :model]`** (new) — a nested span per child detector
   that runs. Metadata:
   - `detector` = the child *module name* (e.g.
@@ -456,10 +475,12 @@ nondeterministic inference.
   a captured-hash parity pin); `obj:car` keys differ and are unaffected by a
   face-model identity bump; `obj:face:car` includes both; class-list
   canonicalization (sorted) yields a stable key regardless of URL order.
-- **Telemetry tests:** aggregate `[:transform, :detect]` carries
-  `requested_classes`/`effective_classes`; a per-model `[:transform, :detect,
-  :model]` span is emitted per child that runs, with `detector` = module name and
-  `model` = the child's `identity/1`; `:skipped` still fires with no detector.
+- **Telemetry tests:** aggregate `[:transform, :detect]` carries the requested
+  `classes`; a per-model `[:transform, :detect, :model]` span is emitted per child
+  that runs, with `detector` = module name, `model` = the child's `identity/1`, and
+  its routed `classes` (the union across per-model spans is the effective set, so a
+  best-effort-dropped class is visible as a requested class absent from every
+  per-model span); `:skipped` still fires with no detector.
 - **Property tests:** parser order-insensitivity for class lists; cache-key
   canonicalization across class orderings.
 - **Real-model lane (one `@tag :image_vision` coarse smoke test only):** a single

--- a/docs/superpowers/specs/2026-05-31-object-gravity-slice1-design.md
+++ b/docs/superpowers/specs/2026-05-31-object-gravity-slice1-design.md
@@ -10,13 +10,13 @@ the cache key, the `detector_required` gate, `[:transform, :detect]` telemetry,
 
 > **Review revisions (2026-05-31).** A four-reviewer parallel cycle (boundary,
 > cache/runtime correctness, `image_vision` integration reality, test
-> strategy/scope) ran against this spec. Accepted changes folded in below:
-> fixed a telemetry leak — the per-model span no longer reflects the opaque
-> host-controlled `identity/1` (which a custom detector may fill with a path/secret);
-> it emits the child **module name** plus a deliberate, telemetry-safe model
-> descriptor the bundled adapters populate (giving model-version visibility without
-> leaking custom-detector identity); made the class-threading wiring explicit at
-> *both* the plug gate and the
+> strategy/scope) ran against this spec. Accepted changes folded in below: the
+> per-model span emits the child **module name** + its `identity/1` (version-bearing
+> `{repo, filename, min_score}` for the bundled adapters), with a one-line doc
+> contract that custom `identity/1` stays secret-free — the model-artifact name is
+> harmless public metadata, and a reviewer's stricter "never emit the identity"
+> reading was relaxed as far-fetched (no guard code); made the class-threading
+> wiring explicit at *both* the plug gate and the
 > runner key-build; enumerated the `:all` producer edits (`detect_classes/1`,
 > `KeyData.guide_data/1`, the `CropGuided`/`crop` typespecs); corrected the Objects
 > adapter to use `:filename` / no `:nms_iou` / `available? =
@@ -88,12 +88,12 @@ The design was brainstormed decision-by-decision. The settled answers:
    (`effective_classes`). No new config knob.
 6. **Telemetry — aggregate span + per-model nested spans.** Keeps honest total
    timing and restores per-model cold-start visibility that today's single face
-   span has. The per-model span identifies the child by **module name** plus a
-   deliberate, telemetry-safe **model descriptor** the bundled adapters populate
-   (so the span shows *which model version* ran, e.g.
-   `face_detection_yunet_2023mar.onnx`, and changes when the model file changes).
-   It never reflects the opaque `identity/1` value — that is cache-key material a
-   custom detector may legitimately fill with a path or secret (see § Telemetry).
+   span has. The per-model span identifies the child by **module name** plus its
+   **`identity/1`** (for the bundled adapters that is `{repo, filename, min_score}`
+   — version-bearing, so the span shows which model version ran). The model-artifact
+   name is harmless public metadata, so this is fine to emit; custom-detector
+   authors are told (one doc line) to keep `identity/1` free of secrets, rather than
+   the library adding guard code for that far-fetched case (see § Telemetry).
 7. **Config — minimal.** Keep `detector` / `detector_required`. `:default` becomes
    the Composite with baked-in default models and per-child default `min_score`.
    Hosts tune via the existing custom-detector extension point. Model
@@ -121,27 +121,9 @@ The design was brainstormed decision-by-decision. The settled answers:
   region this detector can produce" (no class filter).
 
 This is a real `@impl` behaviour callback, not a duck-typing probe — consistent
-with the repo's "call the callback, let missing callbacks raise" stance.
-
-The behaviour also gains an **optional** telemetry-descriptor callback so a
-detector can deliberately expose a safe, human-readable model identifier for the
-per-model span **without** the system ever reflecting its `identity/1` (which is
-cache-key material and may legitimately hold a filesystem path or credential in a
-custom detector):
-
-```elixir
-@callback telemetry_model(opts :: keyword()) :: String.t() | nil
-@optional_callbacks telemetry_model: 1
-```
-
-- Bundled adapters implement it: `Face → "face_detection_yunet_2023mar.onnx"`
-  (or `"<repo>/<model_file>"`), `Objects → "<repo>/<filename>"`. The value is
-  version-bearing, so it changes when the model file changes.
-- A custom detector that does not implement it contributes no `model:` field — the
-  span still carries its module name. The Composite calls it via
-  `function_exported?`-guarded dispatch (the sanctioned optional-callback pattern,
-  same as the existing optional `warmup/1`), never reading `identity/1` for
-  telemetry.
+with the repo's "call the callback, let missing callbacks raise" stance. No other
+new callback is needed — the per-model telemetry span reuses the existing
+`identity/1` (see § Telemetry).
 
 ### Adapters: split the bundled `ImageVision` into Face + Objects
 
@@ -361,33 +343,30 @@ Consequences this guarantees:
 - **`[:transform, :detect, :model]`** (new) — a nested span per child detector
   that runs. Metadata:
   - `detector` = the child *module name* (e.g.
-    `ImagePipe.Transform.Detector.ImageVision.Objects`) — always present.
-  - `model` = the child's `telemetry_model/1` descriptor when implemented (the
-    bundled adapters return the model-artifact id, e.g.
-    `"face_detection_yunet_2023mar.onnx"`); **absent** for detectors that don't
-    implement the callback. This is a *deliberate, telemetry-safe* value chosen by
-    the adapter — it gives model-version visibility (it changes when the model file
-    changes) and is product-neutral public metadata, not a request/source/storage
-    path or cache key.
+    `ImagePipe.Transform.Detector.ImageVision.Objects`), for grouping.
+  - `model` = the child's `identity/1` (for the bundled adapters,
+    `{repo, filename, min_score}`). It is version-bearing, so the span shows which
+    model version ran and changes when the model file changes. A model-artifact name
+    is harmless, product-neutral public metadata — not a request/source/storage path
+    or cache key — so emitting it does not breach the telemetry "no sensitive data"
+    intent.
   - the routed `classes` subset (`:all` or list), `regions` (count), and honest
     inference duration (model inference is real eager work — legitimate compute
     timing, unlike libvips-lazy per-operation spans).
-  - **Never emit the child `identity/1` tuple.** Identity is opaque, host-
-    controlled cache-key material; a custom detector may legitimately put a
-    filesystem path, signed URL, or token there. The `telemetry_model/1` descriptor
-    exists precisely so model-version observability does not require reflecting
-    `identity/1`. (The bundled YuNet/RT-DETR artifact names are themselves harmless
-    public identifiers; the rule we are honoring is "don't blanket-emit opaque
-    host identity," not "model names are sensitive.")
+  - **Documented contract (no guard code):** a detector's `identity/1` appears in
+    this span, so custom-detector authors should keep it free of secrets. We don't
+    add machinery to defend against a detector that both encodes a secret in its
+    identity *and* exports raw telemetry to an external sink — that's a far-fetched
+    misuse, and the repo philosophy is to document the contract, not guard
+    impossible misuse.
 - **`[:transform, :detect, :skipped]`** unchanged (no detector configured),
   carrying `classes`.
 - Metadata stays product-neutral and non-sensitive: module names, class strings,
   counts. No paths, URLs, signatures, or filenames.
 - The opt-in default Logger and `telemetry.md` are updated for the new model span
-  (the `detector` module name + the optional `model` descriptor) and the
-  requested/effective metadata. A test asserts the span **never reflects a
-  detector's `identity/1`** — a custom detector whose `identity/1` carries a
-  sentinel "secret" path must not have it appear in any span metadata.
+  (the `detector` module name + the `model` = `identity/1`) and the
+  requested/effective metadata, including the one-line "keep `identity/1` free of
+  secrets" note in the custom-detector docs.
 
 ### Config & wiring
 
@@ -423,9 +402,9 @@ Per the repo convention to keep the demo in sync with transform changes
   `all` now supported; `objw` / `objects_position` still out (Slice 2 / out of
   scope). Keep the YuNet-vs-imgproxy-YOLO divergence notes; add the RT-DETR/COCO-80
   object model.
-- `docs/telemetry.md` — document the per-model span (`detector` module name + the
-  optional, telemetry-safe `model` descriptor; never the raw `identity/1`) and the
-  requested/effective-classes metadata.
+- `docs/telemetry.md` — document the per-model span (`detector` module name +
+  `model` = the child's `identity/1`) and the requested/effective-classes metadata;
+  add the one-line "keep custom `identity/1` free of secrets" note.
 
 ## Testing
 
@@ -477,11 +456,8 @@ nondeterministic inference.
   canonicalization (sorted) yields a stable key regardless of URL order.
 - **Telemetry tests:** aggregate `[:transform, :detect]` carries
   `requested_classes`/`effective_classes`; a per-model `[:transform, :detect,
-  :model]` span is emitted per child that runs, with `detector` = module name and a
-  `model` descriptor when the child implements `telemetry_model/1` (absent
-  otherwise); and a custom detector whose `identity/1` holds a sentinel secret
-  string has that string appear in **no** span metadata; `:skipped` still fires
-  with no detector.
+  :model]` span is emitted per child that runs, with `detector` = module name and
+  `model` = the child's `identity/1`; `:skipped` still fires with no detector.
 - **Property tests:** parser order-insensitivity for class lists; cache-key
   canonicalization across class orderings.
 - **Real-model lane (one `@tag :image_vision` coarse smoke test only):** a single

--- a/docs/superpowers/specs/2026-05-31-object-gravity-slice1-design.md
+++ b/docs/superpowers/specs/2026-05-31-object-gravity-slice1-design.md
@@ -11,8 +11,12 @@ the cache key, the `detector_required` gate, `[:transform, :detect]` telemetry,
 > **Review revisions (2026-05-31).** A four-reviewer parallel cycle (boundary,
 > cache/runtime correctness, `image_vision` integration reality, test
 > strategy/scope) ran against this spec. Accepted changes folded in below:
-> fixed a telemetry filename-leak (emit child **module name**, not the identity
-> tuple); made the class-threading wiring explicit at *both* the plug gate and the
+> fixed a telemetry leak — the per-model span no longer reflects the opaque
+> host-controlled `identity/1` (which a custom detector may fill with a path/secret);
+> it emits the child **module name** plus a deliberate, telemetry-safe model
+> descriptor the bundled adapters populate (giving model-version visibility without
+> leaking custom-detector identity); made the class-threading wiring explicit at
+> *both* the plug gate and the
 > runner key-build; enumerated the `:all` producer edits (`detect_classes/1`,
 > `KeyData.guide_data/1`, the `CropGuided`/`crop` typespecs); corrected the Objects
 > adapter to use `:filename` / no `:nms_iou` / `available? =
@@ -84,8 +88,12 @@ The design was brainstormed decision-by-decision. The settled answers:
    (`effective_classes`). No new config knob.
 6. **Telemetry — aggregate span + per-model nested spans.** Keeps honest total
    timing and restores per-model cold-start visibility that today's single face
-   span has. The per-model span identifies the child by **module name only** (no
-   model filename/path — see § Telemetry).
+   span has. The per-model span identifies the child by **module name** plus a
+   deliberate, telemetry-safe **model descriptor** the bundled adapters populate
+   (so the span shows *which model version* ran, e.g.
+   `face_detection_yunet_2023mar.onnx`, and changes when the model file changes).
+   It never reflects the opaque `identity/1` value — that is cache-key material a
+   custom detector may legitimately fill with a path or secret (see § Telemetry).
 7. **Config — minimal.** Keep `detector` / `detector_required`. `:default` becomes
    the Composite with baked-in default models and per-child default `min_score`.
    Hosts tune via the existing custom-detector extension point. Model
@@ -114,6 +122,26 @@ The design was brainstormed decision-by-decision. The settled answers:
 
 This is a real `@impl` behaviour callback, not a duck-typing probe — consistent
 with the repo's "call the callback, let missing callbacks raise" stance.
+
+The behaviour also gains an **optional** telemetry-descriptor callback so a
+detector can deliberately expose a safe, human-readable model identifier for the
+per-model span **without** the system ever reflecting its `identity/1` (which is
+cache-key material and may legitimately hold a filesystem path or credential in a
+custom detector):
+
+```elixir
+@callback telemetry_model(opts :: keyword()) :: String.t() | nil
+@optional_callbacks telemetry_model: 1
+```
+
+- Bundled adapters implement it: `Face → "face_detection_yunet_2023mar.onnx"`
+  (or `"<repo>/<model_file>"`), `Objects → "<repo>/<filename>"`. The value is
+  version-bearing, so it changes when the model file changes.
+- A custom detector that does not implement it contributes no `model:` field — the
+  span still carries its module name. The Composite calls it via
+  `function_exported?`-guarded dispatch (the sanctioned optional-callback pattern,
+  same as the existing optional `warmup/1`), never reading `identity/1` for
+  telemetry.
 
 ### Adapters: split the bundled `ImageVision` into Face + Objects
 
@@ -331,23 +359,35 @@ Consequences this guarantees:
   aggregates across children: `:detected` if any child returned regions,
   `:no_regions` if all ran empty, `:unavailable`/`:error` on child failure.
 - **`[:transform, :detect, :model]`** (new) — a nested span per child detector
-  that runs. Metadata: **`detector` = the child *module name* only** (e.g.
-  `ImagePipe.Transform.Detector.ImageVision.Objects`), the routed `classes` subset
-  (`:all` or list), `regions` (count), and honest inference duration (model
-  inference is real eager work — legitimate compute timing, unlike libvips-lazy
-  per-operation spans).
-  - **Do NOT emit the child identity tuple** (`{repo, filename, min_score}`): it
-    contains a model filename/repo path, which the telemetry guidelines forbid
-    ("never emit filenames or other path-derived identifiers"). Module name is the
-    product-neutral discriminator. (If model-version observability is ever needed,
-    derive a non-reversible token — not the raw `{repo, filename}`.)
+  that runs. Metadata:
+  - `detector` = the child *module name* (e.g.
+    `ImagePipe.Transform.Detector.ImageVision.Objects`) — always present.
+  - `model` = the child's `telemetry_model/1` descriptor when implemented (the
+    bundled adapters return the model-artifact id, e.g.
+    `"face_detection_yunet_2023mar.onnx"`); **absent** for detectors that don't
+    implement the callback. This is a *deliberate, telemetry-safe* value chosen by
+    the adapter — it gives model-version visibility (it changes when the model file
+    changes) and is product-neutral public metadata, not a request/source/storage
+    path or cache key.
+  - the routed `classes` subset (`:all` or list), `regions` (count), and honest
+    inference duration (model inference is real eager work — legitimate compute
+    timing, unlike libvips-lazy per-operation spans).
+  - **Never emit the child `identity/1` tuple.** Identity is opaque, host-
+    controlled cache-key material; a custom detector may legitimately put a
+    filesystem path, signed URL, or token there. The `telemetry_model/1` descriptor
+    exists precisely so model-version observability does not require reflecting
+    `identity/1`. (The bundled YuNet/RT-DETR artifact names are themselves harmless
+    public identifiers; the rule we are honoring is "don't blanket-emit opaque
+    host identity," not "model names are sensitive.")
 - **`[:transform, :detect, :skipped]`** unchanged (no detector configured),
   carrying `classes`.
 - Metadata stays product-neutral and non-sensitive: module names, class strings,
   counts. No paths, URLs, signatures, or filenames.
 - The opt-in default Logger and `telemetry.md` are updated for the new model span
-  and the requested/effective metadata. A telemetry test asserts the model span
-  metadata contains **no** filename/path strings.
+  (the `detector` module name + the optional `model` descriptor) and the
+  requested/effective metadata. A test asserts the span **never reflects a
+  detector's `identity/1`** — a custom detector whose `identity/1` carries a
+  sentinel "secret" path must not have it appear in any span metadata.
 
 ### Config & wiring
 
@@ -383,8 +423,9 @@ Per the repo convention to keep the demo in sync with transform changes
   `all` now supported; `objw` / `objects_position` still out (Slice 2 / out of
   scope). Keep the YuNet-vs-imgproxy-YOLO divergence notes; add the RT-DETR/COCO-80
   object model.
-- `docs/telemetry.md` — document the per-model span (module-name discriminator,
-  no filenames) and the requested/effective-classes metadata.
+- `docs/telemetry.md` — document the per-model span (`detector` module name + the
+  optional, telemetry-safe `model` descriptor; never the raw `identity/1`) and the
+  requested/effective-classes metadata.
 
 ## Testing
 
@@ -436,8 +477,11 @@ nondeterministic inference.
   canonicalization (sorted) yields a stable key regardless of URL order.
 - **Telemetry tests:** aggregate `[:transform, :detect]` carries
   `requested_classes`/`effective_classes`; a per-model `[:transform, :detect,
-  :model]` span is emitted per child that runs, with `detector` = module name and
-  **no filename/path string** in metadata; `:skipped` still fires with no detector.
+  :model]` span is emitted per child that runs, with `detector` = module name and a
+  `model` descriptor when the child implements `telemetry_model/1` (absent
+  otherwise); and a custom detector whose `identity/1` holds a sentinel secret
+  string has that string appear in **no** span metadata; `:skipped` still fires
+  with no detector.
 - **Property tests:** parser order-insensitivity for class lists; cache-key
   canonicalization across class orderings.
 - **Real-model lane (one `@tag :image_vision` coarse smoke test only):** a single

--- a/docs/superpowers/specs/2026-05-31-object-gravity-slice1-design.md
+++ b/docs/superpowers/specs/2026-05-31-object-gravity-slice1-design.md
@@ -1,12 +1,29 @@
 # Object-oriented gravity — Slice 1: general object gravity (equal-weight)
 
-**Status:** approved design, pre-implementation
+**Status:** approved design, pre-implementation (revised after parallel review)
 **Date:** 2026-05-31
 **Builds on:** the smart-gravity / ML-detection seam landed in #130 (`g:sm`,
 `g:obj:face`, face-assist, the `ImagePipe.Transform.Detector` behaviour, the
 bundled `ImageVision` YuNet adapter, `focal_from_regions`, detector identity in
 the cache key, the `detector_required` gate, `[:transform, :detect]` telemetry,
 `Detector.Warmup`).
+
+> **Review revisions (2026-05-31).** A four-reviewer parallel cycle (boundary,
+> cache/runtime correctness, `image_vision` integration reality, test
+> strategy/scope) ran against this spec. Accepted changes folded in below:
+> fixed a telemetry filename-leak (emit child **module name**, not the identity
+> tuple); made the class-threading wiring explicit at *both* the plug gate and the
+> runner key-build; enumerated the `:all` producer edits (`detect_classes/1`,
+> `KeyData.guide_data/1`, the `CropGuided`/`crop` typespecs); corrected the Objects
+> adapter to use `:filename` / no `:nms_iou` / `available? =
+> ensure_loaded?(Image.Detection)` and to derive `supported_classes` from the
+> public `Image.Detection.classes/0`; resolved COCO label spelling
+> (underscore↔space normalization); strengthened the test plan (FakeDetector-driven
+> wire pixel test for a non-face class + a no-geometry variant, the gate triad,
+> merge-via-fake-children, continuity-as-invariant); and added ML-nondeterminism
+> and model-size risks. The integration reviewer **confirmed** the central
+> `Image.Detection.detect/2` API assumption against the installed `image_vision
+> 0.4.0` (same `region` shape, COCO-80, options `min_score`/`repo`/`filename`).
 
 ## Goal
 
@@ -67,7 +84,8 @@ The design was brainstormed decision-by-decision. The settled answers:
    (`effective_classes`). No new config knob.
 6. **Telemetry — aggregate span + per-model nested spans.** Keeps honest total
    timing and restores per-model cold-start visibility that today's single face
-   span has.
+   span has. The per-model span identifies the child by **module name only** (no
+   model filename/path — see § Telemetry).
 7. **Config — minimal.** Keep `detector` / `detector_required`. `:default` becomes
    the Composite with baked-in default models and per-child default `min_score`.
    Hosts tune via the existing custom-detector extension point. Model
@@ -90,7 +108,7 @@ The design was brainstormed decision-by-decision. The settled answers:
   `available?/1` is `false` (deps missing), because the vocabulary is metadata,
   not a runtime capability.
 - The Composite uses it to route a requested class set to children and to
-  evaluate per-request availability.
+  evaluate per-request availability and identity.
 - `detect/2`'s `classes` opt is now `:all | [String.t()]`. `:all` means "every
   region this detector can produce" (no class filter).
 
@@ -100,7 +118,17 @@ with the repo's "call the callback, let missing callbacks raise" stance.
 ### Adapters: split the bundled `ImageVision` into Face + Objects
 
 The current single `ImagePipe.Transform.Detector.ImageVision` (YuNet face) is
-split into two product-neutral adapter modules under the same namespace:
+split into two product-neutral adapter modules under the same namespace.
+
+> Integration facts confirmed against the installed `image_vision 0.4.0`
+> (`deps/image_vision/lib/{face_detection,detection}.ex`): both `detect`
+> functions return a bare list of `%{label, score, box: {x, y, width, height}}`
+> (absolute top-left pixels, sorted by score desc) — **identical** to our
+> `Detector.region` shape, with no tuple-order or normalized-vs-abs mismatch.
+> Key asymmetries between the two image_vision APIs to respect:
+> - Face uses option `:model_file`; **Objects uses `:filename`**.
+> - Objects has **no `:nms_iou`** (RT-DETR is NMS-free); Face does.
+> - Objects results carry a real `label`; the Face adapter sets `"face"` itself.
 
 - **`ImagePipe.Transform.Detector.ImageVision.Face`**
   - Wraps `Image.FaceDetection.detect/1` (YuNet), as today.
@@ -110,42 +138,65 @@ split into two product-neutral adapter modules under the same namespace:
   - `available?/1`: `Code.ensure_loaded?(Image.FaceDetection)`, as today.
   - `identity/1`: `{__MODULE__, {repo, model_file, min_score}}`.
   - `warmup/1`: blank-image detect to trigger model load, as today.
+  - Keeps the existing narrow `rescue` boundary around the optional-dep call.
 
 - **`ImagePipe.Transform.Detector.ImageVision.Objects`** (new)
-  - Wraps `Image.Detection.detect/2` (RT-DETR, COCO-80). **Verify the exact
-    function/option names and the COCO-80 label list against the installed
-    `image_vision` before wiring** (assumed: returns `%{label, score, box:
-    {x,y,width,height}}` abs pixels sorted by score; opts `min_score:`, `repo:`,
-    `filename:`).
-  - `supported_classes(_) → <COCO-80 labels>` (owned by this adapter — the
-    parser/planner must never enumerate them).
-  - `detect/2`: runs detection, filters results to the routed classes (or returns
-    all for `:all`), applies `min_score`.
-  - `available?/1`: presence check for `Image.Detection`.
-  - `identity/1`: `{__MODULE__, {repo, filename, min_score}}`.
+  - Wraps `Image.Detection.detect/2` (RT-DETR, COCO-80).
+  - `supported_classes(_)` **derives from the public `Image.Detection.classes/0`**
+    (the 80 COCO labels image_vision exposes) rather than hardcoding a second,
+    drift-prone copy. Cheap, static, no model load.
+  - `detect/2`: runs detection (option `min_score`), filters results to the routed
+    classes (or returns all for `:all`).
+  - `available?/1`: `Code.ensure_loaded?(Image.Detection)` (mirrors Face).
+  - `identity/1`: `{__MODULE__, {repo, filename, min_score}}` — note `:filename`,
+    **not** `:model_file`.
   - `warmup/1`: blank-image detect to trigger model load.
+  - Keeps the same narrow `rescue` boundary as the Face adapter (optional-dep /
+    `Ortex.run` / model-fetch can raise).
+  - **Defaults (from image_vision 0.4.0):** `repo: "onnx-community/rtdetr_r50vd"`,
+    `filename: "onnx/model.onnx"` (~175 MB; a ~45 MB quantized variant exists via
+    `filename: "onnx/model_quantized.onnx"`), `min_score: 0.5`.
+
+**Class spelling — underscore↔space normalization.** The model's COCO labels use
+**spaces** for multi-word classes (`"traffic light"`, `"fire hydrant"`, `"stop
+sign"`, `"sports ball"`, `"baseball bat"`, `"cell phone"`, `"dining table"`, `"hot
+dog"`, `"potted plant"`, `"teddy bear"`, `"hair drier"`, `"wine glass"` — 12 of
+80). Spaces are URL-hostile and imgproxy class files conventionally use
+underscores. So the Objects adapter normalizes underscores↔spaces when matching
+requested classes against `supported_classes` and when filtering results, so a URL
+class like `obj:traffic_light` routes correctly. `supported_classes/1` may report
+the underscore form (the URL-facing spelling); the single-word classes (`person`,
+`car`, `dog`, …) are unaffected. This normalization is a property of the Objects
+adapter (vocabulary owner), not the parser.
 
 ### `ImagePipe.Transform.Detector.Composite` (new)
 
 A product-neutral router holding an **ordered list of child detectors**.
 
 - **Construction:** `:default` resolves to `Composite[Face, Objects]` (in that
-  order, so face wins ties in ordered merges if any). Children carry their own
-  default opts (models, `min_score`).
+  order). Children carry their own default opts (models, `min_score`).
 - **`detect(image, opts)`** where `opts[:classes]` is `:all | [String.t()]`:
   - `:all` → run **every** child with `classes: :all`; merge all regions.
-  - list → for each child, compute `routed = requested ∩ child.supported_classes`;
-    run only children with a non-empty `routed` (passing `classes: routed`); merge
-    regions. Classes claimed by no child are **dropped** (best-effort).
+  - list → for each child, compute `routed = requested ∩ child.supported_classes`
+    (under the adapter's spelling normalization); run only children with a
+    non-empty `routed` (passing `classes: routed`); merge regions. Classes claimed
+    by no child are **dropped** (best-effort).
   - Merge is region-list concatenation (order-independent for the equal-weight
-    area centroid). De-duplication of overlapping `person`/`face` is **not**
-    performed — both contribute by area; Slice 2 weights arbitrate.
+    area centroid). Each merged region **retains its `label`** (so Slice 2 can
+    weight per class with no merge change). De-duplication of overlapping
+    `person`/`face` is **not** performed — both contribute by area; Slice 2 weights
+    arbitrate.
 - **`supported_classes(opts)`** → union of children's `supported_classes`.
 - **`available?(opts)`** → evaluated for the request's class set
-  (`opts[:classes]`): the children that the class set routes to must be available.
-  `:all` routes to all children → all must be available. Used by the strict gate.
-- **`identity(opts)`** → the identities of only the children the request's class
-  set routes to, as an ordered list (see § Cache identity). Class-aware.
+  (`opts[:classes]`, threaded in by the gate): the children that the class set
+  routes to must be available. `:all` routes to all children → all must be
+  available. An all-unknown set routes to **no** child, so there is no
+  required-but-unavailable child → `available?` returns **true** (the request will
+  degrade to attention at execution, not 422). Used by the strict gate.
+- **`identity(opts)`** → the identities of the children the request's class set
+  routes to, built by **filtering the fixed ordered child list** (never by
+  iterating the requested class set), so identity is invariant to URL class order.
+  Class-aware (see § Cache identity).
 
 ### Plan representation
 
@@ -160,19 +211,30 @@ alongside the existing class-list form:
   is never expanded to a concrete class list at parse/plan time — doing so would
   force the parser/planner to know the detector's vocabulary, violating the
   namespace boundary (parser owns syntax, detector owns vocabulary).
-- `ImagePipe.Plan.detect_classes/1` returns `:all | nonempty_list(String.t()) |
-  nil`.
-- `key_data` guide encoding:
-  - `{:detect, :all}` → `[type: :detect, classes: :all]`
-  - `{:detect, classes}` → `[type: :detect, classes: Enum.sort(classes)]`
+
+**Required producer edits for the `:all` shape** (each is a real code path a wire
+`obj`/`obj:all` request hits — missing any one crashes or silently misbehaves):
+
+1. `ImagePipe.Plan.Operation.CropGuided` — `guide` type gains `{:detect, :all}`.
+2. `lib/image_pipe/transform/operation/crop.ex` — the operation `gravity`
+   typespec and the `execute/2` detect arm accept `{:detect, :all}` (the existing
+   `gravity: {:detect, classes}` head matches with `classes = :all`; confirm
+   `run_detect`/telemetry carry `classes` as `:all | list`).
+3. `ImagePipe.Plan.detect_classes/1` — `@spec` and body widen to
+   `:all | nonempty_list(String.t()) | nil`.
+4. `lib/image_pipe/plan/key_data.ex` — add a `guide_data({:detect, :all})` clause
+   returning `[type: :detect, classes: :all]` (today's clause is guarded
+   `when is_list(classes)` and would `FunctionClauseError` on `:all`). The list
+   clause keeps `classes: Enum.sort(classes)`.
 
 ### Parser (imgproxy) — stays vocabulary-free
 
 In `lib/image_pipe/parser/imgproxy/`:
 
 - `option_grammar.ex` already parses `g:obj:…` and `c:W:H:obj:…` into
-  `{:obj, classes}` with no parse-time validation. Confirm it accepts the empty
-  class list (bare `g:obj`) and multi-class lists; both `g:` and `c:W:H:` forms.
+  `{:obj, classes}` with no parse-time validation, preserving the literal class
+  list including `[]` (bare `g:obj`) and a literal `"all"` token. Confirm both
+  `g:` and `c:W:H:` forms; no grammar change expected beyond confirmation.
 - `plan_builder.ex` — replace the hard `["face"]`-only gate in `tagged_gravity/2`:
   - `{:obj, classes}` where `classes == []` or `"all" ∈ classes` → `{:detect, :all}`
   - `{:obj, classes}` (non-empty, no `all`) → `{:detect, classes}`
@@ -188,26 +250,38 @@ In `lib/image_pipe/parser/imgproxy/`:
 
 In `lib/image_pipe/transform/operation/crop.ex`:
 
-- `detect_crop` handles `{:detect, :all}` in addition to the class-list form,
+- `detect_crop` handles `{:detect, :all}` and `{:detect, [classes]}` uniformly,
   threading `classes` (`:all` or list) into the detector opts.
-- `focal_from_regions` is **unchanged** — equal-weight area centroid. (Slice 2
-  introduces the weighted formula.)
+- `focal_from_regions` is **unchanged** — equal-weight area centroid, label-
+  agnostic (reads only `box`, filters in-bounds, area-weights, normalizes, clamps).
+  Concatenating Face + Objects regions feeds it more boxes; the reduce is
+  commutative, so merge order is irrelevant. (Slice 2 introduces the weighted
+  formula.)
 - Detector resolution: `:default` resolves to the Composite via
-  `Transform.resolve_detector/1`. Request/source/response code continues to
-  dispatch only through generic `ImagePipe.Transform` functions and must not name
-  `Composite`, `ImageVision.Face`, or `ImageVision.Objects` directly (Boundary).
+  `Transform.resolve_detector/1` (the `@default_detector` constant in
+  `transform.ex` is repointed from `ImageVision` to `Composite`). Request/source/
+  response/cache code continues to dispatch only through generic
+  `ImagePipe.Transform` functions and must not name `Composite`, `ImageVision.Face`,
+  or `ImageVision.Objects` (Boundary; enforced by `architecture_boundary_test`).
 - **Face-assist is unchanged:** `{:smart, :face_assist}` still calls detection
   with `classes: ["face"]`, which routes to the Face child only. Its blend math,
   weight, and `[:transform, :detect, :blend]` event are untouched.
 
 ### Cache identity (class-aware)
 
-`ImagePipe.Transform.detector_identity/2` becomes class-aware: the cache-key
-build site (`Request.Runner`) threads the plan's detect classes
-(`Plan.detect_classes/1`) into it, and the Composite returns the identities of
-only the children that class set routes to.
+`ImagePipe.Transform.detector_identity/2` becomes class-aware. **Both** class-
+threading call sites must put the plan's detect classes into the opts handed to
+the generic `Transform` facade (reviewer-verified to introduce no forbidden
+boundary edge — request code touches only `Plan` + the generic `Transform`):
 
-Resulting identities:
+- `Request.Runner.put_detector_identity/2` (cache-key build) →
+  `Keyword.put(opts, :classes, Plan.detect_classes(plan))` before
+  `Transform.detector_identity(detector, opts)`.
+- `ImagePipe.Plug.validate_detector_capability/2` (strict gate) → the same
+  threading before `Transform.detector_available?(detector, opts)`.
+
+The Composite then returns the identities of only the children that class set
+routes to. Resulting identities:
 
 | Request        | Children that run | Identity material        |
 | -------------- | ----------------- | ------------------------ |
@@ -220,26 +294,32 @@ Consequences this guarantees:
 
 - Bumping the face model **does not** invalidate `obj:car` results (the face
   model can't change a car crop) — the key reflects response identity, per the
-  cache guidelines.
+  cache guidelines. (Depends on the threading above actually landing.)
+- The identity list order comes from the **fixed child order**, not the requested
+  class order, so `obj:face:dog` and `obj:dog:face` produce an identical identity
+  list (and `term_to_binary([:deterministic])` serializes it stably).
 - Each child identity folds in `(repo, model_file/filename, min_score)`, since
   `min_score` changes which regions survive → changes the crop → changes the
-  bytes.
+  bytes. Identity assumes the model artifact is **immutable per `{repo,
+  filename}`** (a mutable HF tag could change bytes under a stable key — same
+  assumption the existing face detector already carries).
 - Cache key carries the canonical *requested* class set (sorted); unknown classes
   that get dropped at runtime stay in the key (harmless over-keying — never
-  serves wrong bytes). No new cache-key data version bump (greenfield; reshape in
-  place).
+  serves wrong bytes, only an extra miss). No new cache-key data version bump
+  (greenfield; reshape in place).
 
 ### Strict gate (`detector_required`)
 
 `validate_detector_capability/2` (plug, pre-fetch) generalizes from face-only:
 
-- Fires only when `detector_required: true` **and** the plan requests detection.
+- Fires only when `detector_required: true` **and** the plan requests detection
+  (`Plan.detect_classes/1 != nil`, true for `:all` and any class list).
 - Availability is evaluated for the request's class set (threaded into the
-  Composite's `available?`). A 422-before-fetch is returned when a **real,
-  supported, requested** class has no available detector.
-- **Unknown classes never trigger the gate** — they are dropped (not an
-  availability failure). If a request's classes all drop to nothing, it degrades
-  to attention like any other no-detection case (it is not a 422).
+  Composite's `available?`, as above). A 422-before-fetch is returned when a
+  **real, supported, requested** class has no available detector.
+- **Unknown classes never trigger the gate** — they route to no child, so there is
+  no required-but-unavailable child; `available?` returns true and the request
+  degrades to attention (it is not a 422).
 - Graceful default (`detector_required: false`) unchanged: no available detector →
   attention fallback. Face-assist is never hard-rejected.
 
@@ -251,15 +331,23 @@ Consequences this guarantees:
   aggregates across children: `:detected` if any child returned regions,
   `:no_regions` if all ran empty, `:unavailable`/`:error` on child failure.
 - **`[:transform, :detect, :model]`** (new) — a nested span per child detector
-  that runs, with metadata: `detector` (child identity), `classes` (the routed
-  subset, `:all` or list), `regions` (count), and honest inference duration (model
-  inference is real eager work — legitimate compute timing).
+  that runs. Metadata: **`detector` = the child *module name* only** (e.g.
+  `ImagePipe.Transform.Detector.ImageVision.Objects`), the routed `classes` subset
+  (`:all` or list), `regions` (count), and honest inference duration (model
+  inference is real eager work — legitimate compute timing, unlike libvips-lazy
+  per-operation spans).
+  - **Do NOT emit the child identity tuple** (`{repo, filename, min_score}`): it
+    contains a model filename/repo path, which the telemetry guidelines forbid
+    ("never emit filenames or other path-derived identifiers"). Module name is the
+    product-neutral discriminator. (If model-version observability is ever needed,
+    derive a non-reversible token — not the raw `{repo, filename}`.)
 - **`[:transform, :detect, :skipped]`** unchanged (no detector configured),
   carrying `classes`.
 - Metadata stays product-neutral and non-sensitive: module names, class strings,
   counts. No paths, URLs, signatures, or filenames.
 - The opt-in default Logger and `telemetry.md` are updated for the new model span
-  and the requested/effective metadata.
+  and the requested/effective metadata. A telemetry test asserts the model span
+  metadata contains **no** filename/path strings.
 
 ### Config & wiring
 
@@ -267,9 +355,12 @@ Consequences this guarantees:
   `detector_required` (boolean). No new model-tuning options.
 - `:default` = `Composite[Face, Objects]` with image_vision default models and a
   per-child default `min_score`.
-- **Warmup:** the warmup worker warms both children (face + objects). Update the
-  default wiring/docs so a single warmup pre-loads both models (e.g. warm with
-  `classes: :all`, or warm each child).
+- **Warmup:** the warmup worker warms both children (face + objects), e.g. warm
+  with `classes: :all`. Build/deploy alternative: `mix
+  image_vision.download_models --detect` pre-fetches the RT-DETR object model
+  (this *does* include it, unlike YuNet which the task omits). The RT-DETR model
+  is ~175 MB, so cold-start is far heavier than faces — warmup matters much more
+  here; document it.
 - Custom detectors and the Composite remain the host's tuning path.
 
 ### Demo
@@ -279,52 +370,83 @@ Per the repo convention to keep the demo in sync with transform changes
 
 - Add object-class gravity controls: a class multi-select (COCO-80 + an `all`
   option) plus the bare-`obj` form, wired into URL state alongside the existing
-  face and smart-crop controls.
+  face and smart-crop controls. Use the URL-facing (underscore) class spelling.
 - Keep `detector: :default` wiring.
 
 ### Docs
 
 - `docs/content-aware-gravity.md` — add the general object gravity section
   (multi-class, `all`/bare-`obj` includes faces, best-effort unknown-class drop,
-  class-aware cache identity), and note `objw` is Slice 2.
+  class-aware cache identity, underscore class spelling), and note `objw` is
+  Slice 2. Mention RT-DETR cold-start/model-size and the `--detect` download task.
 - `docs/imgproxy_support_matrix.md` — update the obj-gravity row: multi-class and
   `all` now supported; `objw` / `objects_position` still out (Slice 2 / out of
   scope). Keep the YuNet-vs-imgproxy-YOLO divergence notes; add the RT-DETR/COCO-80
   object model.
-- `docs/telemetry.md` — document the per-model span and the
-  requested/effective-classes metadata.
+- `docs/telemetry.md` — document the per-model span (module-name discriminator,
+  no filenames) and the requested/effective-classes metadata.
 
 ## Testing
 
 Following the repo test guidelines (assert at boundaries the caller doesn't
-control; no impossible-internal-misuse, name-policing, or parity-pin tests):
+control; no impossible-internal-misuse, name-policing, or parity-pin tests).
+**All deterministic geometry/identity tests use `FakeDetector` (a real
+`@behaviour` producer) injected via `detector:` — never the real ML model** — so
+they run in the default lane and don't depend on model downloads or
+nondeterministic inference.
 
 - **Parser** (`option_grammar`/`plan_builder` tests): `obj:%c1:…:%cN`, bare
   `obj` → `:all`, `obj:all` → `:all`, `all` among classes → `:all`; both `g:` and
-  `c:W:H:` forms; order-insensitivity of the class list; the former `["face"]`
-  gate no longer rejects other classes.
+  `c:W:H:` forms; order-insensitivity of the class list. Flip the existing
+  `plan_builder_test.exs` "rejects bare/all/multi-class object gravity" cases
+  (currently asserting rejection) to acceptance — these are genuine behavior-change
+  flips, not parity pins.
 - **Planner mapping:** `tagged_gravity` emits `{:detect, :all}` / `{:detect,
-  classes}`; parser remains vocabulary-free (no COCO import — assert via the
-  architecture boundary test, the only place source-scanning is allowed).
-- **Composite unit tests:** routing/partition by `supported_classes`, merge,
-  union `supported_classes`, best-effort drop of unclaimed classes, `:all` runs
-  all children, class-aware `identity/1` (face-only vs objects-only vs both),
-  class-aware `available?/1`.
-- **Wire-level Plug tests** (real `ImagePipe.call/2`, decode the body): `obj:car`,
-  `obj:face:dog`, and `obj:all` produce expected geometry vs a plain/attention
-  baseline; `detector_required` returns 422 **before** source fetch/cache access
-  when a supported class has no available detector; cache reuse for
-  order-equivalent class lists; `Vary: Accept` unaffected.
-- **Cache-key tests:** `obj:face` key equals the pre-change face key (continuity);
-  `obj:car` key differs and is unaffected by a face-model identity bump;
-  `obj:face:car` includes both; class-list canonicalization (sorted) yields a
-  stable key regardless of URL order.
+  classes}`; parser/planner remains detector-vocabulary-free — assert via the
+  `architecture_boundary_test` detector-module scan (extend the forbidden-globs to
+  parser/plan for **detector-module references**, not a COCO-label denylist, which
+  would itself leak vocabulary).
+- **Composite unit tests** (driven by **fake child detectors**, not hand-built
+  region lists): routing/partition by `supported_classes`; `:all` runs all
+  children; best-effort drop of unclaimed classes; union `supported_classes`;
+  class-aware `identity/1` (face-only vs objects-only vs both) and its **URL-order
+  invariance** (`obj:face:dog` identity == `obj:dog:face` identity); class-aware
+  `available?/1` including the all-unknown→`true` case. Assert observable output
+  (merged region count / resulting focal point), not a private merge helper.
+- **Wire-level Plug tests** (real `ImagePipe.call/2`, **decode the body**, inject
+  FakeDetector):
+  - A **non-face class** (e.g. `obj:car`) with a FakeDetector returning a corner
+    box: decode and `refute` body-equality vs **both** a centered crop and a `g:sm`
+    attention crop — proving the crop genuinely moved and did not silently fall back
+    to attention (the central risk of this feature). Template: the `g:sm` pixel test
+    in `imgproxy_wire_conformance_test.exs`.
+  - A **no-geometry** `g:obj:…` variant (gravity without `rs:fill`/`c:`), covered
+    separately per the guideline.
+  - `obj:face:dog` / `obj:all` representative geometry.
+  - **Gate triad** (Composite with Face available, Objects unavailable, under
+    `detector_required: true`): `obj:face` → 200 (Face routes, available);
+    `obj:car` → 422 **before** source fetch/cache (Objects routes, unavailable);
+    `obj:unknownclass` → **not** 422 (dropped → degrades to attention/200).
+  - Cache reuse for order-equivalent class lists; `Vary: Accept` unaffected.
+- **Cache-key tests:** `obj:face` keys to **Face-child-identity-only** and is
+  unchanged by an Objects/other-model identity bump (assert as a *structural
+  invariant* — "face request's identity must not depend on the object model" — not
+  a captured-hash parity pin); `obj:car` keys differ and are unaffected by a
+  face-model identity bump; `obj:face:car` includes both; class-list
+  canonicalization (sorted) yields a stable key regardless of URL order.
 - **Telemetry tests:** aggregate `[:transform, :detect]` carries
   `requested_classes`/`effective_classes`; a per-model `[:transform, :detect,
-  :model]` span is emitted per child that runs; `:skipped` still fires with no
-  detector.
+  :model]` span is emitted per child that runs, with `detector` = module name and
+  **no filename/path string** in metadata; `:skipped` still fires with no detector.
 - **Property tests:** parser order-insensitivity for class lists; cache-key
   canonicalization across class orderings.
+- **Real-model lane (one `@tag :image_vision` coarse smoke test only):** a single
+  test that exercises the live Objects adapter and asserts only *coarse*
+  invariants — status 200, correct output dimensions, `result: :detected`
+  telemetry — and a `supported_classes/1` sanity assert (non-empty, contains a
+  known label like `"person"`, catching a wrong label list). **Never** assert exact
+  pixels or exact box coordinates against the real model (nondeterministic across
+  versions/platforms). Mirrors the existing tagged `image_vision_test.exs` pattern.
 
 ## Boundary / namespace compliance
 
@@ -332,24 +454,39 @@ control; no impossible-internal-misuse, name-policing, or parity-pin tests):
   `Composite`, `ImageVision.Face`, `ImageVision.Objects`.
 - The `Detector` behaviour and the generic `ImagePipe.Transform` entry points are
   the only detector surface exported; concrete adapter/Composite modules are not
-  named by request/source/response code.
-- Parser emits only product-neutral `{:detect, …}` guides; `all`-normalization is
-  isolated in the imgproxy parser.
-- No detector vocabulary leaks into `parser`, `request`, `cache`, or `plan`.
+  named by request/source/response/cache code. The class-threading at the gate and
+  key-build touches only `Plan` + the generic `Transform` facade (no forbidden
+  edge — reviewer-verified against `architecture_boundary_test`).
+- Parser emits only product-neutral `{:detect, …}` guides; `all`-normalization and
+  class-spelling normalization are isolated in the parser and the Objects adapter
+  respectively; no detector vocabulary leaks into `parser`, `request`, `cache`, or
+  `plan`.
 
-## Risks / assumptions to verify during implementation
+## Risks / assumptions
 
-1. **`Image.Detection.detect/2` API** — confirm exact function name, option names
-   (`min_score`/`repo`/`filename`), return shape, and the COCO-80 label list
-   against the installed `image_vision` before wiring the Objects adapter. The
-   region shape is assumed identical to the existing `Detector.region`
-   (`%{label, score, box: {x, y, width, height}}`, abs pixels, sorted by score).
-2. **`ortex`/model download** — RT-DETR pulls a model on first use, like YuNet.
-   The warmup worker must cover it; the first cold object request otherwise pays
-   the download. Document alongside the existing face warmup guidance.
-3. **Both-models cost for `:all`** — `obj`/`obj:all` runs two models. Acceptable
-   and intended; the per-model telemetry span surfaces the cost.
-4. **Equal-weight default bias** — plain `obj:all` on a person photo biases toward
+1. **`Image.Detection.detect/2` API — CONFIRMED** against installed `image_vision
+   0.4.0`: function exists (`detection.ex:131`), returns
+   `%{label, score, box: {x,y,width,height}}` (abs px, sorted desc), options
+   `min_score`/`repo`/`filename`, COCO-80 via the public `Image.Detection.classes/0`.
+   Use `:filename` (not `:model_file`), omit `:nms_iou`.
+2. **ML nondeterminism (test risk).** Real-model detection (box coords, score
+   ordering) varies across versions/platforms, and the `@tag :image_vision` lane
+   downloads models on first detect. Mitigation: all geometry/identity/pixel wire
+   tests inject `FakeDetector`; the real model is exercised by exactly one coarse,
+   tagged smoke test asserting only status/dimensions/`:detected` (no exact
+   pixels). See § Testing.
+3. **Model download & size.** RT-DETR pulls a ~175 MB model on first use (a ~45 MB
+   quantized variant exists via `filename:`). `mix image_vision.download_models
+   --detect` covers it (unlike YuNet); the warmup worker is the runtime path. Cold
+   start is far heavier than faces — warmup guidance is more important here.
+4. **Both-models cost for `:all`.** `obj`/`obj:all` runs two models. Acceptable and
+   intended; the per-model telemetry span surfaces the cost.
+5. **Equal-weight default bias.** Plain `obj:all` on a person photo biases toward
    the larger `person` box, not the face. This is the faithful imgproxy
    equal-weight default; face-centric crops use `obj:face` (Slice 1) or `objw`
    (Slice 2). Documented, not a bug.
+6. **Class-threading is load-bearing.** The class-aware identity/availability story
+   works only if `Plan.detect_classes(plan)` is threaded into opts at **both** the
+   plug gate and the runner key-build. Without it, `obj:car` would be invalidated
+   by a face-model bump and the gate could wrongly 422 a routable request. Covered
+   by the cache-key and gate-triad tests.

--- a/docs/superpowers/specs/2026-05-31-object-gravity-slice2-notes.md
+++ b/docs/superpowers/specs/2026-05-31-object-gravity-slice2-notes.md
@@ -1,0 +1,130 @@
+# Object-oriented gravity — Slice 2 (`objw` weights): design notes
+
+**Status:** pre-spec notes only — NOT a reviewed spec. Slice 2 gets its own
+brainstorm → spec → parallel-review → plan cycle once Slice 1 lands. This file
+captures the design thinking we did while scoping Slice 1 so it isn't lost.
+
+**Depends on:** Slice 1 (general object gravity) —
+`docs/superpowers/specs/2026-05-31-object-gravity-slice1-design.md`. Slice 2 is
+purely additive on top of the Composite/routing + `{:detect, …}` guide that Slice
+1 builds; it requires no rework of Slice 1.
+
+## Scope
+
+Add imgproxy's per-class weighting to object gravity:
+
+- `gravity:objw:%class1:%weight1:…:%classN:%weightN` — per-class weights.
+- The `all` pseudo-class as a **baseline/default** weight, e.g.
+  `objw:all:2:face:3` = "everything weight 2, faces overridden to weight 3".
+- Default weight is `1` (imgproxy).
+
+Out of scope (still): `objects_position` and any further imgproxy object-gravity
+surface beyond `obj`/`objw`.
+
+## Why `all` is a baseline, and why face ∈ all matters
+
+Slice 1 settled that `all` / bare `obj` includes faces (the union of every
+configured detector's classes). That decision is what makes `objw`'s override
+model coherent: `objw:all:2:face:3` reads as "default weight 2 for every detected
+class, with `face` overridden to 3". If faces were excluded from `all`, that
+syntax would be ambiguous (is `face` an addition or an override?). So `objw`
+parses to a weight map like `%{default: 2, "face" => 3}` applied per detected
+region by its `label`.
+
+## The weighted-centroid formula (the core open decision)
+
+Slice 1 keeps the existing **equal-weight `area`** centroid in
+`focal_from_regions` unchanged. Slice 2 introduces a *class-weighted* centroid.
+The formula choice is the crux, because it decides whether a class weight can
+actually move the crop. Three candidates, evaluated against concrete scenes:
+
+**Scenario A — portrait, one person.** RT-DETR emits a large `person` box; YuNet a
+small `face` box inside it (face area ≈ 1/10–1/20 of person). This is the headline
+`objw:all:1:face:3` case ("favor the face").
+
+**Scenario B — clutter: a dominant `car` with a tiny background `person`.** Plain
+weights.
+
+| Formula | Scenario A (boost face) | Scenario B (dominant car) | Verdict |
+| --- | --- | --- | --- |
+| `weight · area` | face stays outvoted — 3×(1/15) still loses to the person box, so the weight is **inert** for its headline use | car correctly dominates | faithful to today, but `objw` face-boosting is cosmetic |
+| **`weight · √area`** (recommended) | √ shrinks the gap to ~1/4, so 3× pulls the focal point onto the face — **weight works** | car's √area still ~6× the background person → car still wins | best balance: "size matters" *and* weights are a real lever |
+| `weight` only (area-ignored) | face=3 vs person=1 → snaps to face | car and tiny background person count **equally** → focal dragged to an incidental object — **wrong crop** | predictable but predictably wrong in clutter |
+
+**Lean:** `weight · √area`. It preserves the sane "dominant object wins" default
+(Scenario B) while making class weights a usable lever for the face-vs-body case
+(Scenario A). `weight · area` ships an `objw` knob that's inert for its most
+natural use; `weight`-only gives incidental small objects a full vote and produces
+bad crops in cluttered scenes (the common case).
+
+**Honest default consequence:** with all weights at 1 (plain `obj:all`), a portrait
+biases toward the larger `person` box, not the face — under *any* formula. Face-
+centric crops use `obj:face` (Slice 1) or an `objw` face boost (Slice 2).
+
+**How the choice is made:** settle `weight·area` vs `weight·√area` vs `weight`-only
+by **dev-loop experimentation on real images**, behind a **dev/test-only toggle**
+(the same way `SimpleServer` is dev/test-only and never compiles into prod). The
+toggle is removed before merge — it is **never** a public/plug option (a formula
+knob would be cache-key-affecting, validated, documented contract surface for a
+question we're only answering once). Isolate the weight in one private function so
+the three strategies are swappable during the experiment, then bake the winner and
+delete the others.
+
+**Riders:**
+- `min_score` stays a **filter** (drop low-confidence detections at the threshold),
+  not a weight multiplier — folding score into the formula adds a third invisible
+  factor that makes crops hard to reason about.
+- Adopting `weight·√area` also slightly changes how *multiple equal-weight faces*
+  combine vs Slice 1's pure `area` (a small far face no longer so completely loses
+  to a large near one). Greenfield, acceptable; unify on one formula everywhere
+  rather than keeping two.
+
+## Threading weights: grammar → plan → focal
+
+- **Parser (imgproxy):** add `objw:%class:%weight:…` grammar (alongside the Slice 1
+  `obj` grammar). Map to a product-neutral guide carrying weights. Like Slice 1,
+  the parser stays vocabulary-free — it carries class *strings* and *weights*, never
+  enumerating a model's classes; `all` stays the baseline sentinel.
+- **Plan guide reshape:** Slice 1's `{:detect, :all} | {:detect, [classes]}` becomes
+  weight-carrying. Options to decide in the Slice 2 spec: a third tuple element
+  (`{:detect, spec, weights}`) or a small struct (`{:detect, %Detect{spec, weights}}`).
+  Greenfield → reshape `CropGuided`/`Resize`/`crop.ex`/`key_data`/`detect_classes`
+  in place (and bump nothing — cache key data reshapes in place per the repo's
+  greenfield cache guideline). Weights go into the cache key (they change pixels).
+- **`focal_from_regions`:** apply `weight(label) · f(area)` per region, where
+  `weight(label)` resolves against the parsed weight map (`label`-keyed, with the
+  `all`/default baseline) and `f` is the chosen area function. The merged regions
+  already retain their `label` (Slice 1 guarantees this), so no Composite change is
+  needed to weight per class.
+
+## Surfaces to update (Slice 2)
+
+- Parser grammar + mapping for `objw` (both `g:` and `c:W:H:` forms, consistent
+  with Slice 1's dual `resize_guide`/`tagged_gravity` mapping).
+- Plan guide shape + `key_data` (weights are key material) + `detect_classes` (it
+  must still report the class set / `:all` for gating and identity).
+- `focal_from_regions` weighted centroid + the dev-only formula toggle.
+- Telemetry: the per-model/detect spans may carry the effective weight map
+  (product-neutral; weights are derived from the public request).
+- Demo: per-class weight controls + URL state.
+- Docs: `content-aware-gravity.md`, `imgproxy_support_matrix.md` (flip the `objw`
+  row from "out (Slice 2)" to supported).
+
+## Tests (Slice 2)
+
+- Parser: `objw:%c:%w:…` grammar, `all` baseline + per-class override, order-
+  insensitivity, both `g:`/`c:` forms.
+- A request-boundary **pixel** test proving a face weight boost *actually moves the
+  crop* (decode body; `objw:all:1:face:3` vs `obj:all` differ, biased toward the
+  face) — using an injected fake detector for determinism, per Slice 1's harness.
+- Cache key: weights are key material (different weights → different key; equal
+  weights in different URL order → same key).
+- The formula-experiment toggle is dev/test-only and removed before merge — no test
+  pins it.
+
+## Open questions for the Slice 2 brainstorm
+
+- Final guide shape (tuple vs struct) for carrying weights.
+- Exact `f(area)` (confirm `√area` empirically; consider a tunable exponent only if
+  experimentation demands it — default to no new knob).
+- Whether the per-model telemetry span should surface the resolved weights.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -134,26 +134,51 @@ outcome categories in this list.
 
 ## Content-aware crop detection
 
-Face-aware crops (`g:obj:face`, `c:W:H:obj:face`, and face-assisted `g:sm`)
-report detection two ways, depending on whether any detection actually ran.
+Detection-aware crops (`g:obj:face`, `g:obj:car`, `g:obj`, `c:W:H:obj:…`, and
+face-assisted `g:sm`) report detection two ways, depending on whether any
+detection actually ran.
 
 When a detector is configured, ImagePipe wraps the detector invocation in a
 `[:image_pipe, :transform, :detect]` span whose duration reflects real inference
 work (useful for spotting model cold-start cost). Stop metadata:
 
-- `:classes` - the requested detection classes, e.g. `["face"]`.
-- `:regions` - the number of regions the detector returned.
+- `:classes` - the requested detection classes, e.g. `["face"]` or `:all`.
+- `:regions` - the total number of regions the detector returned.
 - `:result` - the detector outcome, one of:
   - `:detected` - the detector returned at least one region.
-  - `:no_regions` - the detector ran but found nothing (no face in the frame).
-    This is a normal result, **not** a failure; the crop falls back to libvips
-    attention saliency.
+  - `:no_regions` - the detector ran but found nothing (no matching object in the
+    frame). This is a normal result, **not** a failure; the crop falls back to
+    libvips attention saliency.
   - `:unavailable` - the configured detector reported it is unavailable.
   - `:error` - the detector raised, errored, or returned a malformed result.
 
 `:result` reflects the *detector* outcome, not the final crop decision: a
 `:detected` result whose boxes all fall outside the image still degrades to
 attention downstream.
+
+### Per-model spans (Composite detector)
+
+When using the bundled Composite detector (the default), ImagePipe also emits a
+nested `[:image_pipe, :transform, :detect, :model]` span **per child detector
+that ran**. These spans are emitted inside the outer `[:transform, :detect]`
+span. Stop metadata:
+
+- `:detector` - the child detector module that ran (e.g.
+  `ImagePipe.Transform.Detector.ImageVision.Face`).
+- `:model` - the child's `identity/1` result for this request (e.g.
+  `{ImagePipe.Transform.Detector.ImageVision.Face, {"opencv/face_detection_yunet", "face_detection_yunet_2023mar.onnx"}}`).
+- `:classes` - the class subset routed to this child for the request (a list of
+  class name strings, or `:all`).
+- `:regions` - the number of regions this child returned.
+
+To determine the **effective detected class set** from per-model spans: take the
+union of all `:classes` values across all `:stop` events for a given request. A
+class that was requested but does not appear in any per-model span was unknown to
+all configured detectors and was silently dropped (best-effort).
+
+> **Custom-detector authors:** keep your `identity/1` return value free of
+> secrets — it appears in these per-model spans, which fan out to every attached
+> handler including third-party exporters.
 
 When **no** detector is configured, no detection runs, so there is no span.
 Instead ImagePipe emits a one-shot (non-span) marker:

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -90,7 +90,10 @@ HTTP cache decision events aren't spans. ImagePipe emits them with
 
 ## Metadata
 
-Metadata is intentionally low-cardinality and product-neutral. Common fields are:
+Metadata is product-neutral and free of sensitive data (no secrets, credentials,
+or source-derived paths). Cardinality is a consumer concern — handlers may safely
+accept high-cardinality fields and project or aggregate them as needed. Common
+fields are:
 
 - `:parser` - the configured parser module.
 - `:request_method` - the HTTP method.

--- a/lib/image_pipe/parser/imgproxy/plan_builder.ex
+++ b/lib/image_pipe/parser/imgproxy/plan_builder.ex
@@ -644,10 +644,7 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilder do
 
   defp resize_guide(:sm, true), do: {:ok, {:smart, :face_assist}}
   defp resize_guide(:sm, _face_assist), do: {:ok, :smart}
-  defp resize_guide({:obj, ["face"]}, _face_assist), do: {:ok, {:detect, ["face"]}}
-
-  defp resize_guide({:obj, classes}, _face_assist),
-    do: {:error, {:unsupported_gravity, {:obj, classes}}}
+  defp resize_guide({:obj, classes}, _face_assist), do: {:ok, object_detect_guide(classes)}
 
   defp resize_guide({:anchor, :center, :center}, _face_assist), do: {:ok, :center}
   defp resize_guide({:anchor, x, y}, _face_assist), do: {:ok, {:anchor, x, y}}
@@ -661,10 +658,7 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilder do
 
   defp tagged_gravity(:sm, true), do: {:ok, {:smart, :face_assist}}
   defp tagged_gravity(:sm, _face_assist), do: {:ok, :smart}
-  defp tagged_gravity({:obj, ["face"]}, _face_assist), do: {:ok, {:detect, ["face"]}}
-
-  defp tagged_gravity({:obj, classes}, _face_assist),
-    do: {:error, {:unsupported_gravity, {:obj, classes}}}
+  defp tagged_gravity({:obj, classes}, _face_assist), do: {:ok, object_detect_guide(classes)}
 
   defp tagged_gravity({:anchor, x, y}, _face_assist), do: {:ok, crop_anchor_guide(x, y)}
 
@@ -688,6 +682,18 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilder do
     with {:ok, {numerator, denominator}} <- decimal_ratio_parts(value) do
       gcd = Integer.gcd(numerator, denominator)
       {:ok, {:ratio, div(numerator, gcd), div(denominator, gcd)}}
+    end
+  end
+
+  # Maps imgproxy object gravity classes to a product-neutral detect guide.
+  # Bare `obj` (empty classes) or `all` anywhere collapses to the :all sentinel;
+  # otherwise the explicit class list is carried through. Shared by the fill
+  # (resize_guide) and crop (tagged_gravity) paths so they cannot diverge.
+  defp object_detect_guide(classes) do
+    if classes == [] or "all" in classes do
+      {:detect, :all}
+    else
+      {:detect, classes}
     end
   end
 

--- a/lib/image_pipe/plan.ex
+++ b/lib/image_pipe/plan.ex
@@ -86,7 +86,7 @@ defmodule ImagePipe.Plan do
   end
 
   @doc "Returns the detect-guide classes if any operation requests detection, else nil."
-  @spec detect_classes(t()) :: nonempty_list(String.t()) | nil
+  @spec detect_classes(t()) :: :all | nonempty_list(String.t()) | nil
   def detect_classes(%__MODULE__{pipelines: pipelines}) do
     pipelines
     |> Enum.flat_map(& &1.operations)

--- a/lib/image_pipe/plan.ex
+++ b/lib/image_pipe/plan.ex
@@ -90,12 +90,18 @@ defmodule ImagePipe.Plan do
   def detect_classes(%__MODULE__{pipelines: pipelines}) do
     pipelines
     |> Enum.flat_map(& &1.operations)
-    |> Enum.find_value(fn op ->
+    |> Enum.reduce_while([], fn op, acc ->
       case Map.get(op, :guide) do
-        {:detect, classes} -> classes
-        _ -> nil
+        {:detect, :all} -> {:halt, :all}
+        {:detect, classes} -> {:cont, classes ++ acc}
+        _ -> {:cont, acc}
       end
     end)
+    |> case do
+      :all -> :all
+      [] -> nil
+      classes -> classes |> Enum.uniq() |> Enum.sort()
+    end
   end
 
   @doc "Returns true if any operation requests a face-assisted smart guide."

--- a/lib/image_pipe/plan/key_data.ex
+++ b/lib/image_pipe/plan/key_data.ex
@@ -195,6 +195,8 @@ defmodule ImagePipe.Plan.KeyData do
 
   defp guide_data({:smart, :face_assist}), do: [type: :smart, assist: :face]
 
+  defp guide_data({:detect, :all}), do: [type: :detect, classes: :all]
+
   defp guide_data({:detect, classes}) when is_list(classes),
     do: [type: :detect, classes: Enum.sort(classes)]
 

--- a/lib/image_pipe/plan/operation.ex
+++ b/lib/image_pipe/plan/operation.ex
@@ -676,6 +676,8 @@ defmodule ImagePipe.Plan.Operation do
   defp smart_guide(:smart), do: {:ok, :smart}
   defp smart_guide({:smart, :face_assist} = guide), do: {:ok, guide}
 
+  defp smart_guide({:detect, :all} = guide), do: {:ok, guide}
+
   defp smart_guide({:detect, classes} = guide)
        when is_list(classes) and classes != [] do
     if Enum.all?(classes, &is_binary/1) do

--- a/lib/image_pipe/plan/operation/crop_guided.ex
+++ b/lib/image_pipe/plan/operation/crop_guided.ex
@@ -30,6 +30,7 @@ defmodule ImagePipe.Plan.Operation.CropGuided do
              {:ratio, non_neg_integer(), pos_integer()}}
           | :smart
           | {:smart, :face_assist}
+          | {:detect, :all}
           | {:detect, nonempty_list(String.t())}
   @type offset :: number() | {:pixels, number()} | {:scale, number()}
 

--- a/lib/image_pipe/plan/operation/resize.ex
+++ b/lib/image_pipe/plan/operation/resize.ex
@@ -25,6 +25,7 @@ defmodule ImagePipe.Plan.Operation.Resize do
           | {:focal, ratio(), ratio()}
           | :smart
           | {:smart, :face_assist}
+          | {:detect, :all}
           | {:detect, nonempty_list(String.t())}
   @type ratio :: {:ratio, non_neg_integer(), pos_integer()}
   @type offset :: number() | {:pixels | :scale, number()}

--- a/lib/image_pipe/plug.ex
+++ b/lib/image_pipe/plug.ex
@@ -141,8 +141,12 @@ defmodule ImagePipe.Plug do
   # cheap `Code.ensure_loaded?`-style check (no I/O), so this runs before any
   # source fetch or cache access rather than silently degrading to attention.
   defp validate_detector_capability(%Plan{} = plan, opts) do
-    if Keyword.get(opts, :detector_required, false) and Plan.detect_classes(plan) != nil do
-      if Transform.detector_available?(Keyword.get(opts, :detector, :default), opts),
+    classes = Plan.detect_classes(plan)
+
+    if Keyword.get(opts, :detector_required, false) and classes != nil do
+      opts_with_classes = Keyword.put(opts, :classes, classes)
+
+      if Transform.detector_available?(Keyword.get(opts, :detector, :default), opts_with_classes),
         do: :ok,
         else: {:error, {:detector, :unavailable}}
     else

--- a/lib/image_pipe/request/runner.ex
+++ b/lib/image_pipe/request/runner.ex
@@ -237,7 +237,10 @@ defmodule ImagePipe.Request.Runner do
   # as a key option.
   defp put_detector_identity(opts, plan) do
     if Plan.detect_classes(plan) != nil or Plan.face_assist?(plan) do
-      case Transform.detector_identity(Keyword.get(opts, :detector, :default), opts) do
+      classes = Plan.detect_classes(plan) || ["face"]
+      opts_with_classes = Keyword.put(opts, :classes, classes)
+
+      case Transform.detector_identity(Keyword.get(opts, :detector, :default), opts_with_classes) do
         nil -> opts
         identity -> Keyword.put(opts, :detector_identity, identity)
       end

--- a/lib/image_pipe/request/runner.ex
+++ b/lib/image_pipe/request/runner.ex
@@ -236,9 +236,10 @@ defmodule ImagePipe.Request.Runner do
   # cache boundary never resolves identity itself; the request layer passes it
   # as a key option.
   defp put_detector_identity(opts, plan) do
-    if Plan.detect_classes(plan) != nil or Plan.face_assist?(plan) do
-      classes = Plan.detect_classes(plan) || ["face"]
-      opts_with_classes = Keyword.put(opts, :classes, classes)
+    detect_classes = Plan.detect_classes(plan)
+
+    if detect_classes != nil or Plan.face_assist?(plan) do
+      opts_with_classes = Keyword.put(opts, :classes, detect_classes || ["face"])
 
       case Transform.detector_identity(Keyword.get(opts, :detector, :default), opts_with_classes) do
         nil -> opts

--- a/lib/image_pipe/transform.ex
+++ b/lib/image_pipe/transform.ex
@@ -73,7 +73,7 @@ defmodule ImagePipe.Transform do
     PlanExecutor.execute(plan, state, opts)
   end
 
-  @default_detector ImagePipe.Transform.Detector.ImageVision.Face
+  @default_detector ImagePipe.Transform.Detector.Composite
 
   @spec resolve_detector(:default | nil | module()) :: module() | nil
   def resolve_detector(:default), do: @default_detector

--- a/lib/image_pipe/transform.ex
+++ b/lib/image_pipe/transform.ex
@@ -73,7 +73,7 @@ defmodule ImagePipe.Transform do
     PlanExecutor.execute(plan, state, opts)
   end
 
-  @default_detector ImagePipe.Transform.Detector.ImageVision
+  @default_detector ImagePipe.Transform.Detector.ImageVision.Face
 
   @spec resolve_detector(:default | nil | module()) :: module() | nil
   def resolve_detector(:default), do: @default_detector

--- a/lib/image_pipe/transform/detector.ex
+++ b/lib/image_pipe/transform/detector.ex
@@ -21,6 +21,17 @@ defmodule ImagePipe.Transform.Detector do
           box: {number(), number(), number(), number()}
         }
 
+  @doc """
+  The class names this detector can produce, in the URL-facing spelling.
+
+  Static metadata used to route a requested class set to detectors and to gate
+  availability — it MUST NOT load a model and MUST be answerable even when the
+  detector's optional dependency is absent (so a routing/availability decision
+  can be made without the dep). `available?/1` may be `false` while this still
+  returns the full vocabulary.
+  """
+  @callback supported_classes(opts :: keyword()) :: [String.t()]
+
   @doc "Detect regions of interest. `opts` carries `:classes`."
   @callback detect(image :: Vix.Vips.Image.t(), opts :: keyword()) ::
               {:ok, [region()]} | {:error, term()}

--- a/lib/image_pipe/transform/detector/composite.ex
+++ b/lib/image_pipe/transform/detector/composite.ex
@@ -60,19 +60,34 @@ defmodule ImagePipe.Transform.Detector.Composite do
     end)
   end
 
-  @spec detect(t(), term(), keyword()) :: {:ok, [map()]}
+  @spec detect(t(), term(), keyword()) :: {:ok, [map()]} | {:error, term()}
   def detect(%__MODULE__{} = composite, image, opts) do
     classes = Keyword.get(opts, :classes, :all)
     telemetry_opts = Keyword.get(opts, :telemetry_opts)
 
-    regions =
-      composite
-      |> routed(classes)
-      |> Enum.flat_map(fn {child, child_classes} ->
-        run_child(child, child_classes, image, opts, telemetry_opts)
-      end)
+    composite
+    |> routed(classes)
+    |> Enum.map(fn {child, child_classes} ->
+      run_child(child, child_classes, image, opts, telemetry_opts)
+    end)
+    |> merge_results()
+  end
 
-    {:ok, regions}
+  # Merge the routed children's results. Any successful child yields
+  # {:ok, merged regions} — best-effort across models, even if some children
+  # errored or found nothing. Only when EVERY routed child errored do we surface
+  # the error, so the [:transform, :detect] span reflects a real outage instead
+  # of a misleading :no_regions. An empty routed set (e.g. all-unknown classes)
+  # degrades to {:ok, []}.
+  defp merge_results([]), do: {:ok, []}
+
+  defp merge_results(results) do
+    region_lists = for {:ok, regions} <- results, do: regions
+
+    case region_lists do
+      [] -> Enum.find(results, &match?({:error, _}, &1))
+      lists -> {:ok, List.flatten(lists)}
+    end
   end
 
   defp run_child(child, child_classes, image, opts, nil) do
@@ -83,17 +98,17 @@ defmodule ImagePipe.Transform.Detector.Composite do
     start_meta = %{detector: child, model: child.identity(opts), classes: child_classes}
 
     Telemetry.span(telemetry_opts, [:transform, :detect, :model], start_meta, fn ->
-      regions = detect_child(child, child_classes, image, opts)
-      {regions, %{regions: length(regions)}}
+      result = detect_child(child, child_classes, image, opts)
+      {result, %{regions: region_count(result)}}
     end)
   end
 
   defp detect_child(child, child_classes, image, opts) do
-    case child.detect(image, Keyword.put(opts, :classes, child_classes)) do
-      {:ok, regions} -> regions
-      {:error, _} -> []
-    end
+    child.detect(image, Keyword.put(opts, :classes, child_classes))
   end
+
+  defp region_count({:ok, regions}), do: length(regions)
+  defp region_count({:error, _}), do: 0
 
   @spec available?(t(), keyword()) :: boolean()
   def available?(%__MODULE__{} = composite, opts) do

--- a/lib/image_pipe/transform/detector/composite.ex
+++ b/lib/image_pipe/transform/detector/composite.ex
@@ -12,6 +12,7 @@ defmodule ImagePipe.Transform.Detector.Composite do
   """
   @behaviour ImagePipe.Transform.Detector
 
+  alias ImagePipe.Telemetry
   alias ImagePipe.Transform.Detector.ImageVision
 
   @default_children [ImageVision.Face, ImageVision.Objects]
@@ -61,18 +62,36 @@ defmodule ImagePipe.Transform.Detector.Composite do
   @spec detect(t(), term(), keyword()) :: {:ok, [map()]}
   def detect(%__MODULE__{} = composite, image, opts) do
     classes = Keyword.get(opts, :classes, :all)
+    telemetry_opts = Keyword.get(opts, :telemetry_opts)
 
     regions =
       composite
       |> routed(classes)
       |> Enum.flat_map(fn {child, child_classes} ->
-        case child.detect(image, Keyword.put(opts, :classes, child_classes)) do
-          {:ok, regions} -> regions
-          {:error, _} -> []
-        end
+        run_child(child, child_classes, image, opts, telemetry_opts)
       end)
 
     {:ok, regions}
+  end
+
+  defp run_child(child, child_classes, image, opts, nil) do
+    detect_child(child, child_classes, image, opts)
+  end
+
+  defp run_child(child, child_classes, image, opts, telemetry_opts) do
+    start_meta = %{detector: child, model: child.identity(opts), classes: child_classes}
+
+    Telemetry.span(telemetry_opts, [:transform, :detect, :model], start_meta, fn ->
+      regions = detect_child(child, child_classes, image, opts)
+      {regions, %{regions: length(regions)}}
+    end)
+  end
+
+  defp detect_child(child, child_classes, image, opts) do
+    case child.detect(image, Keyword.put(opts, :classes, child_classes)) do
+      {:ok, regions} -> regions
+      {:error, _} -> []
+    end
   end
 
   @spec available?(t(), keyword()) :: boolean()

--- a/lib/image_pipe/transform/detector/composite.ex
+++ b/lib/image_pipe/transform/detector/composite.ex
@@ -1,0 +1,112 @@
+defmodule ImagePipe.Transform.Detector.Composite do
+  @moduledoc """
+  A `ImagePipe.Transform.Detector` that fans a requested class set out across an
+  ordered list of child detectors and merges their regions.
+
+  Each requested class routes to the child(ren) whose `supported_classes/1` claim
+  it (`:all` routes to every child); classes no child claims are dropped
+  (best-effort). Identity and availability are class-aware: they reflect only the
+  children a given request routes to, so e.g. an object-only request is unaffected
+  by a face-model change. The bundled default composes the face (YuNet) and object
+  (RT-DETR) adapters.
+  """
+  @behaviour ImagePipe.Transform.Detector
+
+  alias ImagePipe.Transform.Detector.ImageVision
+
+  @default_children [ImageVision.Face, ImageVision.Objects]
+
+  @type t :: %__MODULE__{children: [module()]}
+  defstruct children: @default_children
+
+  @spec new([module()]) :: t()
+  def new(children) when is_list(children), do: %__MODULE__{children: children}
+
+  @spec default() :: t()
+  def default, do: %__MODULE__{children: @default_children}
+
+  # --- Explicit-composite helpers and Detector behaviour ---
+  #
+  # supported_classes/1 is shared between the behaviour (takes opts keyword)
+  # and the explicit helper (takes a %Composite{} struct). The struct clause is
+  # listed first so it matches before the catch-all opts clause.
+
+  @spec supported_classes(t()) :: [String.t()]
+  def supported_classes(%__MODULE__{children: children}) do
+    children |> Enum.flat_map(& &1.supported_classes([])) |> Enum.uniq()
+  end
+
+  @impl true
+  def supported_classes(_opts), do: supported_classes(default())
+
+  @impl true
+  def detect(image, opts), do: detect(default(), image, opts)
+
+  @impl true
+  def available?(opts), do: available?(default(), opts)
+
+  @impl true
+  def identity(opts), do: identity(default(), opts)
+
+  @impl true
+  def warmup(opts) do
+    Enum.reduce_while(default().children, :ok, fn child, _ ->
+      case ImagePipe.Transform.Detector.warmup(child, opts) do
+        :ok -> {:cont, :ok}
+        {:error, _} = err -> {:halt, err}
+      end
+    end)
+  end
+
+  @spec detect(t(), term(), keyword()) :: {:ok, [map()]}
+  def detect(%__MODULE__{} = composite, image, opts) do
+    classes = Keyword.get(opts, :classes, :all)
+
+    regions =
+      composite
+      |> routed(classes)
+      |> Enum.flat_map(fn {child, child_classes} ->
+        case child.detect(image, Keyword.put(opts, :classes, child_classes)) do
+          {:ok, regions} -> regions
+          {:error, _} -> []
+        end
+      end)
+
+    {:ok, regions}
+  end
+
+  @spec available?(t(), keyword()) :: boolean()
+  def available?(%__MODULE__{} = composite, opts) do
+    classes = Keyword.get(opts, :classes, :all)
+
+    composite
+    |> routed(classes)
+    |> Enum.all?(fn {child, _} -> child.available?(opts) end)
+  end
+
+  @spec identity(t(), keyword()) :: {module(), [term()]}
+  def identity(%__MODULE__{} = composite, opts) do
+    classes = Keyword.get(opts, :classes, :all)
+    ids = composite |> routed(classes) |> Enum.map(fn {child, _} -> child.identity(opts) end)
+    {__MODULE__, ids}
+  end
+
+  # Returns [{child_module, child_classes}] for the children that the requested
+  # class set routes to, preserving the fixed child order. `:all` -> every child
+  # gets `:all`. A class list -> each child gets the intersection with its
+  # supported set, and children with an empty intersection are dropped.
+  defp routed(%__MODULE__{children: children}, :all) do
+    Enum.map(children, &{&1, :all})
+  end
+
+  defp routed(%__MODULE__{children: children}, classes) when is_list(classes) do
+    requested = MapSet.new(classes)
+
+    children
+    |> Enum.map(fn child ->
+      child_classes = Enum.filter(child.supported_classes([]), &MapSet.member?(requested, &1))
+      {child, child_classes}
+    end)
+    |> Enum.reject(fn {_child, child_classes} -> child_classes == [] end)
+  end
+end

--- a/lib/image_pipe/transform/detector/composite.ex
+++ b/lib/image_pipe/transform/detector/composite.ex
@@ -51,8 +51,18 @@ defmodule ImagePipe.Transform.Detector.Composite do
   def identity(opts), do: identity(default(), opts)
 
   @impl true
-  def warmup(opts) do
-    Enum.reduce_while(default().children, :ok, fn child, _ ->
+  def warmup(opts), do: warmup(default(), opts)
+
+  # Warm only the children the requested classes route to, so e.g.
+  # `classes: ["face"]` warms YuNet but not the larger RT-DETR model. `:all`
+  # (the default) warms every child.
+  @spec warmup(t(), keyword()) :: :ok | {:error, term()}
+  def warmup(%__MODULE__{} = composite, opts) do
+    classes = Keyword.get(opts, :classes, :all)
+
+    composite
+    |> routed(classes)
+    |> Enum.reduce_while(:ok, fn {child, _child_classes}, _ ->
       case Detector.warmup(child, opts) do
         :ok -> {:cont, :ok}
         {:error, _} = err -> {:halt, err}

--- a/lib/image_pipe/transform/detector/composite.ex
+++ b/lib/image_pipe/transform/detector/composite.ex
@@ -13,6 +13,7 @@ defmodule ImagePipe.Transform.Detector.Composite do
   @behaviour ImagePipe.Transform.Detector
 
   alias ImagePipe.Telemetry
+  alias ImagePipe.Transform.Detector
   alias ImagePipe.Transform.Detector.ImageVision
 
   @default_children [ImageVision.Face, ImageVision.Objects]
@@ -52,7 +53,7 @@ defmodule ImagePipe.Transform.Detector.Composite do
   @impl true
   def warmup(opts) do
     Enum.reduce_while(default().children, :ok, fn child, _ ->
-      case ImagePipe.Transform.Detector.warmup(child, opts) do
+      case Detector.warmup(child, opts) do
         :ok -> {:cont, :ok}
         {:error, _} = err -> {:halt, err}
       end

--- a/lib/image_pipe/transform/detector/composite.ex
+++ b/lib/image_pipe/transform/detector/composite.ex
@@ -124,6 +124,9 @@ defmodule ImagePipe.Transform.Detector.Composite do
 
     children
     |> Enum.map(fn child ->
+      # Routing uses each detector's STATIC vocabulary, so `[]` opts here is
+      # deliberate (not a dropped argument): `supported_classes/1` must answer
+      # without request-specific opts or a loaded model.
       child_classes = Enum.filter(child.supported_classes([]), &MapSet.member?(requested, &1))
       {child, child_classes}
     end)

--- a/lib/image_pipe/transform/detector/image_vision.ex
+++ b/lib/image_pipe/transform/detector/image_vision.ex
@@ -13,6 +13,9 @@ defmodule ImagePipe.Transform.Detector.ImageVision do
   @model_file "face_detection_yunet_2023mar.onnx"
 
   @impl true
+  def supported_classes(_opts), do: ["face"]
+
+  @impl true
   def available?(_opts), do: Code.ensure_loaded?(Image.FaceDetection)
 
   @impl true

--- a/lib/image_pipe/transform/detector/image_vision/face.ex
+++ b/lib/image_pipe/transform/detector/image_vision/face.ex
@@ -1,9 +1,9 @@
-defmodule ImagePipe.Transform.Detector.ImageVision do
+defmodule ImagePipe.Transform.Detector.ImageVision.Face do
   @moduledoc """
-  Default `ImagePipe.Transform.Detector` backed by the optional `image_vision`
-  dependency. Faces use `Image.FaceDetection` (YuNet); the dependency is not
-  declared by ImagePipe — hosts opt in. When absent, `available?/1` is false and
-  callers fall back gracefully.
+  `ImagePipe.Transform.Detector` for faces, backed by the optional `image_vision`
+  dependency (`Image.FaceDetection`, YuNet). The dependency is not declared by
+  ImagePipe — hosts opt in. When absent, `available?/1` is false and callers fall
+  back gracefully.
   """
   @behaviour ImagePipe.Transform.Detector
 
@@ -20,7 +20,9 @@ defmodule ImagePipe.Transform.Detector.ImageVision do
 
   @impl true
   def identity(_opts) do
-    if available?([]), do: {__MODULE__, {@repo, @model_file}}, else: {__MODULE__, :unavailable}
+    if available?([]),
+      do: {__MODULE__, {@repo, @model_file}},
+      else: {__MODULE__, :unavailable}
   end
 
   @impl true
@@ -29,8 +31,8 @@ defmodule ImagePipe.Transform.Detector.ImageVision do
 
     cond do
       not available?(opts) -> {:error, {:detector, :unavailable}}
-      classes != ["face"] -> {:error, {:detector, {:unsupported_classes, classes}}}
-      true -> detect_faces(image)
+      classes == :all or classes == ["face"] -> detect_faces(image)
+      true -> {:ok, []}
     end
   end
 

--- a/lib/image_pipe/transform/detector/image_vision/face.ex
+++ b/lib/image_pipe/transform/detector/image_vision/face.ex
@@ -31,7 +31,7 @@ defmodule ImagePipe.Transform.Detector.ImageVision.Face do
 
     cond do
       not available?(opts) -> {:error, {:detector, :unavailable}}
-      classes == :all or classes == ["face"] -> detect_faces(image)
+      classes == :all or (is_list(classes) and "face" in classes) -> detect_faces(image)
       true -> {:ok, []}
     end
   end

--- a/lib/image_pipe/transform/detector/image_vision/objects.ex
+++ b/lib/image_pipe/transform/detector/image_vision/objects.ex
@@ -1,0 +1,87 @@
+defmodule ImagePipe.Transform.Detector.ImageVision.Objects do
+  @moduledoc """
+  `ImagePipe.Transform.Detector` for general objects, backed by the optional
+  `image_vision` dependency (`Image.Detection`, RT-DETR, COCO-80). The dependency
+  is not declared by ImagePipe — hosts opt in. When absent, `available?/1` is
+  false and callers fall back gracefully.
+
+  Class names use the URL-facing underscore spelling (`traffic_light`); the model
+  emits spaces (`"traffic light"`), which this adapter normalizes on both sides.
+  """
+  @behaviour ImagePipe.Transform.Detector
+
+  @compile {:no_warn_undefined, Image.Detection}
+
+  @repo "onnx-community/rtdetr_r50vd"
+  @filename "onnx/model.onnx"
+  @min_score 0.5
+
+  # COCO-80, underscore spelling. Hardcoded (not derived from Image.Detection)
+  # so routing/availability work when the dependency is absent. A tagged drift
+  # test asserts this matches the model's labels.
+  @coco_classes ~w(
+    person bicycle car motorcycle airplane bus train truck boat traffic_light
+    fire_hydrant stop_sign parking_meter bench bird cat dog horse sheep cow
+    elephant bear zebra giraffe backpack umbrella handbag tie suitcase frisbee
+    skis snowboard sports_ball kite baseball_bat baseball_glove skateboard
+    surfboard tennis_racket bottle wine_glass cup fork knife spoon bowl banana
+    apple sandwich orange broccoli carrot hot_dog pizza donut cake chair couch
+    potted_plant bed dining_table toilet tv laptop mouse remote keyboard
+    cell_phone microwave oven toaster sink refrigerator book clock vase scissors
+    teddy_bear hair_drier toothbrush
+  )
+
+  @impl true
+  def supported_classes(_opts), do: @coco_classes
+
+  @impl true
+  def available?(_opts), do: Code.ensure_loaded?(Image.Detection)
+
+  @impl true
+  def identity(_opts) do
+    if available?([]),
+      do: {__MODULE__, {@repo, @filename, @min_score}},
+      else: {__MODULE__, :unavailable}
+  end
+
+  @impl true
+  def detect(image, opts) do
+    classes = Keyword.get(opts, :classes, :all)
+
+    if available?(opts),
+      do: detect_objects(image, classes),
+      else: {:error, {:detector, :unavailable}}
+  end
+
+  @impl true
+  def warmup(opts) do
+    if available?(opts) do
+      {:ok, blank} = Image.new(64, 64, color: :black)
+      _ = detect_objects(blank, :all)
+      :ok
+    else
+      {:error, {:detector, :unavailable}}
+    end
+  end
+
+  defp detect_objects(image, classes) do
+    regions =
+      image
+      |> Image.Detection.detect(min_score: @min_score, repo: @repo, filename: @filename)
+      |> Enum.map(fn %{label: label, score: score, box: box} ->
+        %{label: String.replace(label, " ", "_"), score: score, box: box}
+      end)
+      |> filter_classes(classes)
+
+    {:ok, regions}
+  rescue
+    error -> {:error, {:detector, error}}
+  end
+
+  defp filter_classes(regions, :all), do: regions
+
+  defp filter_classes(regions, classes) when is_list(classes) do
+    wanted = MapSet.new(classes)
+    Enum.filter(regions, fn %{label: label} -> MapSet.member?(wanted, label) end)
+  end
+end

--- a/lib/image_pipe/transform/detector/warmup.ex
+++ b/lib/image_pipe/transform/detector/warmup.ex
@@ -5,7 +5,7 @@ defmodule ImagePipe.Transform.Detector.Warmup do
   Host-wired: add it to the HOST's supervision tree (ImagePipe does not start
   it), e.g.:
 
-      {ImagePipe.Transform.Detector.Warmup, detector: :default, classes: ["face"]}
+      {ImagePipe.Transform.Detector.Warmup, detector: :default}
 
   The `:detector` option mirrors the plug's `:detector` option: `:default` (the
   default when omitted) resolves to the bundled adapter, `nil` disables detection
@@ -34,7 +34,7 @@ defmodule ImagePipe.Transform.Detector.Warmup do
   def init(opts) do
     state = %{
       detector: Keyword.get(opts, :detector, :default),
-      classes: Keyword.get(opts, :classes, ["face"]),
+      classes: Keyword.get(opts, :classes, :all),
       opts: Keyword.get(opts, :opts, []),
       retries: Keyword.get(opts, :retries, 2)
     }

--- a/lib/image_pipe/transform/operation/crop.ex
+++ b/lib/image_pipe/transform/operation/crop.ex
@@ -346,7 +346,8 @@ defmodule ImagePipe.Transform.Operation.Crop do
 
   defp run_detect(module, opts, image, classes, telemetry_opts) do
     Telemetry.span(telemetry_opts, [:transform, :detect], %{classes: classes}, fn ->
-      result = validate_detect_result(module.detect(image, Keyword.put(opts, :classes, classes)))
+      detect_opts = opts |> Keyword.put(:classes, classes) |> Keyword.put(:telemetry_opts, telemetry_opts)
+      result = validate_detect_result(module.detect(image, detect_opts))
       {result, %{regions: region_count(result), result: detect_reason(result)}}
     end)
   end

--- a/lib/image_pipe/transform/operation/crop.ex
+++ b/lib/image_pipe/transform/operation/crop.ex
@@ -129,6 +129,7 @@ defmodule ImagePipe.Transform.Operation.Crop do
             | {:fp, float(), float()}
             | :smart
             | {:smart, :face_assist}
+            | {:detect, :all}
             | {:detect, [String.t()]}
             | nil,
           x_offset: length_unit() | number(),

--- a/lib/image_pipe/transform/operation/crop.ex
+++ b/lib/image_pipe/transform/operation/crop.ex
@@ -346,7 +346,9 @@ defmodule ImagePipe.Transform.Operation.Crop do
 
   defp run_detect(module, opts, image, classes, telemetry_opts) do
     Telemetry.span(telemetry_opts, [:transform, :detect], %{classes: classes}, fn ->
-      detect_opts = opts |> Keyword.put(:classes, classes) |> Keyword.put(:telemetry_opts, telemetry_opts)
+      detect_opts =
+        opts |> Keyword.put(:classes, classes) |> Keyword.put(:telemetry_opts, telemetry_opts)
+
       result = validate_detect_result(module.detect(image, detect_opts))
       {result, %{regions: region_count(result), result: detect_reason(result)}}
     end)

--- a/test/image_pipe/architecture_boundary_test.exs
+++ b/test/image_pipe/architecture_boundary_test.exs
@@ -19,7 +19,9 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
     "lib/image_pipe/response.ex",
     "lib/image_pipe/response/**/*.ex",
     "lib/image_pipe/cache.ex",
-    "lib/image_pipe/cache/**/*.ex"
+    "lib/image_pipe/cache/**/*.ex",
+    "lib/image_pipe/parser/**/*.ex",
+    "lib/image_pipe/plan/**/*.ex"
   ]
   @parser_forbidden_globs [
     "lib/image_pipe/request.ex",

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -215,6 +215,96 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
     def identity(o), do: Composite.identity(c(), o)
   end
 
+  # Task 10: CornerObjectDetector — places a small box near the top-left so a
+  # fill-crop biases up-left, distinct from center and attention saliency.
+  defmodule CornerObjectDetector do
+    @moduledoc false
+    @behaviour ImagePipe.Transform.Detector
+
+    @impl true
+    def supported_classes(_), do: ["car", "dog", "face", "person"]
+
+    @impl true
+    def available?(opts), do: Keyword.get(opts, :available?, true)
+
+    @impl true
+    def identity(_), do: {__MODULE__, :v1}
+
+    @impl true
+    def detect(_image, opts) do
+      classes = Keyword.get(opts, :classes, :all)
+      label = if classes == :all, do: "car", else: List.first(List.wrap(classes))
+      {:ok, [%{label: label, score: 0.95, box: {2, 2, 20, 20}}]}
+    end
+  end
+
+  # Task 10: PartialDetector — Composite with FaceFake (available) and
+  # UnavailableObjectFake (available?=false), used for the gate triad.
+  defmodule GateTriadFaceFake do
+    @moduledoc false
+    @behaviour ImagePipe.Transform.Detector
+
+    @impl true
+    def supported_classes(_), do: ["face"]
+
+    @impl true
+    def available?(_), do: true
+
+    @impl true
+    def identity(_), do: {__MODULE__, :face_v1}
+
+    @impl true
+    def detect(_image, opts) do
+      {:ok, [%{label: "face", score: 0.9, box: {0, 0, 50, 50}}]}
+      |> filter_classes(Keyword.get(opts, :classes, :all))
+    end
+
+    defp filter_classes({:ok, regions}, :all), do: {:ok, regions}
+
+    defp filter_classes({:ok, regions}, classes) when is_list(classes) do
+      wanted = MapSet.new(classes)
+      {:ok, Enum.filter(regions, fn %{label: l} -> MapSet.member?(wanted, l) end)}
+    end
+  end
+
+  defmodule GateTriadUnavailableObjectFake do
+    @moduledoc false
+    @behaviour ImagePipe.Transform.Detector
+
+    @impl true
+    def supported_classes(_), do: ["car"]
+
+    @impl true
+    def available?(_), do: false
+
+    @impl true
+    def identity(_), do: {__MODULE__, :unavailable}
+
+    @impl true
+    def detect(_image, _opts), do: {:error, {:detector, :unavailable}}
+  end
+
+  defmodule PartialDetector do
+    @moduledoc false
+    @behaviour ImagePipe.Transform.Detector
+
+    alias ImagePipe.Transform.Detector.Composite
+
+    defp c, do: Composite.new([GateTriadFaceFake, GateTriadUnavailableObjectFake])
+
+    @impl true
+    def supported_classes(_o), do: Composite.supported_classes(c())
+
+    @impl true
+    def detect(i, o), do: Composite.detect(c(), i, o)
+
+    @impl true
+    def available?(o), do: Composite.available?(c(), o)
+
+    @impl true
+    def identity(o), do: Composite.identity(c(), o)
+  end
+
   @default_opts [
     parser: ImagePipe.Parser.Imgproxy,
     sources: [
@@ -1472,6 +1562,72 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
       assert content_type(conn) == ["image/avif"]
       assert get_resp_header(conn, "vary") == []
     end
+  end
+
+  # Task 10: Pixel divergence — g:obj:car crop biases toward the detected corner
+  # object, distinct from both center gravity and attention (smart) gravity.
+  test "g:obj:car crop biases toward the detected object, differing from center and attention" do
+    opts = Keyword.merge(@default_opts, detector: CornerObjectDetector)
+
+    obj = call_imgproxy("/_/rs:fill:50:50/g:obj:car/f:jpeg/plain/images/beach.jpg", opts)
+    centered = call_imgproxy("/_/rs:fill:50:50/g:ce/f:jpeg/plain/images/beach.jpg", opts)
+    attention = call_imgproxy("/_/rs:fill:50:50/g:sm/f:jpeg/plain/images/beach.jpg", opts)
+
+    assert obj.status == 200
+    assert dimensions(obj) == {50, 50}
+    refute obj.resp_body == centered.resp_body
+    refute obj.resp_body == attention.resp_body
+  end
+
+  # Task 10: No-geometry — g:obj:car without resize/crop must return 200.
+  test "no-geometry g:obj:car returns 200 without a resize or crop" do
+    opts = Keyword.merge(@default_opts, detector: CornerObjectDetector)
+
+    conn = call_imgproxy("/_/g:obj:car/plain/images/beach.jpg", opts)
+
+    assert conn.status == 200
+  end
+
+  # Task 10: Gate triad — class-aware strict gate with PartialDetector.
+  # Face child: available, owns ["face"]. Object child: unavailable, owns ["car"].
+  test "detector_required gate triad: face->200, unicorn->200(degrade), car->422 pre-fetch" do
+    opts = Keyword.merge(@default_opts, detector: PartialDetector, detector_required: true)
+
+    # face child available -> routes and succeeds
+    face_conn = call_imgproxy("/_/rs:fill:50:50/g:obj:face/f:jpeg/plain/images/beach.jpg", opts)
+    assert face_conn.status == 200
+
+    # unknown class routes to no child -> available? vacuously true -> degrades to 200
+    unicorn_conn =
+      call_imgproxy("/_/rs:fill:50:50/g:obj:unicorn/f:jpeg/plain/images/beach.jpg", opts)
+
+    assert unicorn_conn.status == 200
+
+    # object child unavailable -> 422 BEFORE any source fetch or cache access.
+    # Copy the exact setup from "detector_required + unavailable detector" test (~line 599).
+    telemetry_prefix = [:image_pipe_wire_gate_triad]
+    source_resolve_start = telemetry_prefix ++ [:source, :resolve, :start]
+
+    attach_source_resolve_telemetry(telemetry_prefix)
+
+    gate_opts =
+      Keyword.merge(opts,
+        telemetry_prefix: telemetry_prefix,
+        cache: {CacheProbe, []},
+        sources: [
+          path:
+            {RootHTTPAdapter,
+             root_url: "http://origin.test", req_options: [plug: OriginShouldNotFetch]}
+        ]
+      )
+
+    car_conn = call_imgproxy("/_/rs:fill:50:50/g:obj:car/f:jpeg/plain/images/beach.jpg", gate_opts)
+
+    assert car_conn.status == 422
+    refute_received {:telemetry_event, ^source_resolve_start, _, _}
+    refute_received {:cache_lookup, _key}
+    refute_received {:cache_put, _key, _entry}
+    refute_received :origin_fetch
   end
 
   # Capture the cache key the plug looked up for one request. Uses the file's

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -160,6 +160,61 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
     def identity(_opts), do: {__MODULE__, :unavailable}
   end
 
+  defmodule FaceVerFake do
+    @moduledoc false
+    @behaviour ImagePipe.Transform.Detector
+
+    @impl true
+    def supported_classes(_), do: ["face"]
+
+    @impl true
+    def available?(_), do: true
+
+    @impl true
+    def identity(opts), do: {__MODULE__, Keyword.get(opts, :face_ver, :v1)}
+
+    @impl true
+    def detect(_, _), do: {:ok, []}
+  end
+
+  defmodule ObjectVerFake do
+    @moduledoc false
+    @behaviour ImagePipe.Transform.Detector
+
+    @impl true
+    def supported_classes(_), do: ["car", "dog"]
+
+    @impl true
+    def available?(_), do: true
+
+    @impl true
+    def identity(opts), do: {__MODULE__, Keyword.get(opts, :object_ver, :v1)}
+
+    @impl true
+    def detect(_, _), do: {:ok, []}
+  end
+
+  defmodule VerComposite do
+    @moduledoc false
+    @behaviour ImagePipe.Transform.Detector
+
+    alias ImagePipe.Transform.Detector.Composite
+
+    defp c, do: Composite.new([FaceVerFake, ObjectVerFake])
+
+    @impl true
+    def supported_classes(_o), do: Composite.supported_classes(c())
+
+    @impl true
+    def detect(i, o), do: Composite.detect(c(), i, o)
+
+    @impl true
+    def available?(o), do: Composite.available?(c(), o)
+
+    @impl true
+    def identity(o), do: Composite.identity(c(), o)
+  end
+
   @default_opts [
     parser: ImagePipe.Parser.Imgproxy,
     sources: [
@@ -1417,6 +1472,52 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
       assert content_type(conn) == ["image/avif"]
       assert get_resp_header(conn, "vary") == []
     end
+  end
+
+  # Capture the cache key the plug looked up for one request. Uses the file's
+  # existing CacheProbe (it sends {:cache_lookup, key}) and call_imgproxy/2.
+  defp lookup_key(path, opts) do
+    call_imgproxy(path, opts)
+    assert_received {:cache_lookup, key}
+    key
+  end
+
+  defp probe_opts do
+    Keyword.merge(@default_opts, cache: {CacheProbe, []})
+  end
+
+  defp ver_opts(extra) do
+    Keyword.merge(probe_opts(), [detector: VerComposite] ++ extra)
+  end
+
+  test "object-only request key is independent of the face model identity" do
+    assert lookup_key("/_/rs:fill:50:50/g:obj:car/plain/images/beach.jpg", ver_opts(face_ver: :v1)) ==
+             lookup_key("/_/rs:fill:50:50/g:obj:car/plain/images/beach.jpg", ver_opts(face_ver: :v2))
+  end
+
+  test "face-only request key is independent of the object model identity" do
+    assert lookup_key("/_/rs:fill:50:50/g:obj:face/plain/images/beach.jpg", ver_opts(object_ver: :v1)) ==
+             lookup_key("/_/rs:fill:50:50/g:obj:face/plain/images/beach.jpg", ver_opts(object_ver: :v2))
+  end
+
+  test "mixed request key changes when either model identity changes" do
+    base =
+      lookup_key("/_/rs:fill:50:50/g:obj:face:car/plain/images/beach.jpg",
+        ver_opts(face_ver: :v1, object_ver: :v1)
+      )
+
+    diff_face =
+      lookup_key("/_/rs:fill:50:50/g:obj:face:car/plain/images/beach.jpg",
+        ver_opts(face_ver: :v2, object_ver: :v1)
+      )
+
+    diff_obj =
+      lookup_key("/_/rs:fill:50:50/g:obj:face:car/plain/images/beach.jpg",
+        ver_opts(face_ver: :v1, object_ver: :v2)
+      )
+
+    assert base != diff_face
+    assert base != diff_obj
   end
 
   defp cached_opts(overrides \\ []) do

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -1621,7 +1621,8 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
         ]
       )
 
-    car_conn = call_imgproxy("/_/rs:fill:50:50/g:obj:car/f:jpeg/plain/images/beach.jpg", gate_opts)
+    car_conn =
+      call_imgproxy("/_/rs:fill:50:50/g:obj:car/f:jpeg/plain/images/beach.jpg", gate_opts)
 
     assert car_conn.status == 422
     refute_received {:telemetry_event, ^source_resolve_start, _, _}
@@ -1647,28 +1648,43 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
   end
 
   test "object-only request key is independent of the face model identity" do
-    assert lookup_key("/_/rs:fill:50:50/g:obj:car/plain/images/beach.jpg", ver_opts(face_ver: :v1)) ==
-             lookup_key("/_/rs:fill:50:50/g:obj:car/plain/images/beach.jpg", ver_opts(face_ver: :v2))
+    assert lookup_key(
+             "/_/rs:fill:50:50/g:obj:car/plain/images/beach.jpg",
+             ver_opts(face_ver: :v1)
+           ) ==
+             lookup_key(
+               "/_/rs:fill:50:50/g:obj:car/plain/images/beach.jpg",
+               ver_opts(face_ver: :v2)
+             )
   end
 
   test "face-only request key is independent of the object model identity" do
-    assert lookup_key("/_/rs:fill:50:50/g:obj:face/plain/images/beach.jpg", ver_opts(object_ver: :v1)) ==
-             lookup_key("/_/rs:fill:50:50/g:obj:face/plain/images/beach.jpg", ver_opts(object_ver: :v2))
+    assert lookup_key(
+             "/_/rs:fill:50:50/g:obj:face/plain/images/beach.jpg",
+             ver_opts(object_ver: :v1)
+           ) ==
+             lookup_key(
+               "/_/rs:fill:50:50/g:obj:face/plain/images/beach.jpg",
+               ver_opts(object_ver: :v2)
+             )
   end
 
   test "mixed request key changes when either model identity changes" do
     base =
-      lookup_key("/_/rs:fill:50:50/g:obj:face:car/plain/images/beach.jpg",
+      lookup_key(
+        "/_/rs:fill:50:50/g:obj:face:car/plain/images/beach.jpg",
         ver_opts(face_ver: :v1, object_ver: :v1)
       )
 
     diff_face =
-      lookup_key("/_/rs:fill:50:50/g:obj:face:car/plain/images/beach.jpg",
+      lookup_key(
+        "/_/rs:fill:50:50/g:obj:face:car/plain/images/beach.jpg",
         ver_opts(face_ver: :v2, object_ver: :v1)
       )
 
     diff_obj =
-      lookup_key("/_/rs:fill:50:50/g:obj:face:car/plain/images/beach.jpg",
+      lookup_key(
+        "/_/rs:fill:50:50/g:obj:face:car/plain/images/beach.jpg",
         ver_opts(face_ver: :v1, object_ver: :v2)
       )
 

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -148,6 +148,9 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
     @behaviour ImagePipe.Transform.Detector
 
     @impl true
+    def supported_classes(_opts), do: ["face"]
+
+    @impl true
     def detect(_image, _opts), do: {:error, {:detector, :unavailable}}
 
     @impl true

--- a/test/image_pipe/plan/operation_key_data_test.exs
+++ b/test/image_pipe/plan/operation_key_data_test.exs
@@ -1,5 +1,6 @@
 defmodule ImagePipe.Plan.OperationKeyDataTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias ImagePipe.Plan.KeyData
   alias ImagePipe.Plan.Operation
@@ -260,6 +261,35 @@ defmodule ImagePipe.Plan.OperationKeyDataTest do
 
   describe "guide_data via CropGuided cache data" do
     alias ImagePipe.Plan.Operation.CropGuided
+
+    test "detect :all guide encodes as classes: :all" do
+      data = KeyData.data(%CropGuided{width: {:px, 100}, height: {:px, 100}, guide: {:detect, :all}})
+      assert Keyword.fetch!(data, :guide) == [type: :detect, classes: :all]
+    end
+
+    property "detect-guide class order does not change the guide key data" do
+      all_classes = ["car", "dog", "cat", "person", "bird", "truck", "bus", "boat"]
+
+      check all classes <-
+                  list_of(member_of(all_classes), min_length: 1, max_length: 4)
+                  |> map(&Enum.uniq/1) do
+        a =
+          KeyData.data(%CropGuided{
+            width: {:px, 100},
+            height: {:px, 100},
+            guide: {:detect, classes}
+          })
+
+        b =
+          KeyData.data(%CropGuided{
+            width: {:px, 100},
+            height: {:px, 100},
+            guide: {:detect, Enum.shuffle(classes)}
+          })
+
+        assert a == b
+      end
+    end
 
     test "the three content-aware guides serialize distinctly" do
       smart = KeyData.data(%CropGuided{width: {:px, 10}, height: {:px, 10}, guide: :smart})

--- a/test/image_pipe/plan/operation_key_data_test.exs
+++ b/test/image_pipe/plan/operation_key_data_test.exs
@@ -263,7 +263,9 @@ defmodule ImagePipe.Plan.OperationKeyDataTest do
     alias ImagePipe.Plan.Operation.CropGuided
 
     test "detect :all guide encodes as classes: :all" do
-      data = KeyData.data(%CropGuided{width: {:px, 100}, height: {:px, 100}, guide: {:detect, :all}})
+      data =
+        KeyData.data(%CropGuided{width: {:px, 100}, height: {:px, 100}, guide: {:detect, :all}})
+
       assert Keyword.fetch!(data, :guide) == [type: :detect, classes: :all]
     end
 

--- a/test/image_pipe/plan_test.exs
+++ b/test/image_pipe/plan_test.exs
@@ -101,6 +101,17 @@ defmodule ImagePipe.PlanTest do
     assert Plan.detect_classes(plan_with_guide({:detect, ["face"]})) == ["face"]
   end
 
+  test "detect_classes returns a guide's classes sorted and deduped" do
+    assert Plan.detect_classes(plan_with_guide({:detect, ["dog", "car", "dog"]})) == [
+             "car",
+             "dog"
+           ]
+  end
+
+  test "detect_classes returns :all for an all-objects guide" do
+    assert Plan.detect_classes(plan_with_guide({:detect, :all})) == :all
+  end
+
   test "detect_classes is nil when no detect guide is present" do
     assert Plan.detect_classes(plan_with_guide(:center)) == nil
   end

--- a/test/image_pipe/transform/detector/composite_test.exs
+++ b/test/image_pipe/transform/detector/composite_test.exs
@@ -51,7 +51,31 @@ defmodule ImagePipe.Transform.Detector.CompositeTest do
     end
   end
 
+  defmodule ErroringChild do
+    @behaviour ImagePipe.Transform.Detector
+    @impl true
+    def supported_classes(_), do: ["car"]
+    @impl true
+    def available?(_), do: true
+    @impl true
+    def identity(_), do: {__MODULE__, :err_v1}
+    @impl true
+    def detect(_image, _opts), do: {:error, {:detector, :boom}}
+  end
+
   defp composite, do: Composite.new([FaceChild, ObjectChild])
+
+  test "surfaces the error when every routed child fails" do
+    composite = Composite.new([ErroringChild])
+    assert {:error, {:detector, :boom}} = Composite.detect(composite, :image, classes: ["car"])
+  end
+
+  test "best-effort: still succeeds when at least one routed child succeeds" do
+    # car routes to both ErroringChild (fails) and ObjectChild (succeeds)
+    composite = Composite.new([ErroringChild, ObjectChild])
+    assert {:ok, regions} = Composite.detect(composite, :image, classes: ["car"])
+    assert Enum.map(regions, & &1.label) == ["car"]
+  end
 
   test "supported_classes is the union of children" do
     assert Enum.sort(Composite.supported_classes(composite())) == ["car", "dog", "face"]

--- a/test/image_pipe/transform/detector/composite_test.exs
+++ b/test/image_pipe/transform/detector/composite_test.exs
@@ -96,4 +96,25 @@ defmodule ImagePipe.Transform.Detector.CompositeTest do
     assert Composite.available?(c, classes: ["car"], object_available?: false) == false
     assert Composite.available?(c, classes: :all, object_available?: false) == false
   end
+
+  test "emits a per-model span per routed child with detector, model identity, and classes" do
+    ref =
+      :telemetry_test.attach_event_handlers(self(), [
+        [:image_pipe, :transform, :detect, :model, :stop]
+      ])
+
+    on_exit(fn -> :telemetry.detach(ref) end)
+
+    {:ok, _} =
+      Composite.detect(composite(), :image,
+        classes: ["face", "car"],
+        telemetry_opts: [telemetry_prefix: [:image_pipe]]
+      )
+
+    assert_received {[:image_pipe, :transform, :detect, :model, :stop], ^ref, _measurements,
+                     %{detector: FaceChild, model: {FaceChild, :face_v1}, classes: ["face"], regions: 1}}
+
+    assert_received {[:image_pipe, :transform, :detect, :model, :stop], ^ref, _measurements,
+                     %{detector: ObjectChild, model: {ObjectChild, :obj_v1}, classes: ["car"], regions: 1}}
+  end
 end

--- a/test/image_pipe/transform/detector/composite_test.exs
+++ b/test/image_pipe/transform/detector/composite_test.exs
@@ -63,7 +63,56 @@ defmodule ImagePipe.Transform.Detector.CompositeTest do
     def detect(_image, _opts), do: {:error, {:detector, :boom}}
   end
 
+  # Children that report which warmup ran, to verify class-routed warmup.
+  defmodule WarmFace do
+    @behaviour ImagePipe.Transform.Detector
+    @impl true
+    def supported_classes(_), do: ["face"]
+    @impl true
+    def available?(_), do: true
+    @impl true
+    def identity(_), do: {__MODULE__, :v}
+    @impl true
+    def detect(_, _), do: {:ok, []}
+    @impl true
+    def warmup(opts) do
+      send(Keyword.fetch!(opts, :test_pid), {:warmed, :face})
+      :ok
+    end
+  end
+
+  defmodule WarmObject do
+    @behaviour ImagePipe.Transform.Detector
+    @impl true
+    def supported_classes(_), do: ["car"]
+    @impl true
+    def available?(_), do: true
+    @impl true
+    def identity(_), do: {__MODULE__, :v}
+    @impl true
+    def detect(_, _), do: {:ok, []}
+    @impl true
+    def warmup(opts) do
+      send(Keyword.fetch!(opts, :test_pid), {:warmed, :object})
+      :ok
+    end
+  end
+
   defp composite, do: Composite.new([FaceChild, ObjectChild])
+
+  test "warmup with a class list warms only the routed children" do
+    composite = Composite.new([WarmFace, WarmObject])
+    assert :ok = Composite.warmup(composite, classes: ["face"], test_pid: self())
+    assert_received {:warmed, :face}
+    refute_received {:warmed, :object}
+  end
+
+  test "warmup with :all warms every child" do
+    composite = Composite.new([WarmFace, WarmObject])
+    assert :ok = Composite.warmup(composite, classes: :all, test_pid: self())
+    assert_received {:warmed, :face}
+    assert_received {:warmed, :object}
+  end
 
   test "surfaces the error when every routed child fails" do
     composite = Composite.new([ErroringChild])

--- a/test/image_pipe/transform/detector/composite_test.exs
+++ b/test/image_pipe/transform/detector/composite_test.exs
@@ -1,0 +1,99 @@
+defmodule ImagePipe.Transform.Detector.CompositeTest do
+  use ExUnit.Case, async: true
+
+  alias ImagePipe.Transform.Detector.Composite
+
+  # Fake children: each owns a vocabulary and returns one canned region per
+  # routed class (label = class). Real @behaviour producers, so this is not an
+  # impossible-internal-misuse test.
+  defmodule FaceChild do
+    @behaviour ImagePipe.Transform.Detector
+    @impl true
+    def supported_classes(_), do: ["face"]
+    @impl true
+    def available?(opts), do: Keyword.get(opts, :face_available?, true)
+    @impl true
+    def identity(_), do: {__MODULE__, :face_v1}
+    @impl true
+    def detect(_image, opts), do: {:ok, regions_for(opts)}
+    defp regions_for(opts) do
+      requested(opts, ["face"])
+      |> Enum.map(&%{label: &1, score: 0.9, box: {0, 0, 10, 10}})
+    end
+    defp requested(opts, owned) do
+      case Keyword.get(opts, :classes, :all) do
+        :all -> owned
+        list -> Enum.filter(list, &(&1 in owned))
+      end
+    end
+  end
+
+  defmodule ObjectChild do
+    @behaviour ImagePipe.Transform.Detector
+    @owned ["car", "dog"]
+    @impl true
+    def supported_classes(_), do: @owned
+    @impl true
+    def available?(opts), do: Keyword.get(opts, :object_available?, true)
+    @impl true
+    def identity(_), do: {__MODULE__, :obj_v1}
+    @impl true
+    def detect(_image, opts), do: {:ok, regions_for(opts)}
+    defp regions_for(opts) do
+      case Keyword.get(opts, :classes, :all) do
+        :all -> @owned
+        list -> Enum.filter(list, &(&1 in @owned))
+      end
+      |> Enum.map(&%{label: &1, score: 0.8, box: {50, 50, 10, 10}})
+    end
+  end
+
+  defp composite, do: Composite.new([FaceChild, ObjectChild])
+
+  test "supported_classes is the union of children" do
+    assert Enum.sort(Composite.supported_classes(composite())) == ["car", "dog", "face"]
+  end
+
+  test ":all runs every child and merges all regions" do
+    {:ok, regions} = Composite.detect(composite(), :image, classes: :all)
+    assert Enum.map(regions, & &1.label) |> Enum.sort() == ["car", "dog", "face"]
+  end
+
+  test "a class list routes only to the owning children" do
+    {:ok, regions} = Composite.detect(composite(), :image, classes: ["face", "car"])
+    assert Enum.map(regions, & &1.label) |> Enum.sort() == ["car", "face"]
+  end
+
+  test "unknown classes are dropped (best-effort)" do
+    {:ok, regions} = Composite.detect(composite(), :image, classes: ["face", "unicorn"])
+    assert Enum.map(regions, & &1.label) == ["face"]
+  end
+
+  test "all-unknown yields no regions and is available? = true (degrade, not fail)" do
+    {:ok, regions} = Composite.detect(composite(), :image, classes: ["unicorn"])
+    assert regions == []
+    assert Composite.available?(composite(), classes: ["unicorn"]) == true
+  end
+
+  test "identity reflects only routed children, ordered by child order" do
+    assert Composite.identity(composite(), classes: ["face"]) ==
+             {Composite, [{FaceChild, :face_v1}]}
+
+    assert Composite.identity(composite(), classes: ["car"]) ==
+             {Composite, [{ObjectChild, :obj_v1}]}
+
+    # URL order invariance: face:dog vs dog:face produce the same identity list
+    assert Composite.identity(composite(), classes: ["face", "dog"]) ==
+             Composite.identity(composite(), classes: ["dog", "face"])
+
+    assert Composite.identity(composite(), classes: :all) ==
+             {Composite, [{FaceChild, :face_v1}, {ObjectChild, :obj_v1}]}
+  end
+
+  test "available? requires every routed child to be available" do
+    c = composite()
+    assert Composite.available?(c, classes: ["face"], object_available?: false) == true
+    assert Composite.available?(c, classes: ["car"], object_available?: false) == false
+    assert Composite.available?(c, classes: :all, object_available?: false) == false
+  end
+end

--- a/test/image_pipe/transform/detector/composite_test.exs
+++ b/test/image_pipe/transform/detector/composite_test.exs
@@ -16,10 +16,12 @@ defmodule ImagePipe.Transform.Detector.CompositeTest do
     def identity(_), do: {__MODULE__, :face_v1}
     @impl true
     def detect(_image, opts), do: {:ok, regions_for(opts)}
+
     defp regions_for(opts) do
       requested(opts, ["face"])
       |> Enum.map(&%{label: &1, score: 0.9, box: {0, 0, 10, 10}})
     end
+
     defp requested(opts, owned) do
       case Keyword.get(opts, :classes, :all) do
         :all -> owned
@@ -39,6 +41,7 @@ defmodule ImagePipe.Transform.Detector.CompositeTest do
     def identity(_), do: {__MODULE__, :obj_v1}
     @impl true
     def detect(_image, opts), do: {:ok, regions_for(opts)}
+
     defp regions_for(opts) do
       case Keyword.get(opts, :classes, :all) do
         :all -> @owned
@@ -112,9 +115,19 @@ defmodule ImagePipe.Transform.Detector.CompositeTest do
       )
 
     assert_received {[:image_pipe, :transform, :detect, :model, :stop], ^ref, _measurements,
-                     %{detector: FaceChild, model: {FaceChild, :face_v1}, classes: ["face"], regions: 1}}
+                     %{
+                       detector: FaceChild,
+                       model: {FaceChild, :face_v1},
+                       classes: ["face"],
+                       regions: 1
+                     }}
 
     assert_received {[:image_pipe, :transform, :detect, :model, :stop], ^ref, _measurements,
-                     %{detector: ObjectChild, model: {ObjectChild, :obj_v1}, classes: ["car"], regions: 1}}
+                     %{
+                       detector: ObjectChild,
+                       model: {ObjectChild, :obj_v1},
+                       classes: ["car"],
+                       regions: 1
+                     }}
   end
 end

--- a/test/image_pipe/transform/detector/image_vision_test.exs
+++ b/test/image_pipe/transform/detector/image_vision_test.exs
@@ -1,5 +1,12 @@
 defmodule ImagePipe.Transform.Detector.ImageVisionTest do
   use ExUnit.Case, async: true
+
+  # The drift/smoke tests below reference the optional dependency's modules
+  # (`Image.Detection`/`Image.FaceDetection`), which are absent in the default
+  # lane (these tests are `@tag :image_vision` and excluded there). Silence the
+  # compile-time undefined-module warning the same way the adapters do.
+  @compile {:no_warn_undefined, [Image.Detection, Image.FaceDetection]}
+
   alias ImagePipe.Transform.Detector.ImageVision.Face
   alias ImagePipe.Transform.Detector.ImageVision.Objects
 

--- a/test/image_pipe/transform/detector/image_vision_test.exs
+++ b/test/image_pipe/transform/detector/image_vision_test.exs
@@ -1,6 +1,7 @@
 defmodule ImagePipe.Transform.Detector.ImageVisionTest do
   use ExUnit.Case, async: true
   alias ImagePipe.Transform.Detector.ImageVision.Face
+  alias ImagePipe.Transform.Detector.ImageVision.Objects
 
   test "identity reflects availability" do
     expected =
@@ -55,6 +56,39 @@ defmodule ImagePipe.Transform.Detector.ImageVisionTest do
       assert {:ok, regions} = Face.detect(image, classes: :all)
       assert is_list(regions)
       assert {:ok, []} = Face.detect(image, classes: ["car"])
+    end
+  end
+
+  # supported_classes is a hardcoded static list (dep-independent), so this runs
+  # in the DEFAULT lane — it is the deterministic coverage for the underscore
+  # spelling that the normalization depends on.
+  describe "Objects vocabulary (no dependency required)" do
+    test "supported_classes is the static COCO-80 vocabulary in underscore spelling" do
+      classes = Objects.supported_classes([])
+      assert "person" in classes
+      assert "traffic_light" in classes
+      refute "traffic light" in classes
+      assert length(classes) == 80
+    end
+  end
+
+  describe "Objects adapter (real model)" do
+    @describetag :image_vision
+
+    test "supported_classes matches the model's labels (drift guard)" do
+      model_labels =
+        Image.Detection.classes()
+        |> Enum.map(&String.replace(&1, " ", "_"))
+        |> Enum.sort()
+
+      assert Enum.sort(Objects.supported_classes([])) == model_labels
+    end
+
+    test "detect returns product-neutral regions on a synthetic image" do
+      {:ok, image} = Image.new(320, 240, color: :black)
+      assert {:ok, regions} = Objects.detect(image, classes: :all)
+      assert is_list(regions)
+      assert Enum.all?(regions, &match?(%{label: l, score: _, box: {_, _, _, _}} when is_binary(l), &1))
     end
   end
 end

--- a/test/image_pipe/transform/detector/image_vision_test.exs
+++ b/test/image_pipe/transform/detector/image_vision_test.exs
@@ -30,10 +30,13 @@ defmodule ImagePipe.Transform.Detector.ImageVisionTest do
   end
 
   test "Face.detect with :all short-circuits to unavailable when the dep is absent" do
-    # In the default (no image_vision) lane, available? is false, so any classes
-    # value returns the unavailable error rather than crashing.
-    assert {:error, {:detector, :unavailable}} = Face.detect(:image, classes: :all)
-    assert {:error, {:detector, :unavailable}} = Face.detect(:image, classes: ["car"])
+    # Only meaningful in the no-dependency lane: when available? is false the
+    # detect short-circuits before touching the (junk) :image input. With the dep
+    # present it would run real inference, so guard to that lane.
+    unless Face.available?([]) do
+      assert {:error, {:detector, :unavailable}} = Face.detect(:image, classes: :all)
+      assert {:error, {:detector, :unavailable}} = Face.detect(:image, classes: ["car"])
+    end
   end
 
   @tag :image_vision

--- a/test/image_pipe/transform/detector/image_vision_test.exs
+++ b/test/image_pipe/transform/detector/image_vision_test.exs
@@ -1,29 +1,36 @@
 defmodule ImagePipe.Transform.Detector.ImageVisionTest do
   use ExUnit.Case, async: true
-  alias ImagePipe.Transform.Detector.ImageVision
+  alias ImagePipe.Transform.Detector.ImageVision.Face
 
   test "identity reflects availability" do
     expected =
-      if ImageVision.available?([]),
-        do: {ImageVision, {"opencv/face_detection_yunet", "face_detection_yunet_2023mar.onnx"}},
-        else: {ImageVision, :unavailable}
+      if Face.available?([]),
+        do: {Face, {"opencv/face_detection_yunet", "face_detection_yunet_2023mar.onnx"}},
+        else: {Face, :unavailable}
 
-    assert ImageVision.identity([]) == expected
+    assert Face.identity([]) == expected
   end
 
   test "detect returns unavailable when the dependency is absent" do
     # In the default (no-dep) lane, available? is false → detect short-circuits.
-    if ImageVision.available?([]) do
-      assert {:ok, _} = ImageVision.detect(Image.new!(64, 64, color: :black), classes: ["face"])
+    if Face.available?([]) do
+      assert {:ok, _} = Face.detect(Image.new!(64, 64, color: :black), classes: ["face"])
     else
       assert {:error, {:detector, :unavailable}} =
-               ImageVision.detect(Image.new!(64, 64, color: :black), classes: ["face"])
+               Face.detect(Image.new!(64, 64, color: :black), classes: ["face"])
     end
+  end
+
+  test "Face.detect with :all short-circuits to unavailable when the dep is absent" do
+    # In the default (no image_vision) lane, available? is false, so any classes
+    # value returns the unavailable error rather than crashing.
+    assert {:error, {:detector, :unavailable}} = Face.detect(:image, classes: :all)
+    assert {:error, {:detector, :unavailable}} = Face.detect(:image, classes: ["car"])
   end
 
   @tag :image_vision
   test "detect returns face regions when the dependency is present" do
-    unless ImageVision.available?([]) do
+    unless Face.available?([]) do
       flunk("""
       The :image_vision lane needs the real face detector, but Image.FaceDetection \
       is not loaded (available?([]) == false). image_vision compiles that module \
@@ -36,7 +43,18 @@ defmodule ImagePipe.Transform.Detector.ImageVisionTest do
     end
 
     image = Image.open!("priv/static/images/woman.jpg")
-    assert {:ok, regions} = ImageVision.detect(image, classes: ["face"])
+    assert {:ok, regions} = Face.detect(image, classes: ["face"])
     assert Enum.all?(regions, &match?(%{label: "face", box: {_, _, _, _}}, &1))
+  end
+
+  describe "Face.detect routing (real model)" do
+    @describetag :image_vision
+
+    test "classes: :all returns faces; a non-face routed class returns no regions" do
+      {:ok, image} = Image.new(64, 64, color: :black)
+      assert {:ok, regions} = Face.detect(image, classes: :all)
+      assert is_list(regions)
+      assert {:ok, []} = Face.detect(image, classes: ["car"])
+    end
   end
 end

--- a/test/image_pipe/transform/detector/image_vision_test.exs
+++ b/test/image_pipe/transform/detector/image_vision_test.exs
@@ -88,7 +88,11 @@ defmodule ImagePipe.Transform.Detector.ImageVisionTest do
       {:ok, image} = Image.new(320, 240, color: :black)
       assert {:ok, regions} = Objects.detect(image, classes: :all)
       assert is_list(regions)
-      assert Enum.all?(regions, &match?(%{label: l, score: _, box: {_, _, _, _}} when is_binary(l), &1))
+
+      assert Enum.all?(
+               regions,
+               &match?(%{label: l, score: _, box: {_, _, _, _}} when is_binary(l), &1)
+             )
     end
   end
 end

--- a/test/image_pipe/transform/detector/warmup_test.exs
+++ b/test/image_pipe/transform/detector/warmup_test.exs
@@ -5,6 +5,8 @@ defmodule ImagePipe.Transform.Detector.WarmupTest do
   defmodule SignalDetector do
     @behaviour ImagePipe.Transform.Detector
     @impl true
+    def supported_classes(_o), do: ["face"]
+    @impl true
     def detect(_i, _o), do: {:ok, []}
     @impl true
     def available?(_o), do: true
@@ -25,6 +27,8 @@ defmodule ImagePipe.Transform.Detector.WarmupTest do
 
   defmodule UnavailableDetector do
     @behaviour ImagePipe.Transform.Detector
+    @impl true
+    def supported_classes(_o), do: ["face"]
     @impl true
     def detect(_i, _o), do: {:error, :unavailable}
     @impl true

--- a/test/image_pipe/transform/detector_test.exs
+++ b/test/image_pipe/transform/detector_test.exs
@@ -5,6 +5,8 @@ defmodule ImagePipe.Transform.DetectorTest do
   defmodule WithWarmup do
     @behaviour Detector
     @impl true
+    def supported_classes(_o), do: ["face"]
+    @impl true
     def detect(_i, _o), do: {:ok, []}
     @impl true
     def available?(_o), do: true
@@ -16,6 +18,8 @@ defmodule ImagePipe.Transform.DetectorTest do
 
   defmodule NoWarmup do
     @behaviour Detector
+    @impl true
+    def supported_classes(_o), do: ["face"]
     @impl true
     def detect(_i, _o), do: {:ok, []}
     @impl true

--- a/test/parser/imgproxy/plan_builder_test.exs
+++ b/test/parser/imgproxy/plan_builder_test.exs
@@ -896,6 +896,66 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilderTest do
     assert crop.guide == {:detect, ["face", "5", "5"]}
   end
 
+  test "all among classes collapses to :all (fill path)" do
+    assert {:ok, %Plan{pipelines: [%Pipeline{operations: [%Operation.Resize{} = resize]}]}} =
+             plan_pipeline(
+               resizing_type: :fill,
+               width: {:pixels, 100},
+               height: {:pixels, 100},
+               gravity: {:obj, ["car", "all"]}
+             )
+
+    assert resize.guide == {:detect, :all}
+  end
+
+  test "bare object gravity maps to detect :all (crop path)" do
+    assert {:ok,
+            %Plan{
+              pipelines: [%Pipeline{operations: [%Operation.CropGuided{} = crop]}]
+            }} =
+             plan_pipeline(
+               crop: %ImagePipe.Parser.Imgproxy.CropRequest{
+                 width: {:pixels, 100},
+                 height: {:pixels, 100},
+                 gravity: {:obj, []}
+               }
+             )
+
+    assert crop.guide == {:detect, :all}
+  end
+
+  test "the all pseudo-class maps to detect :all (crop path)" do
+    assert {:ok,
+            %Plan{
+              pipelines: [%Pipeline{operations: [%Operation.CropGuided{} = crop]}]
+            }} =
+             plan_pipeline(
+               crop: %ImagePipe.Parser.Imgproxy.CropRequest{
+                 width: {:pixels, 100},
+                 height: {:pixels, 100},
+                 gravity: {:obj, ["all"]}
+               }
+             )
+
+    assert crop.guide == {:detect, :all}
+  end
+
+  test "multi-class object gravity maps to detect with those classes (crop path)" do
+    assert {:ok,
+            %Plan{
+              pipelines: [%Pipeline{operations: [%Operation.CropGuided{} = crop]}]
+            }} =
+             plan_pipeline(
+               crop: %ImagePipe.Parser.Imgproxy.CropRequest{
+                 width: {:pixels, 100},
+                 height: {:pixels, 100},
+                 gravity: {:obj, ["car", "dog"]}
+               }
+             )
+
+    assert crop.guide == {:detect, ["car", "dog"]}
+  end
+
   test "represents output intent outside imgproxy pipeline operations" do
     request = %ParsedRequest{
       signature: "_",

--- a/test/parser/imgproxy/plan_builder_test.exs
+++ b/test/parser/imgproxy/plan_builder_test.exs
@@ -841,38 +841,50 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilderTest do
     end
   end
 
-  test "rejects bare object gravity (all detected objects)" do
-    assert {:error, {:unsupported_gravity, {:obj, []}}} =
+  test "bare object gravity maps to detect :all (fill path)" do
+    assert {:ok, %Plan{pipelines: [%Pipeline{operations: [%Operation.Resize{} = resize]}]}} =
              plan_pipeline(
                resizing_type: :fill,
                width: {:pixels, 100},
                height: {:pixels, 100},
                gravity: {:obj, []}
              )
+
+    assert resize.guide == {:detect, :all}
   end
 
-  test "rejects the all pseudo-class object gravity" do
-    assert {:error, {:unsupported_gravity, {:obj, ["all"]}}} =
+  test "the all pseudo-class maps to detect :all (fill path)" do
+    assert {:ok, %Plan{pipelines: [%Pipeline{operations: [%Operation.Resize{} = resize]}]}} =
              plan_pipeline(
                resizing_type: :fill,
                width: {:pixels, 100},
                height: {:pixels, 100},
                gravity: {:obj, ["all"]}
              )
+
+    assert resize.guide == {:detect, :all}
   end
 
-  test "rejects multi-class object gravity" do
-    assert {:error, {:unsupported_gravity, {:obj, ["face", "cat"]}}} =
+  test "multi-class object gravity maps to detect with those classes (fill path)" do
+    assert {:ok, %Plan{pipelines: [%Pipeline{operations: [%Operation.Resize{} = resize]}]}} =
              plan_pipeline(
                resizing_type: :fill,
                width: {:pixels, 100},
                height: {:pixels, 100},
                gravity: {:obj, ["face", "cat"]}
              )
+
+    assert resize.guide == {:detect, ["face", "cat"]}
   end
 
-  test "rejects object gravity with trailing class tokens treated as offsets" do
-    assert {:error, {:unsupported_gravity, {:obj, ["face", "5", "5"]}}} =
+  # Behavior change: numeric trailing tokens are now unknown classes dropped at
+  # routing, NOT an error. g:obj:face:5:5 -> {:detect, ["face", "5", "5"]} where
+  # "5" is an unknown class dropped later at routing (object gravity has no offsets).
+  test "object gravity with numeric tokens treats them as (unknown) classes, not an error (crop path)" do
+    assert {:ok,
+            %Plan{
+              pipelines: [%Pipeline{operations: [%Operation.CropGuided{} = crop]}]
+            }} =
              plan_pipeline(
                crop: %ImagePipe.Parser.Imgproxy.CropRequest{
                  width: {:pixels, 100},
@@ -880,6 +892,8 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilderTest do
                  gravity: {:obj, ["face", "5", "5"]}
                }
              )
+
+    assert crop.guide == {:detect, ["face", "5", "5"]}
   end
 
   test "represents output intent outside imgproxy pipeline operations" do

--- a/test/support/fake_detector.ex
+++ b/test/support/fake_detector.ex
@@ -3,6 +3,9 @@ defmodule ImagePipe.Test.FakeDetector do
   @behaviour ImagePipe.Transform.Detector
 
   @impl true
+  def supported_classes(opts), do: Keyword.get(opts, :supported_classes, ["face"])
+
+  @impl true
   def detect(_image, opts), do: Keyword.get(opts, :result, {:ok, []})
 
   @impl true


### PR DESCRIPTION
## Summary

Extends content-aware gravity from the single-class `face` subset to imgproxy's general object gravity:

- **`g:obj:%c1:…:%cN`** — multi-class object gravity; **`g:obj` / `g:obj:all`** — all detected objects (the union of every configured detector's classes, faces included); plus the `c:W:H:obj…` crop forms.
- Backed by a product-neutral **`Detector.Composite`** that routes face classes to YuNet (`ImageVision.Face`) and COCO-80 object classes to RT-DETR (`ImageVision.Objects`), fans out to only the needed models, and merges regions. Built on a new `supported_classes/1` behaviour callback.
- **Class-aware cache identity & strict gate:** a request's cache key and `detector_required` availability reflect only the models it actually routes to (bumping the face model can't invalidate `obj:car`; an object-model outage doesn't 422 a face request).
- **Best-effort unknown classes:** a class no configured detector claims is dropped (degrades, never errors); observable via telemetry.
- **Per-model telemetry:** nested `[:transform, :detect, :model]` spans per child (module + model identity + routed classes + region count), preserving honest per-model cold-start visibility.
- Existing `g:obj:face`, face-assist (`g:sm` + `smart_crop_face_detection`), and plain `g:sm` are unchanged. The equal-weight `area` centroid is unchanged.

**Deferred to Slice 2:** per-class weights (`gravity:objw`) and the weighted-centroid formula — see `docs/superpowers/specs/2026-05-31-object-gravity-slice2-notes.md`.

Design/plan/review trail: `docs/superpowers/specs/2026-05-31-object-gravity-slice1-design.md` and `docs/superpowers/plans/2026-05-31-object-gravity-slice1.md` (both went through parallel adversarial review before implementation).

## Test Plan

- [x] `mise run precommit` — `mix format` ✓, `mix compile --warnings-as-errors` ✓, `mix credo --strict` (0 issues) ✓, `mix test` → **1192 tests + 36 properties + 1 doctest, 0 failures**.
- [x] `mise run precommit:demo` — Elixir gate + demo suite (vitest 103, svelte-check, oxlint, vite build) ✓.
- [x] Wire-level pixel proof: `g:obj:car` crop decodes to the target dims and diverges from **both** a centered crop and an attention crop (didn't silently fall back); no-geometry `g:obj` variant covered.
- [x] Gate triad (`detector_required`): supported+available → 200, unknown → 200 (degrade), supported+unavailable → 422 **before** any source fetch or cache access.
- [x] Class-aware cache-key independence verified at the wire level (object-only key independent of face-model identity, and vice versa; mixed key sensitive to both).
- [x] Architecture boundary test extended: parser/plan code may not name concrete detector modules; parser stays vocabulary-free.

**Environment note:** the `@tag :image_vision` *real-inference* tests can't run in this CI environment because Nx isn't wired into the `image` lib (`Image.to_nx!/2` undefined — affects face and object inference equally). The hardcoded COCO-80 vocabulary is guarded by a tagged **drift test** (passes: it matches `Image.Detection.classes/0`), and all behavioral tests use an injected fake detector, so the default lane fully covers the contract. Real inference requires a host with the Nx/EXLA stack configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added object-class gravity selection to the demo UI, allowing crops guided by detected COCO objects (80 classes) beyond face detection.
  * Extended gravity mode to support general object detection with configurable class filtering.

* **Documentation**
  * Expanded content-aware gravity guides with object detection details, cache behavior, and telemetry schemas.
  * Updated imgproxy compatibility matrix to document object gravity support variants and fallback behavior.
  * Enhanced telemetry documentation with per-model detection span details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->