### PR TITLE
ci: add dedicated lint workflow

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -33,8 +33,8 @@ jobs:
             erlang: 28
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           mise_toml: |
             [tools]

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -52,10 +52,6 @@ jobs:
         run: mise exec -- mix compile --warnings-as-errors
         env:
           MIX_ENV: test
-      - name: Check formatting
-        run: mise exec -- mix format --check-formatted
-        env:
-          MIX_ENV: test
       - name: Run tests
         run: mise exec -- mix test --no-compile
         env:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -33,8 +33,8 @@ jobs:
             erlang: 28
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v3
+      - uses: actions/checkout@v6
+      - uses: jdx/mise-action@v4
         with:
           mise_toml: |
             [tools]

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -27,9 +27,9 @@ jobs:
             erlang: 27
           - elixir: 1.19.5-otp-28
             erlang: 28
-          - elixir: 1.20.0-rc.5-otp-27
+          - elixir: 1.20.0-rc.6-otp-27
             erlang: 27
-          - elixir: 1.20.0-rc.5-otp-28
+          - elixir: 1.20.0-rc.6-otp-28
             erlang: 28
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,8 +16,8 @@ jobs:
     env:
       MIX_ENV: test
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v3
+      - uses: actions/checkout@v6
+      - uses: jdx/mise-action@v4
         with:
           mise_toml: |
             [tools]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,8 +16,8 @@ jobs:
     env:
       MIX_ENV: test
     steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           mise_toml: |
             [tools]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    env:
+      MIX_ENV: test
     steps:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,43 @@
+name: Lint
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v3
+        with:
+          mise_toml: |
+            [tools]
+            erlang = "29"
+            elixir = "1.20.0-rc.6-otp-29"
+            node = "latest"
+            pnpm = "latest"
+      - name: Install Hex
+        run: mise exec -- mix local.hex --force
+      - name: Install Rebar
+        run: mise exec -- mix local.rebar --force
+      - name: Install Elixir dependencies
+        run: mise exec -- mix deps.get
+      - name: Install demo dependencies
+        run: mise exec -- mix demo.setup
+      - name: Check formatting
+        run: mise exec -- mix format --check-formatted
+      - name: Run Credo
+        run: mise exec -- mix credo --strict
+      - name: Demo type-check
+        run: mise exec -- mix demo.check
+      - name: Demo format check
+        run: mise exec -- mix demo.format.check
+      - name: Demo lint
+        run: mise exec -- mix demo.lint

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-elixir = "1.20.0-rc.5-otp-29"
+elixir = "1.20.0-rc.6-otp-29"
 node = "latest"
 
 [tasks.setup]

--- a/package.json
+++ b/package.json
@@ -27,15 +27,4 @@
     "bits-ui": "2.18.1",
     "geist": "1.7.0"
   },
-  "pnpm": {
-    "packageExtensions": {
-      "geist@*": {
-        "peerDependenciesMeta": {
-          "next": {
-            "optional": true
-          }
-        }
-      }
-    }
-  }
 }

--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
   "dependencies": {
     "bits-ui": "2.18.1",
     "geist": "1.7.0"
-  },
+  }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packageExtensions:
+  "geist@*":
+    peerDependenciesMeta:
+      next:
+        optional: true


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/lint.yml`: a dedicated lint job pinned to a single Elixir/OTP version (1.20.0-rc.6-otp-29) that runs `mix format --check-formatted`, `mix credo --strict`, and the three demo checks (`demo:check`, `demo:format:check`, `demo:lint`)
- Drops the redundant `mix format --check-formatted` step from the 7-entry test matrix in `elixir.yml` — it now lives only in the lint job
- Bumps Elixir to `1.20.0-rc.6-otp-29` across `elixir.yml`, `lint.yml`, and `mise.toml`

Closes #136

## Test plan

- [x] Lint job appears as a separate CI check on this PR
- [x] `mix format --check-formatted`, `mix credo --strict`, and the three demo checks all pass
- [x] Test matrix no longer runs the format check step

🤖 Generated with [Claude Code](https://claude.com/claude-code)