### PR TITLE
Remove stale linked-reader source-error test and its helper

### DIFF
--- a/test/image_pipe/request_safety_test.exs
+++ b/test/image_pipe/request_safety_test.exs
@@ -103,24 +103,6 @@ defmodule ImagePipe.RequestSafetyTest do
     end
   end
 
-  defmodule LinkedReaderImageOpen do
-    alias ImagePipe.Source
-
-    def open(stream, _decode_options) do
-      pid = spawn_link(fn -> Enum.to_list(stream) end)
-
-      receive do
-        {:EXIT, ^pid, {%Source.StreamError{reason: :stream_exception}, _stacktrace} = reason} ->
-          exit(reason)
-
-        {:EXIT, ^pid, %Source.StreamError{reason: :stream_exception} = reason} ->
-          exit(reason)
-      after
-        1_000 -> raise "linked reader did not exit from source stream error"
-      end
-    end
-  end
-
   test "plug validates product-neutral plan shape before source identity resolution" do
     conn =
       ImagePipe.Plug.call(conn(:get, "/_/plain/images/cat.jpg"),
@@ -396,22 +378,6 @@ defmodule ImagePipe.RequestSafetyTest do
     assert conn.status == 422
     assert conn.resp_body == "invalid image source"
     assert_received :cache_lookup
-    refute_received :cache_put
-  end
-
-  test "linked source stream exits return source response errors" do
-    opts =
-      ImagePipe.Plug.init(
-        parser: ImagePipe.Parser.Imgproxy,
-        sources: [path: {StreamErrorSourceAdapter, []}],
-        cache: {CacheProbe, []},
-        image_open_module: LinkedReaderImageOpen
-      )
-
-    conn = ImagePipe.Plug.call(conn(:get, "/_/plain/images/stream-fails.jpg"), opts)
-
-    assert conn.status == 422
-    assert conn.resp_body == "invalid image source"
     refute_received :cache_put
   end
 end


### PR DESCRIPTION
## Summary

Deletes the `"linked source stream exits return source response errors"` test and its `LinkedReaderImageOpen` helper from `test/image_pipe/request_safety_test.exs`. Both went **dead at #142**, which made `Request.Processor.seekable_input/1` drain the source body to a binary (via `Enum.to_list`) **before** decode.

Because the drain now classifies any source-stream failure as `{:source, _}` and returns before `open_seekable_input` ever calls the injected `image_open_module`, `LinkedReaderImageOpen.open/2` is **never reached**. With its injection dead, the test became an exact behavioral duplicate of `"deferred source stream errors return source response errors"`:

| | `:deferred source stream errors` (kept) | `:linked source stream exits` (removed) |
|---|---|---|
| adapter | `StreamErrorSourceAdapter` (raises during fetch stream) | same |
| fixture | `stream-fails.jpg` | same |
| assertions | `422` / `"invalid image source"` / `refute :cache_put` | same |
| only difference | — | dead `image_open_module: LinkedReaderImageOpen` injection |

The source stream here **raises** (not exits); the "exits" in the name referred to the now-unreachable linked-reader helper process, not a source-stream exit — so this was never exit-during-drain coverage and none is lost.

## Coverage

No coverage lost. The raise-during-drain → 422 behavior remains pinned by:
- `request_safety_test.exs` `"deferred source stream errors return source response errors"` (wire-level 422)
- `test/image_pipe/processor_test.exs` `"deferred source stream errors remain source errors during decode"` (boundary `{:source, :stream_exception}`)

## Verification

`mise run precommit` green: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict` (no issues), `mix test` — 1459 tests + 51 properties + 1 doctest, 0 failures (5 `:image_vision` excluded).

## Independence

Based directly on `main`; disjoint from #159 (which doesn't touch `request_safety_test.exs`). Mergeable in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)