### PR TITLE
SSRF protection for origin fetches and redirects (#48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ sources: [
 Use `:http` or `:https` instead to enable only one scheme, or when the schemes
 need different adapter options.
 
+By default, HTTP/HTTPS sources refuse to connect to non-public addresses and
+re-check the policy on every redirect hop. See
+[Source network policy](docs/source-network-policy.md) to allow private origins.
+
 `_` and `unsafe` work only without Imgproxy signing. Configured signing requires
 a valid HMAC signature or an exact configured trusted signature.
 
@@ -143,6 +147,10 @@ ImagePipe's fixed plan order.
 - [Transform operations](docs/transform_operations.md) documents the boundary
   between parser request syntax, semantic plan operations, and executable
   transform operations.
+- [Source network policy](docs/source-network-policy.md) documents the default
+  SSRF protection on HTTP/HTTPS sources, how to allow private origins
+  (`address_policy`), custom DNS resolution (`address_resolver`), and the
+  DNS-rebinding limitation.
 
 ## Local demo server
 

--- a/docs/source-network-policy.md
+++ b/docs/source-network-policy.md
@@ -1,0 +1,77 @@
+# Source network policy (SSRF protection)
+
+`ImagePipe.Source.HTTP` validates the destination of every origin fetch — and of
+every redirect hop — before connecting. By default it refuses to connect to any
+address that is not public.
+
+## Default policy
+
+For each request, and again for each redirect, the adapter:
+
+1. Requires an `http`/`https` scheme.
+2. Requires the (case-insensitive) host to be in `allowed_hosts` — redirects may
+   not leave the allowlist.
+3. Resolves the host to IP addresses and **denies the fetch if any resolved
+   address is not public** (loopback, unspecified, link-local, private, CGNAT,
+   unique-local, multicast, broadcast, or otherwise reserved).
+
+IPv4 literal encodings (decimal, octal, hex) and IPv4-mapped / NAT64 / 6to4 IPv6
+forms are canonicalized before classification, so they cannot be used to smuggle
+an internal address past the check.
+
+A denied fetch raises `ImagePipe.Source.StreamError` with `reason:
+:denied_scheme`, `:denied_host`, or `:denied_address` when the response stream is
+consumed.
+
+## Allowing private origins
+
+Set `address_policy` on the source adapter. It accepts either a keyword list or a
+function.
+
+### Keyword list
+
+```elixir
+sources: [
+  url: {ImagePipe.Source.HTTP,
+    allowed_hosts: ["assets.internal"],
+    address_policy: [
+      allow_private: true,         # opens ALL RFC1918 ranges
+      allow: ["10.0.5.0/24"]       # OR open exactly one range, precisely
+    ]
+  }
+]
+```
+
+Toggles: `allow_loopback`, `allow_unspecified`, `allow_link_local`,
+`allow_private`, `allow_unique_local`, `allow_multicast`, `allow_broadcast`,
+`allow_cgnat`, `allow_reserved`. `allow:` is a list of CIDR strings. Omitting
+`address_policy` denies everything that is not public.
+
+### Function
+
+```elixir
+address_policy: fn _ip, category -> category == :public end
+```
+
+The function receives the canonicalized IP tuple and its category and returns a
+boolean. It replaces the built-in decision. A non-boolean return or a raised
+exception is treated as **deny** (fail-closed).
+
+## Custom DNS resolution
+
+`address_resolver` overrides how hostnames resolve, e.g. a caching resolver:
+
+```elixir
+address_resolver: fn host -> {:ok, [{93, 184, 216, 34}]} end
+```
+
+It returns `{:ok, [ip_tuple]}` or `{:error, term}`. Any error, an empty list, or a
+raise denies the fetch.
+
+## Known limitation: DNS rebinding
+
+This is **resolve-and-validate**, not connection-pinned: after the policy
+validates the resolved addresses, the HTTP client re-resolves the hostname when it
+actually connects. A DNS-rebinding attacker who returns a public address to our
+lookup and a private address at connect time can still slip past. Closing this
+requires pinning the connection to the validated IP and is tracked separately.

--- a/docs/superpowers/plans/2026-06-01-ssrf-protection.md
+++ b/docs/superpowers/plans/2026-06-01-ssrf-protection.md
@@ -1,0 +1,1457 @@
+# SSRF Protection for Origin Fetches and Redirects — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Block `ImagePipe.Source.HTTP` from connecting to loopback/private/internal addresses — on the origin request and on every redirect hop — with an explicit per-deployment opt-out.
+
+**Architecture:** A pure classifier module (`ImagePipe.Source.HTTP.AddressPolicy`) decides whether a resolved IP is allowed under a compiled policy. A guard module (`ImagePipe.Source.HTTP.TargetGuard`) turns a target URL into an allow/deny decision (scheme → `allowed_hosts` → resolve → classify). `ImagePipe.Source.ReqStream` stops delegating redirect-following to Req (`redirect: false`) and instead owns a bounded redirect loop that runs the guard before opening *each* connection; denials raise `ImagePipe.Source.StreamError` with a `:denied_*` reason. The Req-request-step approach was rejected during review — verified against Req 0.5.17 source, request steps do not re-run on redirect hops.
+
+**Tech Stack:** Elixir, Req 0.5.17 (Finch 0.22 / Mint 1.8), NimbleOptions, ExUnit + StreamData (`~> 1.0`, already a dep), Erlang `:inet`.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-ssrf-protection-design.md`. Read it before starting; this plan implements it.
+
+---
+
+## Background an implementer needs
+
+- **Run everything via mise:** `mise exec -- mix test path`, `mise exec -- mix format`, `mise exec -- mix credo --strict`, `mise exec -- mix compile --warnings-as-errors`. Never call `mix` bare.
+- **`:inet` IP tuples:** IPv4 is a 4-tuple `{a,b,c,d}`; IPv6 is an 8-tuple `{a,b,c,d,e,f,g,h}` of 16-bit groups. `:inet.parse_address(charlist)` returns `{:ok, tuple} | {:error, :einval}`. **Pass it a charlist** (`~c"127.0.0.1"` or `String.to_charlist/1`), not a binary. It canonicalizes octal/hex/dword IPv4 literals (`~c"2130706433"` → `{127,0,0,1}`).
+- **IPv4-mapped IPv6 gotcha (verified):** `:inet.parse_address(~c"::ffff:10.0.0.1")` returns the **8-tuple** `{0,0,0,0,0,65535,2560,1}`, *not* `{10,0,0,1}`. `2560 = 0x0A00` → `10.0`, next group `1` → `0.1`. So `classify/1` must unwrap on the tuple.
+- **The codebase stores IPv6 hosts unbracketed** in `%URL{host: "::1"}`; `build_url/1` adds brackets only for the wire URL. So feed the unbracketed host to `:inet.parse_address`.
+- **How stream errors surface today:** `ReqStream.stream/2` builds a `Stream.resource`. Its init thunk (`open_response`) returns either a success state map or `{:error, reason}`. The reducer clause `{:error, reason} -> raise StreamError, reason: reason` turns that into a raised `StreamError`. The existing redirect test asserts `assert_raise Source.StreamError, fn -> Enum.to_list(stream) end` then `assert error.reason == :bad_status`. We follow that exact pattern with `:denied_*` reasons.
+- **Existing tests use Req's plug adapter:** `req_options: [plug: fn conn -> ... end]`. Request steps and our guard still run, but no real socket/DNS. The guard's resolver is injected so tests stub DNS.
+- **Why existing tests will break:** they fetch the non-resolving hostname `assets.example.com`. Once the guard does real DNS, that's NXDOMAIN → fail-closed. Task 7 adds a shared test-only stub resolver to fix them.
+
+---
+
+## File Structure
+
+**Create:**
+- `lib/image_pipe/source/http/address_policy.ex` — pure: `classify/1`, CIDR parse/match, `compile/1`, `allow?/2`.
+- `lib/image_pipe/source/http/target_guard.ex` — `validate/4` (scheme → host → resolve → policy), `default_resolver/1`.
+- `test/image_pipe/source/http/address_policy_test.exs`
+- `test/image_pipe/source/http/target_guard_test.exs`
+- `docs/source-network-policy.md` — host-facing docs.
+
+**Modify:**
+- `lib/image_pipe/source/req_stream.ex` — own the redirect loop; accept `validate_target` + `max_redirects`; `redirect: false`.
+- `lib/image_pipe/source/http.ex` — new options in schema; strip new keys from `req_options`; build the guard closure; pass it + redirect bound to `ReqStream`.
+- `test/image_pipe/source/http_test.exs` — shared stub resolver; migrate existing tests; new acceptance/edge tests; fix the misleading redirect test.
+- `README.md` — link the new doc and mention `address_policy` by the source example.
+
+**Boundary note:** `AddressPolicy` and `TargetGuard` live in the existing `ImagePipe.Source` boundary as internal siblings of `HTTP`. **Do not** add them to the `Source` boundary `exports:` list in `lib/image_pipe/source.ex` — they are implementation modules consumed only within the boundary.
+
+---
+
+## Task 1: `AddressPolicy.classify/1` — IPv4 categories
+
+**Files:**
+- Create: `lib/image_pipe/source/http/address_policy.ex`
+- Test: `test/image_pipe/source/http/address_policy_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+defmodule ImagePipe.Source.HTTP.AddressPolicyTest do
+  use ExUnit.Case, async: true
+
+  alias ImagePipe.Source.HTTP.AddressPolicy
+
+  describe "classify/1 IPv4" do
+    test "categorizes well-known IPv4 ranges" do
+      assert AddressPolicy.classify({127, 0, 0, 1}) == :loopback
+      assert AddressPolicy.classify({127, 5, 5, 5}) == :loopback
+      assert AddressPolicy.classify({0, 0, 0, 0}) == :unspecified
+      assert AddressPolicy.classify({0, 1, 2, 3}) == :unspecified
+      assert AddressPolicy.classify({169, 254, 169, 254}) == :link_local
+      assert AddressPolicy.classify({10, 0, 0, 1}) == :private
+      assert AddressPolicy.classify({172, 16, 0, 1}) == :private
+      assert AddressPolicy.classify({172, 31, 255, 255}) == :private
+      assert AddressPolicy.classify({172, 32, 0, 1}) == :public
+      assert AddressPolicy.classify({192, 168, 1, 1}) == :private
+      assert AddressPolicy.classify({100, 64, 0, 1}) == :cgnat
+      assert AddressPolicy.classify({224, 0, 0, 1}) == :multicast
+      assert AddressPolicy.classify({255, 255, 255, 255}) == :broadcast
+      assert AddressPolicy.classify({198, 18, 0, 1}) == :reserved
+      assert AddressPolicy.classify({192, 0, 2, 5}) == :reserved
+      assert AddressPolicy.classify({93, 184, 216, 34}) == :public
+      assert AddressPolicy.classify({8, 8, 8, 8}) == :public
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/source/http/address_policy_test.exs`
+Expected: FAIL — `ImagePipe.Source.HTTP.AddressPolicy.classify/1 is undefined (module not available)`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```elixir
+defmodule ImagePipe.Source.HTTP.AddressPolicy do
+  @moduledoc false
+
+  @type category ::
+          :loopback
+          | :unspecified
+          | :link_local
+          | :private
+          | :unique_local
+          | :multicast
+          | :broadcast
+          | :cgnat
+          | :reserved
+          | :public
+
+  @spec classify(:inet.ip_address()) :: category()
+  def classify({a, b, c, d}) do
+    classify_v4(a, b, c, d)
+  end
+
+  defp classify_v4(0, _, _, _), do: :unspecified
+  defp classify_v4(127, _, _, _), do: :loopback
+  defp classify_v4(169, 254, _, _), do: :link_local
+  defp classify_v4(10, _, _, _), do: :private
+  defp classify_v4(172, b, _, _) when b in 16..31, do: :private
+  defp classify_v4(192, 168, _, _), do: :private
+  defp classify_v4(100, b, _, _) when b in 64..127, do: :cgnat
+  defp classify_v4(a, _, _, _) when a in 224..239, do: :multicast
+  defp classify_v4(255, 255, 255, 255), do: :broadcast
+  # benchmarking 198.18.0.0/15
+  defp classify_v4(198, b, _, _) when b in 18..19, do: :reserved
+  # documentation 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24
+  defp classify_v4(192, 0, 2, _), do: :reserved
+  defp classify_v4(198, 51, 100, _), do: :reserved
+  defp classify_v4(203, 0, 113, _), do: :reserved
+  # 240.0.0.0/4 reserved (future use)
+  defp classify_v4(a, _, _, _) when a in 240..255, do: :reserved
+  defp classify_v4(_, _, _, _), do: :public
+end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mise exec -- mix test test/image_pipe/source/http/address_policy_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/source/http/address_policy.ex test/image_pipe/source/http/address_policy_test.exs
+git commit -m "feat(source): AddressPolicy.classify/1 for IPv4 ranges"
+```
+
+---
+
+## Task 2: `classify/1` — IPv6 + canonicalization (mapped, NAT64, 6to4), deny-default
+
+**Files:**
+- Modify: `lib/image_pipe/source/http/address_policy.ex`
+- Test: `test/image_pipe/source/http/address_policy_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+  describe "classify/1 IPv6 and canonicalization" do
+    test "categorizes native IPv6 ranges" do
+      assert AddressPolicy.classify({0, 0, 0, 0, 0, 0, 0, 0}) == :unspecified
+      assert AddressPolicy.classify({0, 0, 0, 0, 0, 0, 0, 1}) == :loopback
+      assert AddressPolicy.classify({0xFE80, 0, 0, 0, 0, 0, 0, 1}) == :link_local
+      assert AddressPolicy.classify({0xFC00, 0, 0, 0, 0, 0, 0, 1}) == :unique_local
+      assert AddressPolicy.classify({0xFD00, 0, 0, 0, 0, 0, 0, 1}) == :unique_local
+      assert AddressPolicy.classify({0xFF00, 0, 0, 0, 0, 0, 0, 1}) == :multicast
+      assert AddressPolicy.classify({0x2606, 0x2800, 0, 0, 0, 0, 0, 1}) == :public
+    end
+
+    test "unwraps IPv4-mapped IPv6 and classifies by embedded v4 (dotted and hex spellings)" do
+      # ::ffff:10.0.0.1  and  ::ffff:0a00:1  are the same tuple
+      assert AddressPolicy.classify({0, 0, 0, 0, 0, 0xFFFF, 0x0A00, 0x0001}) == :private
+      assert AddressPolicy.classify({0, 0, 0, 0, 0, 0xFFFF, 0x7F00, 0x0001}) == :loopback
+      assert AddressPolicy.classify({0, 0, 0, 0, 0, 0xFFFF, 0x5DB8, 0xD822}) == :public
+    end
+
+    test "blocks NAT64 and unwraps 6to4 by embedded v4" do
+      # 64:ff9b::/96 NAT64
+      assert AddressPolicy.classify({0x64, 0xFF9B, 0, 0, 0, 0, 0x0A00, 0x0001}) == :reserved
+      # 2002:V4HI:V4LO::/16 6to4 embedding 127.0.0.1 -> loopback
+      assert AddressPolicy.classify({0x2002, 0x7F00, 0x0001, 0, 0, 0, 0, 0}) == :loopback
+      # 6to4 embedding a public v4 -> public
+      assert AddressPolicy.classify({0x2002, 0x5DB8, 0xD822, 0, 0, 0, 0, 0}) == :public
+    end
+
+    test "unknown IPv6 never defaults to :public (deny-default)" do
+      # 3fff::/20 reserved-ish unknown range must not be :public
+      refute AddressPolicy.classify({0x3FFF, 0, 0, 0, 0, 0, 0, 1}) == :public
+    end
+  end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/source/http/address_policy_test.exs`
+Expected: FAIL — `classify/1` has no IPv6 clause (FunctionClauseError).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add an 8-tuple clause to `classify/1` and supporting private functions. Replace the single `classify({a,b,c,d})` head region with both heads:
+
+```elixir
+  @spec classify(:inet.ip_address()) :: category()
+  def classify({a, b, c, d}), do: classify_v4(a, b, c, d)
+
+  def classify({_, _, _, _, _, _, _, _} = v6) do
+    case canonicalize_v6(v6) do
+      {:v4, {a, b, c, d}} -> classify_v4(a, b, c, d)
+      {:v6, v6} -> classify_v6(v6)
+    end
+  end
+
+  # IPv4-mapped ::ffff:0:0/96
+  defp canonicalize_v6({0, 0, 0, 0, 0, 0xFFFF, g, h}), do: {:v4, embed_v4(g, h)}
+  # 6to4 2002::/16 embeds v4 in the next two groups
+  defp canonicalize_v6({0x2002, g, h, _, _, _, _, _}), do: {:v4, embed_v4(g, h)}
+  defp canonicalize_v6(v6), do: {:v6, v6}
+
+  defp embed_v4(g, h) do
+    <<a, b>> = <<g::16>>
+    <<c, d>> = <<h::16>>
+    {a, b, c, d}
+  end
+
+  defp classify_v6({0, 0, 0, 0, 0, 0, 0, 0}), do: :unspecified
+  defp classify_v6({0, 0, 0, 0, 0, 0, 0, 1}), do: :loopback
+  # NAT64 64:ff9b::/96 — treat as non-public; we did not embed-unwrap it
+  defp classify_v6({0x64, 0xFF9B, 0, 0, 0, 0, _, _}), do: :reserved
+  defp classify_v6({a, _, _, _, _, _, _, _}) when a >= 0xFE80 and a <= 0xFEBF, do: :link_local
+  defp classify_v6({a, _, _, _, _, _, _, _}) when a >= 0xFC00 and a <= 0xFDFF, do: :unique_local
+  defp classify_v6({a, _, _, _, _, _, _, _}) when a >= 0xFF00, do: :multicast
+  # Global unicast 2000::/3 is the only public v6 space; everything else denies.
+  defp classify_v6({a, _, _, _, _, _, _, _}) when a >= 0x2000 and a <= 0x3FFF, do: :public
+  defp classify_v6(_), do: :reserved
+```
+
+Note on `3fff::/20`: it falls in `2000::/3` so the generic rule would call it `:public`. The test only requires `3fff:...` to be non-public *if* you treat it as reserved; IANA reserved `3fff::/20` for documentation (RFC 9637). Add a clause **before** the `2000..3FFF` public clause:
+
+```elixir
+  defp classify_v6({0x3FFF, b, _, _, _, _, _, _}) when b < 0x1000, do: :reserved
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mise exec -- mix test test/image_pipe/source/http/address_policy_test.exs`
+Expected: PASS (both Task 1 and Task 2 describe blocks).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/source/http/address_policy.ex test/image_pipe/source/http/address_policy_test.exs
+git commit -m "feat(source): AddressPolicy IPv6 classify + mapped/NAT64/6to4 canonicalization"
+```
+
+---
+
+## Task 3: CIDR parsing + membership
+
+**Files:**
+- Modify: `lib/image_pipe/source/http/address_policy.ex`
+- Test: `test/image_pipe/source/http/address_policy_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+  describe "CIDR" do
+    test "parse_cidr/1 accepts valid v4/v6 CIDRs and rejects junk" do
+      assert {:ok, _} = AddressPolicy.parse_cidr("10.0.5.0/24")
+      assert {:ok, _} = AddressPolicy.parse_cidr("2001:db8::/32")
+      assert :error = AddressPolicy.parse_cidr("10.0.5.0")
+      assert :error = AddressPolicy.parse_cidr("10.0.5.0/33")
+      assert :error = AddressPolicy.parse_cidr("nonsense")
+      assert :error = AddressPolicy.parse_cidr("2001:db8::/129")
+    end
+
+    test "in_cidr?/2 matches membership" do
+      {:ok, cidr} = AddressPolicy.parse_cidr("10.0.5.0/24")
+      assert AddressPolicy.in_cidr?({10, 0, 5, 7}, cidr)
+      assert AddressPolicy.in_cidr?({10, 0, 5, 0}, cidr)
+      assert AddressPolicy.in_cidr?({10, 0, 5, 255}, cidr)
+      refute AddressPolicy.in_cidr?({10, 0, 6, 1}, cidr)
+      refute AddressPolicy.in_cidr?({10, 0, 5, 7, 0, 0, 0, 0}, cidr)
+
+      {:ok, cidr6} = AddressPolicy.parse_cidr("2001:db8::/32")
+      assert AddressPolicy.in_cidr?({0x2001, 0x0DB8, 1, 2, 3, 4, 5, 6}, cidr6)
+      refute AddressPolicy.in_cidr?({0x2001, 0x0DB9, 0, 0, 0, 0, 0, 0}, cidr6)
+    end
+  end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/source/http/address_policy_test.exs`
+Expected: FAIL — `parse_cidr/1`/`in_cidr?/2` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```elixir
+  @type cidr :: {non_neg_integer(), 0..128, 32 | 128}
+
+  @spec parse_cidr(String.t()) :: {:ok, cidr()} | :error
+  def parse_cidr(string) when is_binary(string) do
+    with [addr, prefix] <- String.split(string, "/", parts: 2),
+         {:ok, tuple} <- :inet.parse_address(String.to_charlist(addr)),
+         {prefix_int, ""} <- Integer.parse(prefix),
+         bits when bits in [32, 128] <- tuple_bits(tuple),
+         true <- prefix_int >= 0 and prefix_int <= bits do
+      {:ok, {tuple_to_int(tuple), prefix_int, bits}}
+    else
+      _ -> :error
+    end
+  end
+
+  @spec in_cidr?(:inet.ip_address(), cidr()) :: boolean()
+  def in_cidr?(ip, {net_int, prefix, bits}) do
+    if tuple_bits(ip) == bits do
+      shift = bits - prefix
+      Bitwise.bsr(tuple_to_int(ip), shift) == Bitwise.bsr(net_int, shift)
+    else
+      false
+    end
+  end
+
+  defp tuple_bits({_, _, _, _}), do: 32
+  defp tuple_bits({_, _, _, _, _, _, _, _}), do: 128
+
+  defp tuple_to_int({a, b, c, d}), do: (a <<< 24) + (b <<< 16) + (c <<< 8) + d
+
+  defp tuple_to_int({a, b, c, d, e, f, g, h}) do
+    [a, b, c, d, e, f, g, h]
+    |> Enum.reduce(0, fn group, acc -> (acc <<< 16) + group end)
+  end
+```
+
+Add `import Bitwise` near the top of the module (after `@moduledoc false`). The `<<<` / `>>>` operators come from `Bitwise`; `Bitwise.bsr/2` is the function form.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mise exec -- mix test test/image_pipe/source/http/address_policy_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/source/http/address_policy.ex test/image_pipe/source/http/address_policy_test.exs
+git commit -m "feat(source): AddressPolicy CIDR parse + membership"
+```
+
+---
+
+## Task 4: `compile/1` + `allow?/2` (toggles, CIDR allow, function form, fail-closed)
+
+**Files:**
+- Modify: `lib/image_pipe/source/http/address_policy.ex`
+- Test: `test/image_pipe/source/http/address_policy_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+  describe "compile/1 + allow?/2" do
+    test "default keyword policy denies all non-public, allows public" do
+      pred = AddressPolicy.compile([])
+      assert AddressPolicy.allow?(pred, [{93, 184, 216, 34}])
+      refute AddressPolicy.allow?(pred, [{10, 0, 0, 1}])
+      refute AddressPolicy.allow?(pred, [{127, 0, 0, 1}])
+    end
+
+    test "category toggles open whole categories" do
+      pred = AddressPolicy.compile(allow_private: true)
+      assert AddressPolicy.allow?(pred, [{10, 0, 0, 1}])
+      refute AddressPolicy.allow?(pred, [{127, 0, 0, 1}])
+    end
+
+    test "CIDR allow opens exactly the named range" do
+      pred = AddressPolicy.compile(allow: ["10.0.5.0/24"])
+      assert AddressPolicy.allow?(pred, [{10, 0, 5, 7}])
+      refute AddressPolicy.allow?(pred, [{10, 0, 6, 7}])
+    end
+
+    test "block-if-any: one bad address denies the whole set" do
+      pred = AddressPolicy.compile([])
+      refute AddressPolicy.allow?(pred, [{93, 184, 216, 34}, {10, 0, 0, 1}])
+    end
+
+    test "malformed / empty address set denies" do
+      pred = AddressPolicy.compile([])
+      refute AddressPolicy.allow?(pred, [])
+      refute AddressPolicy.allow?(pred, [:not_an_ip])
+    end
+
+    test "function form replaces built-in decision" do
+      pred = AddressPolicy.compile(fn _ip, category -> category == :public end)
+      assert AddressPolicy.allow?(pred, [{93, 184, 216, 34}])
+      refute AddressPolicy.allow?(pred, [{10, 0, 0, 1}])
+    end
+
+    test "function form fails closed on non-boolean return and on raise" do
+      pred_bad = AddressPolicy.compile(fn _ip, _cat -> :yes end)
+      refute AddressPolicy.allow?(pred_bad, [{93, 184, 216, 34}])
+
+      pred_raise = AddressPolicy.compile(fn _ip, _cat -> raise "boom" end)
+      refute AddressPolicy.allow?(pred_raise, [{93, 184, 216, 34}])
+    end
+  end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/source/http/address_policy_test.exs`
+Expected: FAIL — `compile/1` / `allow?/2` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```elixir
+  @type predicate :: (:inet.ip_address(), category() -> boolean())
+
+  @category_toggles %{
+    allow_loopback: :loopback,
+    allow_unspecified: :unspecified,
+    allow_link_local: :link_local,
+    allow_private: :private,
+    allow_unique_local: :unique_local,
+    allow_multicast: :multicast,
+    allow_broadcast: :broadcast,
+    allow_cgnat: :cgnat,
+    allow_reserved: :reserved
+  }
+
+  @spec compile(keyword() | predicate()) :: predicate()
+  def compile(fun) when is_function(fun, 2) do
+    fn ip, category -> safe_bool(fun, ip, category) end
+  end
+
+  def compile(opts) when is_list(opts) do
+    allowed_categories =
+      for {toggle, category} <- @category_toggles, Keyword.get(opts, toggle, false), into: MapSet.new() do
+        category
+      end
+
+    cidrs =
+      opts
+      |> Keyword.get(:allow, [])
+      |> Enum.map(fn cidr ->
+        {:ok, parsed} = parse_cidr(cidr)
+        parsed
+      end)
+
+    fn ip, category ->
+      category == :public or
+        MapSet.member?(allowed_categories, category) or
+        Enum.any?(cidrs, &in_cidr?(ip, &1))
+    end
+  end
+
+  @spec allow?(predicate(), [:inet.ip_address()]) :: boolean()
+  def allow?(_predicate, []), do: false
+
+  def allow?(predicate, addresses) when is_list(addresses) do
+    Enum.all?(addresses, fn
+      {_, _, _, _} = ip -> predicate.(ip, classify(ip))
+      {_, _, _, _, _, _, _, _} = ip -> predicate.(ip, classify(ip))
+      _other -> false
+    end)
+  end
+
+  defp safe_bool(fun, ip, category) do
+    case fun.(ip, category) do
+      true -> true
+      _ -> false
+    end
+  rescue
+    _ -> false
+  end
+```
+
+Note: `compile/1` for the keyword form assumes CIDRs already validated at the config boundary (Task 5), so `{:ok, parsed} = parse_cidr(cidr)` is safe.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mise exec -- mix test test/image_pipe/source/http/address_policy_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Add a property test for deny-default totality**
+
+```elixir
+  describe "property: classify is total and deny-default" do
+    use ExUnitProperties
+
+    property "no IPv4 tuple crashes classify/1" do
+      check all a <- integer(0..255), b <- integer(0..255), c <- integer(0..255), d <- integer(0..255) do
+        assert AddressPolicy.classify({a, b, c, d}) in [
+                 :loopback, :unspecified, :link_local, :private, :unique_local,
+                 :multicast, :broadcast, :cgnat, :reserved, :public
+               ]
+      end
+    end
+
+    property "default policy never allows a non-public IPv4" do
+      pred = AddressPolicy.compile([])
+      check all a <- integer(0..255), b <- integer(0..255), c <- integer(0..255), d <- integer(0..255) do
+        ip = {a, b, c, d}
+        if AddressPolicy.classify(ip) != :public do
+          refute AddressPolicy.allow?(pred, [ip])
+        end
+      end
+    end
+  end
+```
+
+Move `use ExUnitProperties` to the top of the test module (next to `use ExUnit.Case`) rather than inside `describe` if the formatter/compiler complains; keep `property` blocks where shown.
+
+- [ ] **Step 6: Run, format, commit**
+
+Run: `mise exec -- mix test test/image_pipe/source/http/address_policy_test.exs`
+Expected: PASS.
+Run: `mise exec -- mix format`
+
+```bash
+git add lib/image_pipe/source/http/address_policy.ex test/image_pipe/source/http/address_policy_test.exs
+git commit -m "feat(source): AddressPolicy compile/allow + deny-default property tests"
+```
+
+---
+
+## Task 5: `TargetGuard.validate/4` + `default_resolver/1`
+
+**Files:**
+- Create: `lib/image_pipe/source/http/target_guard.ex`
+- Test: `test/image_pipe/source/http/target_guard_test.exs`
+
+The guard takes a URL string, the `allowed_hosts` list, a compiled `AddressPolicy` predicate, and a resolver function `(host_string) -> {:ok, [ip]} | {:error, term}`. It returns `:ok | {:error, :denied_scheme | :denied_host | :denied_address}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+defmodule ImagePipe.Source.HTTP.TargetGuardTest do
+  use ExUnit.Case, async: true
+
+  alias ImagePipe.Source.HTTP.{AddressPolicy, TargetGuard}
+
+  defp default_policy, do: AddressPolicy.compile([])
+
+  defp resolver(map) do
+    fn host -> Map.fetch(map, host) end
+  end
+
+  test "allows a public host that resolves to a public IP" do
+    res = resolver(%{"assets.example.com" => {:ok, [{93, 184, 216, 34}]}})
+    assert TargetGuard.validate("https://assets.example.com/x.jpg", ["assets.example.com"], default_policy(), res) == :ok
+  end
+
+  test "denies non-http(s) scheme before host checks" do
+    assert TargetGuard.validate("file:///etc/passwd", ["assets.example.com"], default_policy(), resolver(%{})) ==
+             {:error, :denied_scheme}
+  end
+
+  test "denies a host outside allowed_hosts, case-insensitively matched" do
+    res = resolver(%{"assets.example.com" => {:ok, [{93, 184, 216, 34}]}})
+    assert TargetGuard.validate("https://ASSETS.EXAMPLE.COM/x", ["assets.example.com"], default_policy(), res) == :ok
+    assert TargetGuard.validate("https://evil.example/x", ["assets.example.com"], default_policy(), res) ==
+             {:error, :denied_host}
+  end
+
+  test "denies when the host resolves to a private IP" do
+    res = resolver(%{"assets.example.com" => {:ok, [{10, 0, 0, 1}]}})
+    assert TargetGuard.validate("https://assets.example.com/x", ["assets.example.com"], default_policy(), res) ==
+             {:error, :denied_address}
+  end
+
+  test "classifies IP-literal hosts directly without calling the resolver" do
+    res = fn _ -> flunk("resolver should not be called for a literal") end
+    assert TargetGuard.validate("https://10.0.0.1/x", ["10.0.0.1"], default_policy(), res) == {:error, :denied_address}
+    assert TargetGuard.validate("https://93.184.216.34/x", ["93.184.216.34"], default_policy(), res) == :ok
+  end
+
+  test "classifies bracketed IPv6 literal hosts" do
+    res = fn _ -> flunk("resolver should not be called for a literal") end
+    assert TargetGuard.validate("http://[::1]/x", ["::1"], default_policy(), res) == {:error, :denied_address}
+  end
+
+  test "fails closed on resolver error, empty, and raise" do
+    assert TargetGuard.validate("https://h/x", ["h"], default_policy(), resolver(%{"h" => {:error, :nxdomain}})) ==
+             {:error, :denied_address}
+    assert TargetGuard.validate("https://h/x", ["h"], default_policy(), resolver(%{"h" => {:ok, []}})) ==
+             {:error, :denied_address}
+    raise_res = fn _ -> raise "dns boom" end
+    assert TargetGuard.validate("https://h/x", ["h"], default_policy(), raise_res) == {:error, :denied_address}
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/source/http/target_guard_test.exs`
+Expected: FAIL — `TargetGuard` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```elixir
+defmodule ImagePipe.Source.HTTP.TargetGuard do
+  @moduledoc false
+
+  alias ImagePipe.Source.HTTP.AddressPolicy
+
+  @type resolver :: (String.t() -> {:ok, [:inet.ip_address()]} | {:error, term()})
+
+  @spec validate(String.t(), [String.t()], AddressPolicy.predicate(), resolver()) ::
+          :ok | {:error, :denied_scheme | :denied_host | :denied_address}
+  def validate(url, allowed_hosts, predicate, resolver) when is_binary(url) do
+    uri = URI.parse(url)
+
+    with :ok <- check_scheme(uri),
+         host = String.downcase(uri.host || ""),
+         :ok <- check_host(host, allowed_hosts),
+         {:ok, addresses} <- resolve(host, resolver) do
+      if AddressPolicy.allow?(predicate, addresses), do: :ok, else: {:error, :denied_address}
+    end
+  end
+
+  defp check_scheme(%URI{scheme: scheme}) when scheme in ["http", "https"], do: :ok
+  defp check_scheme(_uri), do: {:error, :denied_scheme}
+
+  defp check_host(host, allowed_hosts) do
+    if host != "" and host in allowed_hosts, do: :ok, else: {:error, :denied_host}
+  end
+
+  defp resolve(host, resolver) do
+    case :inet.parse_address(String.to_charlist(host)) do
+      {:ok, ip} -> {:ok, [ip]}
+      {:error, _} -> resolve_via(host, resolver)
+    end
+  end
+
+  defp resolve_via(host, resolver) do
+    case resolver.(host) do
+      {:ok, addresses} when is_list(addresses) -> {:ok, addresses}
+      _other -> {:error, :denied_address}
+    end
+  rescue
+    _ -> {:error, :denied_address}
+  end
+
+  @spec default_resolver(String.t()) :: {:ok, [:inet.ip_address()]} | {:error, term()}
+  def default_resolver(host) do
+    charlist = String.to_charlist(host)
+
+    v4 = case :inet.getaddrs(charlist, :inet) do
+      {:ok, addrs} -> addrs
+      {:error, _} -> []
+    end
+
+    v6 = case :inet.getaddrs(charlist, :inet6) do
+      {:ok, addrs} -> addrs
+      {:error, _} -> []
+    end
+
+    case v4 ++ v6 do
+      [] -> {:error, :nxdomain}
+      addresses -> {:ok, addresses}
+    end
+  end
+end
+```
+
+Note: `URI.parse("http://[::1]/x").host` returns `"::1"` (brackets stripped) — feed that to `:inet.parse_address`. The empty-resolve case `{:ok, []}` is caught because `AddressPolicy.allow?(_, [])` is `false`, but we map resolver-empty to `{:error, :denied_address}` here for an explicit fail-closed signal; both deny.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mise exec -- mix test test/image_pipe/source/http/target_guard_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Format + commit**
+
+Run: `mise exec -- mix format`
+
+```bash
+git add lib/image_pipe/source/http/target_guard.ex test/image_pipe/source/http/target_guard_test.exs
+git commit -m "feat(source): TargetGuard.validate + default DNS resolver"
+```
+
+---
+
+## Task 6: `ReqStream` owns the redirect loop
+
+**Files:**
+- Modify: `lib/image_pipe/source/req_stream.ex`
+- Test: existing `test/image_pipe/source/req_stream_test.exs` if present; otherwise covered via Task 8 wire tests. (Check: `ls test/image_pipe/source/req_stream_test.exs`.)
+
+This task changes `ReqStream.stream/2` to (a) disable Req redirect-following and (b) follow redirects itself, running an injected `validate_target` closure before each connect.
+
+- [ ] **Step 1: Write the failing test** (new file `test/image_pipe/source/req_stream_test.exs`)
+
+```elixir
+defmodule ImagePipe.Source.ReqStreamTest do
+  use ExUnit.Case, async: true
+
+  alias ImagePipe.Source.ReqStream
+  alias ImagePipe.Source.StreamError
+
+  test "runs validate_target before connecting and raises the denial reason" do
+    plug = fn _conn -> flunk("must not connect when target is denied") end
+
+    stream =
+      ReqStream.stream(
+        [url: "https://blocked.example/x", plug: plug],
+        validate_target: fn _url -> {:error, :denied_address} end
+      )
+
+    error = assert_raise StreamError, fn -> Enum.to_list(stream) end
+    assert error.reason == :denied_address
+  end
+
+  test "follows a redirect itself and validates the hop target" do
+    plug = fn
+      %{request_path: "/redirect.jpg"} = conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "https://hop.example/other.jpg")
+        |> Plug.Conn.send_resp(302, "")
+
+      conn ->
+        send(self(), {:got, conn.host, conn.request_path})
+        Plug.Conn.send_resp(conn, 200, "image bytes")
+    end
+
+    seen = self()
+
+    stream =
+      ReqStream.stream(
+        [url: "https://assets.example.com/redirect.jpg", plug: plug],
+        validate_target: fn url ->
+          send(seen, {:validated, url})
+          :ok
+        end,
+        max_redirects: 1
+      )
+
+    assert Enum.join(stream) == "image bytes"
+    assert_received {:validated, "https://assets.example.com/redirect.jpg"}
+    assert_received {:validated, "https://hop.example/other.jpg"}
+    assert_received {:got, "hop.example", "/other.jpg"}
+  end
+
+  test "denies a redirect hop before connecting to it" do
+    plug = fn
+      %{request_path: "/redirect.jpg"} = conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "https://internal.example/x")
+        |> Plug.Conn.send_resp(302, "")
+
+      %{host: "internal.example"} -> flunk("must not connect to denied hop")
+      conn -> Plug.Conn.send_resp(conn, 200, "ok")
+    end
+
+    stream =
+      ReqStream.stream(
+        [url: "https://assets.example.com/redirect.jpg", plug: plug],
+        validate_target: fn
+          "https://internal.example/x" -> {:error, :denied_host}
+          _ -> :ok
+        end,
+        max_redirects: 3
+      )
+
+    error = assert_raise StreamError, fn -> Enum.to_list(stream) end
+    assert error.reason == :denied_host
+  end
+
+  test "exhausting max_redirects fails with too_many_redirects" do
+    plug = fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("location", "https://assets.example.com/loop")
+      |> Plug.Conn.send_resp(302, "")
+    end
+
+    stream =
+      ReqStream.stream(
+        [url: "https://assets.example.com/loop", plug: plug],
+        validate_target: fn _ -> :ok end,
+        max_redirects: 1
+      )
+
+    error = assert_raise StreamError, fn -> Enum.to_list(stream) end
+    assert error.reason == :too_many_redirects
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/source/req_stream_test.exs`
+Expected: FAIL — current `stream/2` ignores `validate_target`/`max_redirects` and lets Req follow redirects.
+
+- [ ] **Step 3: Write the implementation**
+
+Replace `ReqStream.stream/2` and `open_response/2` with a redirect-following loop. Keep `stream_response/1`, `next_message/2`, `parse_message/2`, `cancel_response/1`, and `timeout/4` unchanged. New top:
+
+```elixir
+  @spec stream(keyword(), keyword()) :: Enumerable.t()
+  def stream(req_options, runtime_opts) when is_list(req_options) and is_list(runtime_opts) do
+    Stream.resource(
+      fn -> open_response(req_options, runtime_opts) end,
+      fn
+        %{response: %Req.Response{}} = state -> stream_response(state)
+        {:done, %{response: %Req.Response{} = response}} -> {:halt, response}
+        {:error, reason} -> raise StreamError, reason: reason
+      end,
+      fn
+        %{response: %Req.Response{} = response} -> cancel_response(response)
+        {:done, %{response: %Req.Response{} = response}} -> cancel_response(response)
+        _other -> :ok
+      end
+    )
+  end
+
+  defp open_response(req_options, runtime_opts) do
+    validate = Keyword.get(runtime_opts, :validate_target, fn _url -> :ok end)
+    max_redirects = Keyword.get(runtime_opts, :max_redirects, 0)
+    follow(req_options, runtime_opts, validate, max_redirects)
+  end
+
+  defp follow(req_options, runtime_opts, validate, redirects_left) do
+    url = Keyword.fetch!(req_options, :url)
+
+    case validate.(url) do
+      :ok -> request_and_route(req_options, runtime_opts, validate, redirects_left)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp request_and_route(req_options, runtime_opts, validate, redirects_left) do
+    case Req.get(request_options(req_options),
+           receive_timeout: timeout(req_options, runtime_opts, :receive_timeout, @default_receive_timeout),
+           pool_timeout: timeout(req_options, runtime_opts, :pool_timeout, @default_pool_timeout),
+           connect_options: connect_options(req_options, runtime_opts)
+         ) do
+      {:ok, %Req.Response{status: status} = response} when status in 200..299 ->
+        %{
+          response: response,
+          receive_timeout: timeout(req_options, runtime_opts, :receive_timeout, @default_receive_timeout)
+        }
+
+      {:ok, %Req.Response{status: status} = response} when status in 300..399 ->
+        route_redirect(response, req_options, runtime_opts, validate, redirects_left)
+
+      {:ok, %Req.Response{} = response} ->
+        cancel_response(response)
+        {:error, :bad_status}
+
+      {:error, _exception} ->
+        {:error, :bad_status}
+    end
+  end
+
+  defp route_redirect(response, req_options, runtime_opts, validate, redirects_left) do
+    location = location_header(response)
+    cancel_response(response)
+
+    cond do
+      redirects_left <= 0 ->
+        {:error, :too_many_redirects}
+
+      is_nil(location) ->
+        {:error, :bad_status}
+
+      true ->
+        next_url =
+          req_options
+          |> Keyword.fetch!(:url)
+          |> URI.parse()
+          |> URI.merge(location)
+          |> URI.to_string()
+
+        follow(Keyword.put(req_options, :url, next_url), runtime_opts, validate, redirects_left - 1)
+    end
+  end
+
+  defp location_header(%Req.Response{} = response) do
+    case Req.Response.get_header(response, "location") do
+      [value | _] -> value
+      [] -> nil
+    end
+  end
+```
+
+And update `request_options/1` to disable Req's own redirect following:
+
+```elixir
+  defp request_options(req_options) do
+    Keyword.merge(req_options,
+      into: :self,
+      retry: false,
+      redirect: false
+    )
+  end
+```
+
+Add the `runtime_opts` keys `:validate_target` and `:max_redirects` to whatever the caller passes (Task 7). `URI.merge/2` accepts a string second arg and resolves relative, protocol-relative, and scheme-changing locations against the base URI.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mise exec -- mix test test/image_pipe/source/req_stream_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Format + commit**
+
+Run: `mise exec -- mix format`
+
+```bash
+git add lib/image_pipe/source/req_stream.ex test/image_pipe/source/req_stream_test.exs
+git commit -m "feat(source): ReqStream owns the redirect loop with a target guard"
+```
+
+---
+
+## Task 7: Wire options + guard into `HTTP`, migrate existing tests
+
+**Files:**
+- Modify: `lib/image_pipe/source/http.ex`
+- Modify: `test/image_pipe/source/http_test.exs`
+
+- [ ] **Step 1: Add the new options to the schema and strip them from `req_options`**
+
+In `lib/image_pipe/source/http.ex`, extend `@internal_option_keys` and `@options_schema`:
+
+```elixir
+  @internal_option_keys [
+    :url,
+    :base_url,
+    :method,
+    :body,
+    :params,
+    :into,
+    :retry,
+    :redirect,
+    :max_redirects,
+    :address_policy,
+    :address_resolver
+  ]
+```
+
+```elixir
+  @options_schema NimbleOptions.new!(
+                    allowed_hosts: [type: {:list, :string}, required: true],
+                    req_options: [type: :keyword_list, default: []],
+                    receive_timeout: [type: :non_neg_integer],
+                    connect_timeout: [type: :non_neg_integer],
+                    pool_timeout: [type: :non_neg_integer],
+                    max_redirects: [type: :non_neg_integer, default: 0],
+                    address_policy: [
+                      type: {:or, [{:fun, 2}, {:custom, __MODULE__, :validate_address_policy_kw, []}]},
+                      default: []
+                    ],
+                    address_resolver: [type: {:fun, 1}],
+                    stable: [type: {:in, [:auto, :trusted]}, default: :auto],
+                    internal_cache: [type: {:in, [:auto, :enabled, :disabled]}, default: :auto],
+                    http_cache: [type: {:in, [:inherit, :disabled, :enabled]}, default: :inherit]
+                  )
+```
+
+Add the custom validator (validates the keyword form, including parsing each CIDR in `allow:`):
+
+```elixir
+  @doc false
+  def validate_address_policy_kw(value) when is_list(value) do
+    allowed_keys = [
+      :allow_loopback, :allow_unspecified, :allow_link_local, :allow_private,
+      :allow_unique_local, :allow_multicast, :allow_broadcast, :allow_cgnat,
+      :allow_reserved, :allow
+    ]
+
+    cond do
+      not Keyword.keyword?(value) ->
+        {:error, "address_policy keyword list expected"}
+
+      Enum.any?(Keyword.keys(value), &(&1 not in allowed_keys)) ->
+        {:error, "unknown address_policy key"}
+
+      Enum.any?(Keyword.get(value, :allow, []), &(ImagePipe.Source.HTTP.AddressPolicy.parse_cidr(&1) == :error)) ->
+        {:error, "invalid CIDR in address_policy :allow"}
+
+      true ->
+        {:ok, value}
+    end
+  end
+
+  def validate_address_policy_kw(_value), do: {:error, "address_policy keyword list expected"}
+```
+
+- [ ] **Step 2: Build the guard closure and pass it to `ReqStream`**
+
+Replace `fetch/3` so it no longer hands `max_redirects` to Req as a follow count, and instead passes `validate_target` + `max_redirects` as stream options:
+
+```elixir
+  @impl Source
+  def fetch(%Resolved{fetch: fetch}, opts, runtime_opts) do
+    req_options =
+      opts
+      |> Keyword.fetch!(:req_options)
+      |> sanitize_req_options(fetch[:strip_byte_headers])
+      |> Keyword.merge(url: fetch[:url], method: :get)
+
+    stream_options =
+      Keyword.take(opts, [:receive_timeout, :pool_timeout, :connect_timeout])
+      |> Keyword.merge(runtime_opts)
+      |> Keyword.put(:validate_target, build_target_guard(opts))
+      |> Keyword.put(:max_redirects, Keyword.fetch!(opts, :max_redirects))
+
+    {:ok, %Response{stream: ReqStream.stream(req_options, stream_options)}}
+  end
+
+  defp build_target_guard(opts) do
+    allowed_hosts = Keyword.fetch!(opts, :allowed_hosts)
+    predicate = AddressPolicy.compile(Keyword.fetch!(opts, :address_policy))
+    resolver = Keyword.get(opts, :address_resolver, &TargetGuard.default_resolver/1)
+
+    fn url -> normalize_guard_result(TargetGuard.validate(url, allowed_hosts, predicate, resolver)) end
+  end
+
+  defp normalize_guard_result(:ok), do: :ok
+  defp normalize_guard_result({:error, reason}), do: {:error, reason}
+```
+
+Add the aliases at the top of the module:
+
+```elixir
+  alias ImagePipe.Source.HTTP.AddressPolicy
+  alias ImagePipe.Source.HTTP.TargetGuard
+```
+
+(`normalize_guard_result/1` is a seam in case HTTP later wants to remap tags; keep it trivial for now.)
+
+- [ ] **Step 3: Add the shared test-only stub resolver and migrate existing tests**
+
+In `test/image_pipe/source/http_test.exs`, add a helper near the top of the module and thread it through `validate_options` calls that perform a real fetch. Hostname-based fetch tests must map their host to a public IP:
+
+```elixir
+  @public_ip {93, 184, 216, 34}
+
+  defp stub_resolver(extra \\ %{}) do
+    base = %{"assets.example.com" => {:ok, [@public_ip]}}
+    map = Map.merge(base, extra)
+    fn host -> Map.get(map, host, {:error, :nxdomain}) end
+  end
+```
+
+For each test that calls `Source.fetch/3` (the ones currently using `req_options: [plug: ...]`), add `address_resolver: stub_resolver()` to the `HTTP.validate_options(...)` opts. Tests that only call `HTTP.resolve/3` (no fetch) need no change, because `resolve/3` does no DNS.
+
+Example migration of the "configured max redirects allows bounded redirects" test — add the resolver and, because the existing plug redirects to a *relative* path `/other.jpg` on the same host, also map nothing extra:
+
+```elixir
+    assert {:ok, opts} =
+             HTTP.validate_options(
+               allowed_hosts: ["assets.example.com"],
+               max_redirects: 1,
+               address_resolver: stub_resolver(),
+               req_options: [plug: plug]
+             )
+```
+
+Run the file and fix each failing fetch test the same way:
+
+Run: `mise exec -- mix test test/image_pipe/source/http_test.exs`
+Expected after migration: PASS (other than the deliberately-broken "redirects cannot bypass" test handled in Step 4).
+
+- [ ] **Step 4: Fix the misleading "redirects cannot bypass allowed host policy" test**
+
+Find that test and change it to actually enable redirects (`max_redirects: 1`) and redirect to an off-allowlist host, asserting the guard denies the hop:
+
+```elixir
+  test "an enabled redirect to an off-allowlist host is denied" do
+    plug = fn
+      %{request_path: "/redirect.jpg"} = conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "https://evil.example/x.jpg")
+        |> Plug.Conn.send_resp(302, "")
+
+      _conn ->
+        flunk("must not connect to the off-allowlist redirect target")
+    end
+
+    source = %URL{scheme: :https, host: "assets.example.com", port: nil, path: ["redirect.jpg"], query: nil}
+
+    assert {:ok, opts} =
+             HTTP.validate_options(
+               allowed_hosts: ["assets.example.com"],
+               max_redirects: 1,
+               address_resolver: stub_resolver(),
+               req_options: [plug: plug]
+             )
+
+    assert {:ok, resolved} = HTTP.resolve(source, opts, [])
+    assert {:ok, %Response{} = response} = Source.fetch(resolved, [sources: %{https: {HTTP, opts}}], max_body_bytes: 20)
+
+    error = assert_raise Source.StreamError, fn -> Enum.to_list(response.stream) end
+    assert error.reason == :denied_host
+  end
+```
+
+- [ ] **Step 5: Run the whole HTTP suite + format + commit**
+
+Run: `mise exec -- mix test test/image_pipe/source/http_test.exs`
+Expected: PASS.
+Run: `mise exec -- mix format`
+
+```bash
+git add lib/image_pipe/source/http.ex test/image_pipe/source/http_test.exs
+git commit -m "feat(source): wire address_policy/resolver guard into HTTP fetch + redirects"
+```
+
+---
+
+## Task 8: Acceptance + edge wire tests
+
+**Files:**
+- Modify: `test/image_pipe/source/http_test.exs`
+
+These assert the spec's acceptance criteria end-to-end through `Source.fetch/3` + the plug adapter. Use the `stub_resolver/1` helper from Task 7.
+
+- [ ] **Step 1: Add acceptance + edge tests**
+
+```elixir
+  describe "SSRF guard" do
+    defp fetch_stream(opts_kw, source) do
+      {:ok, opts} = HTTP.validate_options(opts_kw)
+      {:ok, resolved} = HTTP.resolve(source, opts, [])
+      {:ok, %Response{} = response} = Source.fetch(resolved, [sources: %{https: {HTTP, opts}}], max_body_bytes: 64)
+      response.stream
+    end
+
+    defp ok_plug do
+      fn conn -> Plug.Conn.send_resp(conn, 200, "image bytes") end
+    end
+
+    test "origin host resolving to a private address is blocked (DNS branch)" do
+      source = %URL{scheme: :https, host: "assets.example.com", path: ["x.jpg"]}
+
+      stream =
+        fetch_stream(
+          [
+            allowed_hosts: ["assets.example.com"],
+            address_resolver: stub_resolver(%{"assets.example.com" => {:ok, [{10, 0, 0, 5}]}}),
+            req_options: [plug: ok_plug()]
+          ],
+          source
+        )
+
+      error = assert_raise Source.StreamError, fn -> Enum.to_list(stream) end
+      assert error.reason == :denied_address
+    end
+
+    test "origin IP-literal private host is blocked (literal branch, no resolver)" do
+      source = %URL{scheme: :https, host: "10.0.0.5", path: ["x.jpg"]}
+
+      stream =
+        fetch_stream(
+          [allowed_hosts: ["10.0.0.5"], req_options: [plug: ok_plug()]],
+          source
+        )
+
+      error = assert_raise Source.StreamError, fn -> Enum.to_list(stream) end
+      assert error.reason == :denied_address
+    end
+
+    test "169.254.169.254 cloud metadata literal is blocked" do
+      source = %URL{scheme: :https, host: "169.254.169.254", path: ["latest", "meta-data"]}
+
+      stream =
+        fetch_stream(
+          [allowed_hosts: ["169.254.169.254"], req_options: [plug: ok_plug()]],
+          source
+        )
+
+      error = assert_raise Source.StreamError, fn -> Enum.to_list(stream) end
+      assert error.reason == :denied_address
+    end
+
+    test "trusted origin redirecting to a loopback target is blocked on the hop" do
+      plug = fn
+        %{request_path: "/redirect.jpg"} = conn ->
+          conn
+          |> Plug.Conn.put_resp_header("location", "http://127.0.0.1/x")
+          |> Plug.Conn.send_resp(302, "")
+
+        _conn ->
+          flunk("must not connect to loopback redirect target")
+      end
+
+      source = %URL{scheme: :https, host: "assets.example.com", path: ["redirect.jpg"]}
+
+      stream =
+        fetch_stream(
+          [
+            allowed_hosts: ["assets.example.com", "127.0.0.1"],
+            max_redirects: 1,
+            address_resolver: stub_resolver(),
+            req_options: [plug: plug]
+          ],
+          source
+        )
+
+      error = assert_raise Source.StreamError, fn -> Enum.to_list(stream) end
+      assert error.reason == :denied_address
+    end
+
+    test "non-http(s) redirect scheme is rejected" do
+      plug = fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "file:///etc/passwd")
+        |> Plug.Conn.send_resp(302, "")
+      end
+
+      source = %URL{scheme: :https, host: "assets.example.com", path: ["redirect.jpg"]}
+
+      stream =
+        fetch_stream(
+          [
+            allowed_hosts: ["assets.example.com"],
+            max_redirects: 1,
+            address_resolver: stub_resolver(),
+            req_options: [plug: plug]
+          ],
+          source
+        )
+
+      error = assert_raise Source.StreamError, fn -> Enum.to_list(stream) end
+      assert error.reason == :denied_scheme
+    end
+
+    test "allow_private opt-in lets a private origin through" do
+      source = %URL{scheme: :https, host: "assets.example.com", path: ["x.jpg"]}
+
+      stream =
+        fetch_stream(
+          [
+            allowed_hosts: ["assets.example.com"],
+            address_policy: [allow_private: true],
+            address_resolver: stub_resolver(%{"assets.example.com" => {:ok, [{10, 0, 0, 5}]}}),
+            req_options: [plug: ok_plug()]
+          ],
+          source
+        )
+
+      assert Enum.join(stream) == "image bytes"
+    end
+
+    test "precise CIDR allow lets only the named range through" do
+      source = %URL{scheme: :https, host: "in.example", path: ["x.jpg"]}
+
+      base = [
+        allowed_hosts: ["in.example"],
+        address_policy: [allow: ["10.0.5.0/24"]],
+        req_options: [plug: ok_plug()]
+      ]
+
+      ok_stream =
+        fetch_stream(
+          Keyword.put(base, :address_resolver, stub_resolver(%{"in.example" => {:ok, [{10, 0, 5, 9}]}})),
+          source
+        )
+
+      assert Enum.join(ok_stream) == "image bytes"
+
+      blocked_stream =
+        fetch_stream(
+          Keyword.put(base, :address_resolver, stub_resolver(%{"in.example" => {:ok, [{10, 0, 6, 9}]}})),
+          source
+        )
+
+      error = assert_raise Source.StreamError, fn -> Enum.to_list(blocked_stream) end
+      assert error.reason == :denied_address
+    end
+
+    test "function-form policy replaces the built-in decision" do
+      source = %URL{scheme: :https, host: "assets.example.com", path: ["x.jpg"]}
+
+      blocked =
+        fetch_stream(
+          [
+            allowed_hosts: ["assets.example.com"],
+            address_policy: fn _ip, category -> category == :public end,
+            address_resolver: stub_resolver(%{"assets.example.com" => {:ok, [{10, 0, 0, 5}]}}),
+            req_options: [plug: ok_plug()]
+          ],
+          source
+        )
+
+      error = assert_raise Source.StreamError, fn -> Enum.to_list(blocked) end
+      assert error.reason == :denied_address
+    end
+  end
+```
+
+Note: when a redirect target's host is in `allowed_hosts` but its IP is blocked, the failure is `:denied_address`; when the host is *not* in `allowed_hosts`, it's `:denied_host` (Task 7 Step 4). The loopback test allowlists `127.0.0.1` deliberately to exercise the address path rather than the host path.
+
+- [ ] **Step 2: Run + format + commit**
+
+Run: `mise exec -- mix test test/image_pipe/source/http_test.exs`
+Expected: PASS.
+Run: `mise exec -- mix format`
+
+```bash
+git add test/image_pipe/source/http_test.exs
+git commit -m "test(source): SSRF guard acceptance + edge wire tests"
+```
+
+---
+
+## Task 9: Docs
+
+**Files:**
+- Create: `docs/source-network-policy.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Write `docs/source-network-policy.md`**
+
+```markdown
+# Source network policy (SSRF protection)
+
+`ImagePipe.Source.HTTP` validates the destination of every origin fetch — and of
+every redirect hop — before connecting. By default it refuses to connect to any
+address that is not public.
+
+## Default policy
+
+For each request, and again for each redirect, the adapter:
+
+1. Requires an `http`/`https` scheme.
+2. Requires the (case-insensitive) host to be in `allowed_hosts` — redirects may
+   not leave the allowlist.
+3. Resolves the host to IP addresses and **denies the fetch if any resolved
+   address is not public** (loopback, unspecified, link-local, private, CGNAT,
+   unique-local, multicast, broadcast, or otherwise reserved).
+
+IPv4 literal encodings (decimal, octal, hex) and IPv4-mapped / NAT64 / 6to4 IPv6
+forms are canonicalized before classification, so they cannot be used to smuggle
+an internal address past the check.
+
+A denied fetch raises `ImagePipe.Source.StreamError` with `reason:
+:denied_scheme`, `:denied_host`, or `:denied_address` when the response stream is
+consumed.
+
+## Allowing private origins
+
+Set `address_policy` on the source adapter. It accepts either a keyword list or a
+function.
+
+### Keyword list
+
+```elixir
+sources: [
+  url: {ImagePipe.Source.HTTP,
+    allowed_hosts: ["assets.internal"],
+    address_policy: [
+      allow_private: true,         # opens ALL RFC1918 ranges
+      allow: ["10.0.5.0/24"]       # OR open exactly one range, precisely
+    ]
+  }
+]
+```
+
+Toggles: `allow_loopback`, `allow_unspecified`, `allow_link_local`,
+`allow_private`, `allow_unique_local`, `allow_multicast`, `allow_broadcast`,
+`allow_cgnat`, `allow_reserved`. `allow:` is a list of CIDR strings. Omitting
+`address_policy` denies everything that is not public.
+
+### Function
+
+```elixir
+address_policy: fn _ip, category -> category == :public end
+```
+
+The function receives the canonicalized IP tuple and its category and returns a
+boolean. It replaces the built-in decision. A non-boolean return or a raised
+exception is treated as **deny** (fail-closed).
+
+## Custom DNS resolution
+
+`address_resolver` overrides how hostnames resolve, e.g. a caching resolver:
+
+```elixir
+address_resolver: fn host -> {:ok, [{93, 184, 216, 34}]} end
+```
+
+It returns `{:ok, [ip_tuple]}` or `{:error, term}`. Any error, an empty list, or a
+raise denies the fetch.
+
+## Known limitation: DNS rebinding
+
+This is **resolve-and-validate**, not connection-pinned: after the policy
+validates the resolved addresses, the HTTP client re-resolves the hostname when it
+actually connects. A DNS-rebinding attacker who returns a public address to our
+lookup and a private address at connect time can still slip past. Closing this
+requires pinning the connection to the validated IP and is tracked separately.
+```
+
+- [ ] **Step 2: Link it from `README.md`**
+
+Under the `## Documentation` list, add a bullet:
+
+```markdown
+- [Source network policy](docs/source-network-policy.md) documents the default
+  SSRF protection on HTTP/HTTPS sources, how to allow private origins
+  (`address_policy`), custom DNS resolution (`address_resolver`), and the
+  DNS-rebinding limitation.
+```
+
+And after the source-adapter example block (the `allowed_hosts` snippet around line 93), add a sentence:
+
+```markdown
+By default, HTTP/HTTPS sources refuse to connect to non-public addresses and
+re-check the policy on every redirect hop. See
+[Source network policy](docs/source-network-policy.md) to allow private origins.
+```
+
+- [ ] **Step 3: Commit** (docs only — no compile/test gate needed for pure doc edits)
+
+```bash
+git add docs/source-network-policy.md README.md
+git commit -m "docs(source): document SSRF protection and address_policy config"
+```
+
+---
+
+## Task 10: Full gate + open the IP-pinning follow-up
+
+**Files:** none (verification + issue).
+
+- [ ] **Step 1: Run the full precommit gate**
+
+Run: `mise run precommit`
+Expected: PASS — `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix test` all green.
+
+If credo flags `AddressPolicy` for too many functions or a `Bitwise` import style, address per its suggestion (e.g. `import Bitwise, only: [...]`).
+
+- [ ] **Step 2: Open the tracked IP-pinning / rebinding follow-up issue**
+
+Run:
+
+```bash
+gh issue create \
+  --title "SSRF: pin connections to validated IPs (close DNS-rebinding window)" \
+  --label "type:security,area:source" \
+  --body "Follow-up to #48. The shipped SSRF guard is resolve-and-validate: after validating resolved addresses, Finch re-resolves at connect time, leaving a DNS-rebinding TOCTOU window. Closing it requires pinning the connection to the validated IP (rewrite host->IP, carry original hostname for Host header + TLS SNI, verify cert against the original name). Costs: per-request SNI/transport_opts plumbing through Req 0.5.17 -> Finch 0.22 -> Mint 1.8 (needs a version spike), a real-HTTPS test harness (the plug adapter has no TLS), and HTTP/2 connection-coalescing analysis. See docs/superpowers/specs/2026-06-01-ssrf-protection-design.md (Deferred section)."
+```
+
+- [ ] **Step 3: Final commit if the gate required any fixups**
+
+```bash
+git add -A
+git commit -m "chore(source): satisfy precommit gate for SSRF protection"
+```
+
+---
+
+## Self-Review notes (for the implementer)
+
+- **Spec coverage:** Task 1–4 = `AddressPolicy` (classify, canonicalization, CIDR, compile/allow, deny-default property). Task 5 = `TargetGuard` (scheme/host/resolve/policy order, literal branch, fail-closed). Task 6 = owned redirect loop. Task 7 = config (`address_policy` both forms + `address_resolver`), key-stripping, existing-test migration, fixed misleading test. Task 8 = all four acceptance criteria + named edge cases (169.254.169.254, mapped/NAT64/6to4 covered in Task 2, non-http redirect, protocol-relative via `URI.merge`). Task 9 = docs incl. rebinding limitation. Task 10 = gate + follow-up issue.
+- **`AddressPolicy`/`TargetGuard` stay unexported** from the `Source` boundary — do not touch `lib/image_pipe/source.ex` `exports:`.
+- **Telemetry:** intentionally not added here (denials surface via `StreamError` reason, like `:bad_status`); the spec's telemetry section documents why and defers richer category+IP telemetry.
+- **Type consistency:** the guard returns `:denied_scheme | :denied_host | :denied_address`; `ReqStream` adds `:too_many_redirects` and reuses `:bad_status`; all are `StreamError.reason` atoms asserted on directly in tests.

