### PR TITLE
Simplify source-body WrappedStream to a Stream.transform; remove dead pre-#142 machinery

### DIFF
--- a/docs/superpowers/plans/2026-06-04-wrapped-stream-simplification.md
+++ b/docs/superpowers/plans/2026-06-04-wrapped-stream-simplification.md
@@ -1,0 +1,387 @@
+# WrappedStream Simplification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the ~140-line hand-rolled `ImagePipe.Source.WrappedStream` `Enumerable` with a small `Stream.transform`, and delete the connected atomics error-channel / `prefer_source_*` / facade machinery that became dead when the source-decode path went buffer/file-seekable (#142).
+
+**Architecture:** The source body is fully drained to a binary in `Request.Processor.seekable_input/1` (`Enum.to_list`) *before* decode; libvips decodes from RAM, never from the live stream. So `WrappedStream` only needs to do three things while it is drained: count bytes and enforce `max_body_bytes`, reject non-binary chunks, and let source failures surface as a `StreamError`. Its suspend/resume bookkeeping, consumer-vs-producer failure separation, and `:atomics` side-channel exist only for a *lazy* libvips consumer that no longer exists. This plan moves source-exception **normalization to the single consumer** (`seekable_input`), reduces `WrappedStream` to a `Stream.transform`, and removes the now-dead readers (`Source.body_limit_exceeded?/1`, `Source.stream_error_reason/1`, `Processor.prefer_source_*`).
+
+**Tech Stack:** Elixir, `Stream`/`Enumerable`, ExUnit, libvips via `Vix`/`Image`, `mise` task runner.
+
+---
+
+## Why this is safe: the vestige analysis
+
+The `:atomics` channel and its readers originate in #110 ("Preserve source stream errors **across decode**"), from the era when libvips consumed the wrapped stream lazily, so a source failure surfaced *during decode/materialization* and the reason had to be recovered from a side-channel. Since #142 (seekable unification) the stream is eagerly drained in `seekable_input` (`processor.ex:183-187`):
+
+- Marking the atomics is **always paired with a raise** (`wrapped_stream.ex:102-108`, `:188-201`). So a *successful* drain never sets them, and a *failed* drain raises `StreamError`, caught by the rescue at `processor.ex:186`, which returns `{:error, {:source, reason}}` **before decode is attempted**.
+- Therefore `prefer_source_body_limit` / `prefer_source_stream_error` (`processor.ex:259-275`), which read the atomics during *materialization*, are **no-ops on both the buffer path (drain already raised/returned) and the path response (no `WrappedStream` at all)**.
+- The suspend/resume continuation support and the `consumer_failure_ref` consumer-vs-producer separation only matter for an `Enumerable.reduce` driver that *suspends* or *whose consumer fun raises*. The only production driver is `Enum.to_list`, which does neither.
+
+**Safety net (do not weaken):** the request-boundary behavior is pinned by request-level tests that go through `seekable_input`, not through the deleted units:
+- `processor_test.exs:242` "deferred source stream errors remain source errors during decode" → `{:error, {:source, :stream_exception}}` for a source that raises a *raw* exception.
+- `processor_test.exs:264` "oversized stream body fails closed before decode is attempted" → `{:error, {:source, :body_too_large}}`, and asserts decode is never attempted.
+- Wire-level body-limit/decode-error coverage under `test/image_pipe/` (422/415/413 mapping in `Response.Sender`).
+
+These remain green throughout. The unit tests that pin *deleted machinery* are removed with the machinery (per repo guidelines: delete the production path and its tests, don't keep tests that police removed internals).
+
+## Approach decision (for reviewers to scrutinize)
+
+**Chosen: normalization moves to the consumer.** `WrappedStream.new/2` returns a plain `Stream.transform` that raises `StreamError` for `:body_too_large` / `:invalid_stream_chunk` and lets a source-raised `StreamError` propagate verbatim. *Arbitrary* (non-`StreamError`) source exceptions/throws are normalized to `{:source, :stream_exception}` at the **single drain site** (`seekable_input`), whose broadened rescue is a documented host-boundary degradation (the drained value is a host-implementable `Source` adapter stream). This is preferred over keeping a guarded custom `Enumerable`, because re-adding an in-`WrappedStream` rescue would either reintroduce the `consumer_failure_ref` distinction (no simplification) or rescue-all (semantically muddier than doing it at the consumer that knows it is draining a source).
+
+**Rejected alternative:** keep `WrappedStream` a custom `Enumerable` that self-normalizes. It preserves a couple of unit tests but keeps the bulk of the boilerplate (lawful `{:cont,:halt,:suspend}` handling) the plan is trying to delete.
+
+## File map
+
+- `lib/image_pipe/request/processor.ex` — **modify**: broaden `seekable_input/1`'s rescue to map any non-`StreamError` drain failure to `{:source, :stream_exception}`; delete `prefer_source_body_limit/2` + `prefer_source_stream_error/2` and **all six of their call sites** (four inline in `decode_validate_source_response` at `:65-66` and `:81-82`, two in `handle_materialization_result` at `:241-242`); simplify `handle_materialization_result/2`.
+- `lib/image_pipe/source.ex` — **modify**: delete `body_limit_exceeded?/1` and `stream_error_reason/1`; drop the now-unused `WrappedStream` struct-pattern usage; keep `wrap_response/2` calling `WrappedStream.new/2`.
+- `lib/image_pipe/source/wrapped_stream.ex` — **rewrite**: from a struct + `defimpl Enumerable` (~203 lines) to a module with a single `new/2` returning a `Stream.transform`.
+- `test/image_pipe/source_test.exs` — **modify**: delete the unit tests that exercise removed machinery (consumer-vs-producer separation, suspend/resume continuations, on-stream exception normalization, atomics facade); keep/adjust the byte-limit, invalid-chunk, cleanup, and `StreamError`-passthrough tests; add one `seekable_input`-level normalization test if not already covered.
+- `test/image_pipe/processor_test.exs` — **no behavior change**; it is the safety net (`:242`, `:264`). Confirm green at each step.
+
+> **Line numbers match the tree at authoring time.** Edits shift later line numbers within a file during the same run — treat every `file:line` ref as a starting hint and re-grep the named symbol/string to be exact.
+
+---
+
+## Baseline gate (run once before Task 1, and as the green bar after every task)
+
+- [ ] **Step 0: Confirm the relevant suites are green before any change**
+
+Run: `mise exec -- mix test test/image_pipe/source_test.exs test/image_pipe/processor_test.exs test/image_pipe/telemetry_test.exs`
+Expected: PASS (0 failures). If anything fails before you touch code, STOP and report — the baseline is not green.
+
+---
+
+## Task 1: Confirm the vestige is unreachable (analysis gate, no code change)
+
+**Rationale:** Removing a guard at a boundary is a behavior change; justify it with an unreachable-from-callers analysis (repo guideline), not "looks unused".
+
+- [ ] **Step 1: Confirm the only production consumer of the wrapped stream is the eager drain**
+
+Run: `grep -rn "\.stream" lib/image_pipe/request/processor.ex; grep -rn "Enum.to_list\|Enumerable.reduce\|Stream\." lib/image_pipe/request/processor.ex lib/image_pipe/source.ex`
+Expected: the wrapped stream is consumed only by `stream |> Enum.to_list() |> IO.iodata_to_binary()` in `seekable_input/1` (`processor.ex:184`). No production caller suspends it or passes a failing consumer fun.
+
+> Note the one apparent second consumer that is **not** a counterexample: `open_seekable_input`/`image_open_module` receives the **already-drained buffer** (or a path), never the wrapped stream — `seekable_input` drains and short-circuits first. The `LinkedReaderImageOpen` helper in `request_safety_test.exs` is reached only after that drain, so it is not a lazy consumer of the wrapped stream. (The suspending `Enumerable.reduce` in `source_session/producer.ex` consumes the *encoder output* stream, not the source.)
+
+- [ ] **Step 2: Confirm the atomics readers are reached only via `prefer_source_*`, which are post-decode**
+
+Run: `grep -rn "body_limit_exceeded?\|stream_error_reason" lib/`
+Expected: readers are `Source.body_limit_exceeded?/1` + `Source.stream_error_reason/1`, called only from `prefer_source_body_limit/2` + `prefer_source_stream_error/2` in `processor.ex` (`:260`, `:269`), which run inside `materialize_before_delivery` — after a successful drain (atomics unset) or never (failed drain returned early).
+
+- [ ] **Step 3: Record the safety net**
+
+Confirm `processor_test.exs:242` (raw source exception → `{:source, :stream_exception}`) and `processor_test.exs:264` (`{:source, :body_too_large}`, decode not attempted) exist and pass. These pin the request-boundary behavior the rewrite must preserve. No commit (analysis only).
+
+---
+
+## Task 2: Add the consumer-side normalization safety net (additive, behavior-preserving)
+
+**Rationale:** Before `WrappedStream` stops normalizing arbitrary source exceptions, the single consumer must classify them. Adding generic rescue/catch arms to `seekable_input/1` is additive now (the specific `StreamError` arm still wins for `StreamError`), so all tests stay green; it becomes load-bearing in Task 5.
+
+**Files:**
+- Modify: `lib/image_pipe/request/processor.ex` (`seekable_input/1`, ~`:183-187`)
+
+- [ ] **Step 1: Broaden the `seekable_input/1` rescue**
+
+Replace:
+
+```elixir
+  defp seekable_input(%Source.Response{path: nil, stream: stream}) when not is_nil(stream) do
+    {:ok, {:buffer, stream |> Enum.to_list() |> IO.iodata_to_binary()}}
+  rescue
+    exception in [Source.StreamError] -> {:error, {:source, exception.reason}}
+  end
+```
+
+with:
+
+```elixir
+  # The drained value is a host-implementable Source adapter stream (a boundary we
+  # don't control). A StreamError carries a classified source reason; any other
+  # exception/throw/exit raised while draining the source is normalized to a safe
+  # {:source, :stream_exception} (→ 422) rather than crashing the request.
+  defp seekable_input(%Source.Response{path: nil, stream: stream}) when not is_nil(stream) do
+    {:ok, {:buffer, stream |> Enum.to_list() |> IO.iodata_to_binary()}}
+  rescue
+    exception in [Source.StreamError] -> {:error, {:source, exception.reason}}
+    _exception -> {:error, {:source, :stream_exception}}
+  catch
+    _kind, _reason -> {:error, {:source, :stream_exception}}
+  end
+```
+
+- [ ] **Step 2: Add request-boundary tests pinning the new arms and arm-ordering**
+
+These pass immediately (today `WrappedStream` normalizes; from Task 5 the new `seekable_input` arms do) and guard two things the rewrite depends on: (a) a non-binary chunk must hit the **specific** `StreamError` arm → `{:source, :invalid_stream_chunk}`, NOT the generic arm; (b) an upstream `throw` must hit the new `catch` arm → `{:source, :stream_exception}`. Add to `test/image_pipe/processor_test.exs` (next to the existing `:242` test; re-grep its helpers `plan()`/`opts()`):
+
+```elixir
+  test "non-binary source chunks remain source errors during decode" do
+    response = %Response{stream: ["ok", :bad]}
+    assert {:ok, response} = Source.wrap_response(response, max_body_bytes: 20)
+
+    assert {:error, {:source, :invalid_stream_chunk}} =
+             Processor.decode_validate_source_response(response, plan(), opts())
+  end
+
+  test "upstream throws during the source drain remain source errors" do
+    response = %Response{stream: Stream.map([:throw], fn _ -> throw(:boom) end)}
+    assert {:ok, response} = Source.wrap_response(response, max_body_bytes: 20)
+
+    assert {:error, {:source, :stream_exception}} =
+             Processor.decode_validate_source_response(response, plan(), opts())
+  end
+```
+
+- [ ] **Step 3: Run the safety-net suite (incl. the wire-level 422 pins)**
+
+Run: `mise exec -- mix test test/image_pipe/processor_test.exs test/image_pipe/source_test.exs test/image_pipe/request_safety_test.exs test/image_pipe/telemetry_test.exs`
+Expected: PASS, including the two new tests. `request_safety_test.exs` (deferred-stream-error → 422) and `telemetry_test.exs` (oversized → 422, `:body_too_large`) are part of the observable-422 safety net.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/image_pipe/request/processor.ex test/image_pipe/processor_test.exs
+git commit -m "Normalize source-drain failures at seekable_input (consumer boundary)"
+```
+
+---
+
+## Task 3: Delete the dead `prefer_source_*` readers in Processor
+
+**Rationale:** Per Task 1, all six call sites are no-ops post-#142 (whether in the decode path or the materialize path, they run only after a *successful* drain, so the atomics are unset and both functions pass their input through). Deleting them must leave every test green — that green bar *is* the proof they were dead. **There are six call sites, not two** — missing the four inline ones in `decode_validate_source_response` breaks the compile.
+
+**Files:**
+- Modify: `lib/image_pipe/request/processor.ex` (`decode_validate_source_response/3` inline calls `:65-66`/`:81-82`, `handle_materialization_result/2` `:241-242`, and the `prefer_source_*` defs `:259-275`)
+
+- [ ] **Step 1: Remove the four inline `prefer_source_*` calls in `decode_validate_source_response`**
+
+In the `with` chain of `decode_validate_source_response/3`, strip the two `prefer_source_*` pipe segments from each `open_seekable_input` result so they pipe straight into `wrap_decode_error()`:
+
+```elixir
+         {:ok, header_image} <-
+           open_seekable_input(input, [access: :random, fail_on: :error], opts)
+           |> wrap_decode_error(),
+         ...
+         {:ok, image} <-
+           open_seekable_input(input, decode_options, opts)
+           |> wrap_decode_error() do
+```
+
+(Delete the `|> prefer_source_body_limit(source_response)` and `|> prefer_source_stream_error(source_response)` lines at `:65-66` and `:81-82`. Leave everything else in the chain unchanged.)
+
+- [ ] **Step 2: Simplify `handle_materialization_result` and delete the `prefer_source_*` defs**
+
+Replace:
+
+```elixir
+  defp handle_materialization_result(result, source_response) do
+    result
+    |> prefer_source_body_limit(source_response)
+    |> prefer_source_stream_error(source_response)
+    |> do_handle_materialization_result()
+  end
+```
+
+with:
+
+```elixir
+  defp handle_materialization_result(result, _source_response) do
+    do_handle_materialization_result(result)
+  end
+```
+
+Then delete the four clauses `prefer_source_body_limit/2` (both clauses) and `prefer_source_stream_error/2` (both clauses) entirely (`processor.ex:259-275`).
+
+> Leave `handle_materialization_result/2`'s `_source_response` parameter in place (it keeps `materialize_before_delivery/3`'s signature stable; the leading underscore silences the unused warning). Re-grep `prefer_source` to confirm **zero** remaining references in `lib/` before compiling.
+
+- [ ] **Step 3: Run the suite (no-op deletion must stay green)**
+
+Run: `mise exec -- mix test test/image_pipe/processor_test.exs test/image_pipe/source_test.exs test/image_pipe/telemetry_test.exs test/image_pipe/request_safety_test.exs`
+Expected: PASS. `processor_test.exs:264` (`:body_too_large`) and `:242` (`:stream_exception`) still pass — they resolve via the `seekable_input` rescue, never via `prefer_source_*`.
+
+- [ ] **Step 4: Compile clean**
+
+Run: `mise exec -- mix compile --warnings-as-errors`
+Expected: clean (confirms nothing else referenced the removed functions; if it errors with `undefined function prefer_source_*`, a call site was missed — re-grep `prefer_source`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/request/processor.ex
+git commit -m "Delete dead prefer_source_* readers (vestige of pre-#142 lazy decode)"
+```
+
+---
+
+## Task 4: Delete the dead `Source` facade readers and their unit tests
+
+**Rationale:** After Task 3, `Source.body_limit_exceeded?/1` and `Source.stream_error_reason/1` have no caller. Their unit tests pin removed machinery, so they go with the code.
+
+**Files:**
+- Modify: `lib/image_pipe/source.ex` (delete `body_limit_exceeded?/1`, `stream_error_reason/1`, ~`:117-129`)
+- Modify: `test/image_pipe/source_test.exs` (delete the facade tests)
+
+- [ ] **Step 1: Confirm no remaining caller**
+
+Run: `grep -rn "body_limit_exceeded?\|stream_error_reason" lib/`
+Expected: matches only the producer in `lib/image_pipe/source/wrapped_stream.ex` (removed in Task 5) and the facade definitions in `lib/image_pipe/source.ex` being deleted here — **no callers remain** (Task 3 removed them).
+
+- [ ] **Step 2: Delete the two facade functions**
+
+In `lib/image_pipe/source.ex`, delete the `@spec` + both clauses of `body_limit_exceeded?/1` and `stream_error_reason/1` (`:117-129`). Leave `wrap_response/2` and the `WrappedStream` alias in place (still used by `wrap_response/2`).
+
+- [ ] **Step 3: Delete the facade unit tests**
+
+In `test/image_pipe/source_test.exs`, delete these whole `test` blocks (re-grep to be exact):
+- `"wrap_response accepts explicit source body limit override"` (`:266-275`) — its only WrappedStream-specific assertion is `refute Source.body_limit_exceeded?(wrapped)`; the body-limit-not-exceeded happy path is covered by `"wrapped streams keep adapter cleanup..."` and the request-boundary tests. *(If you prefer to keep a passthrough assertion, keep the block but delete only the final `refute Source.body_limit_exceeded?(wrapped)` line and the `assert Enum.to_list(wrapped.stream) == [body]` already proves passthrough.)*
+- `"wrap_response wrapping a stream enforces the body limit on consumption"` (`:390-396`) — replace with the version in Task 5 Step 4 that drops the `assert Source.body_limit_exceeded?(wrapped)` line and keeps the `assert_raise StreamError`.
+- `"body/stream queries degrade for a path response"` (`:410-413`) — delete entirely (pure facade test).
+
+- [ ] **Step 4: Run the source suite**
+
+Run: `mise exec -- mix test test/image_pipe/source_test.exs`
+Expected: PASS with the deleted tests gone.
+
+- [ ] **Step 5: Compile clean + commit**
+
+Run: `mise exec -- mix compile --warnings-as-errors`
+Expected: clean.
+
+```bash
+git add lib/image_pipe/source.ex test/image_pipe/source_test.exs
+git commit -m "Delete unused Source body-limit/stream-error facade and its unit tests"
+```
+
+---
+
+## Task 5: Rewrite `WrappedStream` as a `Stream.transform`
+
+**Rationale:** With readers and facade gone, `WrappedStream` only needs to count bytes, enforce the limit, and reject non-binary chunks while being drained. Normalization of arbitrary source exceptions now lives at `seekable_input` (Task 2). The struct, `defimpl Enumerable`, atomics, suspend/resume, and `consumer_failure_ref` all go.
+
+**Files:**
+- Rewrite: `lib/image_pipe/source/wrapped_stream.ex`
+- Modify: `test/image_pipe/source_test.exs` (delete machinery tests; keep limit/invalid-chunk/cleanup/passthrough)
+
+- [ ] **Step 1: Replace the whole module**
+
+Replace the entire contents of `lib/image_pipe/source/wrapped_stream.ex` with:
+
+```elixir
+defmodule ImagePipe.Source.WrappedStream do
+  @moduledoc false
+
+  alias ImagePipe.Source.StreamError
+
+  # Wraps a source body stream to enforce `max_body_bytes` and reject non-binary
+  # chunks while it is drained. The sole production consumer drains it eagerly
+  # (`Request.Processor.seekable_input/1`), which classifies any *other* failure
+  # of the underlying source as `{:source, :stream_exception}`. This wrapper only
+  # raises the two source-side `StreamError`s it is responsible for.
+  @spec new(Enumerable.t(), non_neg_integer() | :infinity) :: Enumerable.t()
+  def new(stream, max_body_bytes) do
+    Stream.transform(stream, 0, fn chunk, size ->
+      binary = validate_chunk(chunk)
+      new_size = add_size(size, binary, max_body_bytes)
+      {[binary], new_size}
+    end)
+  end
+
+  defp validate_chunk(chunk) when is_binary(chunk), do: chunk
+  defp validate_chunk(_chunk), do: raise(StreamError, reason: :invalid_stream_chunk)
+
+  defp add_size(size, binary, :infinity), do: size + byte_size(binary)
+
+  defp add_size(size, binary, max_body_bytes)
+       when is_integer(max_body_bytes) and max_body_bytes >= 0 do
+    new_size = size + byte_size(binary)
+
+    if new_size <= max_body_bytes do
+      new_size
+    else
+      raise StreamError, reason: :body_too_large
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Delete the machinery unit tests in `source_test.exs`**
+
+Delete these whole `test` blocks (re-grep names; they assert removed suspend/resume + consumer-separation + on-stream normalization):
+- `"wrapped streams sanitize upstream enumerable exceptions"` (`:285-291`) — normalization now happens at `seekable_input` (pinned by `processor_test.exs:242`), not on the raw stream.
+- `"wrapped streams sanitize upstream throws shaped like consumer failures"` (`:303-316`) — the `consumer_failure_ref` sentinel no longer exists.
+- `"wrapped streams preserve consumer exceptions"` (`:318-328`) — consumer-vs-producer separation removed; no production consumer fails.
+- `"wrapped streams preserve invalid consumer return failures"` (`:330-340`) — same.
+- `"wrapped stream continuations preserve consumer exceptions"` (`:342-356`) — suspend/resume continuation support removed.
+
+- [ ] **Step 3: Keep these tests (they assert behavior the `Stream.transform` still provides)**
+
+Confirm these remain and pass unchanged (re-grep names):
+- `"wrapped streams reject non-binary chunks"` (the `:invalid_stream_chunk` test near `:247-255`) — `validate_chunk/1` still raises it.
+- `"wrapped streams enforce max body bytes"` (`:258-264`) — `add_size/3` still raises `:body_too_large`.
+- `"wrapped streams keep adapter cleanup in enumerable termination path"` (`:277-283`) — `Stream.transform` propagates halt to the source, running its cleanup.
+- `"wrapped streams preserve safe deferred source errors"` (`:293-301`) — a source raising `StreamError(:bad_status)` propagates verbatim through `Stream.transform`.
+
+- [ ] **Step 4: Replace the body-limit-flag test with a flag-free version**
+
+Replace the `"wrap_response wrapping a stream enforces the body limit on consumption"` block (already edited in Task 4 Step 3) with:
+
+```elixir
+  test "wrap_response wrapping a stream enforces the body limit on consumption" do
+    {:ok, wrapped} = Source.wrap_response(%Response{stream: ["abc"]}, max_body_bytes: 2)
+    assert wrapped.path == nil
+
+    assert_raise ImagePipe.Source.StreamError, fn -> Enum.to_list(wrapped.stream) end
+  end
+```
+
+- [ ] **Step 5: Run the source + processor suites**
+
+Run: `mise exec -- mix test test/image_pipe/source_test.exs test/image_pipe/processor_test.exs test/image_pipe/telemetry_test.exs test/image_pipe/request_safety_test.exs`
+Expected: PASS. `processor_test.exs:242` now exercises the Task-2 `seekable_input` normalization (the raw RuntimeError from the source propagates through the plain `Stream.transform` and is caught at the drain's generic `rescue` arm), the new "upstream throws" test exercises the `catch` arm, the "non-binary chunks" test confirms the **specific** `StreamError` arm still wins (→ `:invalid_stream_chunk`), and `:264` still raises `:body_too_large` from `add_size/3`. `request_safety_test.exs` confirms the wire-level 422.
+
+- [ ] **Step 6: Compile clean + commit**
+
+Run: `mise exec -- mix compile --warnings-as-errors`
+Expected: clean (no references to the removed struct, atomics, or `defimpl`).
+
+```bash
+git add lib/image_pipe/source/wrapped_stream.ex test/image_pipe/source_test.exs
+git commit -m "Reduce WrappedStream to a Stream.transform; drop dead suspend/resume + atomics"
+```
+
+---
+
+## Final gate (after all tasks)
+
+- [ ] **Step 1: Full Elixir gate**
+
+Run: `mise run precommit`
+Expected: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, and `mix test` all pass.
+
+- [ ] **Step 2: Architecture boundary test (the change touches `Request` and `Source` boundary modules)**
+
+Run: `mise exec -- mix test test/image_pipe/architecture_boundary_test.exs`
+Expected: PASS — no boundary direction crossed (`Source` still owns `WrappedStream`; `Request.Processor` still consumes via the `Source.Response` it already holds).
+
+---
+
+## Self-review checklist (completed by author)
+
+- **Vestige justification (Tasks 3-4):** atomics readers proven no-op post-#142 by the eager-drain analysis; deletion green bar is the proof. ✅
+- **Normalization preserved (Tasks 2 & 5):** arbitrary source-exception → `{:source, :stream_exception}` moves from `WrappedStream` to `seekable_input`, pinned by `processor_test.exs:242`. ✅
+- **Body-limit / invalid-chunk preserved (Task 5):** `add_size/3` and `validate_chunk/1` still raise the same `StreamError` reasons; pinned by `source_test.exs` limit/chunk tests and `processor_test.exs:264`. ✅
+- **Adapter cleanup preserved (Task 5):** `Stream.transform` propagates halt; pinned by the cleanup test. ✅
+- **Deleted tests only pin removed machinery:** consumer-separation, suspend/resume continuations, on-stream normalization, atomics facade. ✅
+- **Boundaries:** no new cross-boundary helper; `Source` keeps `WrappedStream`. ✅
+- **Placeholders:** none — every step shows exact code/commands. ✅
+
+## Review-cycle record (completed 2026-06-04, before execution)
+
+Three disjoint parallel reviewers ran per repo policy; the imgproxy-compat reviewer checked against real upstream `local/imgproxy-master`.
+
+- **imgproxy/wire-compat — ACCEPT-WITH-CHANGES.** Confirmed against upstream: oversize body → **422** (`imagedata/errors.go`, enforced pre-read), unexpected/incomplete source → 422, fail-closed-before-decode preserved; the broadened `seekable_input` rescue is scoped to the drain expression only (no decode/transform inside it) and the specific `StreamError` arm preserves adapter classifications (`:bad_status`, etc.) so nothing is mis-mapped.
+- **Correctness/unreachability — ACCEPT-WITH-CHANGES.** Independently verified the deadness claim (sole consumer is `Enum.to_list` in `seekable_input`; atomics never read live; the suspending reduce in `producer.ex` consumes the *encoder* stream, not the source) and the `Stream.transform` rewrite's semantics (cleanup-on-halt, `StreamError` passthrough, byte counting).
+- **Test discipline — ACCEPT-WITH-CHANGES.** Confirmed each deleted test pins only removed machinery and the request-boundary safety net (`:242`/`:264`, wire-level 422) is adequate.
+
+**Blocking findings applied:** (1) Task 3 now removes **all six** `prefer_source_*` call sites (the four inline ones in `decode_validate_source_response` were missing and would have broken the compile); (2) added request-boundary tests for `:invalid_stream_chunk` (arm-ordering) and an upstream `throw` (the new `catch` arm) in Task 2.
+**Non-blocking findings applied:** Task 1 names the `LinkedReaderImageOpen` non-counterexample; Task 4 grep wording corrected; `request_safety_test.exs` added to the Task 2/3/5 runs as part of the observable-422 net.

--- a/docs/superpowers/specs/2026-06-04-streaming-subsystem-opportunities.md
+++ b/docs/superpowers/specs/2026-06-04-streaming-subsystem-opportunities.md
@@ -60,18 +60,29 @@ preserved version of spike (a)/(b) as a regression test.
 
 ## Ranked opportunities (post-spike)
 
-### #3 — `WrappedStream` → `Stream.transform` *(recommended first)*
+### #3 — `WrappedStream` → `Stream.transform`, and delete the dead atomics/`prefer_source` vestige *(recommended first)*
 - **What:** Replace the hand-rolled `Enumerable` impl with a byte-counting `Stream.transform` that
-  raises `StreamError` on `max_body_bytes` / non-binary chunks. Likely also collapse the atomics
-  error channel, which appears redundant with the already-caught raised `StreamError`
-  (`processor.ex:186`).
-- **Why simpler:** ~−80 lines; removes a custom `Enumerable` (and its consumer-vs-producer
-  failure separation, which only matters for a *suspending* consumer that can fail — there is none).
-- **Behavior preserved:** `{:source, :body_too_large}` → 422 wire contract; the `StreamError`
-  reason surfacing at `processor.ex:186`.
-- **Risk:** Low-medium. Gone is the only real risk (roadmap collision — see Finding 1).
-- **Pre-req:** A ~10-minute consumer audit confirming no production caller suspends the wrapped
-  stream. **Effort:** Medium.
+  raises `StreamError` on `max_body_bytes` / non-binary chunks. The audit (below) showed the scope
+  is larger and cleaner than first thought: the `:atomics` error channel and its readers are a
+  **verified-dead vestige of the pre-#142 lazy-decode era** (#110, "preserve source stream errors
+  *across decode*"). Post-#142 the source is eagerly drained in `seekable_input` and every
+  `StreamError` is caught by the rescue at `processor.ex:186` *before* decode; marking the atomics is
+  always paired with a raise (`wrapped_stream.ex:102-108`), so a successful drain never sets them and
+  a failed drain returns early — the readers never see a live value.
+- **Removes (gated by verify-then-delete):**
+  - `WrappedStream`: suspend/resume + `consumer_failure_ref` half **and** the `:atomics` channel
+    (`stream_state_ref`, mark/read fns, reason-code maps).
+  - `Source` facade: `body_limit_exceeded?/1` + `stream_error_reason/1` (`source.ex:117-129`).
+  - `Processor`: `prefer_source_body_limit` + `prefer_source_stream_error`; simplify
+    `handle_materialization_result` (`processor.ex:239-275`).
+- **Why simpler:** removes a custom `Enumerable`, a side-channel, two facade functions, and two
+  processor passes — replacing them with one stdlib combinator and the single existing rescue.
+- **Behavior preserved:** `{:source, :body_too_large}` → 422 and `{:source, :stream_exception}` wire
+  contracts; both are pinned by `processor_test.exs:242` and `:264`, which resolve via the
+  `seekable_input` rescue, not via `prefer_source_*`.
+- **Risk:** Low-medium. The only real risk (roadmap collision) is gone (Finding 1). The atomics
+  deletion is a boundary change, so Task 1 must be an unreachable-from-callers proof before deleting.
+  **Effort:** Medium.
 
 ### #5 — Fold the parent-EXIT trap into the supervisor link *(recommended second)*
 - **What:** In the real path `parent == the supervisor pid` (`start_session` deletes `:parent`;
@@ -89,13 +100,19 @@ preserved version of spike (a)/(b) as a regression test.
   `SourceSession` can't `GenServer.call` it (that would block its mailbox during the pull), so the
   async `{ref, result}` + monitor shape is intrinsic — the current bare-`spawn_link` + `make_ref`
   loop is already close to minimal.
-- **Actionable remainder (low payoff):**
-  1. **Correct the load-bearing-but-wrong affinity comment** in the plan/code; cite link topology +
-     cancellation; optionally preserve spike (a)/(b) as a deterministic regression test that finally
-     *justifies* the design with evidence. (Cheap, high doc-honesty value.)
-  2. Optionally revisit the #158-deferred `producer_request_ref` / `terminate/2` double-cleanup nits
-     with the focused state-machine analysis they require — but these are marginal.
-- **Risk:** The rearchitecture is not worth it; the comment fix is ~zero risk. **Effort:** Small (comment) / not recommended (rearchitecture).
+- **Chosen direction — Approach 1 (GenServer, idiom-only):** Convert the bare `spawn_link` + `loop/1`
+  + `make_ref` request/reply into a GenServer. `init/1` does `Process.put(:"$callers", …)` + state;
+  `loop`'s receive becomes `handle_cast({:next, caller, ref}, …)` replying via `send(caller, {ref,
+  reply})`; add `terminate/2` to halt the continuation explicitly. **SourceSession is unchanged** —
+  it still does `request_next` + matches `{ref, result}`. The `make_ref` async-reply protocol does
+  **not** disappear (it is forced by SourceSession needing to stay responsive to owner-DOWN during a
+  multi-second pull), so the win is *standard idiom + OTP lifecycle/introspection at neutral LOC*,
+  not fewer concepts. `Task`-as-owner was rejected: spike (b) shows the continuation dies with its
+  process, so a fire-once or per-chunk Task can't own it.
+- **Fold in:** correct the load-bearing-but-wrong affinity comment (cite link topology +
+  cancellation) and land spike (a)/(b) as the deterministic regression test that finally *justifies*
+  the two-process core with evidence.
+- **Risk:** Low (idiom-preserving, LOC-neutral, zero behavior delta). **Effort:** Small-medium.
 
 ### #4 — Buffered-vs-streamed split by format streamability *(DECLINED)*
 - **Premise falsified by the spike.** It assumed AVIF/WebP can't be cancelled mid-encode, so
@@ -122,8 +139,9 @@ preserved version of spike (a)/(b) as a regression test.
 1. **#3** — the biggest honest simplification, now unblocked; do the consumer audit, then the
    `Stream.transform` rewrite.
 2. **#5** — small, clean liveness-model sharpening.
-3. **#2 comment fix** — correct the affinity myth and, ideally, land spike (a)/(b) as the regression
-   test that finally justifies the two-process core with evidence. Skip the rearchitecture.
+3. **#2 (Approach 1)** — convert the Producer to a GenServer (idiom-only, LOC-neutral), correct the
+   affinity myth, and land spike (a)/(b) as the regression test that finally justifies the two-process
+   core with evidence.
 4. **#4** — declined; record the spike as the rationale.
 
 Per repo policy, any of these that becomes an implementation plan must go through a parallel

--- a/docs/superpowers/specs/2026-06-04-streaming-subsystem-opportunities.md
+++ b/docs/superpowers/specs/2026-06-04-streaming-subsystem-opportunities.md
@@ -1,0 +1,144 @@
+# Request-time streaming subsystem — re-architecture opportunities memo
+
+**Date:** 2026-06-04
+**Status:** Exploration / proposal. No implementation. Ranked opportunities for the maintainer to pick from.
+**Scope:** The request-time encode-streaming path — `ImagePipe.Request.SourceSession`, its `Producer`, `Runner`, `Response.Sender`/`PreparedStream`, and the `Source.WrappedStream` source-body path.
+
+This memo deliberately does **not** re-propose the honest-surface cleanups already landed in #158
+(test-only Producer client relocated, `StreamError`→tag translation collapsed per module, `:busy`
+guard deleted). It revisits the items #158 declined, plus new findings from a fresh read.
+
+---
+
+## Two findings that reframe the subsystem
+
+### Finding 1 — The source is fully buffered before decode; `WrappedStream`'s suspend/resume half is dead
+
+`WrappedStream` wraps the HTTP source enumerable (`source.ex:109`), but its only consumer is
+`Processor.seekable_input/1`, which does `Enum.to_list()` → `IO.iodata_to_binary()`
+(`processor.ex:184`). `Enum.to_list` drives with `{:cont, …}` and **never suspends**, so the entire
+suspend/resume + `continue_safely` + `consumer_failure_ref` machinery (`wrapped_stream.ex:158-202`)
+has no live caller. The only job that runs is: count bytes, enforce `max_body_bytes`, raise
+`StreamError`. That is a `Stream.transform`, not a 140-line hand-rolled `Enumerable`.
+
+There is **no roadmap reason** to keep the dead half: shrink-on-load (#28) is fully merged
+(#142 + #144) and consumes the source via `new_from_buffer`/`new_from_file` — seekable, not
+incremental. Concurrent download+decode (#139) is **closed**, and even its design keeps libvips I/O
+in C against a temp file / growing file; it would never resume a suspended Elixir source
+continuation.
+
+### Finding 2 — The "process affinity" justification was a myth; the property actually worth protecting is prompt cancellation, which is real
+
+The prior plan justified the two-process `SourceSession`+`Producer` split partly with "the libvips
+streaming target has process affinity, hence the `$callers` plumbing." A spike (below) **falsified**
+this. The `$callers` plumbing is stdlib Task ownership (the code comment at `source_session.ex:83`
+says so), not a Vix affinity mechanism.
+
+What the split *does* legitimately buy — prompt kill of an in-progress expensive encode when the
+client disconnects — is **real, and the spike confirmed it works even for non-streamable AVIF**.
+
+---
+
+## The de-risking spike (run 2026-06-04, throwaway)
+
+Four sub-questions, exercising the real `Image.stream!` encode path:
+
+| Sub-question | Result |
+|---|---|
+| (a) Does a suspended encode continuation resume from a *different, unlinked* process? | **Yes — byte-identical** (4,742,486 B same-process vs cross-process), decodes `fail_on: :error`. Affinity falsified. |
+| (b) Does it still work after the *creator* process dies? | **No — `{:noproc}`.** The `Vix.TargetPipe` is linked to its creator. The real constraint is OTP link topology: the owner must outlive the stream. |
+| (c) Killing the owner mid-encode — how fast does the encode writer task die? | **~0 ms for both `.jpg` and `.avif`.** |
+| (d) Does the kill actually *free the CPU*, or does the dirty NIF thread detach and keep burning? | **CPU genuinely freed.** Fresh AVIF encodes immediately after a mid-flight kill averaged 9,280 ms vs a clean baseline of 9,480 ms — identical within noise. The dirty encode NIF aborts; it does not detach. |
+
+**Conclusion:** The two-process core is **vindicated by cancellation, not by affinity.** A killable
+process must own the demand-driven continuation, and `SourceSession` must stay responsive to
+owner-DOWN *during* a chunk pull so it can issue the kill. The affinity comment is wrong and should
+be corrected to cite the real reasons (link topology + cancellation), ideally referencing a
+preserved version of spike (a)/(b) as a regression test.
+
+---
+
+## Ranked opportunities (post-spike)
+
+### #3 — `WrappedStream` → `Stream.transform` *(recommended first)*
+- **What:** Replace the hand-rolled `Enumerable` impl with a byte-counting `Stream.transform` that
+  raises `StreamError` on `max_body_bytes` / non-binary chunks. Likely also collapse the atomics
+  error channel, which appears redundant with the already-caught raised `StreamError`
+  (`processor.ex:186`).
+- **Why simpler:** ~−80 lines; removes a custom `Enumerable` (and its consumer-vs-producer
+  failure separation, which only matters for a *suspending* consumer that can fail — there is none).
+- **Behavior preserved:** `{:source, :body_too_large}` → 422 wire contract; the `StreamError`
+  reason surfacing at `processor.ex:186`.
+- **Risk:** Low-medium. Gone is the only real risk (roadmap collision — see Finding 1).
+- **Pre-req:** A ~10-minute consumer audit confirming no production caller suspends the wrapped
+  stream. **Effort:** Medium.
+
+### #5 — Fold the parent-EXIT trap into the supervisor link *(recommended second)*
+- **What:** In the real path `parent == the supervisor pid` (`start_session` deletes `:parent`;
+  `start_link` defaults `parent` to `self()`, which under `DynamicSupervisor.start_child` is the
+  supervisor). The `{:EXIT, parent, reason}` trap (`source_session.ex:179-187`) and the supervisor
+  link are the same relationship expressed twice. Of the "three liveness mechanisms," only two are
+  distinct: supervisor-link (orderly shutdown) and owner-monitor (request-process disconnect).
+- **Why simpler:** Removes a field and a clause; the liveness model reads as two relationships.
+- **Risk:** Low-medium — tests pin the "parent-shutdown reason ≠ owner-down reason" distinction; the
+  fold must preserve `:shutdown` vs `{:shutdown, {:owner_down, _}}`. **Effort:** Small.
+
+### #2 — Producer rearchitecture *(re-scoped DOWN by the spike)*
+- **Original idea:** collapse the two-process split. The spike **vindicated the core**: a
+  killable, demand-driven encode-owner process is genuinely needed for prompt cancellation, and
+  `SourceSession` can't `GenServer.call` it (that would block its mailbox during the pull), so the
+  async `{ref, result}` + monitor shape is intrinsic — the current bare-`spawn_link` + `make_ref`
+  loop is already close to minimal.
+- **Actionable remainder (low payoff):**
+  1. **Correct the load-bearing-but-wrong affinity comment** in the plan/code; cite link topology +
+     cancellation; optionally preserve spike (a)/(b) as a deterministic regression test that finally
+     *justifies* the design with evidence. (Cheap, high doc-honesty value.)
+  2. Optionally revisit the #158-deferred `producer_request_ref` / `terminate/2` double-cleanup nits
+     with the focused state-machine analysis they require — but these are marginal.
+- **Risk:** The rearchitecture is not worth it; the comment fix is ~zero risk. **Effort:** Small (comment) / not recommended (rearchitecture).
+
+### #4 — Buffered-vs-streamed split by format streamability *(DECLINED)*
+- **Premise falsified by the spike.** It assumed AVIF/WebP can't be cancelled mid-encode, so
+  streaming buys nothing for them. (c)/(d) show AVIF cancellation is prompt *and* frees the CPU.
+  Buffering AVIF would lose the ability to abort a ~8 s encode on disconnect — a real DoS
+  regression. The current "first chunk = whole encode, but abortable" behavior is correct. **Leave it.**
+
+### Minor / parked
+- **#6 Elide the `Prepared` DTO:** `prepare/1` could return its 4 fields directly and let `Runner`
+  build `PreparedStream` in one step, deleting one intra-`Request`-boundary struct without crossing
+  the `Request`/`Response` boundary that (correctly) blocks a full merge. Low payoff, low risk.
+- **#7 `{:protocol,_}` 500 hole:** `Response.Sender` has no `{:protocol,_}` clause, but the tags are
+  unreachable for the single sequential caller, so adding a defensive clause would *violate* the
+  "no guards for impossible internal misuse" rule. The disciplined move is to narrow the taxonomy
+  (are `:invalid_phase`/`:not_prepared` also impossible-misuse, like the removed `:busy`?), engaging
+  #158's explicit decision to keep them. Low payoff.
+- **#8 #158 deferrals** (`producer_request_ref`, `terminate/2` double-cleanup, cache-sink locale):
+  parked; several are subsumed by the (now not-recommended) #2.
+
+---
+
+## Recommended sequencing
+
+1. **#3** — the biggest honest simplification, now unblocked; do the consumer audit, then the
+   `Stream.transform` rewrite.
+2. **#5** — small, clean liveness-model sharpening.
+3. **#2 comment fix** — correct the affinity myth and, ideally, land spike (a)/(b) as the regression
+   test that finally justifies the two-process core with evidence. Skip the rearchitecture.
+4. **#4** — declined; record the spike as the rationale.
+
+Per repo policy, any of these that becomes an implementation plan must go through a parallel
+disjoint-reviewer cycle before implementation, with at least one reviewer on observable imgproxy
+compatibility against real upstream (e.g. `local/imgproxy-master`).
+
+---
+
+## Spike methodology (for reproduction / regression)
+
+The spike built `Image.stream!(image, suffix: …, buffer_size: 0)` continuations via
+`Enumerable.reduce(stream, {:cont, nil}, fn c, _ -> {:suspend, c} end)`. (a) shipped a suspended
+continuation to an unlinked `spawn` and compared the reassembled body to a same-process baseline.
+(b) created the continuation in a separate process, killed it, and observed `{:noproc}` on resume.
+(c) located the `Vix.TargetPipe` writer task via the owner's links + `:sys.get_state(pipe).task_pid`,
+killed the owner mid-encode, and timed the writer's `:DOWN`. (d) timed three fresh AVIF encodes
+immediately after a mid-flight kill against a clean three-encode baseline. Test images were a real
+photo (`priv/static/images/beach.jpg`) upscaled 4× for entropy.

--- a/lib/image_pipe/request/processor.ex
+++ b/lib/image_pipe/request/processor.ex
@@ -180,10 +180,17 @@ defmodule ImagePipe.Request.Processor do
   defp seekable_input(%Source.Response{path: path, stream: nil}) when is_binary(path),
     do: {:ok, {:path, path}}
 
+  # The drained value is a host-implementable Source adapter stream (a boundary we
+  # don't control). A StreamError carries a classified source reason; any other
+  # exception/throw/exit raised while draining the source is normalized to a safe
+  # {:source, :stream_exception} (→ 422) rather than crashing the request.
   defp seekable_input(%Source.Response{path: nil, stream: stream}) when not is_nil(stream) do
     {:ok, {:buffer, stream |> Enum.to_list() |> IO.iodata_to_binary()}}
   rescue
     exception in [Source.StreamError] -> {:error, {:source, exception.reason}}
+    _exception -> {:error, {:source, :stream_exception}}
+  catch
+    _kind, _reason -> {:error, {:source, :stream_exception}}
   end
 
   defp seekable_input(%Source.Response{}), do: {:error, {:source, :invalid_adapter_result}}

--- a/lib/image_pipe/request/processor.ex
+++ b/lib/image_pipe/request/processor.ex
@@ -62,8 +62,6 @@ defmodule ImagePipe.Request.Processor do
     with {:ok, input} <- seekable_input(source_response),
          {:ok, header_image} <-
            open_seekable_input(input, [access: :random, fail_on: :error], opts)
-           |> prefer_source_body_limit(source_response)
-           |> prefer_source_stream_error(source_response)
            |> wrap_decode_error(),
          {:ok, source_format} <- SourceFormat.from_image(header_image),
          original_dims = {Image.width(header_image), Image.height(header_image)},
@@ -78,8 +76,6 @@ defmodule ImagePipe.Request.Processor do
            ),
          {:ok, image} <-
            open_seekable_input(input, decode_options, opts)
-           |> prefer_source_body_limit(source_response)
-           |> prefer_source_stream_error(source_response)
            |> wrap_decode_error() do
       {:ok,
        %{
@@ -243,11 +239,8 @@ defmodule ImagePipe.Request.Processor do
     materializer.materialize(state, opts)
   end
 
-  defp handle_materialization_result(result, source_response) do
-    result
-    |> prefer_source_body_limit(source_response)
-    |> prefer_source_stream_error(source_response)
-    |> do_handle_materialization_result()
+  defp handle_materialization_result(result, _source_response) do
+    do_handle_materialization_result(result)
   end
 
   defp do_handle_materialization_result({:error, {:source, _reason} = error}), do: {:error, error}
@@ -262,24 +255,6 @@ defmodule ImagePipe.Request.Processor do
   defp wrap_decode_error({:error, {:source, _reason}} = error), do: error
   defp wrap_decode_error({:error, error}), do: {:error, {:decode, error}}
   defp wrap_decode_error(result), do: result
-
-  defp prefer_source_body_limit(result, %Source.Response{} = source_response) do
-    case Source.body_limit_exceeded?(source_response) do
-      true -> {:error, {:source, :body_too_large}}
-      false -> result
-    end
-  end
-
-  defp prefer_source_body_limit(result, _source_response), do: result
-
-  defp prefer_source_stream_error({:error, reason}, %Source.Response{} = source_response) do
-    case Source.stream_error_reason(source_response) do
-      {:ok, reason} -> {:error, {:source, reason}}
-      :error -> {:error, reason}
-    end
-  end
-
-  defp prefer_source_stream_error(result, _source_response), do: result
 
   # Whether the source's EXIF orientation implies a 90°/270° turn. The decode
   # planner uses this (together with the `auto_rotate` flag) to decide whether the

--- a/lib/image_pipe/source.ex
+++ b/lib/image_pipe/source.ex
@@ -114,20 +114,6 @@ defmodule ImagePipe.Source do
   # are rejected at this boundary rather than trusted.
   def wrap_response(_response, _runtime_opts), do: {:error, {:source, :invalid_adapter_result}}
 
-  @spec body_limit_exceeded?(Response.t()) :: boolean()
-  def body_limit_exceeded?(%Response{stream: %WrappedStream{} = stream}) do
-    WrappedStream.body_limit_exceeded?(stream)
-  end
-
-  def body_limit_exceeded?(%Response{}), do: false
-
-  @spec stream_error_reason(Response.t()) :: {:ok, term()} | :error
-  def stream_error_reason(%Response{stream: %WrappedStream{} = stream}) do
-    WrappedStream.stream_error_reason(stream)
-  end
-
-  def stream_error_reason(%Response{}), do: :error
-
   defp validate_sources(sources) when is_list(sources) do
     with {:ok, source_configs} <- source_configs(sources) do
       {:ok, expand_url_source_config(source_configs)}

--- a/lib/image_pipe/source/wrapped_stream.ex
+++ b/lib/image_pipe/source/wrapped_stream.ex
@@ -1,203 +1,35 @@
 defmodule ImagePipe.Source.WrappedStream do
   @moduledoc false
 
-  @enforce_keys [:stream, :max_body_bytes, :stream_state_ref]
-  defstruct @enforce_keys
-
-  @type t :: %__MODULE__{
-          stream: Enumerable.t(),
-          max_body_bytes: non_neg_integer() | :infinity,
-          stream_state_ref: :atomics.atomics_ref()
-        }
-
-  @body_limit_index 1
-  @stream_error_index 2
-  @stream_error_reasons %{
-    stream_exception: 1,
-    body_too_large: 2,
-    invalid_stream_chunk: 3
-  }
-  @stream_error_reason_by_code %{
-    1 => :stream_exception,
-    2 => :body_too_large,
-    3 => :invalid_stream_chunk
-  }
-
-  @spec new(Enumerable.t(), non_neg_integer() | :infinity) :: t()
-  def new(stream, max_body_bytes) do
-    %__MODULE__{
-      stream: stream,
-      max_body_bytes: max_body_bytes,
-      stream_state_ref: :atomics.new(2, [])
-    }
-  end
-
-  @spec body_limit_exceeded?(t()) :: boolean()
-  def body_limit_exceeded?(%__MODULE__{stream_state_ref: stream_state_ref}) do
-    :atomics.get(stream_state_ref, @body_limit_index) == 1
-  end
-
-  @spec mark_body_limit_exceeded(t()) :: :ok
-  def mark_body_limit_exceeded(%__MODULE__{stream_state_ref: stream_state_ref}) do
-    :atomics.put(stream_state_ref, @body_limit_index, 1)
-    :ok
-  end
-
-  @spec mark_stream_error(t(), term()) :: :ok
-  def mark_stream_error(%__MODULE__{stream_state_ref: stream_state_ref}, reason) do
-    :atomics.put(stream_state_ref, @stream_error_index, stream_error_code(reason))
-    :ok
-  end
-
-  @spec stream_error_reason(t()) :: {:ok, term()} | :error
-  def stream_error_reason(%__MODULE__{stream_state_ref: stream_state_ref}) do
-    case :atomics.get(stream_state_ref, @stream_error_index) do
-      0 -> :error
-      code -> {:ok, Map.fetch!(@stream_error_reason_by_code, code)}
-    end
-  end
-
-  defp stream_error_code(reason), do: Map.get(@stream_error_reasons, reason, 1)
-end
-
-defimpl Enumerable, for: ImagePipe.Source.WrappedStream do
   alias ImagePipe.Source.StreamError
-  alias ImagePipe.Source.WrappedStream
 
-  def reduce(%WrappedStream{} = wrapped, acc, fun) do
-    reduce_stream(wrapped, acc, fun)
-  end
-
-  def count(_wrapped), do: {:error, __MODULE__}
-  def member?(_wrapped, _value), do: {:error, __MODULE__}
-  def slice(_wrapped), do: {:error, __MODULE__}
-
-  defp reduce_stream(%WrappedStream{stream: stream} = wrapped, {:cont, acc}, fun) do
-    consumer_failure_ref = make_ref()
-
-    with_stream_guard(wrapped, consumer_failure_ref, fn ->
-      stream
-      |> Enumerable.reduce({:cont, {0, acc}}, reducer(wrapped, fun, consumer_failure_ref))
-      |> unwrap_result(wrapped, fun, consumer_failure_ref)
+  # Wraps a source body stream to enforce `max_body_bytes` and reject non-binary
+  # chunks while it is drained. The sole production consumer drains it eagerly
+  # (`Request.Processor.seekable_input/1`), which classifies any *other* failure
+  # of the underlying source as `{:source, :stream_exception}`. This wrapper only
+  # raises the two source-side `StreamError`s it is responsible for.
+  @spec new(Enumerable.t(), non_neg_integer() | :infinity) :: Enumerable.t()
+  def new(stream, max_body_bytes) do
+    Stream.transform(stream, 0, fn chunk, size ->
+      binary = validate_chunk(chunk)
+      new_size = add_size(size, binary, max_body_bytes)
+      {[binary], new_size}
     end)
   end
 
-  defp reduce_stream(%WrappedStream{}, {:halt, acc}, _fun),
-    do: {:halted, acc}
+  defp validate_chunk(chunk) when is_binary(chunk), do: chunk
+  defp validate_chunk(_chunk), do: raise(StreamError, reason: :invalid_stream_chunk)
 
-  defp reduce_stream(%WrappedStream{} = wrapped, {:suspend, acc}, fun),
-    do: {:suspended, acc, &reduce_stream(wrapped, &1, fun)}
-
-  defp reducer(
-         %WrappedStream{max_body_bytes: max_body_bytes} = wrapped,
-         fun,
-         consumer_failure_ref
-       ) do
-    fn chunk, {size, acc} ->
-      with {:ok, binary} <- validate_chunk(chunk),
-           {:ok, new_size} <- add_size(size, binary, max_body_bytes) do
-        advance_consumer(fun, binary, acc, new_size, consumer_failure_ref)
-      else
-        {:error, :body_too_large} ->
-          WrappedStream.mark_body_limit_exceeded(wrapped)
-          WrappedStream.mark_stream_error(wrapped, :body_too_large)
-          raise StreamError, reason: :body_too_large
-
-        {:error, reason} ->
-          WrappedStream.mark_stream_error(wrapped, reason)
-          raise StreamError, reason: reason
-      end
-    end
-  end
-
-  defp advance_consumer(fun, binary, acc, new_size, consumer_failure_ref) do
-    case call_consumer(fun, binary, acc, consumer_failure_ref) do
-      {:cont, acc} -> {:cont, {new_size, acc}}
-      {:halt, acc} -> {:halt, {new_size, acc}}
-      {:suspend, acc} -> {:suspend, {new_size, acc}}
-    end
-  end
-
-  defp call_consumer(fun, binary, acc, consumer_failure_ref) do
-    case fun.(binary, acc) do
-      {:cont, _acc} = result -> result
-      {:halt, _acc} = result -> result
-      {:suspend, _acc} = result -> result
-      invalid -> raise CaseClauseError, term: invalid
-    end
-  rescue
-    exception ->
-      throw({consumer_failure_ref, :error, exception, __STACKTRACE__})
-  catch
-    kind, reason ->
-      throw({consumer_failure_ref, kind, reason, __STACKTRACE__})
-  end
-
-  defp validate_chunk(chunk) when is_binary(chunk), do: {:ok, chunk}
-  defp validate_chunk(_chunk), do: {:error, :invalid_stream_chunk}
-
-  defp add_size(size, binary, :infinity), do: {:ok, size + byte_size(binary)}
+  defp add_size(size, binary, :infinity), do: size + byte_size(binary)
 
   defp add_size(size, binary, max_body_bytes)
        when is_integer(max_body_bytes) and max_body_bytes >= 0 do
     new_size = size + byte_size(binary)
 
     if new_size <= max_body_bytes do
-      {:ok, new_size}
+      new_size
     else
-      {:error, :body_too_large}
+      raise StreamError, reason: :body_too_large
     end
-  end
-
-  defp unwrap_result({:done, {_size, acc}}, _wrapped, _fun, _consumer_failure_ref),
-    do: {:done, acc}
-
-  defp unwrap_result({:halted, {_size, acc}}, _wrapped, _fun, _consumer_failure_ref),
-    do: {:halted, acc}
-
-  defp unwrap_result({:suspended, {size, acc}, continuation}, wrapped, fun, consumer_failure_ref) do
-    {:suspended, acc, &continue(wrapped, continuation, size, &1, fun, consumer_failure_ref)}
-  end
-
-  defp continue(wrapped, continuation, size, {:cont, acc}, fun, consumer_failure_ref) do
-    continue_safely(wrapped, continuation, {:cont, {size, acc}}, fun, consumer_failure_ref)
-  end
-
-  defp continue(wrapped, continuation, size, {:halt, acc}, fun, consumer_failure_ref) do
-    continue_safely(wrapped, continuation, {:halt, {size, acc}}, fun, consumer_failure_ref)
-  end
-
-  defp continue(wrapped, continuation, size, {:suspend, acc}, fun, consumer_failure_ref) do
-    continue_safely(wrapped, continuation, {:suspend, {size, acc}}, fun, consumer_failure_ref)
-  end
-
-  defp continue_safely(wrapped, continuation, command, fun, consumer_failure_ref) do
-    with_stream_guard(wrapped, consumer_failure_ref, fn ->
-      continuation.(command)
-      |> unwrap_result(wrapped, fun, consumer_failure_ref)
-    end)
-  end
-
-  # Shared mark-and-reraise guard: a StreamError marks its own reason; any other
-  # exception/throw is normalized to :stream_exception. The consumer-failure throw
-  # (tagged with consumer_failure_ref) is re-raised verbatim so a *consumer* error
-  # is never misattributed to the source stream.
-  defp with_stream_guard(wrapped, consumer_failure_ref, fun) do
-    fun.()
-  rescue
-    error in StreamError ->
-      WrappedStream.mark_stream_error(wrapped, error.reason)
-      reraise error, __STACKTRACE__
-
-    _error ->
-      WrappedStream.mark_stream_error(wrapped, :stream_exception)
-      reraise StreamError.exception(reason: :stream_exception), __STACKTRACE__
-  catch
-    {^consumer_failure_ref, kind, reason, stacktrace} ->
-      :erlang.raise(kind, reason, stacktrace)
-
-    _kind, _reason ->
-      WrappedStream.mark_stream_error(wrapped, :stream_exception)
-      raise StreamError, reason: :stream_exception
   end
 end

--- a/test/image_pipe/processor_test.exs
+++ b/test/image_pipe/processor_test.exs
@@ -247,6 +247,22 @@ defmodule ImagePipe.Request.ProcessorTest do
              Processor.decode_validate_source_response(response, plan(), opts())
   end
 
+  test "non-binary source chunks remain source errors during decode" do
+    response = %Response{stream: ["ok", :bad]}
+    assert {:ok, response} = Source.wrap_response(response, max_body_bytes: 20)
+
+    assert {:error, {:source, :invalid_stream_chunk}} =
+             Processor.decode_validate_source_response(response, plan(), opts())
+  end
+
+  test "upstream throws during the source drain remain source errors" do
+    response = %Response{stream: Stream.map([:throw], fn _ -> throw(:boom) end)}
+    assert {:ok, response} = Source.wrap_response(response, max_body_bytes: 20)
+
+    assert {:error, {:source, :stream_exception}} =
+             Processor.decode_validate_source_response(response, plan(), opts())
+  end
+
   test "decode_validate_source_response opens a path response via the path" do
     response = %Response{path: "priv/static/images/beach.jpg"}
 

--- a/test/image_pipe/source_test.exs
+++ b/test/image_pipe/source_test.exs
@@ -271,7 +271,6 @@ defmodule ImagePipe.SourceTest do
              Source.wrap_response(response, max_body_bytes: byte_size(body))
 
     assert Enum.to_list(wrapped.stream) == [body]
-    refute Source.body_limit_exceeded?(wrapped)
   end
 
   test "wrapped streams keep adapter cleanup in enumerable termination path" do
@@ -392,7 +391,6 @@ defmodule ImagePipe.SourceTest do
     assert wrapped.path == nil
 
     assert_raise ImagePipe.Source.StreamError, fn -> Enum.to_list(wrapped.stream) end
-    assert Source.body_limit_exceeded?(wrapped)
   end
 
   test "wrap_response passes a path response through unwrapped" do
@@ -407,9 +405,4 @@ defmodule ImagePipe.SourceTest do
              Source.wrap_response(response, max_body_bytes: 10)
   end
 
-  test "body/stream queries degrade for a path response" do
-    response = %Response{path: "/tmp/x.jpg"}
-    refute Source.body_limit_exceeded?(response)
-    assert Source.stream_error_reason(response) == :error
-  end
 end

--- a/test/image_pipe/source_test.exs
+++ b/test/image_pipe/source_test.exs
@@ -341,5 +341,4 @@ defmodule ImagePipe.SourceTest do
     assert {:error, {:source, :invalid_adapter_result}} =
              Source.wrap_response(response, max_body_bytes: 10)
   end
-
 end

--- a/test/image_pipe/source_test.exs
+++ b/test/image_pipe/source_test.exs
@@ -281,14 +281,6 @@ defmodule ImagePipe.SourceTest do
     assert_receive :stream_closed
   end
 
-  test "wrapped streams sanitize upstream enumerable exceptions" do
-    response = %Response{stream: StreamWithCleanup.raising_stream()}
-
-    assert {:ok, %Response{} = wrapped} = Source.wrap_response(response, max_body_bytes: 20)
-    error = assert_raise Source.StreamError, fn -> Enum.to_list(wrapped.stream) end
-    assert error.reason == :stream_exception
-  end
-
   test "wrapped streams preserve safe deferred source errors" do
     response = %Response{
       stream: Stream.map([:error], fn _ -> raise Source.StreamError, reason: :bad_status end)
@@ -297,61 +289,6 @@ defmodule ImagePipe.SourceTest do
     assert {:ok, %Response{} = wrapped} = Source.wrap_response(response, max_body_bytes: 20)
     error = assert_raise Source.StreamError, fn -> Enum.to_list(wrapped.stream) end
     assert error.reason == :bad_status
-  end
-
-  test "wrapped streams sanitize upstream throws shaped like consumer failures" do
-    sentinel = {
-      :image_pipe_wrapped_stream_consumer_failure,
-      :error,
-      RuntimeError.exception("forged consumer failure"),
-      []
-    }
-
-    response = %Response{stream: Stream.map([:error], fn _ -> throw(sentinel) end)}
-
-    assert {:ok, %Response{} = wrapped} = Source.wrap_response(response, max_body_bytes: 20)
-    error = assert_raise Source.StreamError, fn -> Enum.to_list(wrapped.stream) end
-    assert error.reason == :stream_exception
-  end
-
-  test "wrapped streams preserve consumer exceptions" do
-    response = %Response{stream: ["ok"]}
-
-    assert {:ok, %Response{} = wrapped} = Source.wrap_response(response, max_body_bytes: 20)
-
-    assert_raise RuntimeError, "consumer failure", fn ->
-      Enumerable.reduce(wrapped.stream, {:cont, []}, fn _chunk, _acc ->
-        raise "consumer failure"
-      end)
-    end
-  end
-
-  test "wrapped streams preserve invalid consumer return failures" do
-    response = %Response{stream: ["ok"]}
-
-    assert {:ok, %Response{} = wrapped} = Source.wrap_response(response, max_body_bytes: 20)
-
-    assert_raise CaseClauseError, fn ->
-      Enumerable.reduce(wrapped.stream, {:cont, []}, fn _chunk, _acc ->
-        :invalid_consumer_return
-      end)
-    end
-  end
-
-  test "wrapped stream continuations preserve consumer exceptions" do
-    response = %Response{stream: ["first", "second"]}
-
-    assert {:ok, %Response{} = wrapped} = Source.wrap_response(response, max_body_bytes: 20)
-
-    assert {:suspended, ["first"], continuation} =
-             Enumerable.reduce(wrapped.stream, {:cont, []}, fn
-               "first", acc -> {:suspend, ["first" | acc]}
-               "second", _acc -> raise "consumer failure"
-             end)
-
-    assert_raise RuntimeError, "consumer failure", fn ->
-      continuation.({:cont, ["first"]})
-    end
   end
 
   test "resolve surfaces unexpected adapter exceptions" do


### PR DESCRIPTION
## Summary

- Reduce `ImagePipe.Source.WrappedStream` from a ~203-line hand-rolled `Enumerable` (suspend/resume bookkeeping, consumer-vs-producer failure separation, an `:atomics` error channel) to a ~35-line `Stream.transform` that counts bytes, enforces `max_body_bytes`, and rejects non-binary chunks.
- Delete the dead `:atomics` readers — `prefer_source_*` in `Request.Processor` (all six call sites) and the `Source.body_limit_exceeded?/1` + `Source.stream_error_reason/1` facade. These are vestiges of the pre-#142 lazy-decode era: since #142, the source body is drained to a binary in `seekable_input/1` **before** decode, so every source failure already surfaces via that rescue.
- Move generic source-exception normalization to the single drain consumer, `Request.Processor.seekable_input/1` (broadened `rescue`/`catch` → `{:source, :stream_exception}`), where it belongs.
- Net **−255 lines** of lib + tests.

## Background

Came out of a request-time streaming-subsystem exploration. A throwaway de-risking spike (recorded in the included memo) **falsified** the "Vix encode continuation has process affinity" assumption (it resumes byte-identically cross-process; the real constraint is OTP link topology) and confirmed prompt encode cancellation works even for AVIF — which is why the related Producer rearchitecture was scoped down and this WrappedStream cleanup was prioritized. The opportunities memo and the reviewed implementation plan are included under `docs/superpowers/`.

## Behavior preservation (request boundary)

- `{:source, :body_too_large}` → **422**, fail-closed **before** decode.
- `{:source, :invalid_stream_chunk}` for non-binary chunks (specific arm beats the generic one).
- `{:source, :stream_exception}` for raw source exceptions and throws/exits during the drain.
- Classified `StreamError` reasons (e.g. `:bad_status`) preserved verbatim.
- Pinned by `test/image_pipe/processor_test.exs` and `test/image_pipe/request_safety_test.exs`.

## Verification

- `mise run precommit` green: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict` (no issues), `mix test` — **1456 tests + 51 properties + 1 doctest, 0 failures** (5 `:image_vision` excluded).
- Architecture boundary test green (25 tests).
- The implementation plan went through the repo's mandatory **parallel disjoint-reviewer cycle** (imgproxy-compat vs `local/imgproxy-master`, correctness/unreachability, test-discipline); each task passed spec + code-quality review; a final holistic review cleared it for merge.

## Follow-up (separate)

A pre-existing stale test (`request_safety_test.exs` "linked source stream exits…" + its `LinkedReaderImageOpen` helper) went dead at #142 and is flagged for separate cleanup — not in scope here.

## Test plan

- [x] `mise run precommit` green
- [x] architecture boundary test green
- [x] request-boundary source-error mapping pinned (422 / fail-closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architecture planning documents for streaming subsystem refactoring and optimization opportunities.

* **Refactor**
  * Simplified internal stream handling and error normalization logic.
  * Removed dead code paths and unused internal helper functions.
  * Improved consistency in error reporting across streaming operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->