### PR TITLE
Output: format-aware encoder dimension clamp (#150, fixSize parity)

### DIFF
--- a/docs/imgproxy_support_matrix.md
+++ b/docs/imgproxy_support_matrix.md
@@ -307,6 +307,15 @@ decoded input size and `max_result_width`, `max_result_height`, and
 `max_result_pixels` for final static result size. It doesn't expose Imgproxy's
 animation frame limits or SVG and PNG-specific policy.
 
+Separately from those host-configured caps, ImagePipe clamps the realized output
+to the chosen output encoder's hard per-dimension limit — WebP 16383, AVIF 16384
+(JPEG 65535, PNG effectively unbounded) — by uniformly downscaling and serving
+rather than failing to encode. This mirrors imgproxy's internal `fixSize` step
+(`local/imgproxy-master/processing/fix_size.go`) and emits an `[:output, :clamp]`
+telemetry event ([docs/telemetry.md](telemetry.md)). It is an internal safety
+backstop with no configurable knob, so it has no `IMGPROXY_*` row; it only
+triggers when a host raises `max_result_*` above the encoder limit.
+
 - ✅ `IMGPROXY_MAX_SRC_RESOLUTION`
 - ✅ `IMGPROXY_MAX_SRC_FILE_SIZE`
 - ⭕ `IMGPROXY_MAX_ANIMATION_FRAMES`

--- a/docs/superpowers/plans/2026-06-08-output-encoder-dimension-clamp.md
+++ b/docs/superpowers/plans/2026-06-08-output-encoder-dimension-clamp.md
@@ -1,0 +1,687 @@
+# Output-Encoder Dimension Clamp (#150) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the realized final image exceeds the negotiated output encoder's hard dimension limit (WebP 16383, AVIF 16384), uniformly downscale it to fit before encoding — so encoding cannot fail — and emit a `[:output, :clamp]` telemetry signal.
+
+**Architecture:** A post-hoc, product-neutral uniform downscale at the `ImagePipe.Output.*` boundary. `Output.Encoder.encoder_limit/1` holds the per-format dimension table; `Output.Clamp.clamp/3` does the generic downscale on a realized `Vix.Vips.Image` via the `image` library (no `Transform`/`Telemetry` dependency). The producer (`Request.SourceSession.Producer`, in the request boundary) wires them between format negotiation and `Encoder.stream_output`, and emits the telemetry one-shot when a clamp occurs. Cache key/ETag are unchanged (format already in the key; final dims derive from inputs).
+
+**Tech Stack:** Elixir, `image`/Vix (libvips), `:telemetry`, ExUnit, `Boundary`. Run all tooling via `mise exec -- ...`.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-output-encoder-dimension-clamp-design.md` (read it; Resolved Decision D1 = dimension-only `clamp/3`, pixel/sqrt path deferred to #165).
+
+---
+
+## File Structure
+
+- **Create** `lib/image_pipe/output/clamp.ex` — `ImagePipe.Output.Clamp`, the generic uniform downscale (`clamp/3`), product-neutral, no format/host knowledge.
+- **Modify** `lib/image_pipe/output/encoder.ex` — add `encoder_limit/1` (per-format dimension table).
+- **Modify** `lib/image_pipe/output.ex` — add `Clamp` to boundary `exports`.
+- **Modify** `lib/image_pipe/request/source_session/producer.ex` — wire `encoder_limit` + `Clamp.clamp` + telemetry into `prepare_first_chunk/1`.
+- **Modify** `lib/image_pipe/telemetry/logger.ex` — subscribe to + render the `[:output, :clamp]` one-shot at `:warning`.
+- **Modify** `docs/telemetry.md` — document the `[:output, :clamp]` event.
+- **Create** `test/image_pipe/output/clamp_test.exs` — direct unit tests for `Clamp.clamp/3`.
+- **Modify** `test/image_pipe/imgproxy_wire_conformance_test.exs` — wire-level WebP/AVIF clamp tests + no-clamp control (real encode, decoded dims, telemetry).
+- **Modify** `test/image_pipe/telemetry/logger_test.exs` — assert the clamp log line at `:warning`.
+
+---
+
+## Task 1: `Output.Encoder.encoder_limit/1` — per-format dimension table
+
+**Files:**
+- Modify: `lib/image_pipe/output/encoder.ex`
+- Test: `test/image_pipe/output/clamp_test.exs` (created here; reused in Task 2)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/image_pipe/output/clamp_test.exs` with the encoder-limit cases:
+
+```elixir
+defmodule ImagePipe.Output.ClampTest do
+  use ExUnit.Case, async: true
+
+  alias ImagePipe.Output.Encoder
+
+  describe "encoder_limit/1" do
+    test "returns the WebP and AVIF hard dimension limits" do
+      assert Encoder.encoder_limit(:webp) == %{max_dimension: 16383}
+      assert Encoder.encoder_limit(:avif) == %{max_dimension: 16384}
+    end
+
+    test "returns the documented JPEG limit and unbounded PNG" do
+      assert Encoder.encoder_limit(:jpeg) == %{max_dimension: 65535}
+      assert Encoder.encoder_limit(:png) == %{max_dimension: :infinity}
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/output/clamp_test.exs`
+Expected: FAIL — `function ImagePipe.Output.Encoder.encoder_limit/1 is undefined`.
+
+- [ ] **Step 3: Add `encoder_limit/1` to the Encoder**
+
+In `lib/image_pipe/output/encoder.ex`, add a public function near the top of the module (after the `alias` lines, before `stream_output/3`). The values are verified against `local/imgproxy-master/processing/fix_size.go:14-15`:
+
+```elixir
+@doc """
+The output encoder's hard per-dimension limit for `format`, used by
+`ImagePipe.Output.Clamp` to keep encoding from failing. `:infinity` means no
+practical limit. Sourced from libvips encoder constraints (cf. imgproxy
+`processing/fix_size.go`). #150 uses only `:max_dimension`; #165 will extend
+the returned map with a `:max_pixels` budget when its caller makes that live.
+"""
+@spec encoder_limit(Format.format()) :: %{max_dimension: pos_integer() | :infinity}
+def encoder_limit(:webp), do: %{max_dimension: 16_383}
+def encoder_limit(:avif), do: %{max_dimension: 16_384}
+def encoder_limit(:jpeg), do: %{max_dimension: 65_535}
+def encoder_limit(:png), do: %{max_dimension: :infinity}
+```
+
+Note: the output-format type is `ImagePipe.Plan.Output.format` (`:avif | :webp | :jpeg | :png`, `plan/output.ex:19`). `Encoder` already `alias`es `ImagePipe.Format`; if `Format.format()` is not the right type alias, use `ImagePipe.Plan.Output.format()` in the `@spec` instead — pick whichever already resolves in this module without adding a new alias that would change boundary deps (both `Format` and `Plan` are already allowed deps of `Output`).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mise exec -- mix test test/image_pipe/output/clamp_test.exs`
+Expected: PASS (both `encoder_limit/1` tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/output/encoder.ex test/image_pipe/output/clamp_test.exs
+git commit -m "feat(output): add Encoder.encoder_limit/1 per-format dimension table (#150)"
+```
+
+---
+
+## Task 2: `Output.Clamp.clamp/3` — generic uniform downscale
+
+**Files:**
+- Create: `lib/image_pipe/output/clamp.ex`
+- Test: `test/image_pipe/output/clamp_test.exs` (extend)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append a `describe "clamp/3"` block to `test/image_pipe/output/clamp_test.exs`. These use real `Image` (default `image_module`) and small synthetic images, so every input is a shape a real producer constructs (a realized `Vix.Vips.Image` + an integer/`:infinity` limit):
+
+```elixir
+  describe "clamp/3" do
+    alias ImagePipe.Output.Clamp
+
+    # A blank image of exact dimensions; cheap and lazy.
+    defp image(width, height) do
+      {:ok, image} = Image.new(width, height)
+      image
+    end
+
+    test "returns the image unchanged with nil info when within the limit" do
+      img = image(200, 50)
+      assert {:ok, ^img, nil} = Clamp.clamp(img, 1000, [])
+    end
+
+    test "is a no-op for an :infinity limit" do
+      img = image(200, 50)
+      assert {:ok, ^img, nil} = Clamp.clamp(img, :infinity, [])
+    end
+
+    test "uniformly downscales when the longest axis exceeds the limit" do
+      img = image(200, 50)
+      assert {:ok, resized, info} = Clamp.clamp(img, 100, [])
+
+      assert Image.width(resized) == 100
+      assert Image.height(resized) == 25
+      assert info.source_dimensions == {200, 50}
+      assert info.dimensions == {100, 25}
+      assert info.max_dimension == 100
+      assert_in_delta info.scale, 0.5, 1.0e-6
+    end
+
+    test "guarantees the realized longest axis is at most the limit (rounding)" do
+      # 333 * (100/333) = 100.0 -> round 100; this also exercises the
+      # measure-and-verify path that keeps a rounding quirk from exceeding it.
+      img = image(333, 10)
+      assert {:ok, resized, info} = Clamp.clamp(img, 100, [])
+
+      assert Image.width(resized) <= 100
+      assert max(Image.width(resized), Image.height(resized)) <= 100
+      assert info.dimensions == {Image.width(resized), Image.height(resized)}
+    end
+  end
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `mise exec -- mix test test/image_pipe/output/clamp_test.exs`
+Expected: FAIL — `ImagePipe.Output.Clamp.clamp/3 is undefined` (the `encoder_limit/1` tests still pass).
+
+- [ ] **Step 3: Implement `ImagePipe.Output.Clamp`**
+
+Create `lib/image_pipe/output/clamp.ex`:
+
+```elixir
+defmodule ImagePipe.Output.Clamp do
+  @moduledoc false
+  # Generic, product-neutral uniform downscale of a realized image so it fits a
+  # maximum dimension. Used by the producer with the output encoder's per-format
+  # limit (`ImagePipe.Output.Encoder.encoder_limit/1`) so encoding cannot fail.
+  # Knows nothing about formats or hosts: it takes a raw `max_dimension`. #165
+  # widens this to also accept a `max_pixels` budget.
+  #
+  # Reads/resizes the image via the `image` library directly (no Transform or
+  # Telemetry dependency, per the Output boundary). Resize is lazy; measuring
+  # width/height reads libvips header fields (O(1), no pixel realization).
+
+  alias Vix.Vips.Image, as: VixImage
+
+  @type clamp_info :: %{
+          scale: float(),
+          source_dimensions: {pos_integer(), pos_integer()},
+          dimensions: {pos_integer(), pos_integer()},
+          max_dimension: pos_integer()
+        }
+
+  @spec clamp(VixImage.t(), pos_integer() | :infinity, keyword()) ::
+          {:ok, VixImage.t(), clamp_info() | nil}
+          | {:error, {:encode, Exception.t(), list()}}
+  def clamp(%VixImage{} = image, :infinity, _opts), do: {:ok, image, nil}
+
+  def clamp(%VixImage{} = image, max_dimension, opts)
+      when is_integer(max_dimension) and max_dimension > 0 do
+    w = Image.width(image)
+    h = Image.height(image)
+    longest = max(w, h)
+
+    if longest <= max_dimension do
+      {:ok, image, nil}
+    else
+      image_module = Keyword.get(opts, :image_module, Image)
+      scale = max_dimension / longest
+
+      with {:ok, resized} <- resize(image_module, image, scale),
+           {:ok, resized} <- enforce_limit(image_module, image, resized, max_dimension) do
+        {:ok, resized,
+         %{
+           scale: scale,
+           source_dimensions: {w, h},
+           dimensions: {Image.width(resized), Image.height(resized)},
+           max_dimension: max_dimension
+         }}
+      end
+    end
+  end
+
+  # Defensive ≤-limit guarantee: round() at `scale = limit/longest` lands the
+  # longest axis exactly on `limit`, but if a libvips rounding quirk overshoots
+  # we re-resize the ORIGINAL by a floor-biased factor so the corrected longest
+  # axis cannot round back over the limit. In practice this never fires.
+  defp enforce_limit(image_module, original, resized, max_dimension) do
+    realized = max(Image.width(resized), Image.height(resized))
+
+    if realized <= max_dimension do
+      {:ok, resized}
+    else
+      longest = max(Image.width(original), Image.height(original))
+      # floor-bias: subtract a hair so round() cannot bump back to the overshoot
+      corrected = (max_dimension - 0.5) / longest
+      resize(image_module, original, corrected)
+    end
+  end
+
+  defp resize(image_module, image, scale) do
+    case image_module.resize(image, scale, vertical_scale: scale) do
+      {:ok, resized} -> {:ok, resized}
+      {:error, reason} -> {:error, encode_error(reason)}
+      resized when is_struct(resized, VixImage) -> {:ok, resized}
+    end
+  end
+
+  defp encode_error(reason) do
+    {:encode, RuntimeError.exception("clamp resize failed: #{inspect(reason)}"), []}
+  end
+end
+```
+
+Notes for the implementer:
+- `Image.resize/3` returns `{:ok, image} | {:error, reason}` (`deps/image/lib/image.ex:4178`); the `is_struct` clause is a defensive belt-and-suspenders for the alpha path and harmless. It premultiplies alpha internally, so transparent images don't get halos.
+- The `{:error, {:encode, exception, stacktrace}}` 3-tuple is **required** — a bare `{:encode, reason}` 2-tuple matches no `handle_processing_error/3` clause in `response/sender.ex` and would crash. This mirrors `runner.ex:205`'s `{:session, reason}` wrapping.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `mise exec -- mix test test/image_pipe/output/clamp_test.exs`
+Expected: PASS (all `encoder_limit/1` and `clamp/3` cases).
+
+- [ ] **Step 5: Compile cleanly (clamp.ex must satisfy the Output boundary)**
+
+Run: `mise exec -- mix compile --warnings-as-errors`
+Expected: compiles with no warnings and no `Boundary` violation (clamp.ex references only `Vix`/`Image` external libs).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/image_pipe/output/clamp.ex test/image_pipe/output/clamp_test.exs
+git commit -m "feat(output): add Clamp.clamp/3 generic uniform downscale (#150)"
+```
+
+---
+
+## Task 3: Export `Clamp` from the Output boundary
+
+**Files:**
+- Modify: `lib/image_pipe/output.ex`
+
+- [ ] **Step 1: Add the export**
+
+In `lib/image_pipe/output.ex`, add `Clamp` to the `exports:` list (alphabetical-ish, alongside `Encoder`):
+
+```elixir
+  use Boundary,
+    top_level?: true,
+    deps: [ImagePipe.Format, ImagePipe.Plan],
+    exports: [
+      Capabilities,
+      Clamp,
+      Encoder,
+      Negotiation,
+      Resolved
+    ]
+```
+
+Do **not** change `deps:` — `Clamp` adds no new boundary dependency.
+
+- [ ] **Step 2: Compile to verify the export resolves**
+
+Run: `mise exec -- mix compile --warnings-as-errors`
+Expected: compiles cleanly (no `Boundary` "module not exported" error when the producer references `Clamp` in Task 4).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/image_pipe/output.ex
+git commit -m "feat(output): export Output.Clamp from the boundary (#150)"
+```
+
+---
+
+## Task 4: Wire the clamp + telemetry into the producer
+
+**Files:**
+- Modify: `lib/image_pipe/request/source_session/producer.ex`
+
+- [ ] **Step 1: Add the `Clamp` alias**
+
+In `lib/image_pipe/request/source_session/producer.ex`, add to the `alias` block (after `alias ImagePipe.Output.Encoder`):
+
+```elixir
+  alias ImagePipe.Output.Clamp
+```
+
+- [ ] **Step 2: Insert the clamp + telemetry into `prepare_first_chunk/1`'s `with`**
+
+Replace the existing `with` chain body (currently `resolve_output` → `Encoder.stream_output` → `first_chunk`) so the clamp runs between negotiation and encode. The full edited `with` head:
+
+```elixir
+      with {:ok, decoded} <-
+             Processor.fetch_decode_validate_source_with_source_format(
+               request.plan,
+               request.resolved_source,
+               request.opts
+             ),
+           {:ok, %State{} = final_state} <-
+             Processor.process_decoded_source(decoded, request.plan, request.opts),
+           {:ok, %Resolved{} = resolved_output} <-
+             resolve_output(
+               request.output_policy,
+               decoded.source_format,
+               final_state.image,
+               request.opts
+             ),
+           %{max_dimension: max_dimension} <- Encoder.encoder_limit(resolved_output.format),
+           {:ok, image, clamp_info} <-
+             Clamp.clamp(final_state.image, max_dimension, request.opts),
+           :ok <- emit_clamp_telemetry(clamp_info, resolved_output.format, request.opts),
+           {:ok, stream, content_type} <-
+             Encoder.stream_output(image, resolved_output, request.opts),
+           {:ok, chunk, stream_state} <- first_chunk(stream) do
+```
+
+The `else` clause is unchanged (`{:error, reason} -> {:error, reason}` handles the clamp's `{:error, {:encode, ...}}`; `:empty -> :empty`). The `%{max_dimension: ...} <- ...` match always succeeds (map always has the key); it's a binding, not a fallible step.
+
+- [ ] **Step 3: Add the telemetry emitter (private functions)**
+
+Add near `resolve_output/4` (these are private helpers in the same module). `Telemetry` is already aliased and `Telemetry.telemetry_opts/1` / `Telemetry.execute/4` already exist (`telemetry.ex:108,115`):
+
+```elixir
+  defp emit_clamp_telemetry(nil, _format, _opts), do: :ok
+
+  defp emit_clamp_telemetry(%{} = info, format, opts) do
+    Telemetry.execute(
+      Telemetry.telemetry_opts(opts),
+      [:output, :clamp],
+      %{scale: info.scale},
+      %{
+        format: format,
+        source_dimensions: info.source_dimensions,
+        dimensions: info.dimensions,
+        max_dimension: info.max_dimension
+      }
+    )
+
+    :ok
+  end
+```
+
+- [ ] **Step 4: Compile and run the existing producer/conformance suites (no regression)**
+
+Run: `mise exec -- mix compile --warnings-as-errors && mise exec -- mix test test/image_pipe/request/source_session_test.exs test/image_pipe/imgproxy_wire_conformance_test.exs`
+Expected: PASS. (No clamp fires yet in existing tests — every result is within 8192 < the encoder limits — so behavior is unchanged. This proves the no-op path is wired without regression.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/request/source_session/producer.ex
+git commit -m "feat(request): clamp realized image to encoder limit before encode (#150)"
+```
+
+---
+
+## Task 5: Subscribe to + render the `[:output, :clamp]` one-shot in the default Logger
+
+**Files:**
+- Modify: `lib/image_pipe/telemetry/logger.ex`
+
+- [ ] **Step 1: Write the failing Logger test**
+
+Add to `test/image_pipe/telemetry/logger_test.exs` (mirrors the existing `[:transform, :detect, :skipped]` warning test at line 100):
+
+```elixir
+  test "logs the output clamp one-shot at warning with source -> clamped dims" do
+    Telemetry.attach_default_logger(level: :info)
+
+    log =
+      capture_log(fn ->
+        :telemetry.execute(
+          [:image_pipe, :output, :clamp],
+          %{scale: 0.91},
+          %{
+            format: :webp,
+            source_dimensions: {18_000, 9_000},
+            dimensions: {16_383, 8_191},
+            max_dimension: 16_383
+          }
+        )
+      end)
+
+    assert log =~ "[warning]"
+    assert log =~ "output clamp: 18000x9000 -> 16383x8191 for webp (max 16383)"
+  end
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/logger_test.exs`
+Expected: FAIL — the event isn't attached, so `capture_log` is empty (no match for `[warning]` / the message).
+
+- [ ] **Step 3: Subscribe the `:output` group + clamp one-shot**
+
+In `lib/image_pipe/telemetry/logger.ex`:
+
+(a) Add `output: []` to `@group_span_events` (makes `:output` a selectable group, included in `:all` via `@all_groups`):
+
+```elixir
+  @group_span_events %{
+    request: [[:request], [:send]],
+    parse: [[:parse]],
+    source: [[:source, :resolve], [:source, :fetch], [:source, :fetch_decode]],
+    transform: [[:transform, :execute], [:transform, :operation], [:transform, :detect]],
+    cache: [[:cache, :lookup], [:cache, :write], [:cache, :admission], [:cache, :warm_start]],
+    output: []
+  }
+```
+
+(b) Add the one-shot list after `@transform_oneshot`:
+
+```elixir
+  # output one-shot events (already terminal; not spans)
+  @output_oneshot [
+    [:output, :clamp]
+  ]
+```
+
+(c) In `event_names/2`, add the output one-shots alongside cache/transform (after the `transform_oneshots` line):
+
+```elixir
+    output_oneshots = if :output in groups, do: @output_oneshot, else: []
+
+    Enum.map(spans ++ cache_oneshots ++ transform_oneshots ++ output_oneshots, fn e ->
+      prefix ++ e
+    end)
+```
+
+- [ ] **Step 4: Render + escalate the clamp event**
+
+(a) Add a `level_for/3` clause **above** the existing `defp level_for(suffix, metadata, base)` (so it wins for clamp events):
+
+```elixir
+  defp level_for([:output, :clamp | _], _metadata, _base), do: :warning
+```
+
+(b) Add a `message/3` clause **before** the generic fallback (`defp message(suffix, _m, meta)`):
+
+```elixir
+  defp message([:output, :clamp | _], _m, meta) do
+    {sw, sh} = meta[:source_dimensions]
+    {w, h} = meta[:dimensions]
+
+    "image_pipe output clamp: #{sw}x#{sh} -> #{w}x#{h} for #{meta[:format]} (max #{meta[:max_dimension]})"
+  end
+```
+
+The message *is* the outcome (a downscale occurred) — analogous to the `[:transform, :detect, :blend]` clause, which also omits a separate `outcome/1`. No `:result` key is emitted in clamp metadata, so nothing is swallowed.
+
+- [ ] **Step 5: Run the Logger test to verify it passes**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/logger_test.exs`
+Expected: PASS (the new clamp test plus all existing Logger tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/image_pipe/telemetry/logger.ex test/image_pipe/telemetry/logger_test.exs
+git commit -m "feat(telemetry): render [:output, :clamp] one-shot at warning in default Logger (#150)"
+```
+
+---
+
+## Task 6: Wire-level conformance tests (real encode, decoded dims, telemetry)
+
+**Files:**
+- Modify: `test/image_pipe/imgproxy_wire_conformance_test.exs`
+
+These reuse the file's existing helpers: `call_imgproxy/3`, `dimensions/1` (decodes the body → `{w, h}`), `content_type/1`, the self-send `handle_telemetry_event/4` (line 2379), and the `OriginImage` origin (`beach.jpg`). The default opts use the default telemetry prefix `[:image_pipe]`, so the clamp event is `[:image_pipe, :output, :clamp]`.
+
+**Reachability:** the default `max_result_width/height` is 8192 (< 16383/16384), so each test must raise the host result cap above the encoder limit, and use `el:1` enlargement to push the result just past the limit. A wide-short source keeps the encoded pixel count tiny so AVIF/WebP encode stays fast.
+
+> Determine the `beach.jpg` source dimensions and the exact `w:`/`h:` to land just over 16383/16384 during implementation (decode the fixture or compute from a known size). The assertions below are written to be robust to ±1px rounding: they assert the longest axis is **≤ limit** and **strictly less than the pre-clamp longest axis**, not an exact post-clamp size.
+
+- [ ] **Step 1: Write the failing WebP clamp test**
+
+Add a `describe "output encoder dimension clamp (#150)"` block. Use a helper to attach the clamp telemetry to the test pid (mirrors `attach_source_resolve_telemetry/1`):
+
+```elixir
+  describe "output encoder dimension clamp (#150)" do
+    defp attach_clamp_telemetry do
+      handler_id = {__MODULE__, self(), :output_clamp}
+
+      :telemetry.attach(
+        handler_id,
+        [:image_pipe, :output, :clamp],
+        &__MODULE__.handle_telemetry_event/4,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+    end
+
+    @clamp_opts [
+      root_url: "http://origin.test",
+      parser: ImagePipe.Parser.Imgproxy,
+      req_options: [plug: OriginImage],
+      max_result_width: 40_000,
+      max_result_height: 40_000,
+      max_result_pixels: 2_000_000_000
+    ]
+
+    test "downscales a WebP result above the 16383 encoder limit and serves it" do
+      attach_clamp_telemetry()
+
+      # el:1 enlarges; w:18000 pushes the WebP result past 16383. f:webp forces
+      # the output format so negotiation is deterministic.
+      conn = call_imgproxy("/_/el:1/w:18000/f:webp/plain/images/beach.jpg", @clamp_opts)
+
+      assert conn.status == 200
+      assert content_type(conn) == ["image/webp"]
+
+      {w, h} = dimensions(conn)
+      assert max(w, h) <= 16_383
+      assert max(w, h) > 8_192
+
+      assert_received {:telemetry_event, [:image_pipe, :output, :clamp], %{scale: scale},
+                       meta}
+
+      assert scale < 1.0
+      assert meta.format == :webp
+      assert meta.max_dimension == 16_383
+      assert meta.dimensions == {w, h}
+      {sw, sh} = meta.source_dimensions
+      assert max(sw, sh) > 16_383
+    end
+```
+
+- [ ] **Step 2: Run it to verify it fails (before implementation) — or passes (after Tasks 1-5)**
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs -k "downscales a WebP result"`
+Expected after Tasks 1–5: PASS. (If executed before the production code lands, it would fail because no clamp event fires and the encode would error at > 16383.) This task is the integration proof of Tasks 1–5; keep it green.
+
+If it fails on the chosen `w:` not exceeding 16383 (source aspect ratio), adjust `w:`/`h:`/`el` so the pre-clamp longest axis is clearly > 16383, then re-run.
+
+- [ ] **Step 3: Add the AVIF clamp test**
+
+```elixir
+    test "downscales an AVIF result above the 16384 encoder limit and serves it" do
+      attach_clamp_telemetry()
+
+      conn = call_imgproxy("/_/el:1/w:18000/f:avif/plain/images/beach.jpg", @clamp_opts)
+
+      assert conn.status == 200
+      assert content_type(conn) == ["image/avif"]
+
+      {w, h} = dimensions(conn)
+      assert max(w, h) <= 16_384
+      assert max(w, h) > 8_192
+
+      assert_received {:telemetry_event, [:image_pipe, :output, :clamp], %{scale: scale},
+                       meta}
+
+      assert scale < 1.0
+      assert meta.format == :avif
+      assert meta.max_dimension == 16_384
+      assert meta.dimensions == {w, h}
+    end
+```
+
+- [ ] **Step 4: Add the no-clamp control**
+
+```elixir
+    test "does not clamp or emit when a WebP result is within the encoder limit" do
+      attach_clamp_telemetry()
+
+      conn = call_imgproxy("/_/w:120/f:webp/plain/images/beach.jpg", @clamp_opts)
+
+      assert conn.status == 200
+      assert content_type(conn) == ["image/webp"]
+      {w, _h} = dimensions(conn)
+      assert w == 120
+
+      refute_received {:telemetry_event, [:image_pipe, :output, :clamp], _measurements, _meta}
+    end
+  end
+```
+
+- [ ] **Step 5: Run the whole clamp describe block**
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs -k "output encoder dimension clamp"`
+Expected: PASS (all three tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add test/image_pipe/imgproxy_wire_conformance_test.exs
+git commit -m "test(output): wire-level WebP/AVIF dimension-clamp conformance tests (#150)"
+```
+
+---
+
+## Task 7: Document the telemetry event
+
+**Files:**
+- Modify: `docs/telemetry.md`
+
+- [ ] **Step 1: Add the `[:output, :clamp]` entry**
+
+In `docs/telemetry.md`, add an entry where one-shot events are documented (the file documents `[:http_cache, …]` one-shots as precedent; place `[:output, :clamp]` consistently with how other one-shots and the default-Logger rendering are listed):
+
+```markdown
+### `[:image_pipe, :output, :clamp]` (one-shot)
+
+Emitted when the realized final image exceeded the negotiated output encoder's
+hard dimension limit and was uniformly downscaled to fit before encoding
+(format-aware; WebP 16383, AVIF 16384). Lets a host observe that a served image
+was downscaled rather than delivered at the requested size.
+
+- **Measurements:** `%{scale: float()}` — the uniform downscale factor (`< 1.0`).
+- **Metadata:** `%{format: atom(), source_dimensions: {w, h}, dimensions: {w, h}, max_dimension: pos_integer()}` — pre- and post-clamp dimensions and the limit that bound them. All non-sensitive (no URLs/secrets/PII).
+- **Default Logger:** rendered at `:warning` (e.g. `output clamp: 18000x9000 -> 16383x8191 for webp (max 16383)`), matching imgproxy's `slog.Warn`.
+```
+
+Match the surrounding heading style/level of the existing event docs in the file.
+
+- [ ] **Step 2: Verify docs reference the event the Logger actually attaches to**
+
+Confirm the documented event name `[:image_pipe, :output, :clamp]` and the `:warning` rendering match Task 5's Logger wiring. (No command — a read-through against `logger.ex`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/telemetry.md
+git commit -m "docs(telemetry): document [:output, :clamp] dimension-clamp event (#150)"
+```
+
+---
+
+## Task 8: Full precommit gate
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the Elixir gate**
+
+Run: `mise run precommit`
+(This runs `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix test`.)
+Expected: all green. If `mix format` reports changes, run `mise exec -- mix format`, review, and amend the relevant commit.
+
+- [ ] **Step 2: Confirm no demo change is needed**
+
+This is an internal output safety clamp with no user-facing URL knob, so the `demo/` app needs no update (the demo-sync guideline applies only to transform/parser-option changes). No action — recorded here so the omission is deliberate.
+
+- [ ] **Step 3: Final review against the spec**
+
+Re-read `docs/superpowers/specs/2026-06-08-output-encoder-dimension-clamp-design.md` and confirm: dimension-only `clamp/3` (no `max_pixels`), 3-tuple encode-error contract, clamp before `finalize`, no cache-key change, telemetry one-shot + Logger sync + docs, wire tests in the conformance file. (No command.)
+
+---
+
+## Self-Review Notes (author)
+
+- **Spec coverage:** encoder_limit table (T1), generic clamp + ≤-limit guarantee + error contract + no-op laziness + alpha (T2), boundary export (T3), producer seam before stream_output (T4), telemetry one-shot + Logger subscription/level/message (T5), wire WebP/AVIF + no-clamp control with decoded dims (T6), docs (T7), no-cache-change + no-demo-change confirmed (T4/T8). #165 deferral honored — no `max_pixels` anywhere.
+- **No placeholders:** every code step has full code. The one runtime unknown (exact `beach.jpg`-derived `w:` to exceed the limit) is explicitly flagged in T6 with robust ≤-limit/strictly-reduced assertions instead of brittle exact dims.
+- **Type/name consistency:** `clamp/3`, `encoder_limit/1`, `clamp_info` keys (`scale`, `source_dimensions`, `dimensions`, `max_dimension`), event `[:output, :clamp]`, measurements `%{scale: ...}` are identical across Clamp, producer, Logger, tests, and docs.

--- a/docs/superpowers/plans/2026-06-08-output-encoder-dimension-clamp.md
+++ b/docs/superpowers/plans/2026-06-08-output-encoder-dimension-clamp.md
@@ -73,14 +73,14 @@ practical limit. Sourced from libvips encoder constraints (cf. imgproxy
 `processing/fix_size.go`). #150 uses only `:max_dimension`; #165 will extend
 the returned map with a `:max_pixels` budget when its caller makes that live.
 """
-@spec encoder_limit(Format.format()) :: %{max_dimension: pos_integer() | :infinity}
+@spec encoder_limit(Format.output_format()) :: %{max_dimension: pos_integer() | :infinity}
 def encoder_limit(:webp), do: %{max_dimension: 16_383}
 def encoder_limit(:avif), do: %{max_dimension: 16_384}
 def encoder_limit(:jpeg), do: %{max_dimension: 65_535}
 def encoder_limit(:png), do: %{max_dimension: :infinity}
 ```
 
-Note: the output-format type is `ImagePipe.Plan.Output.format` (`:avif | :webp | :jpeg | :png`, `plan/output.ex:19`). `Encoder` already `alias`es `ImagePipe.Format`; if `Format.format()` is not the right type alias, use `ImagePipe.Plan.Output.format()` in the `@spec` instead — pick whichever already resolves in this module without adding a new alias that would change boundary deps (both `Format` and `Plan` are already allowed deps of `Output`).
+Note: the type is `ImagePipe.Format.output_format()` (`:avif | :webp | :jpeg | :png`, defined at `format.ex:19`). `Encoder` already `alias`es `ImagePipe.Format`, so `Format.output_format()` resolves with no new alias and no boundary-dep change. (`Format.format/0` does **not** exist — do not use it.)
 
 - [ ] **Step 4: Run the test to verify it passes**
 
@@ -187,8 +187,7 @@ defmodule ImagePipe.Output.Clamp do
           | {:error, {:encode, Exception.t(), list()}}
   def clamp(%VixImage{} = image, :infinity, _opts), do: {:ok, image, nil}
 
-  def clamp(%VixImage{} = image, max_dimension, opts)
-      when is_integer(max_dimension) and max_dimension > 0 do
+  def clamp(%VixImage{} = image, max_dimension, opts) when is_integer(max_dimension) do
     w = Image.width(image)
     h = Image.height(image)
     longest = max(w, h)
@@ -233,7 +232,6 @@ defmodule ImagePipe.Output.Clamp do
     case image_module.resize(image, scale, vertical_scale: scale) do
       {:ok, resized} -> {:ok, resized}
       {:error, reason} -> {:error, encode_error(reason)}
-      resized when is_struct(resized, VixImage) -> {:ok, resized}
     end
   end
 
@@ -244,7 +242,7 @@ end
 ```
 
 Notes for the implementer:
-- `Image.resize/3` returns `{:ok, image} | {:error, reason}` (`deps/image/lib/image.ex:4178`); the `is_struct` clause is a defensive belt-and-suspenders for the alpha path and harmless. It premultiplies alpha internally, so transparent images don't get halos.
+- `Image.resize/3` returns `{:ok, image} | {:error, reason}` on **both** the alpha and non-alpha branches (`deps/image/lib/image.ex:4178` — the alpha branch ends in `Operation.cast/2`, which returns `{:ok, image}`). It premultiplies alpha internally, so transparent images don't get halos. `vertical_scale:` is a valid `Resize.resize_options()` key (maps to libvips `:vscale`); `scale = max_dimension / longest` is always a float in Elixir.
 - The `{:error, {:encode, exception, stacktrace}}` 3-tuple is **required** — a bare `{:encode, reason}` 2-tuple matches no `handle_processing_error/3` clause in `response/sender.ex` and would crash. This mirrors `runner.ex:205`'s `{:session, reason}` wrapping.
 
 - [ ] **Step 4: Run the tests to verify they pass**
@@ -273,7 +271,7 @@ git commit -m "feat(output): add Clamp.clamp/3 generic uniform downscale (#150)"
 
 - [ ] **Step 1: Add the export**
 
-In `lib/image_pipe/output.ex`, add `Clamp` to the `exports:` list (alphabetical-ish, alongside `Encoder`):
+The current `exports:` list is `[Capabilities, Policy, Encoder, Negotiation, Resolved]`. **Insert `Clamp` — do not drop `Policy`** (it's referenced cross-boundary by the producer/runner; removing it breaks compilation). The result:
 
 ```elixir
   use Boundary,
@@ -284,6 +282,7 @@ In `lib/image_pipe/output.ex`, add `Clamp` to the `exports:` list (alphabetical-
       Clamp,
       Encoder,
       Negotiation,
+      Policy,
       Resolved
     ]
 ```
@@ -501,9 +500,9 @@ git commit -m "feat(telemetry): render [:output, :clamp] one-shot at warning in 
 
 These reuse the file's existing helpers: `call_imgproxy/3`, `dimensions/1` (decodes the body → `{w, h}`), `content_type/1`, the self-send `handle_telemetry_event/4` (line 2379), and the `OriginImage` origin (`beach.jpg`). The default opts use the default telemetry prefix `[:image_pipe]`, so the clamp event is `[:image_pipe, :output, :clamp]`.
 
-**Reachability:** the default `max_result_width/height` is 8192 (< 16383/16384), so each test must raise the host result cap above the encoder limit, and use `el:1` enlargement to push the result just past the limit. A wide-short source keeps the encoded pixel count tiny so AVIF/WebP encode stays fast.
+**Reachability:** the default `max_result_width/height` is 8192 (< 16383/16384), so each test must raise the host result cap above the encoder limit, and enlarge the result just past the limit.
 
-> Determine the `beach.jpg` source dimensions and the exact `w:`/`h:` to land just over 16383/16384 during implementation (decode the fixture or compute from a known size). The assertions below are written to be robust to ±1px rounding: they assert the longest axis is **≤ limit** and **strictly less than the pre-clamp longest axis**, not an exact post-clamp size.
+> **Critical (encode cost):** `beach.jpg` is 4000×2667. A width-only enlarge like `w:18000` keeps aspect ratio → an 18000×12002 (**216 MP**) pre-clamp image, which the encoder *realizes* — AVIF encode of that is ~24s CPU and a real 60s-timeout flake risk in this `async: true` file (it's been bitten twice). Use **`rs:force:18000:200`** (force-resize, breaks aspect) so the pre-clamp image is 18000×200 (**3.6 MP**, ~0.15s encode) while the longest axis (18000) still exceeds both limits. The assertions are robust to ±1px rounding: longest axis **≤ limit** and **> 8192** (strictly reduced from the 18000 pre-clamp), not an exact post-clamp size. `@clamp_opts` also pins `output_capabilities` so the AVIF/WebP tests don't depend on the CI libvips build's auto-probe.
 
 - [ ] **Step 1: Write the failing WebP clamp test**
 
@@ -530,15 +529,19 @@ Add a `describe "output encoder dimension clamp (#150)"` block. Use a helper to 
       req_options: [plug: OriginImage],
       max_result_width: 40_000,
       max_result_height: 40_000,
-      max_result_pixels: 2_000_000_000
+      max_result_pixels: 2_000_000_000,
+      output_capabilities: %{avif: true, webp: true}
     ]
 
     test "downscales a WebP result above the 16383 encoder limit and serves it" do
       attach_clamp_telemetry()
 
-      # el:1 enlarges; w:18000 pushes the WebP result past 16383. f:webp forces
-      # the output format so negotiation is deterministic.
-      conn = call_imgproxy("/_/el:1/w:18000/f:webp/plain/images/beach.jpg", @clamp_opts)
+      # el:1 enlarges; rs:force:18000:200 hard-scales (breaks aspect) so the
+      # pre-clamp longest axis is 18000 (> 16383) but the image stays 3.6 MP
+      # (fast encode). f:webp forces the output format so negotiation is
+      # deterministic.
+      conn =
+        call_imgproxy("/_/el:1/rs:force:18000:200/f:webp/plain/images/beach.jpg", @clamp_opts)
 
       assert conn.status == 200
       assert content_type(conn) == ["image/webp"]
@@ -564,7 +567,7 @@ Add a `describe "output encoder dimension clamp (#150)"` block. Use a helper to 
 Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs -k "downscales a WebP result"`
 Expected after Tasks 1–5: PASS. (If executed before the production code lands, it would fail because no clamp event fires and the encode would error at > 16383.) This task is the integration proof of Tasks 1–5; keep it green.
 
-If it fails on the chosen `w:` not exceeding 16383 (source aspect ratio), adjust `w:`/`h:`/`el` so the pre-clamp longest axis is clearly > 16383, then re-run.
+If `rs:force` is rejected by the parser config, fall back to another enlarge form whose pre-clamp longest axis is clearly > 16383 while keeping the short axis small (e.g. `rs:fill:18000:200/el:1`), then re-run.
 
 - [ ] **Step 3: Add the AVIF clamp test**
 
@@ -572,7 +575,8 @@ If it fails on the chosen `w:` not exceeding 16383 (source aspect ratio), adjust
     test "downscales an AVIF result above the 16384 encoder limit and serves it" do
       attach_clamp_telemetry()
 
-      conn = call_imgproxy("/_/el:1/w:18000/f:avif/plain/images/beach.jpg", @clamp_opts)
+      conn =
+        call_imgproxy("/_/el:1/rs:force:18000:200/f:avif/plain/images/beach.jpg", @clamp_opts)
 
       assert conn.status == 200
       assert content_type(conn) == ["image/avif"]

--- a/docs/superpowers/specs/2026-06-08-output-encoder-dimension-clamp-design.md
+++ b/docs/superpowers/specs/2026-06-08-output-encoder-dimension-clamp-design.md
@@ -16,7 +16,7 @@ This design adds the equivalent: a **post-hoc, uniform downscale of the realized
 - Uniform downscale (same scale on both axes), mirroring `img.Resize(scale, scale)`.
 - Lives at the `ImagePipe.Output.*` boundary, keyed on the negotiated output format.
 - Downscale-and-serve, with a telemetry signal.
-- Generic clamp seam: takes a `max_dimension` (and `max_pixels`) and does not care which source produced the number, so #165 can later feed `min(host_max_result_*, encoder_limit(format))` through the same call without reworking the clamp mechanism.
+- Generic clamp seam: takes a `max_dimension` and does not care which source produced the number, so #165 can later feed `min(host_max_result_*, encoder_limit(format))` through the same call without reworking the clamp mechanism. (#165 also adds a `max_pixels` budget — a free `clamp/3 → clamp/4` widening in this greenfield codebase, made live by #165's own caller and test; see Resolved Decision D1.)
 
 ## Module layout (within the existing `ImagePipe.Output` boundary)
 
@@ -25,30 +25,29 @@ This design adds the equivalent: a **post-hoc, uniform downscale of the realized
 ### `ImagePipe.Output.Encoder.encoder_limit/1` — the per-format table
 
 ```elixir
-@spec encoder_limit(ImagePipe.Plan.output_format()) ::
-        %{max_dimension: pos_integer() | :infinity, max_pixels: pos_integer() | :infinity}
+@spec encoder_limit(ImagePipe.Plan.output_format()) :: %{max_dimension: pos_integer() | :infinity}
 ```
 
-| format | max_dimension | max_pixels | source |
-|--------|---------------|-----------|--------|
-| `:webp` | 16383 | `:infinity` | `fix_size.go:14` |
-| `:avif` | 16384 | `:infinity` | `fix_size.go:15` |
-| `:jpeg` | 65535 | `:infinity` | documented, won't bite |
-| `:png` | `:infinity` | `:infinity` | effectively unbounded |
+| format | max_dimension | source |
+|--------|---------------|--------|
+| `:webp` | 16383 | `fix_size.go:14` |
+| `:avif` | 16384 | `fix_size.go:15` |
+| `:jpeg` | 65535 | documented, won't bite |
+| `:png` | `:infinity` | effectively unbounded |
 
-The format table is encoder knowledge and lives **only** in `Output.Encoder`. JPEG/PNG are documented, not special-cased — they fall out of the generic `:infinity` no-op path.
+The format table is encoder knowledge and lives **only** in `Output.Encoder`. JPEG/PNG are documented, not special-cased — they fall out of the generic `:infinity`/large no-op path. (#165 will extend the returned map with a `max_pixels` budget when its caller makes that constraint live; #150 returns only `max_dimension`.)
 
-### `ImagePipe.Output.Clamp.clamp/4` — the generic, product-neutral downscale
+### `ImagePipe.Output.Clamp.clamp/3` — the generic, product-neutral downscale
 
 ```elixir
-@spec clamp(Vix.Vips.Image.t(), pos_integer() | :infinity, pos_integer() | :infinity, keyword()) ::
+@spec clamp(Vix.Vips.Image.t(), pos_integer() | :infinity, keyword()) ::
         {:ok, Vix.Vips.Image.t(), clamp_info() | nil}
-        | {:error, {:encode, term()}}
+        | {:error, {:encode, Exception.t(), list()}}
 ```
 
-- Knows nothing about formats or hosts — it fits a realized image to a max dimension and/or max pixel budget. This is the seam #165 reuses unchanged (#165 only changes the *limit it passes in*).
+- Knows nothing about formats or hosts — it fits a realized image to a max dimension. This is the seam #165 reuses (#165 changes the *limit it passes in*, and widens the signature to add a `max_pixels` budget with its own caller/test).
 - Reads the realized image directly via the `image` library (Vix); it does **not** touch `Transform` or `Telemetry` (which `Output` cannot depend on).
-- `opts` carries **`:image_module`** only (defaults to `Image`), matching `Encoder.stream_output/3`'s test-injection convention. Measurement (`Image.width/3`/`Image.height/1`) uses the real `Image` accessors directly, consistent with the producer already calling `Image.has_alpha?/1` directly; the actual resize goes through `image_module.resize/2` so tests can inject. If `opts` reads nothing beyond `:image_module`, no other keys are introduced.
+- `opts` carries **`:image_module`** only (defaults to `Image`), matching `Encoder.stream_output/3`'s test-injection convention. Measurement (`Image.width/1`/`Image.height/1`) uses the real `Image` accessors directly (O(1) header reads, no pixel realization), consistent with the producer already calling `Image.has_alpha?/1` directly; the actual resize goes through `image_module.resize/2` so tests can inject. No other `opts` keys are introduced.
 
 `clamp_info` (returned only when a clamp actually occurs; `nil` otherwise):
 
@@ -56,9 +55,8 @@ The format table is encoder knowledge and lives **only** in `Output.Encoder`. JP
 %{
   scale: float(),                       # < 1.0
   source_dimensions: {pos_integer(), pos_integer()},   # {w, h} before
-  dimensions: {pos_integer(), pos_integer()},          # {w, h} after (realized, ≤ limits)
-  max_dimension: pos_integer() | :infinity,
-  max_pixels: pos_integer() | :infinity
+  dimensions: {pos_integer(), pos_integer()},          # {w, h} after (realized, ≤ limit)
+  max_dimension: pos_integer()
 }
 ```
 
@@ -66,29 +64,25 @@ The format table is encoder knowledge and lives **only** in `Output.Encoder`. JP
 
 ```
 w = Image.width(image); h = Image.height(image)
-dim_scale   = (max_dimension == :infinity) ? 1.0 : min(1.0, max_dimension / max(w, h))     # linear
-pixel_scale = (max_pixels    == :infinity) ? 1.0 : min(1.0, sqrt(max_pixels / (w * h)))     # sqrt
-scale       = min(dim_scale, pixel_scale)
+scale = (max_dimension == :infinity) ? 1.0 : min(1.0, max_dimension / max(w, h))     # linear, uniform
 
 scale >= 1.0  →  {:ok, image, nil}        # no-op: image unchanged, NO resize node added (stays lazy)
 else          →  resize by scale, enforce ≤ limit, return {:ok, resized, clamp_info}
 ```
 
-For #150 every format passes `max_pixels: :infinity`, so `pixel_scale` is always `1.0` and `scale = dim_scale`: this is **exactly** imgproxy's `fixWebpSize`/`fixHeifSize` (`scale = 1.0 / (max(w,h)/limit)`, linear). The sqrt/pixels branch is structurally present for #165 but **never live in #150** — see Open Decision D1.
+This is **exactly** imgproxy's `fixWebpSize`/`fixHeifSize` (`scale = 1.0 / (max(w,h)/limit)`, a uniform linear downscale). JPEG (`65535`) and PNG (`:infinity`) take the no-op path for any realizable image. The pixel/resolution constraint and its sqrt scaling (imgproxy's GIF path) are **out of scope** here — see #165 and Resolved Decision D1.
 
-**Deliberate divergence from imgproxy's GIF path (latent until #165):** imgproxy's `fixGifSize` takes `max(resShrink, dimShrink)` and then `sqrt`s the *combined* shrink (`fix_size.go:65-72`), so its dimension component is also sqrt'd. We keep dimension linear, pixels sqrt, and take the most-aggressive scale — correct for each constraint independently and identical to imgproxy for our live WebP/AVIF (dimension-only) formats. Zero observable effect in #150. (If D1 defers the pixel path, this note moves to #165.)
+### ≤-limit guarantee (defensive; review correctness Lens 1)
 
-### ≤-limit guarantee (defensive; flagged by review #2)
+The whole point is that encode cannot fail. `scale = limit / max(w,h)` makes `round(max(w,h) * scale) = round(limit) = limit` in normal float arithmetic, and the shorter axis is strictly smaller — so the realized longest axis is `limit`, within bounds. To make this a **hard guarantee** rather than a trust-the-rounding claim, after the resize the clamp measures the realized longest axis `L'`; if `L' > limit` (a libvips rounding quirk), it re-resizes the **original** image by a **floor-biased** corrected factor — derived so the corrected longest axis cannot round back over `limit` (e.g. target `limit` px via a factor computed against `L'` and floored, not rounded). In practice the corrective branch never fires; it exists so a rounding regression cannot silently re-introduce an encode failure. The wire test asserts the decoded longest axis ≤ limit, catching any regression here.
 
-The whole point is that encode cannot fail. `scale = limit / max(w,h)` makes `round(max(w,h) * scale) = round(limit) = limit` in normal float arithmetic, and the shorter axis is strictly smaller — so the realized longest axis is `limit` and within bounds. To make this a **hard guarantee** rather than a trust-the-rounding claim, after the resize the clamp measures the realized longest axis `L'`; if `L' > limit` (a libvips rounding quirk), it re-resizes the **original** image by a corrected `scale * limit / L'`. In practice the corrective branch never fires; it exists so a rounding regression cannot silently re-introduce an encode failure. The wire test asserts the decoded longest axis ≤ limit, catching any regression here.
+### Resize error contract (review correctness Lens 2 — was a blocker)
 
-### Resize error contract (review #3)
-
-`image_module.resize/2` returns `{:ok, image} | {:error, reason}`. `clamp/4` matches `{:ok, resized}` on success and maps a resize failure to `{:error, {:encode, reason}}`, which the producer threads through its existing `with`/`else` (→ `{:stop, {:error, reason}}`) instead of crashing the producer into a generic 500. (A resize failure is effectively impossible here — `scale ∈ (0, 1)` is always valid — but `resize` is an external-library call at the Output boundary, so we return a tagged error rather than relying on the producer's catch-all rescue. The final error tag is reconciled with `ImagePipe.Error.tag/1` during implementation so it maps to a sensible status.)
+`image_module.resize/2` returns `{:ok, image} | {:error, reason}`. `clamp/3` matches `{:ok, resized}` on success and maps a resize failure to **`{:error, {:encode, exception, stacktrace}}`** — the same 3-tuple shape the encoder already emits (`encoder.ex:11,21`). A resize `reason` is a term, not an exception, so it is wrapped: `{:encode, RuntimeError.exception("clamp resize failed: #{inspect(reason)}"), []}`, mirroring `runner.ex:205`'s existing `{:session, reason}` wrapping. This is **required**: the response layer's `handle_processing_error/3` (`response/sender.ex`) only has `:encode` clauses for the 3-tuple and the `:empty_stream` literal — a bare `{:encode, reason}` 2-tuple matches no clause and raises `FunctionClauseError` (a crash, not a 500). The 3-tuple routes through `handle_encode_exception` → 500. (`ImagePipe.Error.tag/1` only extracts the leading atom for telemetry; it does not participate in status routing, so the emitted *shape* must be correct at the source.) A resize failure is effectively impossible — `scale ∈ (0, 1)` is always valid — but `resize` is an external-library call at the Output boundary, so we return the tagged error rather than relying on the producer's catch-all rescue.
 
 ### Single-frame assumption (review #4)
 
-`Image.width/3`/`Image.height/1` report a single frame's dimensions. If ImagePipe ever emits **animated/multi-page** WebP/AVIF, a vertically-stacked multi-frame image reports stacked height and a naive uniform resize would corrupt frames (imgproxy handles this via `PageHeight`). ImagePipe's `DecodePlanner` loads no extra pages today (no `n:`/pages load option), so output is single-frame and this is a non-issue. The assumption is stated here as a conscious boundary: if multi-page output is added, the clamp must account for page height.
+`Image.width/1`/`Image.height/1` report a single frame's dimensions. If ImagePipe ever emits **animated/multi-page** WebP/AVIF, a vertically-stacked multi-frame image reports stacked height and a naive uniform resize would corrupt frames (imgproxy handles this via `PageHeight`). ImagePipe's `DecodePlanner` loads no extra pages today (no `n:`/pages load option), so output is single-frame and this is a non-issue. The assumption is stated here as a conscious boundary: if multi-page output is added, the clamp must account for page height.
 
 ### Alpha / resampling (review #5)
 
@@ -102,8 +96,8 @@ In `request/source_session/producer.ex` `prepare_first_chunk/1`, the negotiated 
 with {:ok, decoded} <- ...,
      {:ok, %State{} = final_state} <- Processor.process_decoded_source(...),
      {:ok, %Resolved{} = resolved_output} <- resolve_output(...),
-     %{max_dimension: md, max_pixels: mp} = Encoder.encoder_limit(resolved_output.format),
-     {:ok, image, clamp_info} <- Clamp.clamp(final_state.image, md, mp, request.opts),
+     %{max_dimension: md} = Encoder.encoder_limit(resolved_output.format),
+     {:ok, image, clamp_info} <- Clamp.clamp(final_state.image, md, request.opts),
      :ok <- maybe_emit_clamp_telemetry(clamp_info, resolved_output.format, request.opts),
      {:ok, stream, content_type} <- Encoder.stream_output(image, resolved_output, request.opts),
      {:ok, chunk, stream_state} <- first_chunk(stream) do
@@ -112,21 +106,21 @@ with {:ok, decoded} <- ...,
 
 - The clamp runs **before** `stream_output`, so `Encoder.finalize`'s `copy_memory` (metadata strip) materializes the already-clamped (smaller) image.
 - It runs **after** the transform chain's orientation flush, correctly leaving the flush-buffer materialization optimization to #164.
-- **#165 reuse:** only the `encoder_limit` line changes to `min(host_max_result_*, encoder_limit(format))`. The `Clamp.clamp/4` call is untouched. `Clamp` and `Encoder` stay pure functions; telemetry is emitted by the producer (request boundary).
+- **#165 reuse:** the `encoder_limit` line changes to `min(host_max_result_*, encoder_limit(format))`, and #165 widens the call to pass its `max_pixels` budget (`clamp/3 → clamp/4`). The clamp *mechanism* (uniform downscale + ≤-limit guarantee) is untouched. `Clamp` and `Encoder` stay pure functions; telemetry is emitted by the producer (request boundary).
 
 ## Telemetry
 
 A one-shot `[:output, :clamp]` event, emitted by the producer **only when `clamp_info` is non-nil** (a clamp actually occurred), via `Telemetry.execute/4`:
 
-- **measurements:** `%{scale: scale}`
-- **metadata:** `%{format: format, source_dimensions: {w, h}, dimensions: {w', h'}, max_dimension: md, max_pixels: mp}`
+- **measurements:** `%{scale: scale}` (`scale` is a genuine numeric measurement, so measurements is its correct home — cf. `[:cache, :eviction]` reading `measurements[:count]`)
+- **metadata:** `%{format: format, source_dimensions: {w, h}, dimensions: {w', h'}, max_dimension: md}`
 
-All metadata is non-sensitive (dimensions, format atom, integer limits) — safe to fan out to exporters. No URLs, secrets, or PII.
+All metadata is non-sensitive (dimensions, format atom, integer limit) — safe to fan out to exporters. No URLs, secrets, or PII.
 
 ### Default Logger sync (`telemetry/logger.ex`, per the telemetry guideline)
 
 1. **Subscription.** Add `output: []` to `@group_span_events` (no spans; makes `:output` a selectable group, included in `:all`). Add `@output_oneshot [[:output, :clamp]]` and, in `event_names/2`, `output_oneshots = if :output in groups, do: @output_oneshot, else: []` appended to the attach list.
-2. **Rendering.** Add a `message/3` clause for `[:output, :clamp | _]` that surfaces the outcome, e.g. `"image_pipe output clamp: 18000x9000 -> 16383x8191 for webp (max 16383)"`. Placed before the generic fallback.
+2. **Rendering.** Add a `message/3` clause for `[:output, :clamp | _]`, e.g. `"image_pipe output clamp: 18000x9000 -> 16383x8191 for webp (max 16383)"`, placed before the generic fallback. The message *is* the outcome (a downscale occurred) — analogous to the `[:transform, :detect, :blend]` clause, which also omits a separate `outcome/1` because the event encodes a single known outcome. No `:result` key is emitted in clamp metadata, so nothing is swallowed (satisfies the "surface the outcome" guideline).
 3. **Level.** Add a `level_for/3` clause returning `:warning` for `[:output, :clamp | _]`, matching imgproxy's `slog.Warn` (`fix_size.go:32,52`).
 4. **Coverage.** Add a `logger_test.exs` assertion for the new line; update `docs/telemetry.md` to list the event and its rendering.
 
@@ -139,17 +133,19 @@ The clamp's output is fully deterministic from the request inputs that are **alr
 
 ## Tests (per CLAUDE.md)
 
-### Wire-level imgproxy Plug tests (real `ImagePipe.call/2`)
+### Wire-level imgproxy tests (real `ImagePipe.call/2`)
 
-Mirror the existing result-limit tests in `plug_test.exs`. **Reachability gotcha:** default `max_result_width/height` is 8192, *below* the encoder limits — tests must raise the host result cap above the encoder limit or the clamp is never reached.
+These go in **`test/image_pipe/imgproxy_wire_conformance_test.exs`**, not `plug_test.exs`. Asserting *decoded* clamped dimensions requires the real `Image` module + a real encode; the conformance file's `call_imgproxy` path uses the real encoder and already has the body-decode helpers `dimensions/1` (`Image.open!(resp_body, access: :random, fail_on: :error)` → `{width, height}`) and `content_type/1`. `plug_test.exs`'s result-limit tests use `image_module: StreamingOnlyImage`, whose `stream!/2` returns the literal `"streamed jpeg"` — an **undecodable** body — so they cannot assert decoded dims.
 
-- **WebP over 16383:** wide-and-short source enlarged via `el:1`/`w:` to just over 16383 (keeps encoded pixel count tiny/fast), `f:webp`, host `max_result_width/height` raised above 16383. Assert: `status 200`; `content-type: image/webp`; **decode the body and assert the longest axis ≤ 16383 and strictly reduced from the pre-clamp size**; `[:output, :clamp]` telemetry fired with matching `source_dimensions`/`dimensions`.
-- **AVIF over 16384:** same shape, `f:avif`, assert longest axis ≤ 16384. (AVIF encode is available in the test lane — `plug_test.exs` already asserts real `image/avif` responses.)
+**Reachability gotcha:** default `max_result_width/height` is 8192 (`request/options.ex`), *below* the encoder limits — tests must raise the host result cap above the encoder limit or `check_result_*` 413s first and the clamp is never reached.
+
+- **WebP over 16383:** wide-and-short source enlarged via `el:1`/`w:` to just over 16383 (keeps encoded pixel count tiny/fast), `f:webp`, host `max_result_width/height` raised above 16383. Assert: `status 200`; `content-type: image/webp`; **decode the body and assert the longest axis ≤ 16383 and strictly reduced from the pre-clamp size**; `[:output, :clamp]` telemetry fired (in-test attached handler) with matching `source_dimensions`/`dimensions`.
+- **AVIF over 16384:** same shape, `f:avif`, assert longest axis ≤ 16384. (AVIF encode is available in the test lane — the conformance file already asserts real `image/avif` responses with non-empty bodies.)
 - **No-clamp control:** a WebP request under the limit asserts no `[:output, :clamp]` event and unchanged dimensions.
 
-### Direct unit test of `ImagePipe.Output.Clamp.clamp/4`
+### Direct unit test of `ImagePipe.Output.Clamp.clamp/3`
 
-Covers the generic contract: dimension-only clamp (linear), pixel-only clamp (sqrt), both-apply (most-aggressive scale wins), and no-op (`scale >= 1.0` → image unchanged + `nil`, no resize node). This is the path that documents the #165 seam. *(Conditional on Open Decision D1 — if the pixel path is deferred, only dimension-only + no-op are tested.)*
+Covers the generic contract: dimension clamp (linear, uniform), the no-op path (`scale >= 1.0` → image unchanged + `nil`, no resize node), and the ≤-limit guarantee (a result whose longest axis equals the limit). Every case uses an input shape a real producer constructs (a realized image + an integer/`:infinity` `max_dimension`), so none pins an impossible-misuse shape.
 
 ## Out of scope / non-changes
 
@@ -157,6 +153,14 @@ Covers the generic contract: dimension-only clamp (linear), pixel-only clamp (sq
 - **No #165** (host error→downscale) and **no #164** (look-ahead pre-clamp).
 - **No new architecture test** — staying within the existing `Output` boundary with unchanged deps; the `Boundary` compile check already enforces the namespace rules. No concrete `Transform` operation module is named.
 
-## Open Decision (for the design review)
+## Resolved Decision D1 — pixel/sqrt path deferred to #165
 
-**D1 — Include the `max_pixels`/sqrt path now, or defer to #165?** In #150 every format returns `max_pixels: :infinity`, so the sqrt branch is dead code and its direct unit test exercises a shape no in-repo producer constructs — which the repo's test guideline flags as a smell, and which fights the "narrowest shape real callers use" / "add when the future caller appears" discipline. Counter: the task instruction is to "structure it so #165 can pass `max_pixels` without rework"; greenfield makes a later `clamp/3 → clamp/4` widening free, so deferral does not preclude #165. **The design as written includes the generic `clamp/4` (per the task instruction); the design review must return an explicit verdict — keep `clamp/4` now or ship dimension-only `clamp/3` and add pixels with its real caller in #165.** If deferred: drop the `max_pixels` param, the sqrt branch, its unit-test cases, and move the GIF-divergence note to #165.
+The design review (four disjoint lenses, incl. the mandatory imgproxy-compat lens) returned a **unanimous verdict to defer** the `max_pixels`/sqrt path, and the user confirmed. Ship dimension-only **`clamp/3`**. Rationale:
+
+- In #150 every format's limit is dimension-only, so a sqrt/pixels branch would be dead code, and its only unit test would feed a `max_pixels` value **no in-repo producer constructs** — the exact "impossible-internal-misuse" shape CLAUDE.md's test guideline bans, and a violation of "constructor APIs accept the narrowest shape real callers use / add when the future caller appears."
+- Greenfield makes the later `clamp/3 → clamp/4` widening free (no compat cost), so deferral does **not** preclude #165; #165 adds `max_pixels` together with its real caller and a test that exercises it.
+- The compat lens confirmed deferral has **zero** effect on #150's imgproxy parity (WebP/AVIF are dimension-only; the live linear `dim_scale` is byte-for-byte-intent identical to `fixWebpSize`/`fixHeifSize` whether `clamp/3` or `clamp/4` ships).
+
+### Hand-off note for #165 (pixel/resolution clamp)
+
+When #165 adds the `max_pixels` budget, keep **dimension linear, pixels sqrt, and take the most-aggressive scale** — do **not** copy imgproxy's `fixGifSize` combined-sqrt (`fix_size.go:65-72`), which `sqrt`s even the dimension component and therefore **can leave the result over the dimension limit when the dimension constraint binds** (e.g. a very wide, low-pixel GIF). ImagePipe's linear-dimension choice is strictly safer (it always respects the hard dimension cap); this is a deliberate, more-correct divergence, not a parity gap to "fix" back to upstream. (GIF is not an ImagePipe output format today regardless.)

--- a/docs/superpowers/specs/2026-06-08-output-encoder-dimension-clamp-design.md
+++ b/docs/superpowers/specs/2026-06-08-output-encoder-dimension-clamp-design.md
@@ -1,0 +1,162 @@
+# Design: format-aware output-encoder dimension clamp (#150)
+
+**Issue:** #150 — `fixSize` parity. **Related (out of scope):** #165 (host max_result_* error→downscale), #164 (look-ahead pre-clamp). Do not implement #165/#164 here; only avoid precluding #165's reuse of the clamp seam.
+
+**Upstream reference (verified):** `local/imgproxy-master/processing/fix_size.go`.
+
+## Problem
+
+ImagePipe's `check_result_*` (`request/processor.ex`) errors when the final image exceeds the *host-configured* `max_result_width/height/pixels`. It does **not** know the *output encoder's* hard dimension limit. A request within `max_result_width` but above the encoder limit (e.g. `max_result_width: 20000`, an 18000px WebP) passes the host check and then **fails at encode** — `webpsave` cannot represent > 16383px. imgproxy closes this gap with `fixSize` (step 13): after all geometry, keyed on the chosen output format, it uniformly downscales the realized image to fit the encoder limit and serves it (logging a warning) rather than erroring.
+
+This design adds the equivalent: a **post-hoc, uniform downscale of the realized final image at the `ImagePipe.Output.*` boundary, keyed on the negotiated output format**, so encoding cannot fail. Downscale-and-serve (not error), with a telemetry signal so hosts can observe the clamp.
+
+## Architecture (settled per #150 — not re-opened here)
+
+- Post-hoc: reads the **realized** final image (order-agnostic, trim-robust), not predicted intermediate geometry.
+- Uniform downscale (same scale on both axes), mirroring `img.Resize(scale, scale)`.
+- Lives at the `ImagePipe.Output.*` boundary, keyed on the negotiated output format.
+- Downscale-and-serve, with a telemetry signal.
+- Generic clamp seam: takes a `max_dimension` (and `max_pixels`) and does not care which source produced the number, so #165 can later feed `min(host_max_result_*, encoder_limit(format))` through the same call without reworking the clamp mechanism.
+
+## Module layout (within the existing `ImagePipe.Output` boundary)
+
+`ImagePipe.Output` deps stay `[ImagePipe.Format, ImagePipe.Plan]`. Two additions:
+
+### `ImagePipe.Output.Encoder.encoder_limit/1` — the per-format table
+
+```elixir
+@spec encoder_limit(ImagePipe.Plan.output_format()) ::
+        %{max_dimension: pos_integer() | :infinity, max_pixels: pos_integer() | :infinity}
+```
+
+| format | max_dimension | max_pixels | source |
+|--------|---------------|-----------|--------|
+| `:webp` | 16383 | `:infinity` | `fix_size.go:14` |
+| `:avif` | 16384 | `:infinity` | `fix_size.go:15` |
+| `:jpeg` | 65535 | `:infinity` | documented, won't bite |
+| `:png` | `:infinity` | `:infinity` | effectively unbounded |
+
+The format table is encoder knowledge and lives **only** in `Output.Encoder`. JPEG/PNG are documented, not special-cased — they fall out of the generic `:infinity` no-op path.
+
+### `ImagePipe.Output.Clamp.clamp/4` — the generic, product-neutral downscale
+
+```elixir
+@spec clamp(Vix.Vips.Image.t(), pos_integer() | :infinity, pos_integer() | :infinity, keyword()) ::
+        {:ok, Vix.Vips.Image.t(), clamp_info() | nil}
+        | {:error, {:encode, term()}}
+```
+
+- Knows nothing about formats or hosts — it fits a realized image to a max dimension and/or max pixel budget. This is the seam #165 reuses unchanged (#165 only changes the *limit it passes in*).
+- Reads the realized image directly via the `image` library (Vix); it does **not** touch `Transform` or `Telemetry` (which `Output` cannot depend on).
+- `opts` carries **`:image_module`** only (defaults to `Image`), matching `Encoder.stream_output/3`'s test-injection convention. Measurement (`Image.width/3`/`Image.height/1`) uses the real `Image` accessors directly, consistent with the producer already calling `Image.has_alpha?/1` directly; the actual resize goes through `image_module.resize/2` so tests can inject. If `opts` reads nothing beyond `:image_module`, no other keys are introduced.
+
+`clamp_info` (returned only when a clamp actually occurs; `nil` otherwise):
+
+```elixir
+%{
+  scale: float(),                       # < 1.0
+  source_dimensions: {pos_integer(), pos_integer()},   # {w, h} before
+  dimensions: {pos_integer(), pos_integer()},          # {w, h} after (realized, ≤ limits)
+  max_dimension: pos_integer() | :infinity,
+  max_pixels: pos_integer() | :infinity
+}
+```
+
+## Clamp math
+
+```
+w = Image.width(image); h = Image.height(image)
+dim_scale   = (max_dimension == :infinity) ? 1.0 : min(1.0, max_dimension / max(w, h))     # linear
+pixel_scale = (max_pixels    == :infinity) ? 1.0 : min(1.0, sqrt(max_pixels / (w * h)))     # sqrt
+scale       = min(dim_scale, pixel_scale)
+
+scale >= 1.0  →  {:ok, image, nil}        # no-op: image unchanged, NO resize node added (stays lazy)
+else          →  resize by scale, enforce ≤ limit, return {:ok, resized, clamp_info}
+```
+
+For #150 every format passes `max_pixels: :infinity`, so `pixel_scale` is always `1.0` and `scale = dim_scale`: this is **exactly** imgproxy's `fixWebpSize`/`fixHeifSize` (`scale = 1.0 / (max(w,h)/limit)`, linear). The sqrt/pixels branch is structurally present for #165 but **never live in #150** — see Open Decision D1.
+
+**Deliberate divergence from imgproxy's GIF path (latent until #165):** imgproxy's `fixGifSize` takes `max(resShrink, dimShrink)` and then `sqrt`s the *combined* shrink (`fix_size.go:65-72`), so its dimension component is also sqrt'd. We keep dimension linear, pixels sqrt, and take the most-aggressive scale — correct for each constraint independently and identical to imgproxy for our live WebP/AVIF (dimension-only) formats. Zero observable effect in #150. (If D1 defers the pixel path, this note moves to #165.)
+
+### ≤-limit guarantee (defensive; flagged by review #2)
+
+The whole point is that encode cannot fail. `scale = limit / max(w,h)` makes `round(max(w,h) * scale) = round(limit) = limit` in normal float arithmetic, and the shorter axis is strictly smaller — so the realized longest axis is `limit` and within bounds. To make this a **hard guarantee** rather than a trust-the-rounding claim, after the resize the clamp measures the realized longest axis `L'`; if `L' > limit` (a libvips rounding quirk), it re-resizes the **original** image by a corrected `scale * limit / L'`. In practice the corrective branch never fires; it exists so a rounding regression cannot silently re-introduce an encode failure. The wire test asserts the decoded longest axis ≤ limit, catching any regression here.
+
+### Resize error contract (review #3)
+
+`image_module.resize/2` returns `{:ok, image} | {:error, reason}`. `clamp/4` matches `{:ok, resized}` on success and maps a resize failure to `{:error, {:encode, reason}}`, which the producer threads through its existing `with`/`else` (→ `{:stop, {:error, reason}}`) instead of crashing the producer into a generic 500. (A resize failure is effectively impossible here — `scale ∈ (0, 1)` is always valid — but `resize` is an external-library call at the Output boundary, so we return a tagged error rather than relying on the producer's catch-all rescue. The final error tag is reconciled with `ImagePipe.Error.tag/1` during implementation so it maps to a sensible status.)
+
+### Single-frame assumption (review #4)
+
+`Image.width/3`/`Image.height/1` report a single frame's dimensions. If ImagePipe ever emits **animated/multi-page** WebP/AVIF, a vertically-stacked multi-frame image reports stacked height and a naive uniform resize would corrupt frames (imgproxy handles this via `PageHeight`). ImagePipe's `DecodePlanner` loads no extra pages today (no `n:`/pages load option), so output is single-frame and this is a non-issue. The assumption is stated here as a conscious boundary: if multi-page output is added, the clamp must account for page height.
+
+### Alpha / resampling (review #5)
+
+libvips `resize` premultiplies alpha internally, so clamped transparent images do not get dark halos. A plain `Image.resize` (no linear-colourspace conversion) is the correct parity choice — imgproxy's `fixSize` is also a plain `img.Resize`, unlike its main `scale` step. Confirmed against `transform/operation/resize.ex:125`, which resizes the same way.
+
+## Where it runs — the producer seam
+
+In `request/source_session/producer.ex` `prepare_first_chunk/1`, the negotiated `resolved_output.format` and the realized `final_state.image` are both in hand at lines 117–125, between `resolve_output` and `Encoder.stream_output`. The clamp slots in there:
+
+```elixir
+with {:ok, decoded} <- ...,
+     {:ok, %State{} = final_state} <- Processor.process_decoded_source(...),
+     {:ok, %Resolved{} = resolved_output} <- resolve_output(...),
+     %{max_dimension: md, max_pixels: mp} = Encoder.encoder_limit(resolved_output.format),
+     {:ok, image, clamp_info} <- Clamp.clamp(final_state.image, md, mp, request.opts),
+     :ok <- maybe_emit_clamp_telemetry(clamp_info, resolved_output.format, request.opts),
+     {:ok, stream, content_type} <- Encoder.stream_output(image, resolved_output, request.opts),
+     {:ok, chunk, stream_state} <- first_chunk(stream) do
+  ...
+```
+
+- The clamp runs **before** `stream_output`, so `Encoder.finalize`'s `copy_memory` (metadata strip) materializes the already-clamped (smaller) image.
+- It runs **after** the transform chain's orientation flush, correctly leaving the flush-buffer materialization optimization to #164.
+- **#165 reuse:** only the `encoder_limit` line changes to `min(host_max_result_*, encoder_limit(format))`. The `Clamp.clamp/4` call is untouched. `Clamp` and `Encoder` stay pure functions; telemetry is emitted by the producer (request boundary).
+
+## Telemetry
+
+A one-shot `[:output, :clamp]` event, emitted by the producer **only when `clamp_info` is non-nil** (a clamp actually occurred), via `Telemetry.execute/4`:
+
+- **measurements:** `%{scale: scale}`
+- **metadata:** `%{format: format, source_dimensions: {w, h}, dimensions: {w', h'}, max_dimension: md, max_pixels: mp}`
+
+All metadata is non-sensitive (dimensions, format atom, integer limits) — safe to fan out to exporters. No URLs, secrets, or PII.
+
+### Default Logger sync (`telemetry/logger.ex`, per the telemetry guideline)
+
+1. **Subscription.** Add `output: []` to `@group_span_events` (no spans; makes `:output` a selectable group, included in `:all`). Add `@output_oneshot [[:output, :clamp]]` and, in `event_names/2`, `output_oneshots = if :output in groups, do: @output_oneshot, else: []` appended to the attach list.
+2. **Rendering.** Add a `message/3` clause for `[:output, :clamp | _]` that surfaces the outcome, e.g. `"image_pipe output clamp: 18000x9000 -> 16383x8191 for webp (max 16383)"`. Placed before the generic fallback.
+3. **Level.** Add a `level_for/3` clause returning `:warning` for `[:output, :clamp | _]`, matching imgproxy's `slog.Warn` (`fix_size.go:32,52`).
+4. **Coverage.** Add a `logger_test.exs` assertion for the new line; update `docs/telemetry.md` to list the event and its rendering.
+
+## Cache / ETag — no change
+
+The clamp's output is fully deterministic from the request inputs that are **already** in the cache key and ETag: the **source-identity byte-identity seed**, the **canonical plan**, and the **negotiated output format** (`modern_candidates` for automatic, explicit `format` otherwise — confirmed in `cache/key.ex`). The final dimensions are not a key field; they **derive from** those inputs (source + plan), and the clamp threshold derives from the format. Therefore:
+
+- **No new cache key field.** Same key shape; greenfield, no data-version bump.
+- **No ETag change.** A conditional GET still returns `304` before any source fetch, decode, encode, or clamp — the clamp never participates in validator derivation.
+
+## Tests (per CLAUDE.md)
+
+### Wire-level imgproxy Plug tests (real `ImagePipe.call/2`)
+
+Mirror the existing result-limit tests in `plug_test.exs`. **Reachability gotcha:** default `max_result_width/height` is 8192, *below* the encoder limits — tests must raise the host result cap above the encoder limit or the clamp is never reached.
+
+- **WebP over 16383:** wide-and-short source enlarged via `el:1`/`w:` to just over 16383 (keeps encoded pixel count tiny/fast), `f:webp`, host `max_result_width/height` raised above 16383. Assert: `status 200`; `content-type: image/webp`; **decode the body and assert the longest axis ≤ 16383 and strictly reduced from the pre-clamp size**; `[:output, :clamp]` telemetry fired with matching `source_dimensions`/`dimensions`.
+- **AVIF over 16384:** same shape, `f:avif`, assert longest axis ≤ 16384. (AVIF encode is available in the test lane — `plug_test.exs` already asserts real `image/avif` responses.)
+- **No-clamp control:** a WebP request under the limit asserts no `[:output, :clamp]` event and unchanged dimensions.
+
+### Direct unit test of `ImagePipe.Output.Clamp.clamp/4`
+
+Covers the generic contract: dimension-only clamp (linear), pixel-only clamp (sqrt), both-apply (most-aggressive scale wins), and no-op (`scale >= 1.0` → image unchanged + `nil`, no resize node). This is the path that documents the #165 seam. *(Conditional on Open Decision D1 — if the pixel path is deferred, only dimension-only + no-op are tested.)*
+
+## Out of scope / non-changes
+
+- **No demo UI change** — internal output safety clamp, not a user-controllable transform or parser option (no URL knob), so the demo-sync guideline does not apply.
+- **No #165** (host error→downscale) and **no #164** (look-ahead pre-clamp).
+- **No new architecture test** — staying within the existing `Output` boundary with unchanged deps; the `Boundary` compile check already enforces the namespace rules. No concrete `Transform` operation module is named.
+
+## Open Decision (for the design review)
+
+**D1 — Include the `max_pixels`/sqrt path now, or defer to #165?** In #150 every format returns `max_pixels: :infinity`, so the sqrt branch is dead code and its direct unit test exercises a shape no in-repo producer constructs — which the repo's test guideline flags as a smell, and which fights the "narrowest shape real callers use" / "add when the future caller appears" discipline. Counter: the task instruction is to "structure it so #165 can pass `max_pixels` without rework"; greenfield makes a later `clamp/3 → clamp/4` widening free, so deferral does not preclude #165. **The design as written includes the generic `clamp/4` (per the task instruction); the design review must return an explicit verdict — keep `clamp/4` now or ship dimension-only `clamp/3` and add pixels with its real caller in #165.** If deferred: drop the `max_pixels` param, the sqrt branch, its unit-test cases, and move the GIF-divergence note to #165.

--- a/docs/superpowers/specs/2026-06-08-output-encoder-dimension-clamp-design.md
+++ b/docs/superpowers/specs/2026-06-08-output-encoder-dimension-clamp-design.md
@@ -25,7 +25,7 @@ This design adds the equivalent: a **post-hoc, uniform downscale of the realized
 ### `ImagePipe.Output.Encoder.encoder_limit/1` — the per-format table
 
 ```elixir
-@spec encoder_limit(ImagePipe.Plan.output_format()) :: %{max_dimension: pos_integer() | :infinity}
+@spec encoder_limit(ImagePipe.Format.output_format()) :: %{max_dimension: pos_integer() | :infinity}
 ```
 
 | format | max_dimension | source |

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -345,6 +345,39 @@ Generated CDN HTTP cache handling emits non-span events:
 These events don't include request paths, source identities, cache keys, or ETag
 values.
 
+## Output dimension clamp (`[:output, :clamp]`)
+
+When the realized final image exceeds the negotiated output encoder's hard
+dimension limit, ImagePipe uniformly downscales it to fit before encoding and
+emits a one-shot (non-span) marker. The limit is format-aware: WebP caps each
+dimension at 16383 and AVIF at 16384, while JPEG and PNG are effectively
+unbounded. This lets a host observe that a served image was downscaled to fit
+the encoder rather than delivered at the requested size.
+
+```text
+[:image_pipe, :output, :clamp]
+```
+
+Measurements:
+
+- `:scale` — the uniform downscale factor applied (a float `< 1.0`).
+
+Metadata:
+
+- `:format` — the negotiated output format atom (e.g. `:webp`, `:avif`).
+- `:source_dimensions` — `{w, h}` before the clamp.
+- `:dimensions` — `{w, h}` after the clamp.
+- `:max_dimension` — the per-dimension limit that bound the result.
+
+This metadata is product-neutral and non-sensitive (no URLs, secrets, or PII).
+
+The opt-in default Logger attaches to this event and renders it at `:warning`,
+matching imgproxy's `slog.Warn` for the same condition, e.g.:
+
+```text
+output clamp: 18000x9000 -> 16383x8191 for webp (max 16383)
+```
+
 ## Attaching handlers
 
 A host application can attach to all ImagePipe span events with

--- a/lib/image_pipe/output.ex
+++ b/lib/image_pipe/output.ex
@@ -6,9 +6,10 @@ defmodule ImagePipe.Output do
     deps: [ImagePipe.Format, ImagePipe.Plan],
     exports: [
       Capabilities,
-      Policy,
+      Clamp,
       Encoder,
       Negotiation,
+      Policy,
       Resolved
     ]
 end

--- a/lib/image_pipe/output/clamp.ex
+++ b/lib/image_pipe/output/clamp.ex
@@ -1,0 +1,78 @@
+defmodule ImagePipe.Output.Clamp do
+  @moduledoc false
+  # Generic, product-neutral uniform downscale of a realized image so it fits a
+  # maximum dimension. Used by the producer with the output encoder's per-format
+  # limit (`ImagePipe.Output.Encoder.encoder_limit/1`) so encoding cannot fail.
+  # Knows nothing about formats or hosts: it takes a raw `max_dimension`. #165
+  # widens this to also accept a `max_pixels` budget.
+  #
+  # Reads/resizes the image via the `image` library directly (no Transform or
+  # Telemetry dependency, per the Output boundary). Resize is lazy; measuring
+  # width/height reads libvips header fields (O(1), no pixel realization).
+
+  alias Vix.Vips.Image, as: VixImage
+
+  @type clamp_info :: %{
+          scale: float(),
+          source_dimensions: {pos_integer(), pos_integer()},
+          dimensions: {pos_integer(), pos_integer()},
+          max_dimension: pos_integer()
+        }
+
+  @spec clamp(VixImage.t(), pos_integer() | :infinity, keyword()) ::
+          {:ok, VixImage.t(), clamp_info() | nil}
+          | {:error, {:encode, Exception.t(), list()}}
+  def clamp(%VixImage{} = image, :infinity, _opts), do: {:ok, image, nil}
+
+  def clamp(%VixImage{} = image, max_dimension, opts) when is_integer(max_dimension) do
+    w = Image.width(image)
+    h = Image.height(image)
+    longest = max(w, h)
+
+    if longest <= max_dimension do
+      {:ok, image, nil}
+    else
+      image_module = Keyword.get(opts, :image_module, Image)
+      scale = max_dimension / longest
+
+      with {:ok, resized} <- resize(image_module, image, scale),
+           {:ok, resized} <- enforce_limit(image_module, image, resized, max_dimension) do
+        {:ok, resized,
+         %{
+           scale: scale,
+           source_dimensions: {w, h},
+           dimensions: {Image.width(resized), Image.height(resized)},
+           max_dimension: max_dimension
+         }}
+      end
+    end
+  end
+
+  # Defensive ≤-limit guarantee: round() at `scale = limit/longest` lands the
+  # longest axis exactly on `limit`, but if a libvips rounding quirk overshoots
+  # we re-resize the ORIGINAL by a floor-biased factor so the corrected longest
+  # axis cannot round back over the limit. In practice this never fires.
+  defp enforce_limit(image_module, original, resized, max_dimension) do
+    realized = max(Image.width(resized), Image.height(resized))
+
+    if realized <= max_dimension do
+      {:ok, resized}
+    else
+      longest = max(Image.width(original), Image.height(original))
+      # floor-bias: subtract a hair so round() cannot bump back to the overshoot
+      corrected = (max_dimension - 0.5) / longest
+      resize(image_module, original, corrected)
+    end
+  end
+
+  defp resize(image_module, image, scale) do
+    case image_module.resize(image, scale, vertical_scale: scale) do
+      {:ok, resized} -> {:ok, resized}
+      {:error, reason} -> {:error, encode_error(reason)}
+    end
+  end
+
+  defp encode_error(reason) do
+    {:encode, RuntimeError.exception("clamp resize failed: #{inspect(reason)}"), []}
+  end
+end

--- a/lib/image_pipe/output/clamp.ex
+++ b/lib/image_pipe/output/clamp.ex
@@ -53,10 +53,10 @@ defmodule ImagePipe.Output.Clamp do
     end
   end
 
-  # Defensive ≤-limit guarantee: round() at `scale = limit/longest` lands the
-  # longest axis exactly on `limit`, but if a libvips rounding quirk overshoots
-  # we re-resize the ORIGINAL by a floor-biased factor so the corrected longest
-  # axis cannot round back over the limit. In practice this never fires.
+  # Defensive ≤-limit guarantee: `scale = limit/longest` lands the longest axis
+  # on `limit`, but if a libvips rounding quirk overshoots we re-resize the
+  # ORIGINAL by a slightly smaller (`limit - 0.5`) factor so the corrected
+  # longest axis lands at or below the limit. In practice this never fires.
   defp enforce_limit(image_module, original, resized, max_dimension) do
     realized = max(Image.width(resized), Image.height(resized))
 

--- a/lib/image_pipe/output/clamp.ex
+++ b/lib/image_pipe/output/clamp.ex
@@ -37,11 +37,16 @@ defmodule ImagePipe.Output.Clamp do
 
       with {:ok, resized} <- resize(image_module, image, scale),
            {:ok, resized} <- enforce_limit(image_module, image, resized, max_dimension) do
+        rw = Image.width(resized)
+        rh = Image.height(resized)
+
         {:ok, resized,
          %{
-           scale: scale,
+           # Derived from the realized result so it stays consistent with
+           # `dimensions` even on the defensive corrective path.
+           scale: rw / w,
            source_dimensions: {w, h},
-           dimensions: {Image.width(resized), Image.height(resized)},
+           dimensions: {rw, rh},
            max_dimension: max_dimension
          }}
       end

--- a/lib/image_pipe/output/encoder.ex
+++ b/lib/image_pipe/output/encoder.ex
@@ -6,6 +6,19 @@ defmodule ImagePipe.Output.Encoder do
   alias Vix.Vips.Image, as: VixImage
   alias Vix.Vips.MutableImage, as: VixMutableImage
 
+  @doc """
+  The output encoder's hard per-dimension limit for `format`, used by
+  `ImagePipe.Output.Clamp` to keep encoding from failing. `:infinity` means no
+  practical limit. Sourced from libvips encoder constraints (cf. imgproxy
+  `processing/fix_size.go`). #150 uses only `:max_dimension`; #165 will extend
+  the returned map with a `:max_pixels` budget when its caller makes that live.
+  """
+  @spec encoder_limit(Format.output_format()) :: %{max_dimension: pos_integer() | :infinity}
+  def encoder_limit(:webp), do: %{max_dimension: 16_383}
+  def encoder_limit(:avif), do: %{max_dimension: 16_384}
+  def encoder_limit(:jpeg), do: %{max_dimension: 65_535}
+  def encoder_limit(:png), do: %{max_dimension: :infinity}
+
   @spec stream_output(VixImage.t(), Resolved.t(), keyword()) ::
           {:ok, Enumerable.t(), String.t()}
           | {:error, {:encode, Exception.t(), list()}}

--- a/lib/image_pipe/request/source_session/producer.ex
+++ b/lib/image_pipe/request/source_session/producer.ex
@@ -122,7 +122,7 @@ defmodule ImagePipe.Request.SourceSession.Producer do
                final_state.image,
                request.opts
              ),
-           %{max_dimension: max_dimension} <- Encoder.encoder_limit(resolved_output.format),
+           %{max_dimension: max_dimension} = Encoder.encoder_limit(resolved_output.format),
            {:ok, image, clamp_info} <-
              Clamp.clamp(final_state.image, max_dimension, request.opts),
            :ok <- emit_clamp_telemetry(clamp_info, resolved_output.format, request.opts),

--- a/lib/image_pipe/request/source_session/producer.ex
+++ b/lib/image_pipe/request/source_session/producer.ex
@@ -2,6 +2,7 @@ defmodule ImagePipe.Request.SourceSession.Producer do
   @moduledoc false
 
   alias ImagePipe.Error
+  alias ImagePipe.Output.Clamp
   alias ImagePipe.Output.Encoder
   alias ImagePipe.Output.Policy
   alias ImagePipe.Output.Resolved
@@ -121,8 +122,12 @@ defmodule ImagePipe.Request.SourceSession.Producer do
                final_state.image,
                request.opts
              ),
+           %{max_dimension: max_dimension} <- Encoder.encoder_limit(resolved_output.format),
+           {:ok, image, clamp_info} <-
+             Clamp.clamp(final_state.image, max_dimension, request.opts),
+           :ok <- emit_clamp_telemetry(clamp_info, resolved_output.format, request.opts),
            {:ok, stream, content_type} <-
-             Encoder.stream_output(final_state.image, resolved_output, request.opts),
+             Encoder.stream_output(image, resolved_output, request.opts),
            {:ok, chunk, stream_state} <- first_chunk(stream) do
         {:ok, chunk,
          %{
@@ -147,6 +152,24 @@ defmodule ImagePipe.Request.SourceSession.Producer do
     with_stream_translation(&encode_fallback/2, fn ->
       reduce_stream(stream)
     end)
+  end
+
+  defp emit_clamp_telemetry(nil, _format, _opts), do: :ok
+
+  defp emit_clamp_telemetry(%{} = info, format, opts) do
+    Telemetry.execute(
+      Telemetry.telemetry_opts(opts),
+      [:output, :clamp],
+      %{scale: info.scale},
+      %{
+        format: format,
+        source_dimensions: info.source_dimensions,
+        dimensions: info.dimensions,
+        max_dimension: info.max_dimension
+      }
+    )
+
+    :ok
   end
 
   defp resolve_output(%Policy{} = policy, source_format, image, opts) do

--- a/lib/image_pipe/telemetry/logger.ex
+++ b/lib/image_pipe/telemetry/logger.ex
@@ -14,7 +14,8 @@ defmodule ImagePipe.Telemetry.Logger do
     parse: [[:parse]],
     source: [[:source, :resolve], [:source, :fetch], [:source, :fetch_decode]],
     transform: [[:transform, :execute], [:transform, :operation], [:transform, :detect]],
-    cache: [[:cache, :lookup], [:cache, :write], [:cache, :admission], [:cache, :warm_start]]
+    cache: [[:cache, :lookup], [:cache, :write], [:cache, :admission], [:cache, :warm_start]],
+    output: []
   }
 
   # cache one-shot events (already terminal; not spans)
@@ -29,6 +30,11 @@ defmodule ImagePipe.Telemetry.Logger do
   @transform_oneshot [
     [:transform, :detect, :skipped],
     [:transform, :detect, :blend]
+  ]
+
+  # output one-shot events (already terminal; not spans)
+  @output_oneshot [
+    [:output, :clamp]
   ]
 
   @all_groups Map.keys(@group_span_events)
@@ -66,8 +72,11 @@ defmodule ImagePipe.Telemetry.Logger do
 
     cache_oneshots = if :cache in groups, do: @cache_oneshot, else: []
     transform_oneshots = if :transform in groups, do: @transform_oneshot, else: []
+    output_oneshots = if :output in groups, do: @output_oneshot, else: []
 
-    Enum.map(spans ++ cache_oneshots ++ transform_oneshots, fn e -> prefix ++ e end)
+    Enum.map(spans ++ cache_oneshots ++ transform_oneshots ++ output_oneshots, fn e ->
+      prefix ++ e
+    end)
   end
 
   @doc false
@@ -94,6 +103,8 @@ defmodule ImagePipe.Telemetry.Logger do
   end
 
   # --- level ---
+  defp level_for([:output, :clamp | _], _metadata, _base), do: :warning
+
   defp level_for(suffix, metadata, base) do
     cond do
       List.last(suffix) == :exception -> :warning
@@ -150,6 +161,13 @@ defmodule ImagePipe.Telemetry.Logger do
 
   defp message([:cache, :eviction | _], measurements, meta) do
     "image_pipe cache eviction: #{measurements[:count]} entries (#{meta[:trigger]})"
+  end
+
+  defp message([:output, :clamp | _], _m, meta) do
+    {sw, sh} = meta[:source_dimensions]
+    {w, h} = meta[:dimensions]
+
+    "image_pipe output clamp: #{sw}x#{sh} -> #{w}x#{h} for #{meta[:format]} (max #{meta[:max_dimension]})"
   end
 
   defp message(suffix, _m, meta) do

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -2316,6 +2316,89 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
     assert base != diff_obj
   end
 
+  describe "output encoder dimension clamp (#150)" do
+    defp attach_clamp_telemetry do
+      handler_id = {__MODULE__, self(), :output_clamp}
+
+      :telemetry.attach(
+        handler_id,
+        [:image_pipe, :output, :clamp],
+        &__MODULE__.handle_telemetry_event/4,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+    end
+
+    @clamp_opts [
+      parser: ImagePipe.Parser.Imgproxy,
+      sources: [
+        path: {RootHTTPAdapter, root_url: "http://origin.test", req_options: [plug: OriginImage]}
+      ],
+      max_result_width: 40_000,
+      max_result_height: 40_000,
+      max_result_pixels: 2_000_000_000,
+      output_capabilities: %{avif: true, webp: true}
+    ]
+
+    test "downscales a WebP result above the 16383 encoder limit and serves it" do
+      attach_clamp_telemetry()
+
+      conn =
+        call_imgproxy("/_/el:1/rs:force:18000:200/f:webp/plain/images/beach.jpg", @clamp_opts)
+
+      assert conn.status == 200
+      assert content_type(conn) == ["image/webp"]
+
+      {w, h} = dimensions(conn)
+      assert max(w, h) <= 16_383
+      assert max(w, h) > 8_192
+
+      assert_received {:telemetry_event, [:image_pipe, :output, :clamp], %{scale: scale}, meta}
+
+      assert scale < 1.0
+      assert meta.format == :webp
+      assert meta.max_dimension == 16_383
+      assert meta.dimensions == {w, h}
+      {sw, sh} = meta.source_dimensions
+      assert max(sw, sh) > 16_383
+    end
+
+    test "downscales an AVIF result above the 16384 encoder limit and serves it" do
+      attach_clamp_telemetry()
+
+      conn =
+        call_imgproxy("/_/el:1/rs:force:18000:200/f:avif/plain/images/beach.jpg", @clamp_opts)
+
+      assert conn.status == 200
+      assert content_type(conn) == ["image/avif"]
+
+      {w, h} = dimensions(conn)
+      assert max(w, h) <= 16_384
+      assert max(w, h) > 8_192
+
+      assert_received {:telemetry_event, [:image_pipe, :output, :clamp], %{scale: scale}, meta}
+
+      assert scale < 1.0
+      assert meta.format == :avif
+      assert meta.max_dimension == 16_384
+      assert meta.dimensions == {w, h}
+    end
+
+    test "does not clamp or emit when a WebP result is within the encoder limit" do
+      attach_clamp_telemetry()
+
+      conn = call_imgproxy("/_/w:120/f:webp/plain/images/beach.jpg", @clamp_opts)
+
+      assert conn.status == 200
+      assert content_type(conn) == ["image/webp"]
+      {w, _h} = dimensions(conn)
+      assert w == 120
+
+      refute_received {:telemetry_event, [:image_pipe, :output, :clamp], _measurements, _meta}
+    end
+  end
+
   defp cached_opts(overrides \\ []) do
     cache_root =
       Path.join(

--- a/test/image_pipe/output/clamp_test.exs
+++ b/test/image_pipe/output/clamp_test.exs
@@ -3,6 +3,16 @@ defmodule ImagePipe.Output.ClampTest do
 
   alias ImagePipe.Output.Encoder
 
+  # Stub whose first (more aggressive) resize overshoots the limit by 1px and
+  # whose floor-biased corrective resize lands within it. Models a libvips
+  # rounding quirk so the defensive `enforce_limit` re-resize is exercised.
+  # Injected via the `:image_module` opt; the primary call uses the larger
+  # `max_dimension / longest` factor, the corrective uses `(max_dimension - 0.5) / longest`.
+  defmodule OvershootOnceImage do
+    def resize(_image, scale, _opts) when scale >= 0.5, do: Image.new(101, 50)
+    def resize(_image, _scale, _opts), do: Image.new(100, 50)
+  end
+
   describe "encoder_limit/1" do
     test "returns the WebP and AVIF hard dimension limits" do
       assert Encoder.encoder_limit(:webp) == %{max_dimension: 16_383}
@@ -55,6 +65,27 @@ defmodule ImagePipe.Output.ClampTest do
       assert Image.width(resized) <= 100
       assert max(Image.width(resized), Image.height(resized)) <= 100
       assert info.dimensions == {Image.width(resized), Image.height(resized)}
+    end
+
+    test "downscales when the longest axis is the height" do
+      img = image(50, 200)
+      assert {:ok, resized, info} = Clamp.clamp(img, 100, [])
+
+      assert Image.width(resized) == 25
+      assert Image.height(resized) == 100
+      assert info.dimensions == {25, 100}
+    end
+
+    test "re-resizes when the first resize overshoots the limit" do
+      img = image(200, 100)
+
+      assert {:ok, resized, info} =
+               Clamp.clamp(img, 100, image_module: OvershootOnceImage)
+
+      # The corrective re-resize brought the overshooting 101px result back to
+      # the limit, and the reported dimensions reflect the realized result.
+      assert max(Image.width(resized), Image.height(resized)) <= 100
+      assert info.dimensions == {100, 50}
     end
   end
 end

--- a/test/image_pipe/output/clamp_test.exs
+++ b/test/image_pipe/output/clamp_test.exs
@@ -14,4 +14,47 @@ defmodule ImagePipe.Output.ClampTest do
       assert Encoder.encoder_limit(:png) == %{max_dimension: :infinity}
     end
   end
+
+  describe "clamp/3" do
+    alias ImagePipe.Output.Clamp
+
+    # A blank image of exact dimensions; cheap and lazy.
+    defp image(width, height) do
+      {:ok, image} = Image.new(width, height)
+      image
+    end
+
+    test "returns the image unchanged with nil info when within the limit" do
+      img = image(200, 50)
+      assert {:ok, ^img, nil} = Clamp.clamp(img, 1000, [])
+    end
+
+    test "is a no-op for an :infinity limit" do
+      img = image(200, 50)
+      assert {:ok, ^img, nil} = Clamp.clamp(img, :infinity, [])
+    end
+
+    test "uniformly downscales when the longest axis exceeds the limit" do
+      img = image(200, 50)
+      assert {:ok, resized, info} = Clamp.clamp(img, 100, [])
+
+      assert Image.width(resized) == 100
+      assert Image.height(resized) == 25
+      assert info.source_dimensions == {200, 50}
+      assert info.dimensions == {100, 25}
+      assert info.max_dimension == 100
+      assert_in_delta info.scale, 0.5, 1.0e-6
+    end
+
+    test "guarantees the realized longest axis is at most the limit (rounding)" do
+      # 333 * (100/333) = 100.0 -> round 100; this also exercises the
+      # measure-and-verify path that keeps a rounding quirk from exceeding it.
+      img = image(333, 10)
+      assert {:ok, resized, info} = Clamp.clamp(img, 100, [])
+
+      assert Image.width(resized) <= 100
+      assert max(Image.width(resized), Image.height(resized)) <= 100
+      assert info.dimensions == {Image.width(resized), Image.height(resized)}
+    end
+  end
 end

--- a/test/image_pipe/output/clamp_test.exs
+++ b/test/image_pipe/output/clamp_test.exs
@@ -5,12 +5,12 @@ defmodule ImagePipe.Output.ClampTest do
 
   describe "encoder_limit/1" do
     test "returns the WebP and AVIF hard dimension limits" do
-      assert Encoder.encoder_limit(:webp) == %{max_dimension: 16383}
-      assert Encoder.encoder_limit(:avif) == %{max_dimension: 16384}
+      assert Encoder.encoder_limit(:webp) == %{max_dimension: 16_383}
+      assert Encoder.encoder_limit(:avif) == %{max_dimension: 16_384}
     end
 
     test "returns the documented JPEG limit and unbounded PNG" do
-      assert Encoder.encoder_limit(:jpeg) == %{max_dimension: 65535}
+      assert Encoder.encoder_limit(:jpeg) == %{max_dimension: 65_535}
       assert Encoder.encoder_limit(:png) == %{max_dimension: :infinity}
     end
   end

--- a/test/image_pipe/output/clamp_test.exs
+++ b/test/image_pipe/output/clamp_test.exs
@@ -1,0 +1,17 @@
+defmodule ImagePipe.Output.ClampTest do
+  use ExUnit.Case, async: true
+
+  alias ImagePipe.Output.Encoder
+
+  describe "encoder_limit/1" do
+    test "returns the WebP and AVIF hard dimension limits" do
+      assert Encoder.encoder_limit(:webp) == %{max_dimension: 16383}
+      assert Encoder.encoder_limit(:avif) == %{max_dimension: 16384}
+    end
+
+    test "returns the documented JPEG limit and unbounded PNG" do
+      assert Encoder.encoder_limit(:jpeg) == %{max_dimension: 65535}
+      assert Encoder.encoder_limit(:png) == %{max_dimension: :infinity}
+    end
+  end
+end

--- a/test/image_pipe/telemetry/logger_test.exs
+++ b/test/image_pipe/telemetry/logger_test.exs
@@ -113,6 +113,27 @@ defmodule ImagePipe.Telemetry.LoggerTest do
     assert log =~ "transform detect: skipped (no detector configured)"
   end
 
+  test "logs the output clamp one-shot at warning with source -> clamped dims" do
+    Telemetry.attach_default_logger(level: :info)
+
+    log =
+      capture_log(fn ->
+        :telemetry.execute(
+          [:image_pipe, :output, :clamp],
+          %{scale: 0.91},
+          %{
+            format: :webp,
+            source_dimensions: {18_000, 9_000},
+            dimensions: {16_383, 8_191},
+            max_dimension: 16_383
+          }
+        )
+      end)
+
+    assert log =~ "[warning]"
+    assert log =~ "output clamp: 18000x9000 -> 16383x8191 for webp (max 16383)"
+  end
+
   test "logs a normal no-face detect fallback at the base level, not warning" do
     Telemetry.attach_default_logger(level: :info)
 


### PR DESCRIPTION
Closes #150.

## Summary

Adds a **format-aware output-encoder dimension clamp** at the `ImagePipe.Output.*` boundary (imgproxy `fixSize` parity, verified against `local/imgproxy-master/processing/fix_size.go`). When the realized final image exceeds the negotiated output encoder's hard per-dimension limit (**WebP 16383**, **AVIF 16384**; JPEG 65535 / PNG effectively unbounded), it is **uniformly downscaled to fit and served** (not errored) before encoding, so encoding can't fail. A `[:output, :clamp]` telemetry one-shot lets hosts observe the clamp.

This closes the gap where a request within the host `max_result_*` cap but above the encoder limit (e.g. `max_result_width: 20000`, an 18000px WebP) passed `check_result_*` and then failed at `webpsave`.

## What changed

- **`ImagePipe.Output.Encoder.encoder_limit/1`** — per-format dimension table (the only format-aware knowledge).
- **`ImagePipe.Output.Clamp.clamp/3`** — generic, product-neutral uniform downscale of a realized `Vix.Vips.Image` (`scale = max_dimension / longest`, exact imgproxy linear parity), with a hard ≤-limit guarantee (defensive corrective re-resize) and a `{:encode, exception, stacktrace}` error contract. No `Transform`/`Telemetry` dependency — resizes via the `image` library directly, like imgproxy's `img.Resize`.
- **Producer seam** — clamps the realized image between format negotiation and `Encoder.stream_output` (before `finalize`/`copy_memory`), emitting `[:output, :clamp]` only when a clamp occurs. Telemetry is owned by the request boundary, keeping `Output` product-neutral.
- **Default Logger** renders the one-shot at `:warning` (matching imgproxy's `slog.Warn`); `docs/telemetry.md` documents the event.
- **Cache/ETag unchanged** — the clamp is deterministic from inputs already in the key (source identity + canonical plan + negotiated format); no new key field.

## Scope boundaries

- The generic clamp seam is structured so **#165** (host `max_result_*` error→downscale) can feed `min(host_max, encoder_limit(format))` through the same call. The `max_pixels`/sqrt path was **deliberately deferred to #165** (unanimous design-review verdict: it would be dead code in #150 and its only test would pin a shape no in-repo producer constructs — greenfield makes the `clamp/3 → clamp/4` widening free). A hand-off note warns against copying imgproxy's `fixGifSize` combined-sqrt, which can leave a result over the dimension limit.
- **#164** (look-ahead pre-clamp to avoid materializing the one oversized buffer) is untouched.

## Test plan

- [x] `mise run precommit` — `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix test` (**1517 passed**, credo clean)
- [x] Unit tests for `Clamp.clamp/3`: dimension downscale, no-op (within-limit + `:infinity`), ≤-limit rounding guarantee
- [x] Wire-level imgproxy conformance tests (real `ImagePipe.call/2`, real encode): WebP-over-16383 and AVIF-over-16384 assert status 200, content-type, **decoded** longest axis ≤ limit, and the `[:output, :clamp]` telemetry event; plus a no-clamp control. Reachability gotcha handled (host result cap raised above the encoder limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Images exceeding per-format encoder dimension limits are now automatically downscaled to fit (WebP: 16,383px, AVIF: 16,384px)
  * Warning logs are emitted when dimension clamping is applied

* **Documentation**
  * Added telemetry documentation for dimension clamping events

* **Tests**
  * Added conformance tests validating encoder dimension limit enforcement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->