--- a/docs/superpowers/specs/2026-06-01-ssrf-protection-design.md
+++ b/docs/superpowers/specs/2026-06-01-ssrf-protection-design.md
@@ -1,0 +1,343 @@
+# SSRF protection for origin fetches and redirects: design
+
+**Status:** reviewed design, ready for implementation planning. Closes issue #48
+(`type:security`, `priority:P1`, `area:source`, `status:partial`). Supersedes the
+two research comments on #48 — this document keeps what they got right (the
+factual gap analysis, deny-private-by-default posture, product-neutral policy in
+the `Source` boundary) and corrects/extends them where the code review turned up
+non-obvious consequences (see *Why the prior notes were incomplete*).
+
+**Threat-model scope:** **resolve-and-validate**, not connection-pinned. We
+resolve each host through an injectable resolver, classify every returned
+address, and reject before connect. The DNS-rebinding (TOCTOU) window between our
+validation and Finch's own connect-time re-resolution stays **open and
+documented**; closing it (IP-pinning) is a tracked fast-follow, not this issue.
+See *Deferred: DNS-rebinding / IP-pinning*.
+
+## Problem
+
+`ImagePipe.Source.HTTP` can be made to connect to internal infrastructure:
+
+- **Origin host resolves to a private address.** `allowed_hosts` is an exact
+  hostname allowlist; an allowlisted host can still resolve (now or via DNS
+  change) to a loopback/link-local/private/internal IP. Nothing checks resolved
+  addresses today.
+- **Redirects escape every check.** `allowed_hosts` is enforced only in
+  `resolve/3` against the *original* URL (`lib/image_pipe/source/http.ex:53`).
+  When `max_redirects > 0`, `fetch/3` passes the count straight to `Req.get`
+  (`lib/image_pipe/source/http.ex:96`) and nothing re-validates redirect targets
+  — not the host, not the address. A trusted `root_url` path, or any allowlisted
+  host with an open redirect, can bounce to loopback/private/arbitrary hosts.
+
+Default posture is currently safe only because `max_redirects` defaults to `0`.
+The moment a deployment opts into redirects, both gaps above are live.
+
+## Why the prior notes were incomplete
+
+The two #48 comments are factually correct but miss three things that shape the
+design:
+
+1. **`allowed_hosts` already narrows the real surface.** It is `required: true`,
+   so the residual SSRF surface is exactly three vectors: (a) an allowlisted host
+   resolving to a non-public IP, (b) a redirect leaving the allowlist, (c) DNS
+   rebinding. The feature targets these three, not "we have no protection."
+2. **The test harness uses Req's `plug:` adapter — there is no real socket or DNS
+   in tests** (every test in `test/image_pipe/source/http_test.exs` passes
+   `req_options: [plug: plug]`). A transport-layer check (the `net.Dialer.Control`
+   equivalent imgproxy uses) would therefore never run in any test and would exist
+   only in production. This forces the validation **up into the source application
+   layer** and forces DNS resolution to be an **injectable seam**.
+3. **Turning on default-deny breaks the existing suite.** Those plug-based tests
+   fetch the hostname `assets.example.com`, which does not really resolve. Once
+   the guard does DNS, real `:inet` returns `NXDOMAIN` and every existing HTTP
+   test fails. The resolver injection (point 2) is what lets those tests stub the
+   lookup. This is unavoidable churn, called out in *Tests*.
+
+## Design overview
+
+Two pieces:
+
+1. **`ImagePipe.Source.HTTP.AddressPolicy`** — a pure, I/O-free module: canonicalize
+   an IP, classify it into a category, and decide allow/deny against a validated
+   policy. Owns the bypass-canonicalization that is the security-critical core.
+2. **A Req request step**, built in `HTTP.fetch/3` and prepended to the Req
+   pipeline, that on the initial request *and every redirect hop* re-checks
+   `allowed_hosts`, resolves the host via an injected resolver, and runs the
+   address policy — halting the request (no connect) on any failure.
+
+`resolve/3` is unchanged except in role: it stays the cheap, I/O-free
+`allowed_hosts` gate that feeds the cache key. **All DNS and address work happens
+at fetch time**, inside the source side-effect boundary, before the actual TCP
+connect — never in `resolve/3` (which must stay side-effect-free for cache-key
+derivation).
+
+### Why a Req request step (not a transport hook)
+
+- A request step runs **before the adapter connects**; `Req.Request.halt/2` with
+  an error means the connection never opens — fail-closed.
+- Req's redirect follower re-issues the redirected request through the **same
+  request pipeline**, so a prepended step runs again on **every hop**. One step
+  covers origin + all redirects uniformly; no separate redirect-loop code.
+- Request steps **also run under the `plug:` adapter**, so the guard fires in
+  tests. Combined with the injected resolver, an acceptance test needs no real
+  socket and no real DNS.
+
+**Load-bearing assumption to verify first (spike):** that request steps genuinely
+re-run on each redirect hop in **Req 0.5.17** specifically (deps are not vendored
+on disk in this worktree; this rests on Req's documented redirect behavior, not
+its source). Implementation step one is a focused test asserting it. **Fallback if
+false:** own the redirect loop ourselves — pass `max_redirects: 0` to Req and
+follow `Location` manually, running the same guard per hop. Same testability, more
+code, fully under our control.
+
+## `ImagePipe.Source.HTTP.AddressPolicy`
+
+Nested under `HTTP` (its only consumer), inside the existing `Source` boundary.
+IP classification is conceptually transport-agnostic, but `File` is local and `S3`
+hits fixed endpoints, so HTTP is the only source that connects to arbitrary
+resolved hosts. Per the repo rule "add it when the future caller appears, with a
+test," we do **not** promote it to a shared `Source`-level module until a second
+source needs it.
+
+### Classification
+
+`classify/1 :: :inet.ip_address() -> category` where category is one of:
+
+```
+:loopback | :unspecified | :link_local | :private | :unique_local |
+:multicast | :broadcast | :cgnat | :reserved | :public
+```
+
+**Canonicalization is part of classification and is the security core.** Before
+classifying, unwrap:
+
+- IPv4-mapped IPv6 (`::ffff:a.b.c.d`) → classify by the embedded IPv4.
+- IPv4-compatible / deprecated-embedding forms → same.
+
+The concrete default-blocked set (the exact ranges per category) is **owned by
+this module and its property tests**, not pinned in this prose — mirroring the
+cache-key guidance ("which fields compose the key is owned by the module and its
+tests"). Default intent: **everything that is not `:public` is denied.** Includes
+at minimum loopback (`127.0.0.0/8`, `::1`), unspecified (`0.0.0.0`, `::`),
+link-local (`169.254.0.0/16`, `fe80::/10`), private (`10/8`, `172.16/12`,
+`192.168/16`), unique-local (`fc00::/7`), CGNAT (`100.64.0.0/10`), multicast,
+broadcast, and reserved/benchmark/documentation ranges.
+
+### Policy decision
+
+The validated policy compiles to a single internal predicate
+`(ip :: :inet.ip_address(), category :: atom) -> boolean()`. Both config forms
+(below) compile to this shape.
+
+**Multi-address responses: block if *any* returned address is disallowed.** We
+cannot control which address Finch ultimately selects, and a mixed
+public/private answer is itself a rebinding signal. Conservative default; can
+relax behind config later if a real caller needs it.
+
+## Config: `address_policy`
+
+A new `HTTP` option, validated via `NimbleOptions` (host config = a real
+boundary). Accepts **either** form:
+
+### Keyword-list form (ergonomic default)
+
+```elixir
+url: {ImagePipe.Source.HTTP,
+  allowed_hosts: ["assets.example.com"],
+  max_redirects: 3,
+  address_policy: [
+    allow_loopback: false,
+    allow_link_local: false,
+    allow_private: false,          # coarse blanket toggle (opens ALL of RFC1918)
+    allow: ["10.0.5.0/24"]         # precise CIDR opt-in (opens exactly this)
+  ]
+}
+```
+
+- Coarse `allow_*` booleans flip whole categories.
+- `allow:` is a list of exact CIDR strings for the "just this internal host"
+  case — strictly more precise than `allow_private: true`.
+- Omitting `address_policy` entirely ⇒ **default-deny all non-public.**
+
+### Function form (escape hatch)
+
+```elixir
+address_policy: fn _ip, category -> category == :public end
+# or
+address_policy: fn ip, _category -> ip in my_pinned_set end
+```
+
+A 2-arity function receives the **canonicalized IP and our computed category** —
+the host never re-implements the bypass-canonicalization. It returns `true`
+(allow) / `false` (deny). It is a host-implementable value crossing the boundary,
+so we **validate its return and fail closed**: a non-boolean return is treated as
+**deny**. `NimbleOptions` validates up front that `address_policy` is a keyword
+list *or* a 2-arity function.
+
+The function form **replaces** the built-in decision (it does not merge with the
+keyword toggles). A function that wants to defer to defaults composes them in its
+own body.
+
+## Resolver injection
+
+The guard resolves hostnames through an injected resolver rather than calling
+`:inet` directly, for two reasons: testability (point 2 above) and as a genuine
+extension point (custom/caching/pinning resolvers).
+
+- New `HTTP` option `address_resolver` (or equivalent), validated as a function;
+  **default = built-in `:inet`/`:inet_res`-based resolver** returning
+  `{:ok, [:inet.ip_address()]} | {:error, term}`.
+- **IP-literal hosts skip DNS** — `:inet.parse_address/1` succeeds ⇒ classify the
+  literal directly, no resolver call.
+- Resolver error (NXDOMAIN, timeout, empty answer) ⇒ **fail closed** (reject the
+  fetch). This is a host-implementable return crossing the boundary, so its shape
+  is validated at the boundary.
+
+## Redirect host policy: re-enforce `allowed_hosts` on every hop
+
+The guard re-checks each hop's host against the **same** `allowed_hosts` list. A
+redirect to any host outside the allowlist is rejected **regardless of its IP**.
+Rationale:
+
+- `allowed_hosts` is the library's declared trust boundary (`required: true`);
+  letting a redirect walk out of it is incoherent and turns any allowlisted host
+  with an open redirect into a general relay.
+- Redirects to arbitrary *public* hosts are also a real problem here: they exfil
+  request contents (e.g. signed-URL query params) and let an attacker serve bytes
+  that get cached under our identity — IP policy alone catches none of that.
+- It does not contradict #48 ("apply the policy to every hop" is about the IP
+  gap); strict re-check is strictly additive.
+- Redirects are already opt-in (`max_redirects` default `0`) and the deployment
+  owns `allowed_hosts` — a host that legitimately 302s to a CDN edge adds that
+  edge host.
+
+**No configurable opt-out for off-allowlist redirects** in this issue (YAGNI /
+shrink-surface). Add it *with* the first real caller that needs it, plus that
+caller's test.
+
+## Order of checks in the guard (per hop)
+
+1. `allowed_hosts` membership on the hop host. Fail ⇒ halt `{:source, :denied_host}`.
+2. Resolve host → addresses (literal ⇒ classify directly; else injected resolver).
+   Resolver error ⇒ halt (fail closed).
+3. `AddressPolicy.allow?` over the address(es), block-if-any. Fail ⇒ halt
+   `{:source, :denied_address}` (final tag owned by code).
+
+All three are fail-closed and run before connect.
+
+## Wiring
+
+- `HTTP.fetch/3` builds the guard as a closure over
+  `{allowed_hosts, compiled_policy, resolver}` and hands it to the Req pipeline.
+- `ImagePipe.Source.ReqStream` gains a small generic addition: accept a
+  `request_steps:` option and **prepend** them to the Req request, so it stays
+  product-neutral and `HTTP` owns the SSRF policy. (`ReqStream` currently calls
+  `Req.get(request_options, …)`; this becomes a `Req.new |> prepend_request_steps
+  |> Req.get`-style construction, or equivalent, with the steps threaded through.)
+- `resolve/3`: unchanged.
+
+## Boundary / architecture notes
+
+- `AddressPolicy` lives in the `Source` boundary; no new cross-boundary deps.
+- DNS + address policy are source side effects → fetch path only, never
+  `resolve/3`. Preserves the request-safety rule that planner/parser validation
+  returns before source fetch while DNS (a side effect) sits inside fetch.
+- Telemetry: a denied-address rejection is a meaningful source-stage outcome. Emit
+  it on the existing `[:source, …]` span metadata. The **category and the IP are
+  not sensitive** per the telemetry guidelines (product-neutral, low/PII-free);
+  do **not** emit full source URLs (they may embed signed-URL secrets).
+
+## Deferred: DNS-rebinding / IP-pinning (fast-follow, separate issue)
+
+Resolve-and-validate leaves a TOCTOU window: after the guard validates a host's
+addresses, Finch re-resolves at connect time, so a rebind can still slip a private
+IP past us. Closing it means **pinning the connection to the validated IP** —
+rewrite the hop host to the IP, carry the original hostname for `Host` header +
+TLS SNI, and verify the cert against the original name.
+
+Why it is a separate issue, not this one:
+
+- The *logic* is small (the guard already holds the validated IP), but the cost
+  is concentrated in **TLS plumbing** (threading SNI/`server_name_indication`
+  per-request through Req 0.5.17 → Finch 0.22 → Mint 1.8 and confirming cert
+  hostname verification still passes — needs a version-specific spike), a
+  **real-HTTPS test harness** (self-signed cert, loopback HTTPS server,
+  connect-to-IP-verify-against-name — the `plug:` adapter has no TLS), and
+  **HTTP/2 connection-coalescing** analysis (a pooled h2 connection whose cert SAN
+  covers another host can sidestep the pin).
+- That is roughly as much effort again as this whole feature, almost all in test
+  infrastructure and risk, not behavior.
+
+**Action:** open a tracked follow-up issue capturing the spike notes above so they
+are not lost. The #48 docs must state the rebinding residual plainly.
+
+## Documentation
+
+- Document the default network policy (deny-all-non-public) and both
+  `address_policy` config forms, with the precise-CIDR vs blanket-toggle
+  distinction.
+- Document the redirect behavior (every hop re-checked against `allowed_hosts` +
+  address policy).
+- **State the DNS-rebinding residual explicitly** and link the fast-follow issue.
+
+## Tests
+
+All wire-level tests use real `ImagePipe.call/2`-style fetches through the `plug:`
+adapter, per repo test guidelines.
+
+Acceptance criteria (from #48), mapped to mechanics:
+
+1. **Origin host resolving to a blocked private address** — two forms:
+   (a) literal-IP host `https://10.0.0.1/x` with `allowed_hosts: ["10.0.0.1"]`
+   (no resolver needed; classify literal); (b) hostname + **stub resolver**
+   mapping it to a private IP (exercises the DNS branch). Assert rejected before
+   any plug invocation.
+2. **Public/trusted origin redirecting to a blocked private/loopback target** —
+   origin allowlisted, plug returns `302` → `http://127.0.0.1/x`; assert blocked.
+   Cover both the `allowed_hosts` re-check path (target not allowlisted) and the
+   address-policy path (target allowlisted but private).
+3. **`root_url`-based request whose origin response redirects to a blocked
+   target** — same as (2) but via a `root_url`-built source URL.
+4. **Explicit allow / opt-out for private origins** — `address_policy:
+   [allow_private: true]` and the precise `allow: ["10.0.5.0/24"]` form both let a
+   matching private target through; a private target *outside* the CIDR is still
+   blocked. Plus the **function form**: `fn _ip, cat -> cat == :public end` blocks,
+   a permissive function allows.
+
+Unit / property tests on `AddressPolicy`:
+
+- Property tests for `classify/1`: canonicalization (IPv4-mapped IPv6 classifies
+  as its embedded v4), category boundaries, and that the default policy denies
+  every non-`:public` category.
+- Function-form fail-closed: a function returning a non-boolean ⇒ deny.
+- Resolver fail-closed: resolver `{:error, _}` / empty ⇒ reject.
+
+Existing-test migration (unavoidable, per *Why the prior notes were incomplete*
+#3): every current `plug:`-based HTTP test that uses a non-resolving hostname gets
+a shared **stub resolver** mapping that host to a public IP, so default-deny does
+not break them. Keep this in the test setup/helper, not per-test.
+
+Update the misleading **"redirects cannot bypass allowed host policy"** test
+(`test/image_pipe/source/http_test.exs`) to set `max_redirects > 0` so it actually
+exercises an enabled-redirect bypass attempt rather than passing only because
+`max_redirects: 0` rejects the 302.
+
+## Scope
+
+**One PR.** The two-slice split considered during brainstorming was dropped: the
+pure `AddressPolicy` module is not independently shippable value (it does nothing
+until wired), unlike the object-gravity slices. One coherent PR: module +
+property tests → request-step wiring + `ReqStream` change → config + resolver
+plumbing → existing-test migration → acceptance tests → docs.
+
+Out of scope: IP-pinning / rebinding closure (fast-follow issue), any
+configurable off-allowlist-redirect opt-out, promoting `AddressPolicy` to a
+shared `Source`-level module.
+
+## Open questions
+
+- Final error tag spelling for an address rejection (`{:source, :denied_address}`
+  vs a more specific tag) — owned by code, decided at implementation.
+- Whether `address_resolver` is a documented public option or an internal-but-real
+  seam — leaning documented, since it is a legitimate extension point; confirm
+  during planning.

--- a/docs/superpowers/specs/2026-06-01-ssrf-protection-design.md
+++ b/docs/superpowers/specs/2026-06-01-ssrf-protection-design.md
@@ -7,6 +7,13 @@ factual gap analysis, deny-private-by-default posture, product-neutral policy in
 the `Source` boundary) and corrects/extends them where the code review turned up
 non-obvious consequences (see *Why the prior notes were incomplete*).
 
+**Revised after a three-reviewer parallel pass** (security-correctness,
+Elixir/Req feasibility, architecture/conventions). The feasibility reviewer
+verified findings against the actual **Req 0.5.17 / Finch 0.22 / Mint 1.8** source
+(vendored in a sibling worktree). Accepted feedback is folded in below; the
+biggest change is that the **Req-request-step mechanism was disproven and replaced
+by an owned redirect loop** (see *How the guard runs*).
+
 **Threat-model scope:** **resolve-and-validate**, not connection-pinned. We
 resolve each host through an injectable resolver, classify every returned
 address, and reject before connect. The DNS-rebinding (TOCTOU) window between our
@@ -26,8 +33,9 @@ See *Deferred: DNS-rebinding / IP-pinning*.
   `resolve/3` against the *original* URL (`lib/image_pipe/source/http.ex:53`).
   When `max_redirects > 0`, `fetch/3` passes the count straight to `Req.get`
   (`lib/image_pipe/source/http.ex:96`) and nothing re-validates redirect targets
-  — not the host, not the address. A trusted `root_url` path, or any allowlisted
-  host with an open redirect, can bounce to loopback/private/arbitrary hosts.
+  — not the host, not the scheme, not the address. A trusted `root_url` path, or
+  any allowlisted host with an open redirect, can bounce to loopback/private/
+  arbitrary hosts.
 
 Default posture is currently safe only because `max_redirects` defaults to `0`.
 The moment a deployment opts into redirects, both gaps above are live.
@@ -60,10 +68,12 @@ Two pieces:
 1. **`ImagePipe.Source.HTTP.AddressPolicy`** — a pure, I/O-free module: canonicalize
    an IP, classify it into a category, and decide allow/deny against a validated
    policy. Owns the bypass-canonicalization that is the security-critical core.
-2. **A Req request step**, built in `HTTP.fetch/3` and prepended to the Req
-   pipeline, that on the initial request *and every redirect hop* re-checks
-   `allowed_hosts`, resolves the host via an injected resolver, and runs the
-   address policy — halting the request (no connect) on any failure.
+2. **An owned redirect loop with a plain-function guard** in the fetch path. The
+   guard runs before every connection — origin and each redirect hop — re-checking
+   scheme, `allowed_hosts`, resolving the host via an injected resolver, and
+   running the address policy. We follow redirects ourselves rather than letting
+   Req do it (see below), so the guard is ordinary code we call, not a framework
+   hook.
 
 `resolve/3` is unchanged except in role: it stays the cheap, I/O-free
 `allowed_hosts` gate that feeds the cache key. **All DNS and address work happens
@@ -71,24 +81,57 @@ at fetch time**, inside the source side-effect boundary, before the actual TCP
 connect — never in `resolve/3` (which must stay side-effect-free for cache-key
 derivation).
 
-### Why a Req request step (not a transport hook)
+### How the guard runs: an owned redirect loop (NOT a Req request step)
 
-- A request step runs **before the adapter connects**; `Req.Request.halt/2` with
-  an error means the connection never opens — fail-closed.
-- Req's redirect follower re-issues the redirected request through the **same
-  request pipeline**, so a prepended step runs again on **every hop**. One step
-  covers origin + all redirects uniformly; no separate redirect-loop code.
-- Request steps **also run under the `plug:` adapter**, so the guard fires in
-  tests. Combined with the injected resolver, an acceptance test needs no real
-  socket and no real DNS.
+The first draft proposed prepending a **Req request step** that would re-run on
+each redirect hop. **This was disproven against Req 0.5.17 source:**
+`Req.Steps.redirect/1` is a *response* step that rebuilds the request and calls
+`Req.Request.run_request/1` with `current_request_steps` already drained to `[]`
+(`req/lib/req/request.ex:1117`); it does not re-seed request steps from
+`request_steps`. **So request steps run on the origin only, and every redirect hop
+connects unchecked** — exactly the gap we must close. A request-step guard would
+be silently open on hops 2..N. Rejected.
 
-**Load-bearing assumption to verify first (spike):** that request steps genuinely
-re-run on each redirect hop in **Req 0.5.17** specifically (deps are not vendored
-on disk in this worktree; this rests on Req's documented redirect behavior, not
-its source). Implementation step one is a focused test asserting it. **Fallback if
-false:** own the redirect loop ourselves — pass `max_redirects: 0` to Req and
-follow `Location` manually, running the same guard per hop. Same testability, more
-code, fully under our control.
+**Mechanism we use instead — own the loop:**
+
+- Disable Req's redirect following (`max_redirects: 0` / `redirect: false`).
+- The fetch path runs a bounded loop (≤ `max_redirects` + 1 iterations). Each
+  iteration:
+  1. **Guard the target URL** (plain function — order in *Order of checks*).
+     Reject ⇒ return a typed `{:source, …}` error; **no connection is opened**,
+     because the guard runs before the request.
+  2. Open a single streaming request to that exact URL with redirects disabled.
+  3. On `2xx`: hand back the streaming body — done.
+  4. On `3xx` with a `Location`: compute the next absolute target via
+     `URI.merge(current_url, location)` (mirroring Req's own
+     `URI.merge(URI.parse(location))` semantics so relative, protocol-relative,
+     and scheme-changing redirects normalize to a concrete scheme+host), then
+     loop. Hop count exhausted ⇒ error.
+  5. Any other status / error ⇒ error.
+
+This lives in `ReqStream` (which owns the `Stream.resource` lazy open), with the
+guard passed in from `HTTP` as a product-neutral closure
+(`validate_target :: (URI.t()) -> :ok | {:source, reason}`). Because the loop
+runs inside the stream's init thunk, laziness is preserved; intermediate `3xx`
+responses are opened and cancelled, and the final `2xx` body streams as today.
+
+**Why this is strictly better than the step approach, beyond just working:**
+
+- The guard runs **before** we open each connection in *our* code, so
+  "fail-closed before connect" is a structural property of this module, not a bet
+  on Req's halt semantics. (The `plug:` adapter can't prove "halt ⇒ no socket"
+  anyway; owning the loop removes the need to.)
+- We control the error tag end-to-end. (A Req request step's `halt` error is
+  flattened to `:bad_status` by `ReqStream.open_response`'s blanket
+  `{:error, _} -> {:error, :bad_status}` arm, so guard-specific tags like
+  `:denied_address` would never surface — another reason the step approach was a
+  dead end.)
+
+### Plug-adapter testability is preserved
+
+The owned loop runs under `req_options: [plug: plug]` just as well: each hop's
+plug response drives the next loop iteration, and the injected resolver means no
+real DNS. An acceptance test needs no real socket and no real DNS.
 
 ## `ImagePipe.Source.HTTP.AddressPolicy`
 
