### PR TITLE
Pin Elixir 1.20.0 release instead of rc.6

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -27,9 +27,9 @@ jobs:
             erlang: 27
           - elixir: 1.19.5-otp-28
             erlang: 28
-          - elixir: 1.20.0-rc.6-otp-27
+          - elixir: 1.20.0-otp-27
             erlang: 27
-          - elixir: 1.20.0-rc.6-otp-28
+          - elixir: 1.20.0-otp-28
             erlang: 28
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
           mise_toml: |
             [tools]
             erlang = "29"
-            elixir = "1.20.0-rc.6-otp-29"
+            elixir = "1.20.0-otp-29"
             node = "latest"
             pnpm = "latest"
       - name: Install Hex

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-elixir = "1.20.0-rc.6-otp-29"
+elixir = "1.20.0-otp-29"
 node = "latest"
 
 [tasks.setup]


### PR DESCRIPTION
Elixir 1.20.0 has been released. This updates the toolchain pin from the release candidate `1.20.0-rc.6` to the full `1.20.0` release.

## Changes
- `mise.toml` — `1.20.0-rc.6-otp-29` → `1.20.0-otp-29`
- `.github/workflows/lint.yml` — lint job toolchain pin
- `.github/workflows/elixir.yml` — CI matrix entries (OTP 27 + 28)

## Verification
- `mise install` pulls the full `1.20.0-otp-29` release
- The installed binary reports `Elixir 1.20.0 (compiled with Erlang/OTP 29)`
- `mise current elixir` / `mise which elixir` resolve to the 1.20.0 install

🤖 Generated with [Claude Code](https://claude.com/claude-code)