### PR TITLE
Fix flaky telemetry-isolation tests (#153)

### DIFF
--- a/test/image_pipe/response_sender_test.exs
+++ b/test/image_pipe/response_sender_test.exs
@@ -473,8 +473,18 @@ defmodule ImagePipe.Response.SenderTest do
     assert_receive ^cancel_ref
   end
 
+  # Telemetry handlers run synchronously in the emitting process, but the handler
+  # table is global. Under `async: true`, concurrent modules that emit
+  # `[:image_pipe, :encode, :stop]` (e.g. full-request telemetry tests) would
+  # otherwise have this handler fire and deliver their events into this test's
+  # mailbox, contaminating `assert_receive`. Forward only events this test
+  # emitted itself: `self() == test_pid` holds exactly for in-process emissions.
   def handle_telemetry_event(event, measurements, metadata, test_pid) do
-    send(test_pid, {:telemetry_event, event, measurements, metadata})
+    if self() == test_pid do
+      send(test_pid, {:telemetry_event, event, measurements, metadata})
+    end
+
+    :ok
   end
 
   defp prepared_stream(overrides) do

--- a/test/image_pipe/transform/crop_operation_test.exs
+++ b/test/image_pipe/transform/crop_operation_test.exs
@@ -1,6 +1,8 @@
 defmodule ImagePipe.Transform.CropOperationTest do
   use ExUnit.Case, async: true
 
+  import ImagePipe.Test.Telemetry, only: [attach_own_event_handlers: 2]
+
   alias ImagePipe.Transform.Operation.Crop
   alias ImagePipe.Transform.State
 
@@ -235,7 +237,7 @@ defmodule ImagePipe.Transform.CropOperationTest do
 
     test "the detect span carries the resolved weights", %{image: image} do
       ref =
-        :telemetry_test.attach_event_handlers(self(), [[:image_pipe, :transform, :detect, :stop]])
+        attach_own_event_handlers(self(), [[:image_pipe, :transform, :detect, :stop]])
 
       state = %State{
         image: image,
@@ -266,7 +268,7 @@ defmodule ImagePipe.Transform.CropOperationTest do
       image: image
     } do
       ref =
-        :telemetry_test.attach_event_handlers(self(), [[:image_pipe, :transform, :detect, :stop]])
+        attach_own_event_handlers(self(), [[:image_pipe, :transform, :detect, :stop]])
 
       state = %State{
         image: image,
@@ -295,7 +297,7 @@ defmodule ImagePipe.Transform.CropOperationTest do
 
     test "no-detection fallback reports result: :no_regions on the detect span", %{image: image} do
       ref =
-        :telemetry_test.attach_event_handlers(self(), [[:image_pipe, :transform, :detect, :stop]])
+        attach_own_event_handlers(self(), [[:image_pipe, :transform, :detect, :stop]])
 
       state = %State{
         image: image,
@@ -320,7 +322,7 @@ defmodule ImagePipe.Transform.CropOperationTest do
 
     test "detector error reports result: :error on the detect span", %{image: image} do
       ref =
-        :telemetry_test.attach_event_handlers(self(), [[:image_pipe, :transform, :detect, :stop]])
+        attach_own_event_handlers(self(), [[:image_pipe, :transform, :detect, :stop]])
 
       state = %State{
         image: image,
@@ -346,7 +348,7 @@ defmodule ImagePipe.Transform.CropOperationTest do
       image: image
     } do
       ref =
-        :telemetry_test.attach_event_handlers(self(), [
+        attach_own_event_handlers(self(), [
           [:image_pipe, :transform, :detect, :skipped],
           [:image_pipe, :transform, :detect, :stop]
         ])
@@ -434,7 +436,7 @@ defmodule ImagePipe.Transform.CropOperationTest do
       image: image
     } do
       ref =
-        :telemetry_test.attach_event_handlers(self(), [[:image_pipe, :transform, :detect, :blend]])
+        attach_own_event_handlers(self(), [[:image_pipe, :transform, :detect, :blend]])
 
       state = %State{
         image: image,
@@ -466,7 +468,7 @@ defmodule ImagePipe.Transform.CropOperationTest do
 
     test "no blend one-shot fires when detection finds no face", %{image: image} do
       ref =
-        :telemetry_test.attach_event_handlers(self(), [[:image_pipe, :transform, :detect, :blend]])
+        attach_own_event_handlers(self(), [[:image_pipe, :transform, :detect, :blend]])
 
       state = %State{
         image: image,

--- a/test/support/telemetry.ex
+++ b/test/support/telemetry.ex
@@ -1,0 +1,49 @@
+defmodule ImagePipe.Test.Telemetry do
+  @moduledoc """
+  Test-only telemetry capture that is safe under `async: true`.
+
+  `:telemetry` handlers run synchronously in the process that *emits* the event,
+  but the handler table is global to the VM. `:telemetry_test.attach_event_handlers/2`
+  therefore fires for events emitted by *any* process — including concurrent async
+  test modules — and stamps each one with the attaching test's `ref` before
+  delivering it to the attaching test's mailbox. That contaminates
+  `assert_receive`/`refute_received`: a foreign module emitting the same event
+  (e.g. another module exercising `[:transform, :detect, :stop]` or
+  `[:image_pipe, :encode, :stop]`) lands a `^ref`-matching message in this test's
+  mailbox even though this test never triggered it.
+
+  `attach_own_event_handlers/2` closes that hole by forwarding only events emitted
+  by the *attaching* process. Because handlers run in the emitter, `self() == owner`
+  inside the handler is true exactly when this test triggered the event and false
+  for every concurrent module. The message shape and the `ref`-as-handler-id
+  contract match `:telemetry_test.attach_event_handlers/2`, so `:telemetry.detach(ref)`
+  still works.
+
+  This is sound only for events the test triggers synchronously in its own process,
+  which is the case for the transform and response-sender tests that use it.
+  """
+
+  @spec attach_own_event_handlers(pid(), [[atom()]]) :: reference()
+  def attach_own_event_handlers(owner, events) when is_pid(owner) and is_list(events) do
+    ref = make_ref()
+
+    :ok =
+      :telemetry.attach_many(
+        ref,
+        events,
+        &__MODULE__.handle_event/4,
+        %{owner: owner, ref: ref}
+      )
+
+    ref
+  end
+
+  @doc false
+  def handle_event(event, measurements, metadata, %{owner: owner, ref: ref}) do
+    if self() == owner do
+      send(owner, {event, ref, measurements, metadata})
+    end
+
+    :ok
+  end
+end


### PR DESCRIPTION
Fixes #153.

## Root cause

Both flaky tests share **one** cause — not the process race hypothesized for part 1. `:telemetry` handlers run synchronously **in the emitting process**, but the handler table is global to the VM. A handler attached by one `async: true` test therefore also fires for events emitted by *concurrent* test modules, and stamps each foreign event with the attaching test's `ref`/message-shape before delivering it to that test's mailbox. This contaminates `assert_receive`/`refute_received`:

- **`crop_operation_test`** — `refute_received {[:transform, :detect, :stop|:blend], ^ref, _, _}` fails when another async module exercising `Crop` emits the same detect event. The unique `ref` gives no protection, because *this* test's handler is what stamps the foreign event.
- **`response_sender_test`** — the `[:image_pipe, :encode, :stop]` capture absorbs encode-stop events from concurrent full-request modules. The sender path is fully synchronous (no producer process), so there is nothing to `Process.monitor` — the defect is telemetry isolation, exactly as diagnosed for part 2.

Demonstrated deterministically: a foreign `Task` emitting the event lands a `^ref`-matching message in the mailbox; the filter below blocks it while still delivering own events.

## Fix

Forward only events emitted by the attaching process. `self() == owner` inside the handler is true exactly for in-process emissions and false for every concurrent module.

- New shared helper `ImagePipe.Test.Telemetry.attach_own_event_handlers/2` — mirrors `:telemetry_test.attach_event_handlers/2` (same `{event, ref, measurements, metadata}` shape, `ref`-as-handler-id so existing `:telemetry.detach(ref)` calls keep working) with that filter.
- `crop_operation_test.exs` — all 7 `:telemetry_test.attach_event_handlers` calls swapped to the filtered helper.
- `response_sender_test.exs` — same `self() == test_pid` guard added to its own `handle_telemetry_event/4`.

This implements the issue's own "scope the handler to a unique pid per test" recommendation while keeping `async: true` parallelism (better than `async: false` or threading a per-test token through `State`).

## Verification

- 12-seed stress run of the two files alongside the concurrent detect/encode emitters (composite, detector, imgproxy conformance): **0 failures**.
- Full `mise run precommit`: format ✓, `compile --warnings-as-errors` ✓, `credo --strict` ✓, **1455 tests + 51 properties + 1 doctest, 0 failures**.
- Full suite at `--seed 0` and `--seed 1`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)