@@ -99,6 +142,12 @@ resolved hosts. Per the repo rule "add it when the future caller appears, with a
 test," we do **not** promote it to a shared `Source`-level module until a second
 source needs it.
 
+**Boundary export:** `AddressPolicy` is an **internal** `Source`-boundary module,
+consumed only by its sibling `HTTP`. It is intentionally **not** added to the
+`Source` boundary `exports:` list (`lib/image_pipe/source.ex`) — exporting it would
+violate "export only behaviours and stable entry points, not implementation
+helpers." Sibling modules in the same boundary do not need an export to call it.
+
 ### Classification
 
 `classify/1 :: :inet.ip_address() -> category` where category is one of:
@@ -108,20 +157,40 @@ source needs it.
 :multicast | :broadcast | :cgnat | :reserved | :public
 ```
 
-**Canonicalization is part of classification and is the security core.** Before
-classifying, unwrap:
+**Two hard rules, both load-bearing for fail-closed:**
 
-- IPv4-mapped IPv6 (`::ffff:a.b.c.d`) → classify by the embedded IPv4.
-- IPv4-compatible / deprecated-embedding forms → same.
+1. **Canonicalize on the parsed tuple, inside `classify/1`, for *both* the literal
+   branch and the resolver branch.** `:inet.parse_address("::ffff:10.0.0.1")`
+   returns the **8-element IPv6 tuple** `{0,0,0,0,0,65535,2560,1}`, *not*
+   `{10,0,0,1}`. So an IP-literal host that skips DNS must still be canonicalized
+   or a mapped-literal private target slips through. Unwrap must be **tuple-based**
+   (detect `elem(addr,5) == 0xffff`, rebuild embedded v4 from groups 6–7) so the
+   hex spelling `::ffff:7f00:1` — which parses to the *same* tuple as
+   `::ffff:127.0.0.1` — is caught identically. A string match on `"::ffff:"` would
+   miss it.
+2. **`classify/1` is total and defaults to DENY, never `:public`.** Unknown /
+   unmatched IPv6 prefixes must classify to a blocked category (`:reserved`), not
+   fall through to `:public`. A property test asserts *no* unknown v6 prefix
+   returns `:public`. Given the sparse v6 space, the safe shape is an explicit
+   public-range allowlist → `:public`, everything else → blocked.
 
-The concrete default-blocked set (the exact ranges per category) is **owned by
-this module and its property tests**, not pinned in this prose — mirroring the
-cache-key guidance ("which fields compose the key is owned by the module and its
-tests"). Default intent: **everything that is not `:public` is denied.** Includes
-at minimum loopback (`127.0.0.0/8`, `::1`), unspecified (`0.0.0.0`, `::`),
-link-local (`169.254.0.0/16`, `fe80::/10`), private (`10/8`, `172.16/12`,
-`192.168/16`), unique-local (`fc00::/7`), CGNAT (`100.64.0.0/10`), multicast,
-broadcast, and reserved/benchmark/documentation ranges.
+**Default-blocked set** (exact ranges owned by this module + its property tests,
+not pinned in prose — mirroring the cache-key guidance). Must include at minimum:
+
+- IPv4: `0.0.0.0/8` (whole "this host" block, not just `0.0.0.0`), loopback
+  `127.0.0.0/8`, link-local `169.254.0.0/16` (covers `169.254.169.254` cloud
+  metadata), private `10/8` `172.16/12` `192.168/16`, CGNAT `100.64.0.0/10`,
+  multicast `224.0.0.0/4`, broadcast `255.255.255.255`, benchmark `198.18.0.0/15`,
+  documentation `192.0.2.0/24` `198.51.100.0/24` `203.0.113.0/24`.
+- IPv6: unspecified `::`, loopback `::1`, link-local `fe80::/10`, unique-local
+  `fc00::/7`, multicast `ff00::/8`, NAT64 `64:ff9b::/96`, 6to4 `2002::/16`
+  (**unwrap** the embedded v4 `2002:V4HI:V4LO::/16` and classify *that* — a 6to4
+  address embedding `10.x`/`127.x` must be denied), plus IPv4-mapped (rule 1).
+
+The literal-encoding IPv4 bypasses (`http://2130706433/`, `http://0x7f.1/`,
+`http://0177.0.0.1/`, `http://127.1/`, `http://0/`) are **already canonicalized by
+`:inet.parse_address/1`** to their real tuples — do **not** hand-roll octal/hex/
+dword decoding; route every literal through `:inet.parse_address` then `classify`.
 
 ### Policy decision
 
