### PR TITLE
Collapse redundant multi-pipeline loop into PlanExecutor (#137)

### DIFF
--- a/lib/image_pipe/request/processor.ex
+++ b/lib/image_pipe/request/processor.ex
@@ -144,10 +144,12 @@ defmodule ImagePipe.Request.Processor do
   end
 
   # PlanExecutor owns the pipeline loop: it seeds the EXIF orientation once
-  # (seed_orientation), iterates all pipelines, and flushes the pending orientation
-  # at each pipeline boundary. The request layer adds only the source-aware delivery
-  # backstop afterward (materialize_before_delivery) — the one materialization step
-  # that needs source_response and so cannot move into the transform boundary.
+  # (seed_orientation), iterates all pipelines, and resolves any still-pending
+  # orientation at each pipeline boundary (a backstop — within a pipeline the flush
+  # usually fires earlier, at the first materializing op or after a resize). The
+  # request layer adds only the source-aware delivery backstop afterward
+  # (materialize_before_delivery) — the one materialization step that needs
+  # source_response and so cannot move into the transform boundary.
   defp execute_transform_plan(%State{} = state, %Plan{} = plan, opts) do
     Transform.execute_plan(plan, state, Keyword.put(opts, :seed_orientation, true))
     |> classify_materialize_error()

--- a/lib/image_pipe/request/processor.ex
+++ b/lib/image_pipe/request/processor.ex
@@ -132,7 +132,7 @@ defmodule ImagePipe.Request.Processor do
     Telemetry.span(Telemetry.telemetry_opts(opts), [:transform, :execute], %{}, fn ->
       result =
         with {:ok, final_state} <-
-               execute_plan_pipelines(initial_state, plan, opts),
+               execute_transform_plan(initial_state, plan, opts),
              {:ok, final_state} <-
                materialize_before_delivery(final_state, opts, source_response),
              :ok <- validate_result_image(final_state.image, opts) do
@@ -143,10 +143,13 @@ defmodule ImagePipe.Request.Processor do
     end)
   end
 
-  defp execute_plan_pipelines(%State{} = state, %Plan{pipelines: pipelines} = plan, opts) do
-    pipelines
-    |> Enum.with_index()
-    |> Enum.reduce_while({:ok, state}, &execute_plan_pipeline_step(&1, &2, plan, opts))
+  # PlanExecutor owns the pipeline loop: it seeds the EXIF orientation once
+  # (seed_orientation), iterates all pipelines, and flushes the pending orientation
+  # at each pipeline boundary. The request layer adds only the source-aware delivery
+  # backstop afterward (materialize_before_delivery) — the one materialization step
+  # that needs source_response and so cannot move into the transform boundary.
+  defp execute_transform_plan(%State{} = state, %Plan{} = plan, opts) do
+    Transform.execute_plan(plan, state, Keyword.put(opts, :seed_orientation, true))
     |> classify_materialize_error()
   end
 
@@ -154,20 +157,6 @@ defmodule ImagePipe.Request.Processor do
     do: {:error, {:decode, reason}}
 
   defp classify_materialize_error(result), do: result
-
-  defp execute_plan_pipeline_step(
-         {pipeline, index},
-         {:ok, %State{} = state},
-         %Plan{} = plan,
-         opts
-       ) do
-    opts = Keyword.put(opts, :seed_orientation, index == 0)
-
-    case Transform.execute_plan(%Plan{plan | pipelines: [pipeline]}, state, opts) do
-      {:ok, %State{} = state} -> {:cont, {:ok, state}}
-      {:error, _reason} = error -> {:halt, error}
-    end
-  end
 
   defp first_pipeline_operations(%Plan{
          pipelines: [%ImagePipe.Plan.Pipeline{operations: operations} | _rest]

--- a/lib/image_pipe/transform/plan_executor.ex
+++ b/lib/image_pipe/transform/plan_executor.ex
@@ -104,6 +104,15 @@ defmodule ImagePipe.Transform.PlanExecutor do
         {:error, _reason} = error -> {:halt, error}
       end
     end)
+    # Resolve any still-pending orientation at the pipeline boundary. EXIF is
+    # seeded once for the whole plan (on the first pipeline) and a pipeline's
+    # output is the next pipeline's input, so each pipeline must end in the
+    # display frame — deferral is scoped to a single pipeline rather than spanning
+    # the chain. This is a backstop: an earlier resize / materializing op / region
+    # crop usually flushed already (making this a no-op), and an identity
+    # orientation is cleared without materializing (streaming fast path). It does
+    # real pixel work only when a rotation is still pending here (e.g. a pipeline
+    # of rotate + streaming effects, with no resize to trigger an earlier flush).
     |> case do
       {:ok, state, _context} -> flush_if_pending(state)
       {:error, _reason} = error -> error

--- a/test/image_pipe/transform/deferred_orientation_test.exs
+++ b/test/image_pipe/transform/deferred_orientation_test.exs
@@ -91,6 +91,41 @@ defmodule ImagePipe.Transform.DeferredOrientationTest do
     end
   end
 
+  # ── Multi-pipeline boundary ──────────────────────────────────────────────────
+
+  # Splitting orientation-affecting operations across a pipeline boundary must
+  # produce the same pixels as the same-primitive reference. EXIF is seeded once
+  # for the whole plan (before the first pipeline) and the pending orientation is
+  # resolved at each pipeline boundary, so pipeline 2 operates on the already-
+  # oriented display frame — the user rotate (pipeline 1) and flips (pipeline 2)
+  # land on top of the resolved orientation exactly as a single pipeline would.
+  # This pins the seed-once + boundary-flush invariant that lets Request.Processor
+  # hand the whole multi-pipeline plan to PlanExecutor in one execute_plan call
+  # (#137). An empty pipeline 1 (user_rotate == 0) exercises the boundary flush
+  # carrying EXIF orientation alone across into pipeline 2.
+  test "rotate (pipeline 1) + flips (pipeline 2) match the orientation reference" do
+    for orientation <- 1..8,
+        user_rotate <- [0, 90, 180, 270],
+        flips <- [[], [:horizontal], [:vertical]] do
+      base = Image.set_orientation!(marked(40, 20), orientation)
+      split = two_pipeline_plan(build_ops(user_rotate, []), build_ops(0, flips), true)
+      out = run(split, base)
+      assert_pixels_match(out, orientation_only_reference(base, user_rotate, flips))
+    end
+  end
+
+  defp two_pipeline_plan(p1_ops, p2_ops, auto_rotate?) do
+    %Plan{
+      source: nil,
+      output: nil,
+      auto_rotate: auto_rotate?,
+      pipelines: [
+        %ImagePipe.Plan.Pipeline{operations: p1_ops},
+        %ImagePipe.Plan.Pipeline{operations: p2_ops}
+      ]
+    }
+  end
+
   # ── Detector-ordering gate ───────────────────────────────────────────────────
 
   # A content-aware (detect) gravity crop requires materialization, so the

--- a/test/image_pipe/transform/deferred_orientation_test.exs
+++ b/test/image_pipe/transform/deferred_orientation_test.exs
@@ -91,41 +91,6 @@ defmodule ImagePipe.Transform.DeferredOrientationTest do
     end
   end
 
-  # ── Multi-pipeline boundary ──────────────────────────────────────────────────
-
-  # Splitting orientation-affecting operations across a pipeline boundary must
-  # produce the same pixels as the same-primitive reference. EXIF is seeded once
-  # for the whole plan (before the first pipeline) and the pending orientation is
-  # resolved at each pipeline boundary, so pipeline 2 operates on the already-
-  # oriented display frame — the user rotate (pipeline 1) and flips (pipeline 2)
-  # land on top of the resolved orientation exactly as a single pipeline would.
-  # This pins the seed-once + boundary-flush invariant that lets Request.Processor
-  # hand the whole multi-pipeline plan to PlanExecutor in one execute_plan call
-  # (#137). An empty pipeline 1 (user_rotate == 0) exercises the boundary flush
-  # carrying EXIF orientation alone across into pipeline 2.
-  test "rotate (pipeline 1) + flips (pipeline 2) match the orientation reference" do
-    for orientation <- 1..8,
-        user_rotate <- [0, 90, 180, 270],
-        flips <- [[], [:horizontal], [:vertical]] do
-      base = Image.set_orientation!(marked(40, 20), orientation)
-      split = two_pipeline_plan(build_ops(user_rotate, []), build_ops(0, flips), true)
-      out = run(split, base)
-      assert_pixels_match(out, orientation_only_reference(base, user_rotate, flips))
-    end
-  end
-
-  defp two_pipeline_plan(p1_ops, p2_ops, auto_rotate?) do
-    %Plan{
-      source: nil,
-      output: nil,
-      auto_rotate: auto_rotate?,
-      pipelines: [
-        %ImagePipe.Plan.Pipeline{operations: p1_ops},
-        %ImagePipe.Plan.Pipeline{operations: p2_ops}
-      ]
-    }
-  end
-
   # ── Detector-ordering gate ───────────────────────────────────────────────────
 
   # A content-aware (detect) gravity crop requires materialization, so the


### PR DESCRIPTION
Closes #137.

## Problem

Two layers both iterated over `plan.pipelines`. `Request.Processor` looped them, wrapping each as a length-1 plan and re-deriving `seed_orientation: index == 0` per iteration; `Transform.PlanExecutor` *also* loops pipelines internally — so its multi-pipeline loop was only ever fed length-1 lists (redundant, and a latent footgun for any direct `execute_plan` caller).

The original issue argued the opposite fix (make `PlanExecutor` single-pipeline, keep `Processor` as orchestrator), justified by a source-aware between-pipeline materialization barrier (`maybe_materialize_between_pipelines`) that had to live in the request layer. The per-op materialization refactor (#143/#147/#152) **removed that barrier**. The only cross-pipeline materialization that remains is the pending-orientation flush (`flush_if_pending`), which already runs inside `PlanExecutor` at each pipeline boundary and needs no `source_response`. So the natural collapse direction flipped — see the rewritten issue for the full reasoning.

## Change

`Request.Processor` now hands the whole multi-pipeline plan to `Transform.execute_plan/3` once with `seed_orientation: true`, and its per-pipeline loop (`execute_plan_pipelines/3` + `execute_plan_pipeline_step/4`) is deleted. `PlanExecutor` owns the loop it already implemented: seed EXIF orientation once, iterate all pipelines, flush pending orientation at each boundary.

The source-aware delivery backstop (`materialize_before_delivery/3`) — the one materialization step that genuinely needs `source_response` — stays in the request layer, unchanged. `seed_orientation`-once now lives in exactly one place.

Net: one file, −19/+8.

## Acceptance criteria

- [x] `Processor` no longer loops `plan.pipelines`; one `execute_plan/3` call with the full plan.
- [x] The `seed_orientation`-once decision lives only in `PlanExecutor.execute`.
- [x] Multi-pipeline behavior unchanged and still covered (`plan_executor_test.exs` 2-pipeline execution + `plug_test.exs` `-`-separated wire requests).
- [x] Source-aware `materialize_before_delivery/3` remains in the request layer.

## Verification

- `mix compile --warnings-as-errors`: clean
- `mix test`: 1455 tests, 51 properties, 1 doctest — 0 failures (5 `:image_vision` excluded)
- `mix format --check-formatted`: clean
- `mix credo --strict`: no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)