@@ -129,10 +198,10 @@ The validated policy compiles to a single internal predicate
 `(ip :: :inet.ip_address(), category :: atom) -> boolean()`. Both config forms
 (below) compile to this shape.
 
-**Multi-address responses: block if *any* returned address is disallowed.** We
-cannot control which address Finch ultimately selects, and a mixed
-public/private answer is itself a rebinding signal. Conservative default; can
-relax behind config later if a real caller needs it.
+**Multi-address responses: allow only if *every* returned address is present,
+well-formed, and allowed.** Block-if-any: we cannot control which address Finch
+dials, a mixed public/private answer is a rebinding signal, and a malformed/
+unparseable entry from a custom resolver counts as a denial (not skipped).
 
 ## Config: `address_policy`
 
@@ -169,35 +238,70 @@ address_policy: fn ip, _category -> ip in my_pinned_set end
 
 A 2-arity function receives the **canonicalized IP and our computed category** —
 the host never re-implements the bypass-canonicalization. It returns `true`
-(allow) / `false` (deny). It is a host-implementable value crossing the boundary,
-so we **validate its return and fail closed**: a non-boolean return is treated as
-**deny**. `NimbleOptions` validates up front that `address_policy` is a keyword
-list *or* a 2-arity function.
+(allow) / `false` (deny), and **replaces** the built-in decision (it does not
+merge with the keyword toggles).
 
-The function form **replaces** the built-in decision (it does not merge with the
-keyword toggles). A function that wants to defer to defaults composes them in its
-own body.
+### NimbleOptions spelling (verified)
+
+```elixir
+address_policy: [
+  type: {:or, [
+    {:fun, 2},
+    keyword_list: [
+      allow_loopback: [type: :boolean, default: false],
+      allow_link_local: [type: :boolean, default: false],
+      allow_private: [type: :boolean, default: false],
+      # ... remaining category toggles ...
+      allow: [type: {:list, :string}, default: []]
+    ]
+  ]}
+]
+```
+
+The keyword-list subtype inside `{:or, …}` must use the 2-tuple form
+`keyword_list: [<nested schema>]` (per-key validation), **not** the bare atom
+`:keyword_list` (which validates "any keyword list" with no nesting). CIDR strings
+in `allow:` need a `{:custom, …}` parse/validate (NimbleOptions does not parse
+CIDRs). The `{:fun, 2}` subtype is unambiguous against `keyword_list`, so order is
+safe; test both forms.
 
 ## Resolver injection
 
 The guard resolves hostnames through an injected resolver rather than calling
-`:inet` directly, for two reasons: testability (point 2 above) and as a genuine
-extension point (custom/caching/pinning resolvers).
+`:inet` directly, for two reasons: testability (point 2 of *Why the prior notes
+were incomplete*) and as a genuine extension point (custom/caching/pinning
+resolvers).
 
-- New `HTTP` option `address_resolver` (or equivalent), validated as a function;
-  **default = built-in `:inet`/`:inet_res`-based resolver** returning
+- New `HTTP` option `address_resolver`, validated as a function; **default =
+  built-in `:inet`/`:inet_res`-based resolver** returning
   `{:ok, [:inet.ip_address()]} | {:error, term}`.
-- **IP-literal hosts skip DNS** — `:inet.parse_address/1` succeeds ⇒ classify the
-  literal directly, no resolver call.
-- Resolver error (NXDOMAIN, timeout, empty answer) ⇒ **fail closed** (reject the
-  fetch). This is a host-implementable return crossing the boundary, so its shape
-  is validated at the boundary.
+- The built-in `:inet` resolver is the library default whenever `address_resolver`
+  is omitted; the **stub resolver is test-only** (injected per-test via the option
+  / a shared test helper), never the production default.
+- **IP-literal hosts skip DNS** — feed the **unbracketed** host (the codebase
+  stores IPv6 hosts unbracketed in `URL.host`; `:inet.parse_address("[::1]")`
+  fails) to `:inet.parse_address/1`; success ⇒ classify the literal directly.
+- **Fail closed on every failure mode:** resolver `{:error, _}`, `{:ok, []}`, a
+  malformed address entry, **or a raised exception** from the resolver ⇒ reject
+  the fetch. The host-supplied resolver and policy-function calls are wrapped so a
+  raise becomes a denial, never an open path or an unhandled crash that bypasses
+  the guard.
 
-## Redirect host policy: re-enforce `allowed_hosts` on every hop
+## Redirect host policy: re-enforce scheme + `allowed_hosts` on every hop
 
-The guard re-checks each hop's host against the **same** `allowed_hosts` list. A
-redirect to any host outside the allowlist is rejected **regardless of its IP**.
-Rationale:
+The guard re-checks each hop's **scheme** and **host**:
+
+- **Scheme:** must be `:http` or `:https`. `Location: file:///…`, `gopher://`,
+  `data:`, etc. are rejected before the host/address checks. (`resolve/3` guards
+  scheme only on the *original* URL; the per-hop guard re-asserts it.)
+- **Host:** **downcased** (mirroring `resolve/3`'s `String.downcase`), then checked
+  against the **same** `allowed_hosts` list. A redirect to any host outside the
+  allowlist is rejected **regardless of its IP**.
+
+The host/scheme are read from the **`URI.merge`'d absolute target** (step 4 of the
+loop), never the raw `Location` header, so protocol-relative (`//evil/…`),
+relative (`/other.jpg`), and scheme-downgrade (`https→http`) redirects normalize
+before checking. Rationale for re-enforcing the allowlist on hops:
 
 - `allowed_hosts` is the library's declared trust boundary (`required: true`);
   letting a redirect walk out of it is incoherent and turns any allowlisted host
@@ -205,55 +309,77 @@ Rationale:
 - Redirects to arbitrary *public* hosts are also a real problem here: they exfil
   request contents (e.g. signed-URL query params) and let an attacker serve bytes
   that get cached under our identity — IP policy alone catches none of that.
-- It does not contradict #48 ("apply the policy to every hop" is about the IP
-  gap); strict re-check is strictly additive.
-- Redirects are already opt-in (`max_redirects` default `0`) and the deployment
-  owns `allowed_hosts` — a host that legitimately 302s to a CDN edge adds that
-  edge host.
+- It does not contradict #48; strict re-check is strictly additive.
 
 **No configurable opt-out for off-allowlist redirects** in this issue (YAGNI /
 shrink-surface). Add it *with* the first real caller that needs it, plus that
 caller's test.
 
-## Order of checks in the guard (per hop)
+## Order of checks in the guard (per hop, before any connect)
 
-1. `allowed_hosts` membership on the hop host. Fail ⇒ halt `{:source, :denied_host}`.
-2. Resolve host → addresses (literal ⇒ classify directly; else injected resolver).
-   Resolver error ⇒ halt (fail closed).
-3. `AddressPolicy.allow?` over the address(es), block-if-any. Fail ⇒ halt
-   `{:source, :denied_address}` (final tag owned by code).
+1. **Scheme** ∈ {`:http`, `:https`} on the merged target. Fail ⇒
+   `{:source, :denied_scheme}`.
+2. **`allowed_hosts`** membership on the downcased target host. Fail ⇒
+   `{:source, :denied_host}`.
+3. **Resolve** host → addresses (literal ⇒ canonicalize+classify directly; else
+   injected resolver). Resolver error / empty / raise ⇒ fail closed.
+4. **`AddressPolicy.allow?`** over the address(es), block-if-any. Fail ⇒
+   `{:source, :denied_address}`.
 
-All three are fail-closed and run before connect.
+All four are fail-closed and run before connect. (Final tag spellings owned by
+code; the `denied_*` set here is the design intent.)
 
 ## Wiring
 
-- `HTTP.fetch/3` builds the guard as a closure over
-  `{allowed_hosts, compiled_policy, resolver}` and hands it to the Req pipeline.
-- `ImagePipe.Source.ReqStream` gains a small generic addition: accept a
-  `request_steps:` option and **prepend** them to the Req request, so it stays
-  product-neutral and `HTTP` owns the SSRF policy. (`ReqStream` currently calls
-  `Req.get(request_options, …)`; this becomes a `Req.new |> prepend_request_steps
-  |> Req.get`-style construction, or equivalent, with the steps threaded through.)
+- `HTTP.fetch/3` builds the guard closure over
+  `{allowed_hosts, compiled_policy, resolver}` and the redirect bound, and hands
+  it to `ReqStream` as `validate_target` + a redirect limit. It passes
+  `max_redirects: 0` to Req so Req never follows redirects itself.
+- `ImagePipe.Source.ReqStream` owns the redirect loop inside its
+  `Stream.resource` open thunk: validate target → open one request (redirects
+  disabled) → on `3xx` merge `Location`, re-validate, re-open → on `2xx` stream.
+  It stays product-neutral (`HTTP` owns the policy closure). Guard rejections
+  surface with their own `{:source, …}` reason — **do not** collapse them through
+  the existing `{:error, _} -> {:error, :bad_status}` arm.
+- `HTTP.fetch/3` must **strip `:address_policy` and `:address_resolver` from
+  `req_options`** before they reach Req (add to `@internal_option_keys`), or Req's
+  `validate_options` will reject the unregistered keys.
 - `resolve/3`: unchanged.
 
 ## Boundary / architecture notes
 
-- `AddressPolicy` lives in the `Source` boundary; no new cross-boundary deps.
+- `AddressPolicy` lives in the `Source` boundary, **unexported** (see above); no
+  new cross-boundary deps (pure IP math; `Source` already deps only on
+  `Error`/`Plan`/`Telemetry`).
 - DNS + address policy are source side effects → fetch path only, never
   `resolve/3`. Preserves the request-safety rule that planner/parser validation
   returns before source fetch while DNS (a side effect) sits inside fetch.
-- Telemetry: a denied-address rejection is a meaningful source-stage outcome. Emit
-  it on the existing `[:source, …]` span metadata. The **category and the IP are
-  not sensitive** per the telemetry guidelines (product-neutral, low/PII-free);
-  do **not** emit full source URLs (they may embed signed-URL secrets).
+- No concrete-transform-module references introduced; this is source-only work.
+
+## Telemetry
+
+A denied-address/host/scheme rejection is a returned `{:error, {:source, …}}`,
+i.e. a **normal `:stop`** of the existing `[:source, :fetch]` span with an error
+result — **not** an `:exception`. Today `source.ex`'s `result_metadata/1` turns
+that into `%{result: :source_error, error: …}` for free, so the rejection is
+already observable.
+
+To additionally surface **category + canonicalized IP** (which `result_metadata/1`
+does not carry today), thread those values back through the adapter's error return
+so the span's stop metadata can include them, using the shared `Telemetry`
+helpers rather than ad-hoc emission. Category + IP are **product-neutral and
+PII-free** (sensitivity-not-cardinality rule), so they are fine to emit. **Do not
+emit the full source URL** — it may embed signed-URL secrets.
 
 ## Deferred: DNS-rebinding / IP-pinning (fast-follow, separate issue)
 
 Resolve-and-validate leaves a TOCTOU window: after the guard validates a host's
 addresses, Finch re-resolves at connect time, so a rebind can still slip a private
-IP past us. Closing it means **pinning the connection to the validated IP** —
-rewrite the hop host to the IP, carry the original hostname for `Host` header +
-TLS SNI, and verify the cert against the original name.
+IP past us. Owning the redirect loop does **not** close this — each hop's
+`Req.get` still lets Finch re-resolve the host we validated. Closing it means
+**pinning the connection to the validated IP** — rewrite the hop host to the IP,
+carry the original hostname for `Host` header + TLS SNI, and verify the cert
+against the original name.
 
 Why it is a separate issue, not this one:
 
@@ -276,8 +402,8 @@ are not lost. The #48 docs must state the rebinding residual plainly.
 - Document the default network policy (deny-all-non-public) and both
   `address_policy` config forms, with the precise-CIDR vs blanket-toggle
   distinction.
-- Document the redirect behavior (every hop re-checked against `allowed_hosts` +
-  address policy).
+- Document the redirect behavior (every hop re-checked against scheme +
+  `allowed_hosts` + address policy).
 - **State the DNS-rebinding residual explicitly** and link the fast-follow issue.
 
 ## Tests
@@ -293,9 +419,11 @@ Acceptance criteria (from #48), mapped to mechanics:
    mapping it to a private IP (exercises the DNS branch). Assert rejected before
    any plug invocation.
 2. **Public/trusted origin redirecting to a blocked private/loopback target** —
-   origin allowlisted, plug returns `302` → `http://127.0.0.1/x`; assert blocked.
-   Cover both the `allowed_hosts` re-check path (target not allowlisted) and the
-   address-policy path (target allowlisted but private).
+   origin allowlisted, plug returns `302` → `http://127.0.0.1/x`; assert blocked,
+   and assert the guard fired **on the redirect target specifically** (deny on
+   hop 2, not merely a non-2xx final status). Cover both the `allowed_hosts`
+   re-check path (target not allowlisted) and the address-policy path (target
+   allowlisted but private).
 3. **`root_url`-based request whose origin response redirects to a blocked
    target** — same as (2) but via a `root_url`-built source URL.
 4. **Explicit allow / opt-out for private origins** — `address_policy:
@@ -304,31 +432,49 @@ Acceptance criteria (from #48), mapped to mechanics:
    blocked. Plus the **function form**: `fn _ip, cat -> cat == :public end` blocks,
    a permissive function allows.
 
+Named regression / edge cases (security review):
+
+- **`169.254.169.254`** (cloud metadata) — explicit named test, blocked as
+  link-local.
+- **IPv4-mapped literal** `https://[::ffff:10.0.0.1]/x` — blocked (canonicalizes
+  to private), and the hex spelling `::ffff:7f00:1` — blocked as loopback.
+- **NAT64 / 6to4** — `64:ff9b::…` blocked; `2002:…` embedding a private/loopback
+  v4 blocked.
+- **Non-http(s) redirect** — `Location: file:///etc/passwd` rejected (scheme).
+- **Protocol-relative / scheme-downgrade redirect** — `Location: //evil/x` and
+  `https→http` normalize via `URI.merge` and are checked against the allowlist.
+- **Uppercase redirect host** — `Location: https://ASSETS.EXAMPLE.COM/x` matches
+  `allowed_hosts: ["assets.example.com"]` (downcased).
+- **IPv6 zone-id literal** in a redirect target is denied (link-local), not
+  silently NXDOMAIN'd.
+
 Unit / property tests on `AddressPolicy`:
 
-- Property tests for `classify/1`: canonicalization (IPv4-mapped IPv6 classifies
-  as its embedded v4), category boundaries, and that the default policy denies
-  every non-`:public` category.
-- Function-form fail-closed: a function returning a non-boolean ⇒ deny.
-- Resolver fail-closed: resolver `{:error, _}` / empty ⇒ reject.
+- Property: `classify/1` canonicalization (mapped/6to4 classify by embedded v4),
+  category boundaries, and **no unknown v6 prefix returns `:public`** (totality /
+  deny-default).
+- Function-form fail-closed: non-boolean return ⇒ deny; raised exception ⇒ deny.
+- Resolver fail-closed: `{:error, _}` / empty / malformed entry / raise ⇒ reject.
 
 Existing-test migration (unavoidable, per *Why the prior notes were incomplete*
 #3): every current `plug:`-based HTTP test that uses a non-resolving hostname gets
-a shared **stub resolver** mapping that host to a public IP, so default-deny does
-not break them. Keep this in the test setup/helper, not per-test.
+a shared **test-only stub resolver** mapping that host to a public IP, so
+default-deny does not break them. Keep this in the test setup/helper, not per-test,
+and ensure it is never the library default.
 
 Update the misleading **"redirects cannot bypass allowed host policy"** test
 (`test/image_pipe/source/http_test.exs`) to set `max_redirects > 0` so it actually
 exercises an enabled-redirect bypass attempt rather than passing only because
-`max_redirects: 0` rejects the 302.
+`max_redirects: 0` rejects the 302. Do **not** introduce `*_characterization_test`
+parity pins during the existing-test churn.
 
 ## Scope
 
 **One PR.** The two-slice split considered during brainstorming was dropped: the
 pure `AddressPolicy` module is not independently shippable value (it does nothing
 until wired), unlike the object-gravity slices. One coherent PR: module +
-property tests → request-step wiring + `ReqStream` change → config + resolver
-plumbing → existing-test migration → acceptance tests → docs.
+property tests → owned-redirect-loop wiring in `ReqStream`/`HTTP` → config +
+resolver plumbing → existing-test migration → acceptance + edge tests → docs.
 
 Out of scope: IP-pinning / rebinding closure (fast-follow issue), any
 configurable off-allowlist-redirect opt-out, promoting `AddressPolicy` to a
@@ -336,8 +482,8 @@ shared `Source`-level module.
 
 ## Open questions
 
-- Final error tag spelling for an address rejection (`{:source, :denied_address}`
-  vs a more specific tag) — owned by code, decided at implementation.
+- Final error-tag spellings for the `denied_*` set — owned by code, decided at
+  implementation.
 - Whether `address_resolver` is a documented public option or an internal-but-real
   seam — leaning documented, since it is a legitimate extension point; confirm
   during planning.

--- a/docs/superpowers/specs/2026-06-01-ssrf-protection-design.md
+++ b/docs/superpowers/specs/2026-06-01-ssrf-protection-design.md
@@ -358,18 +358,27 @@ code; the `denied_*` set here is the design intent.)
 
 ## Telemetry
 
-A denied-address/host/scheme rejection is a returned `{:error, {:source, …}}`,
-i.e. a **normal `:stop`** of the existing `[:source, :fetch]` span with an error
-result — **not** an `:exception`. Today `source.ex`'s `result_metadata/1` turns
-that into `%{result: :source_error, error: …}` for free, so the rejection is
-already observable.
+**Reality check against the lazy-stream architecture:** `HTTP.fetch/3` returns
+`{:ok, %Response{stream: …}}` *immediately*; the actual connect — and therefore
+any denial, since the guard runs inside the redirect loop in `ReqStream`'s stream
+init — happens later, during stream **consumption**. So a denial is **not** seen
+by the `[:source, :fetch]` span (which wraps only the `{:ok, stream}` return).
+This is exactly how today's `:bad_status` already behaves: it surfaces as a
+`StreamError` raised during consumption, outside the fetch span.
 
-To additionally surface **category + canonicalized IP** (which `result_metadata/1`
-does not carry today), thread those values back through the adapter's error return
-so the span's stop metadata can include them, using the shared `Telemetry`
-helpers rather than ad-hoc emission. Category + IP are **product-neutral and
-PII-free** (sensitivity-not-cardinality rule), so they are fine to emit. **Do not
-emit the full source URL** — it may embed signed-URL secrets.
+Therefore, for parity and to keep this PR focused, a denial surfaces the same way:
+**`ImagePipe.Source.StreamError` with `reason: :denied_scheme | :denied_host |
+:denied_address`** (the reason atom is preserved on the raised exception and is
+what tests assert on, mirroring `:bad_status`). No bespoke telemetry threading is
+added in this issue.
+
+**Deferred (not this issue):** richer denial telemetry carrying **category +
+canonicalized IP** (product-neutral and PII-free per the sensitivity-not-
+cardinality rule; **never** the full source URL, which may embed signed-URL
+secrets). Doing it properly means either a discrete `Telemetry.execute/4` event
+from the guard or making the origin guard eager in `fetch/3` — both are larger
+than the denial-signal this issue needs, and the same gap exists for `:bad_status`
+today. Capture it with the IP-pinning fast-follow or a separate telemetry issue.
 
 ## Deferred: DNS-rebinding / IP-pinning (fast-follow, separate issue)
 

--- a/lib/image_pipe/source/http.ex
+++ b/lib/image_pipe/source/http.ex
@@ -6,6 +6,8 @@ defmodule ImagePipe.Source.HTTP do
   alias ImagePipe.Plan.Source.URL
   alias ImagePipe.Source
   alias ImagePipe.Source.CacheSemantics
+  alias ImagePipe.Source.HTTP.AddressPolicy
+  alias ImagePipe.Source.HTTP.TargetGuard
   alias ImagePipe.Source.ReqStream
   alias ImagePipe.Source.Resolved
   alias ImagePipe.Source.Response
@@ -19,7 +21,9 @@ defmodule ImagePipe.Source.HTTP do
     :into,
     :retry,
     :redirect,
-    :max_redirects
+    :max_redirects,
+    :address_policy,
+    :address_resolver
   ]
   @host_header_names ["host"]
   @cacheable_byte_header_names ["range", "accept", "accept-encoding"]
@@ -34,7 +38,13 @@ defmodule ImagePipe.Source.HTTP do
                     max_redirects: [type: :non_neg_integer, default: 0],
                     stable: [type: {:in, [:auto, :trusted]}, default: :auto],
                     internal_cache: [type: {:in, [:auto, :enabled, :disabled]}, default: :auto],
-                    http_cache: [type: {:in, [:inherit, :disabled, :enabled]}, default: :inherit]
+                    http_cache: [type: {:in, [:inherit, :disabled, :enabled]}, default: :inherit],
+                    address_policy: [
+                      type:
+                        {:or, [{:fun, 2}, {:custom, __MODULE__, :validate_address_policy_kw, []}]},
+                      default: []
+                    ],
+                    address_resolver: [type: {:fun, 1}]
                   )
 
   @impl Source
@@ -44,6 +54,38 @@ defmodule ImagePipe.Source.HTTP do
       {:error, error} -> {:error, {:invalid_source_config, Exception.message(error)}}
     end
   end
+
+  @doc false
+  def validate_address_policy_kw(value) when is_list(value) do
+    allowed_keys = [
+      :allow_loopback,
+      :allow_unspecified,
+      :allow_link_local,
+      :allow_private,
+      :allow_unique_local,
+      :allow_multicast,
+      :allow_broadcast,
+      :allow_cgnat,
+      :allow_reserved,
+      :allow
+    ]
+
+    cond do
+      not Keyword.keyword?(value) ->
+        {:error, "address_policy keyword list expected"}
+
+      Enum.any?(Keyword.keys(value), &(&1 not in allowed_keys)) ->
+        {:error, "unknown address_policy key"}
+
+      Enum.any?(Keyword.get(value, :allow, []), &(AddressPolicy.parse_cidr(&1) == :error)) ->
+        {:error, "invalid CIDR in address_policy :allow"}
+
+      true ->
+        {:ok, value}
+    end
+  end
+
+  def validate_address_policy_kw(_value), do: {:error, "address_policy keyword list expected"}
 
   @impl Source
   def resolve(%URL{scheme: scheme} = source, opts, _runtime_opts)
@@ -90,19 +132,23 @@ defmodule ImagePipe.Source.HTTP do
       opts
       |> Keyword.fetch!(:req_options)
       |> sanitize_req_options(fetch[:strip_byte_headers])
-      |> Keyword.merge(
-        url: fetch[:url],
-        method: :get,
-        max_redirects: Keyword.fetch!(opts, :max_redirects)
-      )
+      |> Keyword.merge(url: fetch[:url], method: :get)
 
     stream_options =
-      Keyword.merge(
-        Keyword.take(opts, [:receive_timeout, :pool_timeout, :connect_timeout]),
-        runtime_opts
-      )
+      Keyword.take(opts, [:receive_timeout, :pool_timeout, :connect_timeout])
+      |> Keyword.merge(runtime_opts)
+      |> Keyword.put(:validate_target, build_target_guard(opts))
+      |> Keyword.put(:max_redirects, Keyword.fetch!(opts, :max_redirects))
 
     {:ok, %Response{stream: ReqStream.stream(req_options, stream_options)}}
+  end
+
+  defp build_target_guard(opts) do
+    allowed_hosts = Keyword.fetch!(opts, :allowed_hosts)
+    predicate = AddressPolicy.compile(Keyword.fetch!(opts, :address_policy))
+    resolver = Keyword.get(opts, :address_resolver, &TargetGuard.default_resolver/1)
+
+    fn url -> TargetGuard.validate(url, allowed_hosts, predicate, resolver) end
   end
 
   defp sanitize_req_options(req_options, strip_byte_headers?) do

--- a/lib/image_pipe/source/http.ex
+++ b/lib/image_pipe/source/http.ex
@@ -77,6 +77,9 @@ defmodule ImagePipe.Source.HTTP do
       Enum.any?(Keyword.keys(value), &(&1 not in allowed_keys)) ->
         {:error, "unknown address_policy key"}
 
+      not is_list(Keyword.get(value, :allow, [])) ->
+        {:error, "address_policy :allow must be a list of CIDR strings"}
+
       Enum.any?(Keyword.get(value, :allow, []), &(AddressPolicy.parse_cidr(&1) == :error)) ->
         {:error, "invalid CIDR in address_policy :allow"}
 

--- a/lib/image_pipe/source/http/address_policy.ex
+++ b/lib/image_pipe/source/http/address_policy.ex
@@ -94,6 +94,68 @@ defmodule ImagePipe.Source.HTTP.AddressPolicy do
   defp classify_v4(a, _, _, _) when a in 240..255, do: :reserved
   defp classify_v4(_, _, _, _), do: :public
 
+  @type predicate :: (:inet.ip_address(), category() -> boolean())
+
+  @category_toggles %{
+    allow_loopback: :loopback,
+    allow_unspecified: :unspecified,
+    allow_link_local: :link_local,
+    allow_private: :private,
+    allow_unique_local: :unique_local,
+    allow_multicast: :multicast,
+    allow_broadcast: :broadcast,
+    allow_cgnat: :cgnat,
+    allow_reserved: :reserved
+  }
+
+  @spec compile(keyword() | predicate()) :: predicate()
+  def compile(fun) when is_function(fun, 2) do
+    fn ip, category -> safe_bool(fun, ip, category) end
+  end
+
+  def compile(opts) when is_list(opts) do
+    allowed_categories =
+      for {toggle, category} <- @category_toggles,
+          Keyword.get(opts, toggle, false),
+          into: MapSet.new() do
+        category
+      end
+
+    cidrs =
+      opts
+      |> Keyword.get(:allow, [])
+      |> Enum.map(fn cidr ->
+        {:ok, parsed} = parse_cidr(cidr)
+        parsed
+      end)
+
+    fn ip, category ->
+      category == :public or
+        MapSet.member?(allowed_categories, category) or
+        Enum.any?(cidrs, &in_cidr?(ip, &1))
+    end
+  end
+
+  @spec allow?(predicate(), [:inet.ip_address()]) :: boolean()
+  def allow?(_predicate, []), do: false
+
+  def allow?(predicate, addresses) when is_list(addresses) do
+    Enum.all?(addresses, fn
+      {_, _, _, _} = ip -> predicate.(ip, classify(ip))
+      {_, _, _, _, _, _, _, _} = ip -> predicate.(ip, classify(ip))
+      _other -> false
+    end)
+  end
+
+  defp safe_bool(fun, ip, category) do
+    case fun.(ip, category) do
+      true -> true
+      _ -> false
+    end
+  rescue
+    _ -> false
+  end
+
   defp tuple_bits({_, _, _, _}), do: 32
   defp tuple_bits({_, _, _, _, _, _, _, _}), do: 128
 

--- a/lib/image_pipe/source/http/address_policy.ex
+++ b/lib/image_pipe/source/http/address_policy.ex
@@ -29,6 +29,8 @@ defmodule ImagePipe.Source.HTTP.AddressPolicy do
     end
   end
 
+  def parse_cidr(_value), do: :error
+
   @spec in_cidr?(:inet.ip_address(), cidr()) :: boolean()
   def in_cidr?(ip, {net_int, prefix, bits}) do
     if tuple_bits(ip) == bits do
@@ -71,6 +73,8 @@ defmodule ImagePipe.Source.HTTP.AddressPolicy do
 
   # 3fff::/20 reserved for documentation (RFC 9637) — MUST come BEFORE the 2000..3FFF public clause
   defp classify_v6({0x3FFF, b, _, _, _, _, _, _}) when b < 0x1000, do: :reserved
+  # 2001:db8::/32 documentation (RFC 3849)
+  defp classify_v6({0x2001, 0x0DB8, _, _, _, _, _, _}), do: :reserved
   # Global unicast 2000::/3 is the only public v6 space; everything else denies.
   defp classify_v6({a, _, _, _, _, _, _, _}) when a >= 0x2000 and a <= 0x3FFF, do: :public
   defp classify_v6(_), do: :reserved

--- a/lib/image_pipe/source/http/address_policy.ex
+++ b/lib/image_pipe/source/http/address_policy.ex
@@ -1,5 +1,6 @@
 defmodule ImagePipe.Source.HTTP.AddressPolicy do
   @moduledoc false
+  import Bitwise
 
   @type category ::
           :loopback
@@ -12,6 +13,31 @@ defmodule ImagePipe.Source.HTTP.AddressPolicy do
           | :cgnat
           | :reserved
           | :public
+
+  @type cidr :: {non_neg_integer(), 0..128, 32 | 128}
+
+  @spec parse_cidr(String.t()) :: {:ok, cidr()} | :error
+  def parse_cidr(string) when is_binary(string) do
+    with [addr, prefix] <- String.split(string, "/", parts: 2),
+         {:ok, tuple} <- :inet.parse_address(String.to_charlist(addr)),
+         {prefix_int, ""} <- Integer.parse(prefix),
+         bits when bits in [32, 128] <- tuple_bits(tuple),
+         true <- prefix_int >= 0 and prefix_int <= bits do
+      {:ok, {tuple_to_int(tuple), prefix_int, bits}}
+    else
+      _ -> :error
+    end
+  end
+
+  @spec in_cidr?(:inet.ip_address(), cidr()) :: boolean()
+  def in_cidr?(ip, {net_int, prefix, bits}) do
+    if tuple_bits(ip) == bits do
+      shift = bits - prefix
+      Bitwise.bsr(tuple_to_int(ip), shift) == Bitwise.bsr(net_int, shift)
+    else
+      false
+    end
+  end
 
   @spec classify(:inet.ip_address()) :: category()
   def classify({a, b, c, d}), do: classify_v4(a, b, c, d)
@@ -67,4 +93,14 @@ defmodule ImagePipe.Source.HTTP.AddressPolicy do
   # 240.0.0.0/4 reserved (future use)
   defp classify_v4(a, _, _, _) when a in 240..255, do: :reserved
   defp classify_v4(_, _, _, _), do: :public
+
+  defp tuple_bits({_, _, _, _}), do: 32
+  defp tuple_bits({_, _, _, _, _, _, _, _}), do: 128
+
+  defp tuple_to_int({a, b, c, d}), do: (a <<< 24) + (b <<< 16) + (c <<< 8) + d
+
+  defp tuple_to_int({a, b, c, d, e, f, g, h}) do
+    [a, b, c, d, e, f, g, h]
+    |> Enum.reduce(0, fn group, acc -> (acc <<< 16) + group end)
+  end
 end

--- a/lib/image_pipe/source/http/address_policy.ex
+++ b/lib/image_pipe/source/http/address_policy.ex
@@ -1,0 +1,39 @@
+defmodule ImagePipe.Source.HTTP.AddressPolicy do
+  @moduledoc false
+
+  @type category ::
+          :loopback
+          | :unspecified
+          | :link_local
+          | :private
+          | :unique_local
+          | :multicast
+          | :broadcast
+          | :cgnat
+          | :reserved
+          | :public
+
+  @spec classify(:inet.ip_address()) :: category()
+  def classify({a, b, c, d}) do
+    classify_v4(a, b, c, d)
+  end
+
+  defp classify_v4(0, _, _, _), do: :unspecified
+  defp classify_v4(127, _, _, _), do: :loopback
+  defp classify_v4(169, 254, _, _), do: :link_local
+  defp classify_v4(10, _, _, _), do: :private
+  defp classify_v4(172, b, _, _) when b in 16..31, do: :private
+  defp classify_v4(192, 168, _, _), do: :private
+  defp classify_v4(100, b, _, _) when b in 64..127, do: :cgnat
+  defp classify_v4(a, _, _, _) when a in 224..239, do: :multicast
+  defp classify_v4(255, 255, 255, 255), do: :broadcast
+  # benchmarking 198.18.0.0/15
+  defp classify_v4(198, b, _, _) when b in 18..19, do: :reserved
+  # documentation 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24
+  defp classify_v4(192, 0, 2, _), do: :reserved
+  defp classify_v4(198, 51, 100, _), do: :reserved
+  defp classify_v4(203, 0, 113, _), do: :reserved
+  # 240.0.0.0/4 reserved (future use)
+  defp classify_v4(a, _, _, _) when a in 240..255, do: :reserved
+  defp classify_v4(_, _, _, _), do: :public
+end

--- a/lib/image_pipe/source/http/address_policy.ex
+++ b/lib/image_pipe/source/http/address_policy.ex
@@ -14,9 +14,40 @@ defmodule ImagePipe.Source.HTTP.AddressPolicy do
           | :public
 
   @spec classify(:inet.ip_address()) :: category()
-  def classify({a, b, c, d}) do
-    classify_v4(a, b, c, d)
+  def classify({a, b, c, d}), do: classify_v4(a, b, c, d)
+
+  def classify({_, _, _, _, _, _, _, _} = v6) do
+    case canonicalize_v6(v6) do
+      {:v4, {a, b, c, d}} -> classify_v4(a, b, c, d)
+      {:v6, v6} -> classify_v6(v6)
+    end
   end
+
+  # IPv4-mapped ::ffff:0:0/96
+  defp canonicalize_v6({0, 0, 0, 0, 0, 0xFFFF, g, h}), do: {:v4, embed_v4(g, h)}
+  # 6to4 2002::/16 embeds v4 in the next two groups
+  defp canonicalize_v6({0x2002, g, h, _, _, _, _, _}), do: {:v4, embed_v4(g, h)}
+  defp canonicalize_v6(v6), do: {:v6, v6}
+
+  defp embed_v4(g, h) do
+    <<a, b>> = <<g::16>>
+    <<c, d>> = <<h::16>>
+    {a, b, c, d}
+  end
+
+  defp classify_v6({0, 0, 0, 0, 0, 0, 0, 0}), do: :unspecified
+  defp classify_v6({0, 0, 0, 0, 0, 0, 0, 1}), do: :loopback
+  # NAT64 64:ff9b::/96 — treat as non-public (we did not embed-unwrap it)
+  defp classify_v6({0x64, 0xFF9B, 0, 0, 0, 0, _, _}), do: :reserved
+  defp classify_v6({a, _, _, _, _, _, _, _}) when a >= 0xFE80 and a <= 0xFEBF, do: :link_local
+  defp classify_v6({a, _, _, _, _, _, _, _}) when a >= 0xFC00 and a <= 0xFDFF, do: :unique_local
+  defp classify_v6({a, _, _, _, _, _, _, _}) when a >= 0xFF00, do: :multicast
+
+  # 3fff::/20 reserved for documentation (RFC 9637) — MUST come BEFORE the 2000..3FFF public clause
+  defp classify_v6({0x3FFF, b, _, _, _, _, _, _}) when b < 0x1000, do: :reserved
+  # Global unicast 2000::/3 is the only public v6 space; everything else denies.
+  defp classify_v6({a, _, _, _, _, _, _, _}) when a >= 0x2000 and a <= 0x3FFF, do: :public
+  defp classify_v6(_), do: :reserved
 
   defp classify_v4(0, _, _, _), do: :unspecified
   defp classify_v4(127, _, _, _), do: :loopback

--- a/lib/image_pipe/source/http/target_guard.ex
+++ b/lib/image_pipe/source/http/target_guard.ex
@@ -1,0 +1,65 @@
+defmodule ImagePipe.Source.HTTP.TargetGuard do
+  @moduledoc false
+
+  alias ImagePipe.Source.HTTP.AddressPolicy
+
+  @type resolver :: (String.t() -> {:ok, [:inet.ip_address()]} | {:error, term()})
+
+  @spec validate(String.t(), [String.t()], AddressPolicy.predicate(), resolver()) ::
+          :ok | {:error, :denied_scheme | :denied_host | :denied_address}
+  def validate(url, allowed_hosts, predicate, resolver) when is_binary(url) do
+    uri = URI.parse(url)
+
+    with :ok <- check_scheme(uri),
+         host = String.downcase(uri.host || ""),
+         :ok <- check_host(host, allowed_hosts),
+         {:ok, addresses} <- resolve(host, resolver) do
+      if AddressPolicy.allow?(predicate, addresses), do: :ok, else: {:error, :denied_address}
+    end
+  end
+
+  defp check_scheme(%URI{scheme: scheme}) when scheme in ["http", "https"], do: :ok
+  defp check_scheme(_uri), do: {:error, :denied_scheme}
+
+  defp check_host(host, allowed_hosts) do
+    if host != "" and host in allowed_hosts, do: :ok, else: {:error, :denied_host}
+  end
+
+  defp resolve(host, resolver) do
+    case :inet.parse_address(String.to_charlist(host)) do
+      {:ok, ip} -> {:ok, [ip]}
+      {:error, _} -> resolve_via(host, resolver)
+    end
+  end
+
+  defp resolve_via(host, resolver) do
+    case resolver.(host) do
+      {:ok, addresses} when is_list(addresses) -> {:ok, addresses}
+      _ -> {:error, :denied_address}
+    end
+  rescue
+    _ -> {:error, :denied_address}
+  end
+
+  @spec default_resolver(String.t()) :: {:ok, [:inet.ip_address()]} | {:error, term()}
+  def default_resolver(host) do
+    charlist = String.to_charlist(host)
+
+    v4 =
+      case :inet.getaddrs(charlist, :inet) do
+        {:ok, addrs} -> addrs
+        {:error, _} -> []
+      end
+
+    v6 =
+      case :inet.getaddrs(charlist, :inet6) do
+        {:ok, addrs} -> addrs
+        {:error, _} -> []
+      end
+
+    case v4 ++ v6 do
+      [] -> {:error, :nxdomain}
+      addresses -> {:ok, addresses}
+    end
+  end
+end

--- a/lib/image_pipe/source/req_stream.ex
+++ b/lib/image_pipe/source/req_stream.ex
@@ -30,9 +30,26 @@ defmodule ImagePipe.Source.ReqStream do
   end
 
   defp open_response(req_options, runtime_opts) do
-    request_options = request_options(req_options)
+    validate = Keyword.get(runtime_opts, :validate_target, fn _url -> :ok end)
+    max_redirects = timeout(req_options, runtime_opts, :max_redirects, 0)
+    redirects_allowed? = max_redirects > 0
+    follow(req_options, runtime_opts, validate, max_redirects, redirects_allowed?)
+  end
 
-    case Req.get(request_options,
+  defp follow(req_options, runtime_opts, validate, redirects_left, redirects_allowed?) do
+    url = Keyword.fetch!(req_options, :url)
+
+    case validate.(url) do
+      :ok ->
+        request_and_route(req_options, runtime_opts, validate, redirects_left, redirects_allowed?)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp request_and_route(req_options, runtime_opts, validate, redirects_left, redirects_allowed?) do
+    case Req.get(request_options(req_options),
            receive_timeout:
              timeout(req_options, runtime_opts, :receive_timeout, @default_receive_timeout),
            pool_timeout: timeout(req_options, runtime_opts, :pool_timeout, @default_pool_timeout),
@@ -45,12 +62,65 @@ defmodule ImagePipe.Source.ReqStream do
             timeout(req_options, runtime_opts, :receive_timeout, @default_receive_timeout)
         }
 
+      {:ok, %Req.Response{status: status} = response} when status in 300..399 ->
+        route_redirect(
+          response,
+          req_options,
+          runtime_opts,
+          validate,
+          redirects_left,
+          redirects_allowed?
+        )
+
       {:ok, %Req.Response{} = response} ->
         cancel_response(response)
         {:error, :bad_status}
 
       {:error, _exception} ->
         {:error, :bad_status}
+    end
+  end
+
+  defp route_redirect(
+         response,
+         req_options,
+         runtime_opts,
+         validate,
+         redirects_left,
+         redirects_allowed?
+       ) do
+    location = location_header(response)
+    cancel_response(response)
+
+    cond do
+      redirects_left <= 0 ->
+        if redirects_allowed?, do: {:error, :too_many_redirects}, else: {:error, :bad_status}
+
+      is_nil(location) ->
+        {:error, :bad_status}
+
+      true ->
+        next_url =
+          req_options
+          |> Keyword.fetch!(:url)
+          |> URI.parse()
+          |> URI.merge(location)
+          |> URI.to_string()
+
+        follow(
+          Keyword.put(req_options, :url, next_url),
+          runtime_opts,
+          validate,
+          redirects_left - 1,
+          redirects_allowed?
+        )
+    end
+  end
+
+  defp location_header(%Req.Response{} = response) do
+    case Req.Response.get_header(response, "location") do
+      [value | _] -> value
+      [] -> nil
     end
   end
 
@@ -91,7 +161,8 @@ defmodule ImagePipe.Source.ReqStream do
   defp request_options(req_options) do
     Keyword.merge(req_options,
       into: :self,
-      retry: false
+      retry: false,
+      redirect: false
     )
   end
 

--- a/test/image_pipe/source/http/address_policy_test.exs
+++ b/test/image_pipe/source/http/address_policy_test.exs
@@ -52,4 +52,28 @@ defmodule ImagePipe.Source.HTTP.AddressPolicyTest do
       refute AddressPolicy.classify({0x3FFF, 0, 0, 0, 0, 0, 0, 1}) == :public
     end
   end
+
+  describe "CIDR" do
+    test "parse_cidr/1 accepts valid v4/v6 CIDRs and rejects junk" do
+      assert {:ok, _} = AddressPolicy.parse_cidr("10.0.5.0/24")
+      assert {:ok, _} = AddressPolicy.parse_cidr("2001:db8::/32")
+      assert :error = AddressPolicy.parse_cidr("10.0.5.0")
+      assert :error = AddressPolicy.parse_cidr("10.0.5.0/33")
+      assert :error = AddressPolicy.parse_cidr("nonsense")
+      assert :error = AddressPolicy.parse_cidr("2001:db8::/129")
+    end
+
+    test "in_cidr?/2 matches membership" do
+      {:ok, cidr} = AddressPolicy.parse_cidr("10.0.5.0/24")
+      assert AddressPolicy.in_cidr?({10, 0, 5, 7}, cidr)
+      assert AddressPolicy.in_cidr?({10, 0, 5, 0}, cidr)
+      assert AddressPolicy.in_cidr?({10, 0, 5, 255}, cidr)
+      refute AddressPolicy.in_cidr?({10, 0, 6, 1}, cidr)
+      refute AddressPolicy.in_cidr?({10, 0, 5, 7, 0, 0, 0, 0}, cidr)
+
+      {:ok, cidr6} = AddressPolicy.parse_cidr("2001:db8::/32")
+      assert AddressPolicy.in_cidr?({0x2001, 0x0DB8, 1, 2, 3, 4, 5, 6}, cidr6)
+      refute AddressPolicy.in_cidr?({0x2001, 0x0DB9, 0, 0, 0, 0, 0, 0}, cidr6)
+    end
+  end
 end

--- a/test/image_pipe/source/http/address_policy_test.exs
+++ b/test/image_pipe/source/http/address_policy_test.exs
@@ -1,5 +1,6 @@
 defmodule ImagePipe.Source.HTTP.AddressPolicyTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias ImagePipe.Source.HTTP.AddressPolicy
 
@@ -74,6 +75,89 @@ defmodule ImagePipe.Source.HTTP.AddressPolicyTest do
       {:ok, cidr6} = AddressPolicy.parse_cidr("2001:db8::/32")
       assert AddressPolicy.in_cidr?({0x2001, 0x0DB8, 1, 2, 3, 4, 5, 6}, cidr6)
       refute AddressPolicy.in_cidr?({0x2001, 0x0DB9, 0, 0, 0, 0, 0, 0}, cidr6)
+    end
+  end
+
+  describe "compile/1 + allow?/2" do
+    test "default keyword policy denies all non-public, allows public" do
+      pred = AddressPolicy.compile([])
+      assert AddressPolicy.allow?(pred, [{93, 184, 216, 34}])
+      refute AddressPolicy.allow?(pred, [{10, 0, 0, 1}])
+      refute AddressPolicy.allow?(pred, [{127, 0, 0, 1}])
+    end
+
+    test "category toggles open whole categories" do
+      pred = AddressPolicy.compile(allow_private: true)
+      assert AddressPolicy.allow?(pred, [{10, 0, 0, 1}])
+      refute AddressPolicy.allow?(pred, [{127, 0, 0, 1}])
+    end
+
+    test "CIDR allow opens exactly the named range" do
+      pred = AddressPolicy.compile(allow: ["10.0.5.0/24"])
+      assert AddressPolicy.allow?(pred, [{10, 0, 5, 7}])
+      refute AddressPolicy.allow?(pred, [{10, 0, 6, 7}])
+    end
+
+    test "block-if-any: one bad address denies the whole set" do
+      pred = AddressPolicy.compile([])
+      refute AddressPolicy.allow?(pred, [{93, 184, 216, 34}, {10, 0, 0, 1}])
+    end
+
+    test "malformed / empty address set denies" do
+      pred = AddressPolicy.compile([])
+      refute AddressPolicy.allow?(pred, [])
+      refute AddressPolicy.allow?(pred, [:not_an_ip])
+    end
+
+    test "function form replaces built-in decision" do
+      pred = AddressPolicy.compile(fn _ip, category -> category == :public end)
+      assert AddressPolicy.allow?(pred, [{93, 184, 216, 34}])
+      refute AddressPolicy.allow?(pred, [{10, 0, 0, 1}])
+    end
+
+    test "function form fails closed on non-boolean return and on raise" do
+      pred_bad = AddressPolicy.compile(fn _ip, _cat -> :yes end)
+      refute AddressPolicy.allow?(pred_bad, [{93, 184, 216, 34}])
+
+      pred_raise = AddressPolicy.compile(fn _ip, _cat -> raise "boom" end)
+      refute AddressPolicy.allow?(pred_raise, [{93, 184, 216, 34}])
+    end
+  end
+
+  describe "property: classify is total and deny-default" do
+    property "no IPv4 tuple crashes classify/1" do
+      check all a <- integer(0..255),
+                b <- integer(0..255),
+                c <- integer(0..255),
+                d <- integer(0..255) do
+        assert AddressPolicy.classify({a, b, c, d}) in [
+                 :loopback,
+                 :unspecified,
+                 :link_local,
+                 :private,
+                 :unique_local,
+                 :multicast,
+                 :broadcast,
+                 :cgnat,
+                 :reserved,
+                 :public
+               ]
+      end
+    end
+
+    property "default policy never allows a non-public IPv4" do
+      pred = AddressPolicy.compile([])
+
+      check all a <- integer(0..255),
+                b <- integer(0..255),
+                c <- integer(0..255),
+                d <- integer(0..255) do
+        ip = {a, b, c, d}
+
+        if AddressPolicy.classify(ip) != :public do
+          refute AddressPolicy.allow?(pred, [ip])
+        end
+      end
     end
   end
 end

--- a/test/image_pipe/source/http/address_policy_test.exs
+++ b/test/image_pipe/source/http/address_policy_test.exs
@@ -1,0 +1,27 @@
+defmodule ImagePipe.Source.HTTP.AddressPolicyTest do
+  use ExUnit.Case, async: true
+
+  alias ImagePipe.Source.HTTP.AddressPolicy
+
+  describe "classify/1 IPv4" do
+    test "categorizes well-known IPv4 ranges" do
+      assert AddressPolicy.classify({127, 0, 0, 1}) == :loopback
+      assert AddressPolicy.classify({127, 5, 5, 5}) == :loopback
+      assert AddressPolicy.classify({0, 0, 0, 0}) == :unspecified
+      assert AddressPolicy.classify({0, 1, 2, 3}) == :unspecified
+      assert AddressPolicy.classify({169, 254, 169, 254}) == :link_local
+      assert AddressPolicy.classify({10, 0, 0, 1}) == :private
+      assert AddressPolicy.classify({172, 16, 0, 1}) == :private
+      assert AddressPolicy.classify({172, 31, 255, 255}) == :private
+      assert AddressPolicy.classify({172, 32, 0, 1}) == :public
+      assert AddressPolicy.classify({192, 168, 1, 1}) == :private
+      assert AddressPolicy.classify({100, 64, 0, 1}) == :cgnat
+      assert AddressPolicy.classify({224, 0, 0, 1}) == :multicast
+      assert AddressPolicy.classify({255, 255, 255, 255}) == :broadcast
+      assert AddressPolicy.classify({198, 18, 0, 1}) == :reserved
+      assert AddressPolicy.classify({192, 0, 2, 5}) == :reserved
+      assert AddressPolicy.classify({93, 184, 216, 34}) == :public
+      assert AddressPolicy.classify({8, 8, 8, 8}) == :public
+    end
+  end
+end

--- a/test/image_pipe/source/http/address_policy_test.exs
+++ b/test/image_pipe/source/http/address_policy_test.exs
@@ -49,6 +49,10 @@ defmodule ImagePipe.Source.HTTP.AddressPolicyTest do
       assert AddressPolicy.classify({0x2002, 0x5DB8, 0xD822, 0, 0, 0, 0, 0}) == :public
     end
 
+    test "blocks the IPv6 documentation range 2001:db8::/32" do
+      assert AddressPolicy.classify({0x2001, 0x0DB8, 0, 0, 0, 0, 0, 1}) == :reserved
+    end
+
     test "unknown IPv6 never defaults to :public (deny-default)" do
       refute AddressPolicy.classify({0x3FFF, 0, 0, 0, 0, 0, 0, 1}) == :public
     end
@@ -157,6 +161,33 @@ defmodule ImagePipe.Source.HTTP.AddressPolicyTest do
         if AddressPolicy.classify(ip) != :public do
           refute AddressPolicy.allow?(pred, [ip])
         end
+      end
+    end
+
+    property "IPv6 classify is total over all 8-group tuples" do
+      check all groups <- list_of(integer(0..0xFFFF), length: 8) do
+        assert AddressPolicy.classify(List.to_tuple(groups)) in [
+                 :loopback,
+                 :unspecified,
+                 :link_local,
+                 :private,
+                 :unique_local,
+                 :multicast,
+                 :broadcast,
+                 :cgnat,
+                 :reserved,
+                 :public
+               ]
+      end
+    end
+
+    property "IPv6 outside the 2000::/3 public window denies (deny-default)" do
+      # Leading group strictly above the public window (0x2000..0x3FFF) and below
+      # the ULA/link-local/multicast prefixes (which start at 0xFC00) — this is the
+      # unassigned/reserved space that must NEVER classify as :public.
+      check all first <- integer(0x4000..0xEFFF),
+                rest <- list_of(integer(0..0xFFFF), length: 7) do
+        assert AddressPolicy.classify(List.to_tuple([first | rest])) == :reserved
       end
     end
   end

--- a/test/image_pipe/source/http/address_policy_test.exs
+++ b/test/image_pipe/source/http/address_policy_test.exs
@@ -24,4 +24,32 @@ defmodule ImagePipe.Source.HTTP.AddressPolicyTest do
       assert AddressPolicy.classify({8, 8, 8, 8}) == :public
     end
   end
+
+  describe "classify/1 IPv6 and canonicalization" do
+    test "categorizes native IPv6 ranges" do
+      assert AddressPolicy.classify({0, 0, 0, 0, 0, 0, 0, 0}) == :unspecified
+      assert AddressPolicy.classify({0, 0, 0, 0, 0, 0, 0, 1}) == :loopback
+      assert AddressPolicy.classify({0xFE80, 0, 0, 0, 0, 0, 0, 1}) == :link_local
+      assert AddressPolicy.classify({0xFC00, 0, 0, 0, 0, 0, 0, 1}) == :unique_local
+      assert AddressPolicy.classify({0xFD00, 0, 0, 0, 0, 0, 0, 1}) == :unique_local
+      assert AddressPolicy.classify({0xFF00, 0, 0, 0, 0, 0, 0, 1}) == :multicast
+      assert AddressPolicy.classify({0x2606, 0x2800, 0, 0, 0, 0, 0, 1}) == :public
+    end
+
+    test "unwraps IPv4-mapped IPv6 and classifies by embedded v4 (dotted and hex spellings)" do
+      assert AddressPolicy.classify({0, 0, 0, 0, 0, 0xFFFF, 0x0A00, 0x0001}) == :private
+      assert AddressPolicy.classify({0, 0, 0, 0, 0, 0xFFFF, 0x7F00, 0x0001}) == :loopback
+      assert AddressPolicy.classify({0, 0, 0, 0, 0, 0xFFFF, 0x5DB8, 0xD822}) == :public
+    end
+
+    test "blocks NAT64 and unwraps 6to4 by embedded v4" do
+      assert AddressPolicy.classify({0x64, 0xFF9B, 0, 0, 0, 0, 0x0A00, 0x0001}) == :reserved
+      assert AddressPolicy.classify({0x2002, 0x7F00, 0x0001, 0, 0, 0, 0, 0}) == :loopback
+      assert AddressPolicy.classify({0x2002, 0x5DB8, 0xD822, 0, 0, 0, 0, 0}) == :public
+    end
+
+    test "unknown IPv6 never defaults to :public (deny-default)" do
+      refute AddressPolicy.classify({0x3FFF, 0, 0, 0, 0, 0, 0, 1}) == :public
+    end
+  end
 end

--- a/test/image_pipe/source/http/target_guard_test.exs
+++ b/test/image_pipe/source/http/target_guard_test.exs
@@ -1,0 +1,107 @@
+defmodule ImagePipe.Source.HTTP.TargetGuardTest do
+  use ExUnit.Case, async: true
+
+  alias ImagePipe.Source.HTTP.{AddressPolicy, TargetGuard}
+
+  defp default_policy, do: AddressPolicy.compile([])
+
+  defp resolver(map) do
+    fn host -> Map.get(map, host, {:error, :nxdomain}) end
+  end
+
+  test "allows a public host that resolves to a public IP" do
+    res = resolver(%{"assets.example.com" => {:ok, [{93, 184, 216, 34}]}})
+
+    assert TargetGuard.validate(
+             "https://assets.example.com/x.jpg",
+             ["assets.example.com"],
+             default_policy(),
+             res
+           ) == :ok
+  end
+
+  test "denies non-http(s) scheme before host checks" do
+    assert TargetGuard.validate(
+             "file:///etc/passwd",
+             ["assets.example.com"],
+             default_policy(),
+             resolver(%{})
+           ) ==
+             {:error, :denied_scheme}
+  end
+
+  test "denies a host outside allowed_hosts, case-insensitively matched" do
+    res = resolver(%{"assets.example.com" => {:ok, [{93, 184, 216, 34}]}})
+
+    assert TargetGuard.validate(
+             "https://ASSETS.EXAMPLE.COM/x",
+             ["assets.example.com"],
+             default_policy(),
+             res
+           ) == :ok
+
+    assert TargetGuard.validate(
+             "https://evil.example/x",
+             ["assets.example.com"],
+             default_policy(),
+             res
+           ) ==
+             {:error, :denied_host}
+  end
+
+  test "denies when the host resolves to a private IP" do
+    res = resolver(%{"assets.example.com" => {:ok, [{10, 0, 0, 1}]}})
+
+    assert TargetGuard.validate(
+             "https://assets.example.com/x",
+             ["assets.example.com"],
+             default_policy(),
+             res
+           ) ==
+             {:error, :denied_address}
+  end
+
+  test "classifies IP-literal hosts directly without calling the resolver" do
+    res = fn _ -> flunk("resolver should not be called for a literal") end
+
+    assert TargetGuard.validate("https://10.0.0.1/x", ["10.0.0.1"], default_policy(), res) ==
+             {:error, :denied_address}
+
+    assert TargetGuard.validate(
+             "https://93.184.216.34/x",
+             ["93.184.216.34"],
+             default_policy(),
+             res
+           ) == :ok
+  end
+
+  test "classifies bracketed IPv6 literal hosts" do
+    res = fn _ -> flunk("resolver should not be called for a literal") end
+
+    assert TargetGuard.validate("http://[::1]/x", ["::1"], default_policy(), res) ==
+             {:error, :denied_address}
+  end
+
+  test "fails closed on resolver error, empty, and raise" do
+    assert TargetGuard.validate(
+             "https://h/x",
+             ["h"],
+             default_policy(),
+             resolver(%{"h" => {:error, :nxdomain}})
+           ) ==
+             {:error, :denied_address}
+
+    assert TargetGuard.validate(
+             "https://h/x",
+             ["h"],
+             default_policy(),
+             resolver(%{"h" => {:ok, []}})
+           ) ==
+             {:error, :denied_address}
+
+    raise_res = fn _ -> raise "dns boom" end
+
+    assert TargetGuard.validate("https://h/x", ["h"], default_policy(), raise_res) ==
+             {:error, :denied_address}
+  end
+end

--- a/test/image_pipe/source/http_test.exs
+++ b/test/image_pipe/source/http_test.exs
@@ -15,6 +15,20 @@ defmodule ImagePipe.Source.HTTPTest do
     fn host -> Map.get(map, host, {:error, :nxdomain}) end
   end
 
+  defp fetch_stream(opts_kw, source) do
+    {:ok, opts} = HTTP.validate_options(opts_kw)
+    {:ok, resolved} = HTTP.resolve(source, opts, [])
+
+    {:ok, %Response{} = response} =
+      Source.fetch(resolved, [sources: %{https: {HTTP, opts}}], max_body_bytes: 64)
+
+    response.stream
+  end
+
+  defp ok_plug do
+    fn conn -> Plug.Conn.send_resp(conn, 200, "image bytes") end
+  end
+
   test "http source defaults to not stable and disables internal cache in auto mode" do
     assert {:ok, opts} = HTTP.validate_options(allowed_hosts: ["example.com"])
     source = %URL{scheme: :https, host: "example.com", path: ["cat.jpg"]}
@@ -430,5 +444,172 @@ defmodule ImagePipe.Source.HTTPTest do
 
     error = assert_raise Source.StreamError, fn -> Enum.to_list(response.stream) end
     assert error.reason == :denied_host
+  end
+
+  describe "SSRF guard" do
+    test "origin host resolving to a private address is blocked (DNS branch)" do
+      source = %URL{scheme: :https, host: "assets.example.com", path: ["x.jpg"]}
+
+      stream =
+        fetch_stream(
+          [
+            allowed_hosts: ["assets.example.com"],
+            address_resolver: stub_resolver(%{"assets.example.com" => {:ok, [{10, 0, 0, 5}]}}),
+            req_options: [plug: ok_plug()]
+          ],
+          source
+        )
+
+      error = assert_raise Source.StreamError, fn -> Enum.to_list(stream) end
+      assert error.reason == :denied_address
+    end
+
+    test "origin IP-literal private host is blocked (literal branch, no resolver)" do
+      source = %URL{scheme: :https, host: "10.0.0.5", path: ["x.jpg"]}
+
+      stream =
+        fetch_stream(
+          [allowed_hosts: ["10.0.0.5"], req_options: [plug: ok_plug()]],
+          source
+        )
+
+      error = assert_raise Source.StreamError, fn -> Enum.to_list(stream) end
+      assert error.reason == :denied_address
+    end
+
+    test "169.254.169.254 cloud metadata literal is blocked" do
+      source = %URL{scheme: :https, host: "169.254.169.254", path: ["latest", "meta-data"]}
+
+      stream =
+        fetch_stream(
+          [allowed_hosts: ["169.254.169.254"], req_options: [plug: ok_plug()]],
+          source
+        )
+
+      error = assert_raise Source.StreamError, fn -> Enum.to_list(stream) end
+      assert error.reason == :denied_address
+    end
+
+    test "trusted origin redirecting to a loopback target is blocked on the hop" do
+      plug = fn
+        %{request_path: "/redirect.jpg"} = conn ->
+          conn
+          |> Plug.Conn.put_resp_header("location", "http://127.0.0.1/x")
+          |> Plug.Conn.send_resp(302, "")
+
+        _conn ->
+          flunk("must not connect to loopback redirect target")
+      end
+
+      source = %URL{scheme: :https, host: "assets.example.com", path: ["redirect.jpg"]}
+
+      stream =
+        fetch_stream(
+          [
+            allowed_hosts: ["assets.example.com", "127.0.0.1"],
+            max_redirects: 1,
+            address_resolver: stub_resolver(),
+            req_options: [plug: plug]
+          ],
+          source
+        )
+
+      error = assert_raise Source.StreamError, fn -> Enum.to_list(stream) end
+      assert error.reason == :denied_address
+    end
+
+    test "non-http(s) redirect scheme is rejected" do
+      plug = fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "file:///etc/passwd")
+        |> Plug.Conn.send_resp(302, "")
+      end
+
+      source = %URL{scheme: :https, host: "assets.example.com", path: ["redirect.jpg"]}
+
+      stream =
+        fetch_stream(
+          [
+            allowed_hosts: ["assets.example.com"],
+            max_redirects: 1,
+            address_resolver: stub_resolver(),
+            req_options: [plug: plug]
+          ],
+          source
+        )
+
+      error = assert_raise Source.StreamError, fn -> Enum.to_list(stream) end
+      assert error.reason == :denied_scheme
+    end
+
+    test "allow_private opt-in lets a private origin through" do
+      source = %URL{scheme: :https, host: "assets.example.com", path: ["x.jpg"]}
+
+      stream =
+        fetch_stream(
+          [
+            allowed_hosts: ["assets.example.com"],
+            address_policy: [allow_private: true],
+            address_resolver: stub_resolver(%{"assets.example.com" => {:ok, [{10, 0, 0, 5}]}}),
+            req_options: [plug: ok_plug()]
+          ],
+          source
+        )
+
+      assert Enum.join(stream) == "image bytes"
+    end
+
+    test "precise CIDR allow lets only the named range through" do
+      source = %URL{scheme: :https, host: "in.example", path: ["x.jpg"]}
+
+      base = [
+        allowed_hosts: ["in.example"],
+        address_policy: [allow: ["10.0.5.0/24"]],
+        req_options: [plug: ok_plug()]
+      ]
+
+      ok_stream =
+        fetch_stream(
+          Keyword.put(
+            base,
+            :address_resolver,
+            stub_resolver(%{"in.example" => {:ok, [{10, 0, 5, 9}]}})
+          ),
+          source
+        )
+
+      assert Enum.join(ok_stream) == "image bytes"
+
+      blocked_stream =
+        fetch_stream(
+          Keyword.put(
+            base,
+            :address_resolver,
+            stub_resolver(%{"in.example" => {:ok, [{10, 0, 6, 9}]}})
+          ),
+          source
+        )
+
+      error = assert_raise Source.StreamError, fn -> Enum.to_list(blocked_stream) end
+      assert error.reason == :denied_address
+    end
+
+    test "function-form policy replaces the built-in decision" do
+      source = %URL{scheme: :https, host: "assets.example.com", path: ["x.jpg"]}
+
+      blocked =
+        fetch_stream(
+          [
+            allowed_hosts: ["assets.example.com"],
+            address_policy: fn _ip, category -> category == :public end,
+            address_resolver: stub_resolver(%{"assets.example.com" => {:ok, [{10, 0, 0, 5}]}}),
+            req_options: [plug: ok_plug()]
+          ],
+          source
+        )
+
+      error = assert_raise Source.StreamError, fn -> Enum.to_list(blocked) end
+      assert error.reason == :denied_address
+    end
   end
 end

--- a/test/image_pipe/source/http_test.exs
+++ b/test/image_pipe/source/http_test.exs
@@ -7,6 +7,14 @@ defmodule ImagePipe.Source.HTTPTest do
   alias ImagePipe.Source.Resolved
   alias ImagePipe.Source.Response
 
+  @public_ip {93, 184, 216, 34}
+
+  defp stub_resolver(extra \\ %{}) do
+    base = %{"assets.example.com" => {:ok, [@public_ip]}}
+    map = Map.merge(base, extra)
+    fn host -> Map.get(map, host, {:error, :nxdomain}) end
+  end
+
   test "http source defaults to not stable and disables internal cache in auto mode" do
     assert {:ok, opts} = HTTP.validate_options(allowed_hosts: ["example.com"])
     source = %URL{scheme: :https, host: "example.com", path: ["cat.jpg"]}
@@ -110,6 +118,7 @@ defmodule ImagePipe.Source.HTTPTest do
     assert {:ok, opts} =
              HTTP.validate_options(
                allowed_hosts: ["assets.example.com"],
+               address_resolver: stub_resolver(),
                req_options: [plug: plug]
              )
 
@@ -145,6 +154,7 @@ defmodule ImagePipe.Source.HTTPTest do
              HTTP.validate_options(
                allowed_hosts: ["assets.example.com"],
                internal_cache: :enabled,
+               address_resolver: stub_resolver(),
                req_options: [
                  plug: plug,
                  url: "https://evil.example/other.jpg",
@@ -200,6 +210,7 @@ defmodule ImagePipe.Source.HTTPTest do
                allowed_hosts: ["assets.example.com"],
                stable: :trusted,
                internal_cache: :disabled,
+               address_resolver: stub_resolver(),
                req_options: [
                  plug: plug,
                  headers: [
@@ -251,6 +262,7 @@ defmodule ImagePipe.Source.HTTPTest do
              HTTP.validate_options(
                allowed_hosts: ["assets.example.com"],
                max_redirects: 1,
+               address_resolver: stub_resolver(),
                req_options: [plug: plug]
              )
 
@@ -281,6 +293,7 @@ defmodule ImagePipe.Source.HTTPTest do
     assert {:ok, opts} =
              HTTP.validate_options(
                allowed_hosts: ["assets.example.com"],
+               address_resolver: stub_resolver(),
                req_options: [plug: plug, max_redirects: 10]
              )
 
@@ -310,6 +323,7 @@ defmodule ImagePipe.Source.HTTPTest do
     assert {:ok, opts} =
              HTTP.validate_options(
                allowed_hosts: ["assets.example.com"],
+               address_resolver: stub_resolver(),
                req_options: [plug: plug]
              )
 
@@ -339,6 +353,8 @@ defmodule ImagePipe.Source.HTTPTest do
     assert {:ok, opts} =
              HTTP.validate_options(
                allowed_hosts: ["::1"],
+               address_resolver: stub_resolver(%{"::1" => {:ok, [{0, 0, 0, 0, 0, 0, 0, 1}]}}),
+               address_policy: [allow_loopback: true],
                req_options: [plug: plug]
              )
 
@@ -367,6 +383,7 @@ defmodule ImagePipe.Source.HTTPTest do
     assert {:ok, opts} =
              HTTP.validate_options(
                allowed_hosts: ["assets.example.com"],
+               address_resolver: stub_resolver(),
                req_options: [plug: plug]
              )
 
@@ -379,11 +396,15 @@ defmodule ImagePipe.Source.HTTPTest do
     assert error.reason == :bad_status
   end
 
-  test "redirects cannot bypass allowed host policy" do
-    plug = fn conn ->
-      conn
-      |> Plug.Conn.put_resp_header("location", "https://evil.example/cat.jpg")
-      |> Plug.Conn.send_resp(302, "")
+  test "an enabled redirect to an off-allowlist host is denied" do
+    plug = fn
+      %{request_path: "/redirect.jpg"} = conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "https://evil.example/x.jpg")
+        |> Plug.Conn.send_resp(302, "")
+
+      _conn ->
+        flunk("must not connect to the off-allowlist redirect target")
     end
 
     source = %URL{
@@ -397,6 +418,8 @@ defmodule ImagePipe.Source.HTTPTest do
     assert {:ok, opts} =
              HTTP.validate_options(
                allowed_hosts: ["assets.example.com"],
+               max_redirects: 1,
+               address_resolver: stub_resolver(),
                req_options: [plug: plug]
              )
 
@@ -406,6 +429,6 @@ defmodule ImagePipe.Source.HTTPTest do
              Source.fetch(resolved, [sources: %{https: {HTTP, opts}}], max_body_bytes: 20)
 
     error = assert_raise Source.StreamError, fn -> Enum.to_list(response.stream) end
-    assert error.reason == :bad_status
+    assert error.reason == :denied_host
   end
 end

--- a/test/image_pipe/source/http_test.exs
+++ b/test/image_pipe/source/http_test.exs
@@ -446,6 +446,45 @@ defmodule ImagePipe.Source.HTTPTest do
     assert error.reason == :denied_host
   end
 
+  describe "address_policy validation" do
+    test "rejects a non-list :allow without raising" do
+      assert {:error, {:invalid_source_config, _}} =
+               HTTP.validate_options(allowed_hosts: ["x"], address_policy: [allow: "10.0.0.0/8"])
+    end
+
+    test "rejects non-binary :allow entries without raising" do
+      assert {:error, {:invalid_source_config, _}} =
+               HTTP.validate_options(allowed_hosts: ["x"], address_policy: [allow: [123]])
+    end
+
+    test "rejects an invalid CIDR string" do
+      assert {:error, {:invalid_source_config, _}} =
+               HTTP.validate_options(
+                 allowed_hosts: ["x"],
+                 address_policy: [allow: ["10.0.0.0/99"]]
+               )
+    end
+
+    test "rejects an unknown address_policy key" do
+      assert {:error, {:invalid_source_config, _}} =
+               HTTP.validate_options(allowed_hosts: ["x"], address_policy: [bogus: true])
+    end
+
+    test "accepts a valid keyword policy and a 2-arity function" do
+      assert {:ok, _} =
+               HTTP.validate_options(
+                 allowed_hosts: ["x"],
+                 address_policy: [allow_private: true, allow: ["10.0.5.0/24"]]
+               )
+
+      assert {:ok, _} =
+               HTTP.validate_options(
+                 allowed_hosts: ["x"],
+                 address_policy: fn _ip, cat -> cat == :public end
+               )
+    end
+  end
+
   describe "SSRF guard" do
     test "origin host resolving to a private address is blocked (DNS branch)" do
       source = %URL{scheme: :https, host: "assets.example.com", path: ["x.jpg"]}
@@ -592,6 +631,33 @@ defmodule ImagePipe.Source.HTTPTest do
 
       error = assert_raise Source.StreamError, fn -> Enum.to_list(blocked_stream) end
       assert error.reason == :denied_address
+    end
+
+    test "an uppercase redirect host still matches the downcased allowlist and is fetched" do
+      plug = fn
+        %{request_path: "/redirect.jpg"} = conn ->
+          conn
+          |> Plug.Conn.put_resp_header("location", "https://ASSETS.EXAMPLE.COM/other.jpg")
+          |> Plug.Conn.send_resp(302, "")
+
+        conn ->
+          Plug.Conn.send_resp(conn, 200, "image bytes")
+      end
+
+      source = %URL{scheme: :https, host: "assets.example.com", path: ["redirect.jpg"]}
+
+      stream =
+        fetch_stream(
+          [
+            allowed_hosts: ["assets.example.com"],
+            max_redirects: 1,
+            address_resolver: stub_resolver(),
+            req_options: [plug: plug]
+          ],
+          source
+        )
+
+      assert Enum.join(stream) == "image bytes"
     end
 
     test "function-form policy replaces the built-in decision" do

--- a/test/image_pipe/source/http_test.exs
+++ b/test/image_pipe/source/http_test.exs
@@ -367,7 +367,6 @@ defmodule ImagePipe.Source.HTTPTest do
     assert {:ok, opts} =
              HTTP.validate_options(
                allowed_hosts: ["::1"],
-               address_resolver: stub_resolver(%{"::1" => {:ok, [{0, 0, 0, 0, 0, 0, 0, 1}]}}),
                address_policy: [allow_loopback: true],
                req_options: [plug: plug]
              )

--- a/test/image_pipe/source/req_stream_test.exs
+++ b/test/image_pipe/source/req_stream_test.exs
@@ -92,4 +92,65 @@ defmodule ImagePipe.Source.ReqStreamTest do
     error = assert_raise StreamError, fn -> Enum.to_list(stream) end
     assert error.reason == :too_many_redirects
   end
+
+  test "a protocol-relative redirect Location is merged to an absolute target before validation" do
+    plug = fn
+      %{request_path: "/r.jpg"} = conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "//hop.example/other.jpg")
+        |> Plug.Conn.send_resp(302, "")
+
+      conn ->
+        send(self(), {:got, conn.host, conn.request_path})
+        Plug.Conn.send_resp(conn, 200, "image bytes")
+    end
+
+    seen = self()
+
+    stream =
+      ReqStream.stream(
+        [url: "https://assets.example.com/r.jpg", plug: plug],
+        validate_target: fn url ->
+          send(seen, {:validated, url})
+          :ok
+        end,
+        max_redirects: 1
+      )
+
+    assert Enum.join(stream) == "image bytes"
+    # protocol-relative // inherits the https scheme from the base URL
+    assert_received {:validated, "https://assets.example.com/r.jpg"}
+    assert_received {:validated, "https://hop.example/other.jpg"}
+    assert_received {:got, "hop.example", "/other.jpg"}
+  end
+
+  test "a scheme-downgrade redirect is normalized and validated with the new scheme" do
+    plug = fn
+      %{request_path: "/r.jpg"} = conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "http://assets.example.com/plain.jpg")
+        |> Plug.Conn.send_resp(302, "")
+
+      conn ->
+        send(self(), {:got, conn.scheme, conn.request_path})
+        Plug.Conn.send_resp(conn, 200, "image bytes")
+    end
+
+    seen = self()
+
+    stream =
+      ReqStream.stream(
+        [url: "https://assets.example.com/r.jpg", plug: plug],
+        validate_target: fn url ->
+          send(seen, {:validated, url})
+          :ok
+        end,
+        max_redirects: 1
+      )
+
+    assert Enum.join(stream) == "image bytes"
+    assert_received {:validated, "https://assets.example.com/r.jpg"}
+    assert_received {:validated, "http://assets.example.com/plain.jpg"}
+    assert_received {:got, :http, "/plain.jpg"}
+  end
 end

--- a/test/image_pipe/source/req_stream_test.exs
+++ b/test/image_pipe/source/req_stream_test.exs
@@ -1,0 +1,95 @@
+defmodule ImagePipe.Source.ReqStreamTest do
+  use ExUnit.Case, async: true
+
+  alias ImagePipe.Source.ReqStream
+  alias ImagePipe.Source.StreamError
+
+  test "runs validate_target before connecting and raises the denial reason" do
+    plug = fn _conn -> flunk("must not connect when target is denied") end
+
+    stream =
+      ReqStream.stream(
+        [url: "https://blocked.example/x", plug: plug],
+        validate_target: fn _url -> {:error, :denied_address} end
+      )
+
+    error = assert_raise StreamError, fn -> Enum.to_list(stream) end
+    assert error.reason == :denied_address
+  end
+
+  test "follows a redirect itself and validates the hop target" do
+    plug = fn
+      %{request_path: "/redirect.jpg"} = conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "https://hop.example/other.jpg")
+        |> Plug.Conn.send_resp(302, "")
+
+      conn ->
+        send(self(), {:got, conn.host, conn.request_path})
+        Plug.Conn.send_resp(conn, 200, "image bytes")
+    end
+
+    seen = self()
+
+    stream =
+      ReqStream.stream(
+        [url: "https://assets.example.com/redirect.jpg", plug: plug],
+        validate_target: fn url ->
+          send(seen, {:validated, url})
+          :ok
+        end,
+        max_redirects: 1
+      )
+
+    assert Enum.join(stream) == "image bytes"
+    assert_received {:validated, "https://assets.example.com/redirect.jpg"}
+    assert_received {:validated, "https://hop.example/other.jpg"}
+    assert_received {:got, "hop.example", "/other.jpg"}
+  end
+
+  test "denies a redirect hop before connecting to it" do
+    plug = fn
+      %{request_path: "/redirect.jpg"} = conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "https://internal.example/x")
+        |> Plug.Conn.send_resp(302, "")
+
+      %{host: "internal.example"} ->
+        flunk("must not connect to denied hop")
+
+      conn ->
+        Plug.Conn.send_resp(conn, 200, "ok")
+    end
+
+    stream =
+      ReqStream.stream(
+        [url: "https://assets.example.com/redirect.jpg", plug: plug],
+        validate_target: fn
+          "https://internal.example/x" -> {:error, :denied_host}
+          _ -> :ok
+        end,
+        max_redirects: 3
+      )
+
+    error = assert_raise StreamError, fn -> Enum.to_list(stream) end
+    assert error.reason == :denied_host
+  end
+
+  test "exhausting max_redirects fails with too_many_redirects" do
+    plug = fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("location", "https://assets.example.com/loop")
+      |> Plug.Conn.send_resp(302, "")
+    end
+
+    stream =
+      ReqStream.stream(
+        [url: "https://assets.example.com/loop", plug: plug],
+        validate_target: fn _ -> :ok end,
+        max_redirects: 1
+      )
+
+    error = assert_raise StreamError, fn -> Enum.to_list(stream) end
+    assert error.reason == :too_many_redirects
+  end
+end

--- a/test/image_pipe/source_test.exs
+++ b/test/image_pipe/source_test.exs
@@ -138,7 +138,11 @@ defmodule ImagePipe.SourceTest do
     assert {:ok, opts} =
              Source.validate_config(
                sources: [
-                 url: {HTTP, allowed_hosts: ["assets.example.com"], req_options: [plug: plug]}
+                 url:
+                   {HTTP,
+                    allowed_hosts: ["assets.example.com"],
+                    req_options: [plug: plug],
+                    address_resolver: fn _host -> {:ok, [{93, 184, 216, 34}]} end}
                ]
              )
 


### PR DESCRIPTION
## Summary

Adds default SSRF protection to `ImagePipe.Source.HTTP`: every origin fetch **and every redirect hop** is validated before connecting. Closes #48.

- **`ImagePipe.Source.HTTP.AddressPolicy`** — pure IP classifier (IPv4 + IPv6) with bypass-canonicalization (IPv4 dword/octal/hex via `:inet.parse_address`, IPv4-mapped/NAT64/6to4 unwrapped on the parsed tuple). Total and **deny-by-default**: only public addresses pass; unknown IPv6 prefixes classify as `:reserved`, never `:public`. Compiles a policy from either category toggles + CIDR allowlist or a `(ip, category) -> boolean` function (fail-closed on non-boolean/raise).
- **`ImagePipe.Source.HTTP.TargetGuard`** — turns a URL into a decision: scheme → `allowed_hosts` (case-insensitive) → resolve (injectable resolver; IP-literals skip DNS) → address policy. All paths fail closed.
- **`ImagePipe.Source.ReqStream`** — now **owns the redirect loop** (`redirect: false`) and runs the guard before every connect; denials raise `StreamError` with `:denied_scheme | :denied_host | :denied_address`. (Req's own redirect step verifiably does *not* re-run request steps per hop in 0.5.17, so a request-step guard was rejected.)
- **`address_policy` / `address_resolver`** options on the HTTP source; redirects are re-checked against `allowed_hosts` (closes the open-redirect/allowlist-escape gap).
- Docs: `docs/source-network-policy.md` + README, including the **DNS-rebinding limitation** (this is resolve-and-validate, not connection-pinned — tracked as #141).

## Usage

Default — no config needed; non-public addresses are denied on the origin and every redirect hop:

```elixir
sources: [
  url: {ImagePipe.Source.HTTP, allowed_hosts: ["assets.example.com"]}
]
```

Allow private origins, either by blanket category or by precise CIDR:

```elixir
sources: [
  url: {ImagePipe.Source.HTTP,
    allowed_hosts: ["assets.internal"],
    address_policy: [
      allow_private: true,         # opens ALL RFC1918 ranges
      allow: ["10.0.5.0/24"]       # OR open exactly one range, precisely
    ]
  }
]
```

Function-form policy (receives the canonicalized IP + its category; replaces the built-in decision; non-boolean/raise ⇒ deny):

```elixir
address_policy: fn _ip, category -> category == :public end
```

Custom DNS resolution (`{:ok, [ip_tuple]} | {:error, term}`; error/empty/raise ⇒ deny):

```elixir
address_resolver: fn host -> {:ok, [{93, 184, 216, 34}]} end
```

A denied fetch raises `ImagePipe.Source.StreamError` with `reason: :denied_scheme | :denied_host | :denied_address` when the response stream is consumed.

## Threat model

Resolve-and-validate. The DNS-rebinding (TOCTOU) window between validation and the client's connect-time re-resolution is a documented, deliberate deferral — tracked in #141 (IP-pinning).

## Test Plan

- [x] `mise run precommit` green: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix test` (1270 tests, 43 properties, 0 failures).
- [x] Unit + property tests for classification/CIDR/policy (incl. IPv4 & IPv6 deny-default totality properties).
- [x] Wire-level acceptance tests through `ImagePipe.call`-style `Source.fetch` for all four issue acceptance criteria (origin→private via DNS and via literal, redirect→loopback, redirect→off-allowlist, explicit allow/opt-out incl. function form), plus edge cases (cloud-metadata `169.254.169.254`, `file:` redirect, protocol-relative & scheme-downgrade redirect normalization, uppercase redirect host).
- [x] Reviewed via a multi-agent cycle (adversarial bypass — none found; robustness; test-quality with mutation testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)