### PR TITLE
Host max_result_* error→downscale (#165, limitScale parity)

### DIFF
--- a/docs/imgproxy_support_matrix.md
+++ b/docs/imgproxy_support_matrix.md
@@ -88,7 +88,7 @@ imgproxy's `mainPipeline` (`processing/processing.go`), applied per frame:
 | 10 | `extend` | `lib/image_pipe/transform/operation/extend_canvas.ex` | ✅ | Canvas extension with anchor gravity and offsets. |
 | 11 | `extendAspectRatio` | `lib/image_pipe/transform/operation/extend_canvas.ex` (`{:aspect_ratio, ratio}` rule) | ✅ | `extend_ar`/`exar`; no-op when a resize dimension is auto/zero. `fp` extend-gravity not supported. |
 | 12 | `padding` | `lib/image_pipe/transform/operation/padding.ex` | ✅ | CSS-style shorthand, effective DPR scaling. |
-| 13 | `fixSize` | **output boundary** — `lib/image_pipe/output/clamp.ex` (#150) | ✅ | Format-aware encoder dimension clamp. Realized at the **Output boundary**, not the transform chain: the realized image is uniformly downscaled to the chosen encoder's hard limit (WebP 16383, AVIF 16384). Mirrors imgproxy's `processing/fix_size.go` (`fixWebpSize`/`fixHeifSize`). Emits `[:output, :clamp]` ([telemetry.md](telemetry.md)); covered by the wire conformance tests. The `max_pixels`/sqrt branch (imgproxy's `fixGifSize`) is deferred to #165. |
+| 13 | `fixSize` | **output boundary** — `lib/image_pipe/output/clamp.ex` (#150) | ✅ | Format-aware encoder dimension clamp. Realized at the **Output boundary**, not the transform chain: the realized image is uniformly downscaled to the chosen encoder's hard limit (WebP 16383, AVIF 16384). Mirrors imgproxy's `processing/fix_size.go` (`fixWebpSize`/`fixHeifSize`). Emits `[:output, :clamp]` ([telemetry.md](telemetry.md)); covered by the wire conformance tests. The host `max_result_*` caps fold into this same clamp via `min(host, encoder)` (#165); ImagePipe's result-pixel cap uses an **independent linear-dimension + sqrt-pixel** rule, deliberately **not** `fixGifSize`'s combined-sqrt (which can leave a result over the dimension limit). |
 | 14 | `flatten` | `lib/image_pipe/transform/operation/background.ex` | ✅ | Alpha flatten onto `background`/`background_alpha` (`bg`/`bga`); default black. |
 | 15 | `watermark` | — | ⭕ | In scope, not yet implemented (consistent with the watermark rows in "Background, effects, and overlays" and "Watermark defaults and custom watermark cache"). |
 
@@ -110,7 +110,7 @@ save. ImagePipe realizes these at request and output boundaries:
 | --- | --- | --- | --- |
 | Initial load + source-resolution gate (`MaxSrcResolution`) | decode + `max_input_pixels` (hard error) | ✅ | The image-bomb gate is a hard error, not a downscale — matches imgproxy. `max_body_bytes` caps the fetched body. |
 | Output format determination | `lib/image_pipe/output/negotiation.ex`, `lib/image_pipe/output/policy.ex` | ✅ | `Accept` negotiation for AVIF/WebP with `Vary: Accept`; explicit `@extension`/`.extension` bypasses it. JXL, `enforce_*`, `preferred_formats` missing. |
-| Host result-dimension cap (`limitScale`, `processing/prepare.go`) | `lib/image_pipe/request/processor.ex` (`check_result_*`) | ⚠️ | imgproxy **downscales** the result to fit `max_result_*`; ImagePipe currently **errors**. Issue #165 changes this to downscale-and-serve, reusing the #150 clamp with `min(host_max, encoder_limit)`. |
+| Host result-dimension cap (`limitScale`, `processing/prepare.go`) | `lib/image_pipe/output/clamp.ex` via the producer (`min(host max_result_*, encoder_limit)`) | ✅ | imgproxy downscales the result to fit `max_result_*`; ImagePipe matches for the common no-padding/no-extend request (#165), reusing the #150 `Output.Clamp` — byte-intent identical to `limitScale`'s linear `downScale = maxResultDim/max(outW,outH)` (`prepare.go:247`) when caps are equal and a dimension binds. **Diverges (superset):** ImagePipe honors independent `max_result_width`/`max_result_height` and a result `max_result_pixels` cap (sqrt), where imgproxy's `limitScale` has a single `MaxResultDimension` and no result-pixel cap. **Diverges (composition):** ImagePipe clamps the **composited** final image, whereas imgproxy folds the downscale into the resize scale and re-applies padding/extend at the reduced scale (`prepare.go:233-263`) — both land ≤ cap, but padded/extended requests differ in the **content-to-padding ratio of the final frame**. ImagePipe mirrors imgproxy's per-axis sub-1px floor (`prepare.go:252-258`) via `max(scale, 1/dim)`; in the extreme-aspect 1px regime the realized pixels can still differ for the same composited-vs-fold-back reason. |
 | Save / encode | `lib/image_pipe/output/encoder.ex` | ✅ | Streams the encoded result. Advanced/codec-specific encoder knobs missing (see "Advanced encoder options"). |
 
 ### Key takeaways
@@ -121,8 +121,10 @@ save. ImagePipe realizes these at request and output boundaries:
 - **Not every imgproxy stage is a transform op** — `scaleOnLoad` is decode
   planning, `fixSize` is the output boundary, `stripMetadata`/`colorspaceToResult`
   are encoder finalize. The "Realized in" column is the map.
-- **The standing divergences are color management (#124) and the host result cap
-  (#165).** Everything else either matches or is an explicitly missing/out-of-scope
+- **The standing divergence is color management (#124).** The host result cap now
+  downscales to match imgproxy (#165), with a deliberate, strictly-safe superset:
+  independent per-axis width/height + a result-pixel cap, and a composited-image
+  clamp point. Everything else either matches or is an explicitly missing/out-of-scope
   surface documented in the tables below.
 
 ## Status legend
@@ -424,17 +426,22 @@ Top-level `max_body_bytes` caps fetched source bodies and defaults to
 `10_000_000` bytes. Cache adapter `max_body_bytes` still caps encoded response
 staging for adapters that configure it. ImagePipe uses `max_input_pixels` for
 decoded input size and `max_result_width`, `max_result_height`, and
-`max_result_pixels` for final static result size. It doesn't expose Imgproxy's
+`max_result_pixels` for final static result size. `max_input_pixels` remains the
+hard image-bomb gate (a `413` error on oversize decoded input), while the
+`max_result_*` caps now **downscale the served result to fit** rather than
+erroring — imgproxy `limitScale` parity (#165). It doesn't expose Imgproxy's
 animation frame limits or SVG and PNG-specific policy.
 
-Separately from those host-configured caps, ImagePipe clamps the realized output
-to the chosen output encoder's hard per-dimension limit — WebP 16383, AVIF 16384
-(JPEG 65535, PNG effectively unbounded) — by uniformly downscaling and serving
-rather than failing to encode. This mirrors imgproxy's internal `fixSize` step
-(`processing/fix_size.go`) and emits an `[:output, :clamp]`
-telemetry event ([docs/telemetry.md](telemetry.md)). It is an internal safety
-backstop with no configurable knob, so it has no `IMGPROXY_*` row; it only
-triggers when a host raises `max_result_*` above the encoder limit.
+ImagePipe realizes both the host `max_result_*` caps and the chosen output
+encoder's hard per-dimension limit — WebP 16383, AVIF 16384 (JPEG 65535, PNG
+effectively unbounded) — through the same `Output.Clamp` seam, uniformly
+downscaling and serving rather than failing to encode. The encoder limit mirrors
+imgproxy's internal `fixSize` step (`processing/fix_size.go`) and the host caps
+mirror `limitScale`; it emits an `[:output, :clamp]`
+telemetry event ([docs/telemetry.md](telemetry.md)). The encoder backstop has no
+configurable knob, so it has no `IMGPROXY_*` row; the clamp triggers whenever the
+realized result exceeds the tighter of the host caps and the encoder limit —
+commonly the host cap (default 8192 per axis), which is below the encoder limits.
 
 - ✅ `IMGPROXY_MAX_SRC_RESOLUTION`
 - ✅ `IMGPROXY_MAX_SRC_FILE_SIZE`

--- a/docs/operational_notes.md
+++ b/docs/operational_notes.md
@@ -38,7 +38,9 @@ Static result limits run after transform execution and before final output
 resolution or encoding. `:max_result_width` and `:max_result_height` default
 to `8_192`. `:max_result_pixels` defaults to `40_000_000`. Result dimensions
 mean the final static image width, height, and pixel count. Oversize static
-results return `413` with `result image is too large`. Animation frame limits
+results now **downscale the served image to fit** these caps rather than erroring
+(imgproxy `limitScale` parity); `:max_input_pixels` remains a hard `413`
+image-bomb gate on oversize decoded input. Animation frame limits
 remain out of scope and aren't implemented.
 
 These limits gate response generation. They don't change cache identity.

--- a/docs/superpowers/plans/2026-06-08-host-max-result-downscale.md
+++ b/docs/superpowers/plans/2026-06-08-host-max-result-downscale.md
@@ -86,7 +86,7 @@ In `lib/image_pipe/output/encoder.ex`, update the doc and the four clauses:
 - [ ] **Step 4: Run, verify pass**
 
 Run: `mise exec -- mix test test/image_pipe/output/clamp_test.exs -v`
-Expected: the `encoder_limit/1` tests PASS. (The `clamp/3` tests still reference the old signature and will be rewritten in Task 2 — they may fail now; that is expected and fixed in Task 2. If you want a green checkpoint here, run only the `encoder_limit` describe: `mise exec -- mix test test/image_pipe/output/clamp_test.exs:18`.)
+Expected: **PASS — the whole file is green.** This task only touches `encoder.ex` and the `encoder_limit/1` describe block. The existing `clamp/3` tests run against the still-unchanged (scalar-signature) `clamp.ex` and keep passing; the producer's `%{max_dimension: max_dimension} = Encoder.encoder_limit(...)` destructure still matches the now-wider map (extra `:max_pixels` key ignored). Run the full suite too: `mise exec -- mix test` — also green. The `clamp/3` signature change happens in Task 2.
 
 - [ ] **Step 5: Commit**
 
@@ -111,7 +111,9 @@ This is the core task. It changes `clamp/3`'s contract, so it updates the clamp,
 
 - [ ] **Step 1: Write the new `clamp/3` unit tests**
 
-Replace the entire `describe "clamp/3"` block in `test/image_pipe/output/clamp_test.exs` with the following (and add `use ExUnitProperties` to the module — keep `use ExUnit.Case, async: true`):
+First, **delete the now-dead `OvershootOnceImage` stub module and its leading comment** (the `defmodule OvershootOnceImage … end` block near the top of `test/image_pipe/output/clamp_test.exs`) — it was only used by the old corrective-resize test, which the rewrite below replaces.
+
+Then add `use ExUnitProperties` to the module (keep `use ExUnit.Case, async: true`) and replace the entire `describe "clamp/3"` block in `test/image_pipe/output/clamp_test.exs` with the following:
 
 ```elixir
   describe "clamp/3" do
@@ -204,23 +206,63 @@ Replace the entire `describe "clamp/3"` block in `test/image_pipe/output/clamp_t
       assert Image.width(resized) <= 100
       assert Image.height(resized) >= 1
     end
+
+    # Deterministic cover for the deep pixel verify-and-shrink loop — the exact
+    # path the bounded loop, the `long - 1` floor, and the 1px floor exist for.
+    # (Traced: ~8 and ~10 iterations respectively, both well under the bound.)
+    test "pixel cap on an extreme aspect ratio converges and fits (deep loop, 1px floor)" do
+      img = image(40_000, 1)
+      assert {:ok, resized, _info} = Clamp.clamp(img, limits(max_pixels: 100), [])
+
+      w = Image.width(resized)
+      h = Image.height(resized)
+      assert h >= 1
+      assert w * h <= 100
+    end
+
+    test "pixel cap on a tall sliver converges and fits (deep loop)" do
+      img = image(1, 6000)
+      assert {:ok, resized, _info} = Clamp.clamp(img, limits(max_pixels: 1300), [])
+
+      w = Image.width(resized)
+      h = Image.height(resized)
+      assert w >= 1
+      assert w * h <= 1300
+    end
   end
 
   describe "clamp/3 pixel ≤-cap property" do
     alias ImagePipe.Output.Clamp
 
+    # Bias the generator toward the regimes that actually drive the pixel loop
+    # deep: extreme aspect ratios (one axis tiny) and small pixel caps. A uniform
+    # square generator almost never reaches the >1-iteration path (~72% no-op),
+    # leaving the loop the test exists to protect essentially unexercised.
+    defp dim_gen do
+      StreamData.frequency([
+        {3, StreamData.integer(1..6000)},
+        {2, StreamData.integer(1..8)}
+      ])
+    end
+
     property "realized dims and pixel product never exceed the caps" do
       check all(
-              w <- StreamData.integer(1..6000),
-              h <- StreamData.integer(1..6000),
-              max_w <- StreamData.integer(8..6000),
-              max_h <- StreamData.integer(8..6000),
-              max_px <- StreamData.integer(64..2_000_000),
-              max_runs: 300
+              w <- dim_gen(),
+              h <- dim_gen(),
+              max_w <- StreamData.integer(1..6000),
+              max_h <- StreamData.integer(1..6000),
+              max_px <-
+                StreamData.frequency([
+                  {2, StreamData.integer(64..5000)},
+                  {1, StreamData.integer(5001..2_000_000)}
+                ]),
+              max_runs: 400
             ) do
         {:ok, image} = Image.new(w, h)
         lim = %{max_width: max_w, max_height: max_h, max_pixels: max_px}
 
+        # A `{:error, {:encode, ...}}` here would mean the bounded loop exhausted
+        # (non-termination within the bound) — the pattern-match failure surfaces it.
         assert {:ok, resized, _info} = Clamp.clamp(image, lim, [])
         rw = Image.width(resized)
         rh = Image.height(resized)
@@ -474,10 +516,10 @@ In `lib/image_pipe/telemetry/logger.ex`, replace the `[:output, :clamp | _]` `me
   end
 ```
 
-Add a small private renderer (place it among the other `defp`s, e.g. just below the `message/3` clauses):
+Add a small private renderer (place it among the other `defp`s, e.g. just below the `message/3` clauses). Use the ASCII token `inf` (not `∞`) so the line stays grep-friendly for log sinks; today the host caps are always integers, so this fallback is rarely hit:
 
 ```elixir
-  defp cap(:infinity), do: "∞"
+  defp cap(:infinity), do: "inf"
   defp cap(value), do: value
 ```
 
@@ -645,7 +687,10 @@ After the `describe "output encoder dimension clamp (#150)"` block, add:
       assert content_type(conn) == ["image/jpeg"]
 
       {w, h} = dimensions(conn)
-      assert max(w, h) <= 8192
+      # Parity, not just safety: when the width cap binds on a non-degenerate
+      # aspect, the long axis lands EXACTLY on 8192 — byte-intent identical to
+      # imgproxy's linear `downScale = maxResultDim/max(outW,outH)`.
+      assert w == 8192
 
       assert_received {:telemetry_event, [:image_pipe, :output, :clamp], %{scale: scale}, meta}
       assert scale < 1.0
@@ -654,6 +699,28 @@ After the `describe "output encoder dimension clamp (#150)"` block, add:
       assert meta.dimensions == {w, h}
       {sw, _sh} = meta.source_dimensions
       assert sw > 8192
+    end
+
+    # The one place ImagePipe and imgproxy observably diverge: a PADDED request
+    # whose composited frame exceeds the cap. imgproxy folds the downscale into
+    # the resize scale before re-applying padding (prepare.go:233-263); ImagePipe
+    # clamps the already-composited frame. Both land <= cap; the framing differs.
+    # This test pins ImagePipe's contract (status 200, composite <= cap, clamp
+    # fired) so a future change to the clamp point can't silently alter padded
+    # behavior with a green suite.
+    test "clamps a padded result whose composited frame exceeds the host cap" do
+      attach_clamp_telemetry()
+
+      # w:100 then pad 5000px each side -> composited width ~10100 > 8192.
+      conn =
+        call_imgproxy("/_/w:100/pd:5000/f:jpeg/plain/images/beach.jpg", @host_default_opts)
+
+      assert conn.status == 200
+      {w, h} = dimensions(conn)
+      assert max(w, h) <= 8192
+
+      assert_received {:telemetry_event, [:image_pipe, :output, :clamp], %{scale: scale}, _meta}
+      assert scale < 1.0
     end
 
     test "honors asymmetric per-axis caps without over-shrinking" do
@@ -741,7 +808,7 @@ git commit -m "test(imgproxy): wire-level host result-cap downscale conformance 
 In `docs/imgproxy_support_matrix.md`, the "Surrounding stages" table row for the host result-dimension cap currently reads ⚠️ and points at `check_result_*`. Replace it with:
 
 ```markdown
-| Host result-dimension cap (`limitScale`, `processing/prepare.go`) | `lib/image_pipe/output/clamp.ex` via the producer (`min(host max_result_*, encoder_limit)`) | ✅ | imgproxy downscales the result to fit `max_result_*`; ImagePipe now matches (#165), reusing the #150 `Output.Clamp`. **Diverges (superset):** ImagePipe honors independent `max_result_width`/`max_result_height` and a result `max_result_pixels` cap (sqrt), where imgproxy's `limitScale` has a single `MaxResultDimension` and no result-pixel cap. **Diverges (composition):** ImagePipe clamps the **composited** final image, whereas imgproxy folds the downscale into the resize scale before padding/extend (`prepare.go:233-263`) — both land ≤ cap; padded/extended requests differ in internal composition. Matches imgproxy's sub-1px floor via a per-axis `max(scale, 1/dim)`. |
+| Host result-dimension cap (`limitScale`, `processing/prepare.go`) | `lib/image_pipe/output/clamp.ex` via the producer (`min(host max_result_*, encoder_limit)`) | ✅ | imgproxy downscales the result to fit `max_result_*`; ImagePipe matches for the common no-padding/no-extend request (#165), reusing the #150 `Output.Clamp` — byte-intent identical to `limitScale`'s linear `downScale = maxResultDim/max(outW,outH)` (`prepare.go:247`) when caps are equal and a dimension binds. **Diverges (superset):** ImagePipe honors independent `max_result_width`/`max_result_height` and a result `max_result_pixels` cap (sqrt), where imgproxy's `limitScale` has a single `MaxResultDimension` and no result-pixel cap. **Diverges (composition):** ImagePipe clamps the **composited** final image, whereas imgproxy folds the downscale into the resize scale and re-applies padding/extend at the reduced scale (`prepare.go:233-263`) — both land ≤ cap, but padded/extended requests differ in the **content-to-padding ratio of the final frame**. ImagePipe mirrors imgproxy's per-axis sub-1px floor (`prepare.go:252-258`) via `max(scale, 1/dim)`; in the extreme-aspect 1px regime the realized pixels can still differ for the same composited-vs-fold-back reason. |
 ```
 
 - [ ] **Step 2: Support matrix — fix the stale `fixSize` row (row 13)**
@@ -766,51 +833,37 @@ The "Key takeaways" bullet currently reads "The standing divergences are color m
 
 - [ ] **Step 4: Support matrix — input/output safety-limits section**
 
-In the "Input and output safety limits" prose (~426-437), update the sentence that frames `max_result_*` as an error to state it now downscales-to-fit (imgproxy `limitScale` parity), while `max_input_pixels` remains the hard image-bomb gate. (Edit the existing sentences in place; keep the `max_input_pixels`/`max_body_bytes` description unchanged.)
+In the "Input and output safety limits" prose (~426-437):
+- Update the sentence that frames `max_result_*` as an **error** to state it now downscales-to-fit (imgproxy `limitScale` parity), while `max_input_pixels` remains the hard image-bomb gate.
+- **Also rewrite the now-stale clause** (~line 437) that says the clamp "only triggers when a host raises `max_result_*` above the encoder limit" — after #165 the clamp commonly triggers at the **host** cap (default 8192), which is *below* the encoder limits. Reword to: it triggers whenever the realized result exceeds the tighter of the host caps and the encoder limit.
+- Keep the `max_input_pixels`/`max_body_bytes` description unchanged.
+
+Verify nothing else in the doc still describes the result cap as an error: `grep -n "result image is too large\|max_result.*error\|errors" docs/imgproxy_support_matrix.md` and reconcile any remaining hit.
 
 - [ ] **Step 5: telemetry.md — rewrite the Output dimension clamp section**
 
-Replace the "Output dimension clamp" section body so it covers both the host and encoder caps and the `limits` metadata:
+Rewrite the body of the "Output dimension clamp (`[:output, :clamp]`)" section. To avoid nested code fences in this plan, the replacement is described below (the two `[:image_pipe, …]` / `output clamp: …` snippets stay in their existing ` ```text ` fenced blocks in the doc — only their *content* and the surrounding prose/metadata change):
 
-```markdown
-## Output dimension clamp (`[:output, :clamp]`)
+- **Opening paragraph** → replace with:
 
-When the realized final image exceeds the effective result caps — the tighter of
-the host `max_result_width`/`max_result_height`/`max_result_pixels` config and the
-negotiated output encoder's hard limit (`min(host, encoder)`) — ImagePipe uniformly
-downscales it to fit before encoding and emits a one-shot (non-span) marker. This
-both keeps encoding from failing (WebP caps each dimension at 16383, AVIF at 16384;
-JPEG/PNG effectively unbounded) and serves the host result cap as a downscale rather
-than an error (imgproxy `limitScale` parity). The common trigger is the host cap
-(default 8192 per axis), which is below the encoder limits.
+  > When the realized final image exceeds the effective result caps — the tighter of the host `max_result_width`/`max_result_height`/`max_result_pixels` config and the negotiated output encoder's hard limit (`min(host, encoder)`) — ImagePipe uniformly downscales it to fit before encoding and emits a one-shot (non-span) marker. This both keeps encoding from failing (WebP caps each dimension at 16383, AVIF at 16384; JPEG/PNG effectively unbounded) and serves the host result cap as a downscale rather than an error (imgproxy `limitScale` parity). The common trigger is the host cap (default 8192 per axis), which is below the encoder limits.
 
-​```text
-[:image_pipe, :output, :clamp]
-​```
+- **Keep** the ` ```text ` block containing `[:image_pipe, :output, :clamp]` unchanged.
+- **Keep** the `Measurements:` list (`:scale`) unchanged.
+- **Replace the `Metadata:` list** so the final bullet is `:limits` instead of `:max_dimension`:
 
-Measurements:
+      - `:format` — the negotiated output format atom (e.g. `:webp`, `:avif`).
+      - `:source_dimensions` — `{w, h}` before the clamp.
+      - `:dimensions` — `{w, h}` after the clamp.
+      - `:limits` — the effective caps applied: `%{max_width, max_height, max_pixels}` (each a `pos_integer` or `:infinity`).
 
-- `:scale` — the uniform downscale factor applied (a float `< 1.0`).
+- **Keep** the "product-neutral and non-sensitive" sentence and the "`:warning` … imgproxy `slog.Warn`" sentence.
+- **Update the example** in the trailing ` ```text ` block to the new rendering:
 
-Metadata:
+      output clamp: 18000x9000 -> 8192x4096 for webp (caps w:8192 h:8192 px:40000000)
 
-- `:format` — the negotiated output format atom (e.g. `:webp`, `:avif`).
-- `:source_dimensions` — `{w, h}` before the clamp.
-- `:dimensions` — `{w, h}` after the clamp.
-- `:limits` — the effective caps applied: `%{max_width, max_height, max_pixels}`
-  (each a `pos_integer` or `:infinity`).
-
-This metadata is product-neutral and non-sensitive (no URLs, secrets, or PII).
-
-The opt-in default Logger attaches to this event and renders it at `:warning`,
-matching imgproxy's `slog.Warn` for the same condition, e.g.:
-
-​```text
-output clamp: 18000x9000 -> 8192x4096 for webp (caps w:8192 h:8192 px:40000000)
-​```
-```
-
-(Remove the leading zero-width characters from the fenced-code backticks above — they are only here to keep this plan's markdown from closing early. Use plain triple backticks.)
+After editing, confirm the doc has no stray `:max_dimension` and no broken fences:
+`grep -nP '[\x{200B}\x{200C}\x{200D}\x{FEFF}]|max_dimension' docs/telemetry.md` (expect: no output).
 
 - [ ] **Step 6: operational_notes.md**
 
@@ -846,4 +899,6 @@ git add -A && git commit -m "chore: precommit fixups (#165)"
 - **Do not reintroduce a `{:result_limit, _}` tag** anywhere. After Task 3 it has no emitter and no handler; a stray one would crash with `FunctionClauseError` in the sender.
 - **`max_result_*` must stay out of the cache key and ETag** (`lib/image_pipe/cache/key.ex`, `lib/image_pipe/request/http_cache.ex`) — they are absent today and this change must not add them. The clamp output is deterministic from inputs already in the key (source identity + plan + negotiated format) for a given deployment.
 - **No demo UI change** — `max_result_*` are host config, not URL/transform knobs.
+- **`cdn_http_cache_wire_test.exs` (the "stricter result limit does not change generated etag" test) is unaffected** — don't be alarmed by its tight `max_result_width: 32`. Its loose request (`w:64`, cap 64) is a clamp no-op, and its strict request matches the loose ETag and returns `304` *before* the producer clamp ever runs. It stays green without edits.
+- **The padded-over-cap wire test (Task 4) needs the imgproxy `pd:` token to parse** — padding is a supported ImagePipe transform (`lib/image_pipe/transform/operation/padding.ex`, matrix stage 12). If `pd:5000` doesn't push the composite over 8192 with the test source, adjust the padding amount until `meta.source_dimensions` exceeds the cap; keep the asserted contract (200, composite ≤ cap, clamp fired).
 - **Out of scope:** the shrink-on-load decode fold (`DecodePlanner`) and #164 look-ahead pre-clamp.

--- a/docs/superpowers/plans/2026-06-08-host-max-result-downscale.md
+++ b/docs/superpowers/plans/2026-06-08-host-max-result-downscale.md
@@ -1,0 +1,849 @@
+# Host `max_result_*` error→downscale Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Change ImagePipe's host result-dimension cap (`max_result_width`/`max_result_height`/`max_result_pixels`) from a 413 error to a uniform downscale-and-serve, matching imgproxy `limitScale`, by reusing the #150 `ImagePipe.Output.Clamp` seam fed `min(host_cap, encoder_limit)`.
+
+**Architecture:** Widen `Output.Clamp.clamp/3`'s second argument from a single square `max_dimension` to a per-axis + pixel **limits map** (`%{max_width, max_height, max_pixels}`). Dimension caps use a linear per-axis scale (satisfied by construction); the pixel cap uses a **bounded verify-and-shrink loop** (a closed form cannot guarantee a rounded *product* ≤ cap). The producer computes the effective limits = `min(host max_result_*, encoder_limit(format))` and passes them in. The old `check_result_*`/413 error path is deleted; `max_input_pixels` stays the only hard error.
+
+**Tech Stack:** Elixir, `Vix.Vips.Image`, the `image` library (`Image.width/1`, `Image.resize/2`), `:telemetry`, ExUnit + StreamData.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-host-max-result-downscale-design.md`
+
+**Tooling note:** all commands run through `mise exec -- …`. The imgproxy upstream checkout for parity is at `/Users/hlindset/src/image_plug/local/imgproxy-master/` (in the **main repo**, not the worktree).
+
+---
+
+## File map
+
+- **Modify** `lib/image_pipe/output/encoder.ex` — `encoder_limit/1` gains `:max_pixels`.
+- **Rewrite** `lib/image_pipe/output/clamp.ex` — limits-map signature, per-axis scale, pixel verify-shrink loop, per-axis 1px floor, new `clamp_info`.
+- **Modify** `lib/image_pipe/request/source_session/producer.ex` — `effective_limits/2` + `min_limit/2`, the `with`-chain call, `emit_clamp_telemetry` metadata (`max_dimension` → `limits`).
+- **Modify** `lib/image_pipe/request/processor.ex` — delete `validate_result_image/2` + `check_result_*` and their use in `process_decoded_source`.
+- **Modify** `lib/image_pipe/response/sender.ex` — delete the `{:result_limit, _}` clause + `send_result_limit_error/3`.
+- **Modify** `lib/image_pipe/telemetry/logger.ex` — `message/3` for `[:output, :clamp]` renders `limits`, with graceful `:infinity`.
+- **Rewrite** `test/image_pipe/output/clamp_test.exs` — limits-map unit tests + pixel property test.
+- **Modify** `test/image_pipe/telemetry/logger_test.exs` — `limits` metadata + rendered string.
+- **Modify** `test/image_pipe/imgproxy_wire_conformance_test.exs` — update #150 tests' `max_dimension`→`limits`; add #165 downscale tests.
+- **Modify** `test/image_pipe/processor_test.exs` — delete the two result-limit tests (~181, ~197).
+- **Modify** `test/image_pipe/plug_test.exs` — delete the 413 result-limit test (~2051); keep the within-limits no-clamp control (~2069).
+- **Modify** `docs/imgproxy_support_matrix.md`, `docs/telemetry.md`, `docs/operational_notes.md`.
+
+---
+
+## Task 1: Add `:max_pixels` to `encoder_limit/1`
+
+**Files:**
+- Modify: `lib/image_pipe/output/encoder.ex:13-22`
+- Test: `test/image_pipe/output/clamp_test.exs` (the `encoder_limit/1` describe block)
+
+- [ ] **Step 1: Update the failing tests**
+
+In `test/image_pipe/output/clamp_test.exs`, replace the `encoder_limit/1` describe block with:
+
+```elixir
+  describe "encoder_limit/1" do
+    test "returns the WebP and AVIF hard dimension limits with unbounded pixels" do
+      assert Encoder.encoder_limit(:webp) == %{max_dimension: 16_383, max_pixels: :infinity}
+      assert Encoder.encoder_limit(:avif) == %{max_dimension: 16_384, max_pixels: :infinity}
+    end
+
+    test "returns the documented JPEG limit and unbounded PNG" do
+      assert Encoder.encoder_limit(:jpeg) == %{max_dimension: 65_535, max_pixels: :infinity}
+      assert Encoder.encoder_limit(:png) == %{max_dimension: :infinity, max_pixels: :infinity}
+    end
+  end
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `mise exec -- mix test test/image_pipe/output/clamp_test.exs:18 -v`
+Expected: FAIL (current return lacks `:max_pixels`).
+
+- [ ] **Step 3: Implement**
+
+In `lib/image_pipe/output/encoder.ex`, update the doc and the four clauses:
+
+```elixir
+  @doc """
+  The output encoder's hard per-format limits, used by `ImagePipe.Output.Clamp`
+  to keep encoding from failing. `:max_dimension` is the hard per-axis pixel
+  limit; `:max_pixels` is a total-resolution budget. `:infinity` means no
+  practical limit. Sourced from libvips encoder constraints (cf. imgproxy
+  `processing/fix_size.go`). #165 folds these with the host `max_result_*` caps
+  via `min/2` at the producer before calling `Clamp.clamp/3`.
+  """
+  @spec encoder_limit(Format.output_format()) :: %{
+          max_dimension: pos_integer() | :infinity,
+          max_pixels: pos_integer() | :infinity
+        }
+  def encoder_limit(:webp), do: %{max_dimension: 16_383, max_pixels: :infinity}
+  def encoder_limit(:avif), do: %{max_dimension: 16_384, max_pixels: :infinity}
+  def encoder_limit(:jpeg), do: %{max_dimension: 65_535, max_pixels: :infinity}
+  def encoder_limit(:png), do: %{max_dimension: :infinity, max_pixels: :infinity}
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `mise exec -- mix test test/image_pipe/output/clamp_test.exs -v`
+Expected: the `encoder_limit/1` tests PASS. (The `clamp/3` tests still reference the old signature and will be rewritten in Task 2 — they may fail now; that is expected and fixed in Task 2. If you want a green checkpoint here, run only the `encoder_limit` describe: `mise exec -- mix test test/image_pipe/output/clamp_test.exs:18`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/output/encoder.ex test/image_pipe/output/clamp_test.exs
+git commit -m "feat(output): add :max_pixels to encoder_limit/1 (#165)"
+```
+
+---
+
+## Task 2: Migrate `Output.Clamp` to a per-axis + pixel limits map
+
+This is the core task. It changes `clamp/3`'s contract, so it updates the clamp, its only call site (the producer), the telemetry metadata, the Logger rendering, and all of their tests **together** — the task ends with the full suite green.
+
+**Files:**
+- Rewrite: `lib/image_pipe/output/clamp.ex`
+- Modify: `lib/image_pipe/request/source_session/producer.ex:124-128` (the `with` lines), `:160-176` (`emit_clamp_telemetry`)
+- Modify: `lib/image_pipe/telemetry/logger.ex:166-171`
+- Rewrite: `test/image_pipe/output/clamp_test.exs` (the `clamp/3` describe)
+- Modify: `test/image_pipe/telemetry/logger_test.exs:116-135`
+- Modify: `test/image_pipe/imgproxy_wire_conformance_test.exs` (#150 tests' `meta.max_dimension` → `meta.limits`)
+
+- [ ] **Step 1: Write the new `clamp/3` unit tests**
+
+Replace the entire `describe "clamp/3"` block in `test/image_pipe/output/clamp_test.exs` with the following (and add `use ExUnitProperties` to the module — keep `use ExUnit.Case, async: true`):
+
+```elixir
+  describe "clamp/3" do
+    alias ImagePipe.Output.Clamp
+
+    @inf %{max_width: :infinity, max_height: :infinity, max_pixels: :infinity}
+
+    defp image(width, height) do
+      {:ok, image} = Image.new(width, height)
+      image
+    end
+
+    defp limits(opts) do
+      %{
+        max_width: Keyword.get(opts, :max_width, :infinity),
+        max_height: Keyword.get(opts, :max_height, :infinity),
+        max_pixels: Keyword.get(opts, :max_pixels, :infinity)
+      }
+    end
+
+    test "no-op (unchanged image, nil info) when within all caps" do
+      img = image(200, 50)
+      assert {:ok, ^img, nil} = Clamp.clamp(img, limits(max_width: 1000, max_height: 1000), [])
+    end
+
+    test "no-op for an all-:infinity limits map" do
+      img = image(200, 50)
+      assert {:ok, ^img, nil} = Clamp.clamp(img, @inf, [])
+    end
+
+    test "no-op when a cap exactly equals a dimension (no degenerate resize)" do
+      img = image(200, 50)
+      assert {:ok, ^img, nil} = Clamp.clamp(img, limits(max_width: 200, max_height: 50), [])
+    end
+
+    test "downscales linearly when the width cap binds" do
+      img = image(200, 50)
+      assert {:ok, resized, info} = Clamp.clamp(img, limits(max_width: 100), [])
+
+      assert Image.width(resized) == 100
+      assert Image.height(resized) == 25
+      assert info.source_dimensions == {200, 50}
+      assert info.dimensions == {100, 25}
+      assert info.limits == limits(max_width: 100)
+      assert_in_delta info.scale, 0.5, 1.0e-6
+    end
+
+    test "downscales when the height cap binds" do
+      img = image(50, 200)
+      assert {:ok, resized, info} = Clamp.clamp(img, limits(max_height: 100), [])
+
+      assert Image.width(resized) == 25
+      assert Image.height(resized) == 100
+      assert info.dimensions == {25, 100}
+    end
+
+    test "respects asymmetric caps without over-shrinking (per-axis)" do
+      # 8000x4000, caps w<=10000 (slack), h<=4000 (exactly met) -> no clamp.
+      img = image(8000, 4000)
+      assert {:ok, ^img, nil} = Clamp.clamp(img, limits(max_width: 10_000, max_height: 4000), [])
+    end
+
+    test "downscales on the pixel budget, preserving aspect, realized product <= cap" do
+      # 2000x2000 = 4_000_000 px; cap 1_000_000 -> scale 0.5 -> 1000x1000.
+      img = image(2000, 2000)
+      assert {:ok, resized, info} = Clamp.clamp(img, limits(max_pixels: 1_000_000), [])
+
+      w = Image.width(resized)
+      h = Image.height(resized)
+      assert w * h <= 1_000_000
+      assert_in_delta w / 2000, h / 2000, 1.0e-6
+      assert info.dimensions == {w, h}
+    end
+
+    test "takes the most-aggressive scale when pixel and dimension caps disagree" do
+      # 4000x1000 = 4_000_000 px. max_width 2000 -> dim scale 0.5 (-> 2000x500=1_000_000).
+      # max_pixels 250_000 -> sqrt(250000/4e6)=0.25 (-> 1000x250=250_000). Pixels win.
+      img = image(4000, 1000)
+      assert {:ok, resized, _info} =
+               Clamp.clamp(img, limits(max_width: 2000, max_pixels: 250_000), [])
+
+      assert Image.width(resized) <= 2000
+      assert Image.width(resized) * Image.height(resized) <= 250_000
+    end
+
+    test "keeps each axis >= 1px for an extreme aspect ratio with a tight cap" do
+      img = image(40_000, 1)
+      assert {:ok, resized, _info} = Clamp.clamp(img, limits(max_width: 100), [])
+
+      assert Image.width(resized) <= 100
+      assert Image.height(resized) >= 1
+    end
+  end
+
+  describe "clamp/3 pixel ≤-cap property" do
+    alias ImagePipe.Output.Clamp
+
+    property "realized dims and pixel product never exceed the caps" do
+      check all(
+              w <- StreamData.integer(1..6000),
+              h <- StreamData.integer(1..6000),
+              max_w <- StreamData.integer(8..6000),
+              max_h <- StreamData.integer(8..6000),
+              max_px <- StreamData.integer(64..2_000_000),
+              max_runs: 300
+            ) do
+        {:ok, image} = Image.new(w, h)
+        lim = %{max_width: max_w, max_height: max_h, max_pixels: max_px}
+
+        assert {:ok, resized, _info} = Clamp.clamp(image, lim, [])
+        rw = Image.width(resized)
+        rh = Image.height(resized)
+
+        assert rw >= 1 and rh >= 1
+        assert rw <= max_w
+        assert rh <= max_h
+        assert rw * rh <= max_px
+      end
+    end
+  end
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `mise exec -- mix test test/image_pipe/output/clamp_test.exs -v`
+Expected: FAIL — `clamp/3` still takes a scalar `max_dimension`; the map-arg calls won't match / `info.limits` is undefined.
+
+- [ ] **Step 3: Rewrite `lib/image_pipe/output/clamp.ex`**
+
+Replace the whole file with:
+
+```elixir
+defmodule ImagePipe.Output.Clamp do
+  @moduledoc false
+  # Generic, product-neutral uniform downscale of a realized image so it fits a
+  # set of result caps: per-axis dimensions (`:max_width`/`:max_height`) and a
+  # total pixel budget (`:max_pixels`). The producer passes the EFFECTIVE caps =
+  # min(host max_result_*, encoder limit), so encoding cannot fail AND the host
+  # result cap downscales rather than errors (imgproxy `limitScale` parity).
+  # Knows nothing about formats or hosts.
+  #
+  # Reads/resizes via the `image` library directly (no Transform/Telemetry dep).
+  # Resize is lazy; measuring width/height reads libvips header fields (O(1)).
+
+  alias Vix.Vips.Image, as: VixImage
+
+  @type limit :: pos_integer() | :infinity
+  @type limits :: %{max_width: limit(), max_height: limit(), max_pixels: limit()}
+
+  @type clamp_info :: %{
+          scale: float(),
+          source_dimensions: {pos_integer(), pos_integer()},
+          dimensions: {pos_integer(), pos_integer()},
+          limits: limits()
+        }
+
+  # Bounded escape for the pixel verify-and-shrink loop. Realistic caps converge
+  # in one iteration; the bound only guards an adversarially tiny pixel cap (a
+  # few hundred px) that needs several geometric steps.
+  @max_pixel_iterations 16
+
+  @spec clamp(VixImage.t(), limits(), keyword()) ::
+          {:ok, VixImage.t(), clamp_info() | nil}
+          | {:error, {:encode, Exception.t(), list()}}
+  def clamp(%VixImage{} = image, %{} = limits, opts) do
+    w = Image.width(image)
+    h = Image.height(image)
+    scale = primary_scale(limits, w, h)
+
+    if scale >= 1.0 do
+      {:ok, image, nil}
+    else
+      image_module = Keyword.get(opts, :image_module, Image)
+
+      with {:ok, resized} <- resize(image_module, image, scale),
+           {:ok, resized} <- enforce(image_module, image, resized, limits, @max_pixel_iterations) do
+        rw = Image.width(resized)
+        rh = Image.height(resized)
+
+        {:ok, resized,
+         %{
+           scale: rw / w,
+           source_dimensions: {w, h},
+           dimensions: {rw, rh},
+           limits: limits
+         }}
+      end
+    end
+  end
+
+  # Most-aggressive scale across the per-axis dimension caps (linear) and the
+  # pixel budget (sqrt). >= 1.0 means no cap binds -> no-op.
+  defp primary_scale(%{max_width: mw, max_height: mh, max_pixels: mp}, w, h) do
+    [axis_scale(mw, w), axis_scale(mh, h), pixel_scale(mp, w * h)]
+    |> Enum.min()
+    |> min(1.0)
+  end
+
+  defp axis_scale(:infinity, _dim), do: 1.0
+  defp axis_scale(max_dim, dim) when dim <= max_dim, do: 1.0
+  defp axis_scale(max_dim, dim), do: max_dim / dim
+
+  defp pixel_scale(:infinity, _px), do: 1.0
+  defp pixel_scale(max_px, px) when px <= max_px, do: 1.0
+  defp pixel_scale(max_px, px), do: :math.sqrt(max_px / px)
+
+  # Dimension caps are satisfied by the primary resize's construction; only the
+  # pixel budget can overshoot (a product of two independently rounded axes), so
+  # this loop verifies the realized result and shrinks the dominant axis toward
+  # the aspect-preserving pixel budget until it fits. Always resizes from the
+  # ORIGINAL (never the already-resized image) to avoid compounding rounding;
+  # only ever shrinks, so dimension caps stay satisfied. Checks ALL caps each
+  # iteration (defensive). Exhausting the bound is a tagged encode error.
+  defp enforce(image_module, original, resized, limits, iters_left) do
+    rw = Image.width(resized)
+    rh = Image.height(resized)
+
+    cond do
+      within_caps?(rw, rh, limits) ->
+        {:ok, resized}
+
+      iters_left == 0 ->
+        {:error, encode_error(:pixel_enforce_exhausted)}
+
+      true ->
+        target_long = shrink_target(rw, rh, limits)
+        long_orig = max(Image.width(original), Image.height(original))
+        # round-to target_long on the long axis; +0.49 lands on target_long, not target_long+1.
+        scale = (target_long + 0.49) / long_orig
+
+        with {:ok, resized} <- resize(image_module, original, scale) do
+          enforce(image_module, original, resized, limits, iters_left - 1)
+        end
+    end
+  end
+
+  defp within_caps?(w, h, %{max_width: mw, max_height: mh, max_pixels: mp}) do
+    within?(w, mw) and within?(h, mh) and within?(w * h, mp)
+  end
+
+  defp within?(_value, :infinity), do: true
+  defp within?(value, limit), do: value <= limit
+
+  # Largest dominant-axis length that fits the long axis's own dimension cap and
+  # (aspect-preserving) the pixel budget, with a strict -1 progress floor so the
+  # loop always advances at least one pixel and therefore terminates. The
+  # :infinity terms are naturally ignored by Enum.min (an atom sorts above the
+  # always-present `long - 1` integer).
+  defp shrink_target(rw, rh, %{max_width: mw, max_height: mh, max_pixels: mp}) do
+    long = max(rw, rh)
+    short = min(rw, rh)
+    long_dim_cap = if rw >= rh, do: mw, else: mh
+
+    Enum.min([long - 1, dim_target(long_dim_cap), pixel_target(mp, long, short)])
+  end
+
+  defp dim_target(:infinity), do: :infinity
+  defp dim_target(max_dim), do: max_dim
+
+  defp pixel_target(:infinity, _long, _short), do: :infinity
+  # long' * (long' * short / long) <= max_px  =>  long' = floor(sqrt(max_px * long / short))
+  defp pixel_target(max_px, long, short), do: trunc(:math.sqrt(max_px * long / short))
+
+  # Per-axis 1px floor: never scale an axis below one realized pixel. This is the
+  # equivalent of imgproxy's `WScale >= 1/widthToScale` (prepare.go:252-258) and
+  # is what keeps an extreme aspect ratio (e.g. 40000x1) from rounding the short
+  # axis to 0 under a tight cap.
+  defp resize(image_module, image, scale) do
+    w = Image.width(image)
+    h = Image.height(image)
+    hscale = max(scale, 1.0 / w)
+    vscale = max(scale, 1.0 / h)
+
+    case image_module.resize(image, hscale, vertical_scale: vscale) do
+      {:ok, resized} -> {:ok, resized}
+      {:error, reason} -> {:error, encode_error(reason)}
+    end
+  end
+
+  defp encode_error(reason) do
+    {:encode, RuntimeError.exception("clamp resize failed: #{inspect(reason)}"), []}
+  end
+end
+```
+
+- [ ] **Step 4: Run the clamp tests, verify pass**
+
+Run: `mise exec -- mix test test/image_pipe/output/clamp_test.exs`
+Expected: PASS (unit + property). If the property test finds a counterexample (a 0px axis or an over-cap product), the bug is in `resize`/`shrink_target` — fix it; do not weaken the assertion.
+
+- [ ] **Step 5: Wire the producer to the limits map**
+
+In `lib/image_pipe/request/source_session/producer.ex`, in `prepare_first_chunk/1`'s `with` chain, replace the two clamp lines:
+
+```elixir
+# REMOVE:
+           %{max_dimension: max_dimension} = Encoder.encoder_limit(resolved_output.format),
+           {:ok, image, clamp_info} <-
+             Clamp.clamp(final_state.image, max_dimension, request.opts),
+# WITH:
+           limits = effective_limits(resolved_output.format, request.opts),
+           {:ok, image, clamp_info} <-
+             Clamp.clamp(final_state.image, limits, request.opts),
+```
+
+Add these private helpers to the module (near `emit_clamp_telemetry`):
+
+```elixir
+  # Effective per-axis + pixel result caps: the tighter of the host `max_result_*`
+  # config and the chosen encoder's hard limit. The clamp does not care which
+  # source won the `min`.
+  defp effective_limits(format, opts) do
+    %{max_dimension: enc_dim, max_pixels: enc_px} = Encoder.encoder_limit(format)
+
+    %{
+      max_width: min_limit(Keyword.fetch!(opts, :max_result_width), enc_dim),
+      max_height: min_limit(Keyword.fetch!(opts, :max_result_height), enc_dim),
+      max_pixels: min_limit(Keyword.fetch!(opts, :max_result_pixels), enc_px)
+    }
+  end
+
+  # `:infinity` means "no limit from this source". Host caps are always integers.
+  defp min_limit(a, :infinity), do: a
+  defp min_limit(:infinity, b), do: b
+  defp min_limit(a, b), do: min(a, b)
+```
+
+Update `emit_clamp_telemetry/3`'s metadata map (`max_dimension:` → `limits:`):
+
+```elixir
+  defp emit_clamp_telemetry(%{} = info, format, opts) do
+    Telemetry.execute(
+      Telemetry.telemetry_opts(opts),
+      [:output, :clamp],
+      %{scale: info.scale},
+      %{
+        format: format,
+        source_dimensions: info.source_dimensions,
+        dimensions: info.dimensions,
+        limits: info.limits
+      }
+    )
+
+    :ok
+  end
+```
+
+- [ ] **Step 6: Update the Logger rendering**
+
+In `lib/image_pipe/telemetry/logger.ex`, replace the `[:output, :clamp | _]` `message/3` clause (currently ~166-171):
+
+```elixir
+  defp message([:output, :clamp | _], _m, meta) do
+    {sw, sh} = meta[:source_dimensions]
+    {w, h} = meta[:dimensions]
+    %{max_width: mw, max_height: mh, max_pixels: mp} = meta[:limits]
+
+    "image_pipe output clamp: #{sw}x#{sh} -> #{w}x#{h} for #{meta[:format]} " <>
+      "(caps w:#{cap(mw)} h:#{cap(mh)} px:#{cap(mp)})"
+  end
+```
+
+Add a small private renderer (place it among the other `defp`s, e.g. just below the `message/3` clauses):
+
+```elixir
+  defp cap(:infinity), do: "∞"
+  defp cap(value), do: value
+```
+
+- [ ] **Step 7: Update the Logger test**
+
+In `test/image_pipe/telemetry/logger_test.exs:116-135`, replace the event metadata and the asserted string:
+
+```elixir
+        :telemetry.execute(
+          [:image_pipe, :output, :clamp],
+          %{scale: 0.91},
+          %{
+            format: :webp,
+            source_dimensions: {18_000, 9_000},
+            dimensions: {8_192, 4_096},
+            limits: %{max_width: 8_192, max_height: 8_192, max_pixels: 40_000_000}
+          }
+        )
+```
+
+```elixir
+    assert log =~ "[warning]"
+    assert log =~ "output clamp: 18000x9000 -> 8192x4096 for webp (caps w:8192 h:8192 px:40000000)"
+```
+
+- [ ] **Step 8: Update the #150 conformance assertions**
+
+In `test/image_pipe/imgproxy_wire_conformance_test.exs`, the `describe "output encoder dimension clamp (#150)"` block asserts `meta.max_dimension`. Replace each such assertion with a `limits` check. For the WebP test (~2357-2363):
+
+```elixir
+      assert scale < 1.0
+      assert meta.format == :webp
+      assert meta.limits.max_width == 16_383
+      assert meta.limits.max_height == 16_383
+      assert meta.dimensions == {w, h}
+      {sw, sh} = meta.source_dimensions
+      assert max(sw, sh) > 16_383
+```
+
+For the AVIF test (~2380-2384):
+
+```elixir
+      assert scale < 1.0
+      assert meta.format == :avif
+      assert meta.limits.max_width == 16_384
+      assert meta.limits.max_height == 16_384
+      assert meta.dimensions == {w, h}
+```
+
+(The `@clamp_opts` already raise the host caps to 40_000 / 2_000_000_000, so the *encoder* limit wins the `min` and `limits.max_width == 16_383`/`16_384` as asserted.)
+
+- [ ] **Step 9: Run the full suite, verify green**
+
+Run: `mise exec -- mix test`
+Expected: PASS. (The result-limit *error* tests in `processor_test.exs`/`plug_test.exs` still assert 413 and still pass here, because `validate_result_image` is not removed until Task 3.)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add lib/image_pipe/output/clamp.ex \
+        lib/image_pipe/request/source_session/producer.ex \
+        lib/image_pipe/telemetry/logger.ex \
+        test/image_pipe/output/clamp_test.exs \
+        test/image_pipe/telemetry/logger_test.exs \
+        test/image_pipe/imgproxy_wire_conformance_test.exs
+git commit -m "feat(output): per-axis + pixel limits map for Clamp; fold host caps at producer (#165)"
+```
+
+---
+
+## Task 3: Delete the `check_result_*` error path
+
+With Task 2 wired, the producer now clamps at `min(host, encoder)`. Removing `validate_result_image` lets host-cap-exceeding results reach that clamp and downscale instead of 413.
+
+**Files:**
+- Modify: `lib/image_pipe/request/processor.ex:143-145` (the `with` line) and `:291-315` (the functions)
+- Modify: `lib/image_pipe/response/sender.ex:129-130, 196-203`
+- Modify: `test/image_pipe/processor_test.exs` (delete ~181 and ~197 tests)
+- Modify: `test/image_pipe/plug_test.exs` (delete the ~2051 413 test)
+
+- [ ] **Step 1: Delete the result-limit tests first (they assert the old behavior)**
+
+In `test/image_pipe/processor_test.exs`, delete both tests:
+- "process_source rejects final images wider than configured result limit" (~181)
+- "process_source accepts final images within configured result limits" (~197)
+
+In `test/image_pipe/plug_test.exs`, delete the test "rejects static result dimensions above configured limits before encoding" (~2051). **Keep** "allows static result dimensions within configured limits" (~2069) — it is the no-clamp control.
+
+- [ ] **Step 2: Remove `validate_result_image` from the transform pipeline**
+
+In `lib/image_pipe/request/processor.ex`, in `process_decoded_source/3`, remove the `validate_result_image` step from the `with`:
+
+```elixir
+        result =
+          with {:ok, final_state} <-
+                 execute_transform_plan(initial_state, plan, opts),
+               {:ok, final_state} <-
+                 materialize_before_delivery(final_state, opts, source_response) do
+            {:ok, final_state}
+          end
+```
+
+Delete the now-unused functions `validate_result_image/2`, `check_result_width/2`, `check_result_height/2`, `check_result_pixels/2` (the block at ~291-315).
+
+- [ ] **Step 3: Remove the `{:result_limit, _}` response handling**
+
+In `lib/image_pipe/response/sender.ex`, delete the clause:
+
+```elixir
+  defp handle_processing_error(conn, {:result_limit, error}, response_headers),
+    do: send_result_limit_error(conn, error, response_headers)
+```
+
+and the function `send_result_limit_error/3` (~196-203).
+
+- [ ] **Step 4: Compile with warnings-as-errors (catches any leftover reference)**
+
+Run: `mise exec -- mix compile --warnings-as-errors`
+Expected: clean compile. (No unused-function or undefined-reference warnings; the `{:result_limit, _}` tag now has zero emitters and zero handlers.)
+
+- [ ] **Step 5: Run the full suite, verify green**
+
+Run: `mise exec -- mix test`
+Expected: PASS. Oversized-result requests now downscale (covered by Task 2's clamp); the deleted 413 tests are gone; `max_input_pixels` 413 tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/image_pipe/request/processor.ex lib/image_pipe/response/sender.ex \
+        test/image_pipe/processor_test.exs test/image_pipe/plug_test.exs
+git commit -m "feat(request): host result cap downscales instead of 413; drop check_result_* (#165)"
+```
+
+---
+
+## Task 4: Wire-level #165 conformance tests
+
+Add real-`call/2` downscale coverage at **default** host caps (the common path), plus per-axis and pixel-cap cases.
+
+**Files:**
+- Modify: `test/image_pipe/imgproxy_wire_conformance_test.exs` (add a new describe block near the #150 one)
+
+- [ ] **Step 1: Add the #165 describe block**
+
+After the `describe "output encoder dimension clamp (#150)"` block, add:
+
+```elixir
+  describe "host result cap downscale (#165, limitScale parity)" do
+    # Default host caps: max_result_width/height = 8192, max_result_pixels = 40M.
+    @host_default_opts [
+      parser: ImagePipe.Parser.Imgproxy,
+      sources: [
+        path: {RootHTTPAdapter, root_url: "http://origin.test", req_options: [plug: OriginImage]}
+      ],
+      output_capabilities: %{avif: true, webp: true}
+    ]
+
+    test "downscales a result above the default 8192 host cap and serves 200" do
+      attach_clamp_telemetry()
+
+      conn =
+        call_imgproxy("/_/el:1/rs:force:12000:200/f:jpeg/plain/images/beach.jpg", @host_default_opts)
+
+      assert conn.status == 200
+      assert content_type(conn) == ["image/jpeg"]
+
+      {w, h} = dimensions(conn)
+      assert max(w, h) <= 8192
+
+      assert_received {:telemetry_event, [:image_pipe, :output, :clamp], %{scale: scale}, meta}
+      assert scale < 1.0
+      assert meta.limits.max_width == 8192
+      assert meta.limits.max_height == 8192
+      assert meta.dimensions == {w, h}
+      {sw, _sh} = meta.source_dimensions
+      assert sw > 8192
+    end
+
+    test "honors asymmetric per-axis caps without over-shrinking" do
+      attach_clamp_telemetry()
+
+      # Realize ~6000x200, raise width cap above it, keep height cap slack:
+      # both axes within caps -> NO clamp, served at full requested size.
+      conn =
+        call_imgproxy(
+          "/_/el:1/rs:force:6000:200/f:jpeg/plain/images/beach.jpg",
+          Keyword.merge(@host_default_opts, max_result_width: 10_000, max_result_height: 8192)
+        )
+
+      assert conn.status == 200
+      {w, h} = dimensions(conn)
+      assert w == 6000
+      assert h == 200
+      refute_received {:telemetry_event, [:image_pipe, :output, :clamp], _m, _meta}
+    end
+
+    test "downscales on the host pixel cap with dims within the per-axis caps" do
+      attach_clamp_telemetry()
+
+      # ~5000x5000 = 25M px. Per-axis caps slack (8000), pixel cap 4M -> clamp on pixels.
+      conn =
+        call_imgproxy(
+          "/_/el:1/rs:force:5000:5000/f:jpeg/plain/images/beach.jpg",
+          Keyword.merge(@host_default_opts,
+            max_result_width: 8000,
+            max_result_height: 8000,
+            max_result_pixels: 4_000_000
+          )
+        )
+
+      assert conn.status == 200
+      {w, h} = dimensions(conn)
+      assert w <= 8000 and h <= 8000
+      assert w * h <= 4_000_000
+
+      assert_received {:telemetry_event, [:image_pipe, :output, :clamp], %{scale: scale}, _meta}
+      assert scale < 1.0
+    end
+
+    test "does not clamp or emit when the result is within all default caps" do
+      attach_clamp_telemetry()
+
+      conn = call_imgproxy("/_/w:300/f:jpeg/plain/images/beach.jpg", @host_default_opts)
+
+      assert conn.status == 200
+      {w, _h} = dimensions(conn)
+      assert w == 300
+      refute_received {:telemetry_event, [:image_pipe, :output, :clamp], _m, _meta}
+    end
+  end
+```
+
+- [ ] **Step 2: Run the conformance file, verify pass**
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs`
+Expected: PASS. If `rs:force:` geometry or `OriginImage` source size differs from the assumed dimensions, adjust the geometry tokens / source so the realized pre-clamp size actually exceeds (or stays under) the asserted cap — verify by temporarily logging `meta.source_dimensions`. The **contract** asserted (status 200, decoded dims ≤ caps, pixel product ≤ cap, telemetry fired/not-fired) must not change.
+
+- [ ] **Step 3: Confirm the kept no-clamp control still passes**
+
+Run: `mise exec -- mix test test/image_pipe/plug_test.exs`
+Expected: PASS, including "allows static result dimensions within configured limits" (the `StreamingOnlyImage` no-op control — `max_result_width: 64` == realized `w:64`, so the producer clamp no-ops and the stub streams `"streamed jpeg"`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/image_pipe/imgproxy_wire_conformance_test.exs
+git commit -m "test(imgproxy): wire-level host result-cap downscale conformance (#165)"
+```
+
+---
+
+## Task 5: Documentation sync
+
+**Files:**
+- Modify: `docs/imgproxy_support_matrix.md`
+- Modify: `docs/telemetry.md`
+- Modify: `docs/operational_notes.md`
+
+- [ ] **Step 1: Support matrix — the host-result-cap row**
+
+In `docs/imgproxy_support_matrix.md`, the "Surrounding stages" table row for the host result-dimension cap currently reads ⚠️ and points at `check_result_*`. Replace it with:
+
+```markdown
+| Host result-dimension cap (`limitScale`, `processing/prepare.go`) | `lib/image_pipe/output/clamp.ex` via the producer (`min(host max_result_*, encoder_limit)`) | ✅ | imgproxy downscales the result to fit `max_result_*`; ImagePipe now matches (#165), reusing the #150 `Output.Clamp`. **Diverges (superset):** ImagePipe honors independent `max_result_width`/`max_result_height` and a result `max_result_pixels` cap (sqrt), where imgproxy's `limitScale` has a single `MaxResultDimension` and no result-pixel cap. **Diverges (composition):** ImagePipe clamps the **composited** final image, whereas imgproxy folds the downscale into the resize scale before padding/extend (`prepare.go:233-263`) — both land ≤ cap; padded/extended requests differ in internal composition. Matches imgproxy's sub-1px floor via a per-axis `max(scale, 1/dim)`. |
+```
+
+- [ ] **Step 2: Support matrix — fix the stale `fixSize` row (row 13)**
+
+Replace the trailing sentence of the `fixSize` row ("The `max_pixels`/sqrt branch (imgproxy's `fixGifSize`) is deferred to #165.") with:
+
+```markdown
+The host `max_result_*` caps fold into this same clamp via `min(host, encoder)` (#165); ImagePipe's result-pixel cap uses an **independent linear-dimension + sqrt-pixel** rule, deliberately **not** `fixGifSize`'s combined-sqrt (which can leave a result over the dimension limit).
+```
+
+- [ ] **Step 3: Support matrix — the "standing divergences" takeaway**
+
+The "Key takeaways" bullet currently reads "The standing divergences are color management (#124) and the host result cap (#165)." Update it to drop the host-result-cap divergence (now matched) and note the superset:
+
+```markdown
+- **The standing divergence is color management (#124).** The host result cap now
+  downscales to match imgproxy (#165), with a deliberate, strictly-safe superset:
+  independent per-axis width/height + a result-pixel cap, and a composited-image
+  clamp point. Everything else either matches or is an explicitly missing/out-of-scope
+  surface documented in the tables below.
+```
+
+- [ ] **Step 4: Support matrix — input/output safety-limits section**
+
+In the "Input and output safety limits" prose (~426-437), update the sentence that frames `max_result_*` as an error to state it now downscales-to-fit (imgproxy `limitScale` parity), while `max_input_pixels` remains the hard image-bomb gate. (Edit the existing sentences in place; keep the `max_input_pixels`/`max_body_bytes` description unchanged.)
+
+- [ ] **Step 5: telemetry.md — rewrite the Output dimension clamp section**
+
+Replace the "Output dimension clamp" section body so it covers both the host and encoder caps and the `limits` metadata:
+
+```markdown
+## Output dimension clamp (`[:output, :clamp]`)
+
+When the realized final image exceeds the effective result caps — the tighter of
+the host `max_result_width`/`max_result_height`/`max_result_pixels` config and the
+negotiated output encoder's hard limit (`min(host, encoder)`) — ImagePipe uniformly
+downscales it to fit before encoding and emits a one-shot (non-span) marker. This
+both keeps encoding from failing (WebP caps each dimension at 16383, AVIF at 16384;
+JPEG/PNG effectively unbounded) and serves the host result cap as a downscale rather
+than an error (imgproxy `limitScale` parity). The common trigger is the host cap
+(default 8192 per axis), which is below the encoder limits.
+
+​```text
+[:image_pipe, :output, :clamp]
+​```
+
+Measurements:
+
+- `:scale` — the uniform downscale factor applied (a float `< 1.0`).
+
+Metadata:
+
+- `:format` — the negotiated output format atom (e.g. `:webp`, `:avif`).
+- `:source_dimensions` — `{w, h}` before the clamp.
+- `:dimensions` — `{w, h}` after the clamp.
+- `:limits` — the effective caps applied: `%{max_width, max_height, max_pixels}`
+  (each a `pos_integer` or `:infinity`).
+
+This metadata is product-neutral and non-sensitive (no URLs, secrets, or PII).
+
+The opt-in default Logger attaches to this event and renders it at `:warning`,
+matching imgproxy's `slog.Warn` for the same condition, e.g.:
+
+​```text
+output clamp: 18000x9000 -> 8192x4096 for webp (caps w:8192 h:8192 px:40000000)
+​```
+```
+
+(Remove the leading zero-width characters from the fenced-code backticks above — they are only here to keep this plan's markdown from closing early. Use plain triple backticks.)
+
+- [ ] **Step 6: operational_notes.md**
+
+In `docs/operational_notes.md`, update the `max_result_*` mention (the 413 "result image is too large" behavior) to: the result caps now downscale the served image to fit (imgproxy `limitScale` parity); `max_input_pixels` remains a hard 413 image-bomb gate.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/imgproxy_support_matrix.md docs/telemetry.md docs/operational_notes.md
+git commit -m "docs: host result cap downscales (limitScale parity); clamp telemetry limits metadata (#165)"
+```
+
+---
+
+## Task 6: Full gate
+
+- [ ] **Step 1: Run the Elixir precommit gate**
+
+Run: `mise run precommit`
+Expected: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix test` all pass. Fix any formatting/credo findings in place and re-run.
+
+- [ ] **Step 2: Commit any gate fixups (if needed)**
+
+```bash
+git add -A && git commit -m "chore: precommit fixups (#165)"
+```
+
+---
+
+## Notes for the implementer
+
+- **The pixel ≤-cap property test is the safety net.** It is the test that would have caught the closed-form overshoot the design review found. If you change `shrink_target`/`resize`, keep it passing; do not narrow its input ranges to dodge a failure — a failure means the loop is wrong.
+- **Do not reintroduce a `{:result_limit, _}` tag** anywhere. After Task 3 it has no emitter and no handler; a stray one would crash with `FunctionClauseError` in the sender.
+- **`max_result_*` must stay out of the cache key and ETag** (`lib/image_pipe/cache/key.ex`, `lib/image_pipe/request/http_cache.ex`) — they are absent today and this change must not add them. The clamp output is deterministic from inputs already in the key (source identity + plan + negotiated format) for a given deployment.
+- **No demo UI change** — `max_result_*` are host config, not URL/transform knobs.
+- **Out of scope:** the shrink-on-load decode fold (`DecodePlanner`) and #164 look-ahead pre-clamp.

--- a/docs/superpowers/specs/2026-06-08-host-max-result-downscale-design.md
+++ b/docs/superpowers/specs/2026-06-08-host-max-result-downscale-design.md
@@ -83,24 +83,56 @@ When all three caps are `:infinity` (or non-binding) the no-op path is taken —
 JPEG/PNG behavior. When `max_width == max_height` (the default 8192/8192) and only dimension binds, the math
 reduces to `max_dimension / max(w, h)` — byte-intent identical to imgproxy's `limitScale` linear downscale.
 
-**≤-cap guarantee (defensive — generalizes #150's `enforce_limit`).** After the resize, measure realized
-`rw`, `rh`, `rw*rh`. If **any** cap is exceeded (libvips rounding quirk), re-resize the **original** by a
-floor-biased corrected factor that is the `min` across the binding caps:
+**≤-cap guarantee.** The **dimension** caps are satisfied **by construction** and need no corrective pass:
+the primary scale is the most-aggressive per-axis ratio, so each axis lands ≤ its cap — the binding axis
+exactly on its cap (`round(d · max_d/d) = max_d` for integer `max_d`), and the other axis is scaled by the
+same-or-smaller factor, so `other · scale ≤ max_other`. (#150's single-axis linear corrective is therefore
+dropped; it was only ever a defensive no-op for the dimension case.)
+
+The **pixel** cap is the one real subtlety — flagged by the design review (clamp-math lens) as a blocker in
+the original closed-form draft. After an isotropic resize the realized pixel count is
+`round(w·s) · round(h·s)`: a product of two *independently* rounded factors. A closed-form
+`s = sqrt(max_pixels / (w·h))` (or any fixed-epsilon variant like `sqrt((max_pixels − 0.5)/(w·h))`) does
+**not** guarantee `round(w·s)·round(h·s) ≤ max_pixels` — the two roundings can each add ~0.5px, injecting
+≈ `0.5·(w·s + h·s)` extra area, which for any non-tiny image dwarfs a half-pixel epsilon (verified
+overshoots of thousands of pixels for large/extreme-aspect images; **unbounded** overshoot when the short
+axis floors to 1px, where a single scalar can never satisfy a *product* cap). So the pixel cap is enforced
+by a **bounded verify-and-shrink loop on the realized image**, not a closed form:
 
 ```
-dim_c(:infinity, _)      = 1.0
-dim_c(maxd, dim)         = (maxd - 0.5) / dim          # floor-bias: round() cannot bump back over
-
-px_c(:infinity, _, _)    = 1.0
-px_c(maxp, w, h)         = :math.sqrt((maxp - 0.5) / (w * h))
-
-corrected = min(dim_c(max_width, w), dim_c(max_height, h), px_c(max_pixels, w, h))
+enforce(original, resized, limits, max_iters):
+  rw, rh = realized(resized)
+  if within_all_caps?(rw, rh, limits): return {:ok, resized}        # common case: pixels not binding
+  if max_iters == 0: return {:error, {:encode, <pixel-enforce-exhausted>, []}}   # bounded escape → 500
+  long_real  = max(rw, rh); short_real = min(rw, rh)                # short_real ≥ 1
+  # aspect-preserving long-axis target that fits the pixel budget, plus the long axis's own dim cap,
+  # and a strict −1 progress floor so the loop always advances at least one pixel:
+  t_pixels = (max_pixels == :infinity) -> long_real
+             else floor(:math.sqrt(max_pixels * long_real / short_real))
+  t_dim    = long-axis dimension cap (max_width or max_height, whichever axis is longer; :infinity → long_real)
+  target_long = min(long_real - 1, t_pixels, t_dim)
+  s = (target_long + 0.49) / max(orig_w, orig_h)                    # rounds the long axis to target_long
+  enforce(original, resize(original, s), limits, max_iters - 1)
 ```
 
-Single corrective pass on the **original** (not the already-resized image, to avoid compounding rounding),
-matching the established #150 pattern. In practice this branch never fires; it exists so a rounding
-regression cannot silently re-introduce an over-cap result. The unit and wire tests assert realized
-dimensions/pixels ≤ caps, catching any regression here.
+- The `floor(sqrt(max_pixels · long/short))` target preserves the realized aspect, so it lands the product
+  near the budget in **one step** for realistic caps; the `min(long_real − 1, …)` floor guarantees ≥1px of
+  progress per iteration, so the loop **always terminates**, even in the 1px-floored regime (where it
+  converges geometrically toward the cap, e.g. an absurd `max_result_pixels = 100` on a `40000×1` source
+  settles in ~8 steps). `max_iters` is set with ample margin (e.g. 16) so realistic configs finish in one
+  iteration and only pathological tiny caps could exhaust it; exhaustion returns the standard `{:encode, …}`
+  error contract (→ 500), an acceptable outcome for a misconfiguration that asks for a few-pixel result.
+- The loop checks **all** caps each iteration (`within_all_caps?`) and resizes from the **original** every
+  time (never the already-resized image, to avoid compounding rounding). Because it only ever shrinks, the
+  dimension caps stay satisfied throughout.
+- The exact stepping constants are an implementation detail **pinned by a property test** (see Tests): the
+  realized `w ≤ max_width`, `h ≤ max_height`, **and** `w·h ≤ max_pixels` after `clamp/3`, across a grid of
+  sizes, extreme aspect ratios, and small/large pixel caps including the 1px-floor regime, plus a
+  termination self-check within the iteration bound.
+
+ImagePipe deliberately does **not** replicate imgproxy's explicit `WScale ≥ 1/widthToScale` floor
+(`prepare.go:252-258`): for dimension caps (always ≥ 1) a downscale of a ≥1px image never yields a sub-1px
+axis, and the pixel-enforce loop handles the short-axis-floored regime directly.
 
 **`clamp_info`** (returned only when a clamp actually occurs; `nil` otherwise) replaces `max_dimension` with
 the effective `limits` applied:
@@ -185,12 +217,21 @@ the extra branch — the effective caps and the before/after dimensions are the 
 - **measurements:** `%{scale: scale}` (unchanged).
 - **metadata:** `%{format: format, source_dimensions: {w, h}, dimensions: {w', h'}, limits: limits}`.
 
-All metadata stays non-sensitive (dimensions, format atom, integer/`:infinity` caps).
+All metadata stays non-sensitive (dimensions, format atom, integer/`:infinity` caps). The clamp event remains
+**outcome-free** by design: it carries no `:result`/error field — a downscale *is* the single known outcome,
+fully expressed by the before→after dimensions + caps, and its severity is carried structurally by
+`level_for/3`'s hard-coded `:warning` (not by a metadata field). This satisfies the *Telemetry guidelines*
+"must surface the outcome" rule without an `outcome/1` projection; a future editor must not add a `:result`
+field without also threading it into the message.
 
 **Default Logger sync** (`telemetry/logger.ex`, per the *Telemetry guidelines*): update the existing
 `message/3` clause for `[:output, :clamp | _]` to render the new `limits` shape, e.g.
-`"image_pipe output clamp: 18000x9000 -> 8192x4096 for webp (caps w:8192 h:8192 px:40000000)"`. Level stays
-`:warning`. Update the `logger_test.exs` assertion and `docs/telemetry.md` to the `limits` metadata.
+`"image_pipe output clamp: 18000x9000 -> 8192x4096 for webp (caps w:8192 h:8192 px:40000000)"`. Render
+`:infinity` caps gracefully (e.g. `px:∞` / `px:none`) rather than interpolating the raw atom — today
+`min_limit/2` resolves effective caps to host integers, but a future format/host combo could leave one
+`:infinity`. Level stays `:warning`. Update the `logger_test.exs` assertion (its `max_dimension: 16_383`
+metadata and `(max 16383)` substring → the `limits` shape) and `docs/telemetry.md`. Also update
+`clamp.ex`'s `@type clamp_info` and `@spec` (drop `max_dimension`, add `limits`).
 
 ### Cache / ETag — no change
 
@@ -221,8 +262,9 @@ validator derivation.
 Verified against `local/imgproxy-master/processing/prepare.go:222-265`:
 
 - **Dimension, equal caps:** `limitScale` computes `downScale = maxResultDim / max(outWidth, outHeight)`
-  (`prepare.go:245-247`) — a uniform linear downscale on the longest axis. ImagePipe's per-axis math reduces
-  to exactly this when `max_width == max_height` and dimension binds. ✅ byte-intent identical.
+  (`prepare.go:247`) — a uniform linear downscale on the longest axis. ImagePipe's per-axis math reduces
+  to exactly this when `max_width == max_height` and dimension binds. ✅ byte-intent identical **in the
+  no-padding / no-extend / DPR=1 case** (see the composition divergence below).
 - **Deliberate divergences — ImagePipe is a strict superset:**
   - imgproxy's `limitScale` has a **single** `MaxResultDimension` applied to both axes; ImagePipe honors
     **independent** `max_result_width` / `max_result_height`. More granular; strictly safer (never exceeds
@@ -232,8 +274,23 @@ Verified against `local/imgproxy-master/processing/prepare.go:222-265`:
     shrink). This has no `limitScale` counterpart; it is an ImagePipe-specific output safety knob. The sqrt
     choice (dimension linear, pixels sqrt, most-aggressive) is the #150 hand-off recommendation, **not**
     `fixGifSize`'s combined-sqrt.
-- **Input gate stays a hard error:** `max_input_pixels` ↔ `MaxSrcResolution` — mirrors imgproxy's split
-  (downscale the output cap, hard-error the input gate). ✅
+  - **Clamp point — composited result vs. fold-back into the resize scale (behavioral/pixel divergence).**
+    imgproxy's `limitScale` does *not* clamp the realized output: it computes the cap against a *projected*
+    output dimension that includes extend and padding (`prepare.go:230-244`), then folds the downscale back
+    into `WScale`/`HScale`/`DprScale` and re-runs `calcSizes` (`prepare.go:249-263`) — so the image content
+    is re-resized and padding/extend is re-applied at the reduced scale. ImagePipe instead clamps the
+    **already-composited** final image (content **with** extend/padding/background baked in, matrix stages
+    10–12) uniformly at the Output boundary. For the common no-padding/no-extend/DPR=1 request the two are
+    byte-intent identical; when padding or extend is present both still land ≤ cap, but the internal
+    content-to-padding composition differs (ImagePipe scales the composite as one unit; imgproxy scales
+    content then re-applies scaled padding). This is documented as a deliberate "Diverges" note in the
+    conformance doc.
+  - ImagePipe omits imgproxy's explicit `WScale ≥ 1/widthToScale` sub-1px floor (`prepare.go:252-258`): for
+    dimension caps (≥ 1) a downscale never produces a sub-1px axis, and the pixel-enforce loop handles the
+    floored-short-axis regime directly. Functionally covered; no separate floor needed.
+- **Input gate stays a hard error:** `max_input_pixels` ↔ `MaxSrcResolution` (checked on the loaded source at
+  `processing.go:114`, *before* `transformImage`/`limitScale`) — mirrors imgproxy's split (downscale the
+  output cap, hard-error the input gate). ✅
 
 These divergences are documented in `docs/imgproxy_support_matrix.md` as more-granular, strictly-safe
 choices, in the same spirit as #150's linear-dimension divergence from `fixGifSize`.
@@ -247,10 +304,22 @@ integers/`:infinity`):
 
 - width binds (per-axis): `max_width` small, `max_height`/`max_pixels` large → scale = `max_width/w`.
 - height binds (per-axis): symmetric.
-- pixels bind (sqrt): dims within `max_width`/`max_height` but `w*h > max_pixels` → scale = `sqrt(max_pixels/(w*h))`, dimensions reduced, realized `w'*h' <= max_pixels`.
+- pixels bind: dims within `max_width`/`max_height` but `w*h > max_pixels` → dimensions reduced, realized
+  `w'*h' <= max_pixels`.
 - most-aggressive: a shape where pixel and dimension constraints disagree → the smaller scale wins.
-- no-op: within all caps (and all-`:infinity`) → `{:ok, image, nil}`, no resize node.
-- ≤-cap guarantee: realized longest axis == cap and realized pixels ≤ pixel cap.
+- no-op: within all caps (and all-`:infinity`) → `{:ok, image, nil}`, no resize node; cap exactly equal to a
+  dimension is a no-op (no degenerate resize).
+- ≤-cap guarantee: realized longest axis == its cap and realized pixels ≤ pixel cap.
+- `clamp_info.scale` faithfulness: on a pixel-bound clamp, `rw/w == rh/h` (within fp tolerance) — the resize
+  is isotropic, so the reported scalar is not a half-truth.
+
+**Pixel ≤-cap property test** (the blocker fix from review — `StreamData`, the *correctness gate* per CLAUDE.md
+"Add StreamData property tests when correctness depends on invariants across many input shapes"): over a grid
+of widths/heights (including extreme aspect ratios and 1×N / N×1 shapes) × small-and-large `max_pixels`
+(including caps small enough to force the short axis to 1px), assert after `clamp/3` that realized
+`w ≤ max_width`, `h ≤ max_height`, **and** `w*h ≤ max_pixels`, and that the enforce loop terminates within its
+iteration bound. This is the test that would have caught the closed-form overshoot; it pins the loop, not the
+exact stepping constants.
 
 ### Wire conformance — `test/image_pipe/imgproxy_wire_conformance_test.exs`
 
@@ -266,14 +335,22 @@ Real `ImagePipe.call/2` + real encode + body decode (the file already has `dimen
 - **No-clamp control:** a request under all caps → no `[:output, :clamp]` event, unchanged dimensions.
 - Update #150's existing encoder-clamp conformance tests if they assert `max_dimension` metadata → `limits`.
 
-### Converted error tests
+### Converted / deleted error tests (full inventory — completed per review)
 
-- `plug_test.exs` "rejects static result dimensions…" → a downscale assertion (200 + clamp). Because the new
-  behavior decodes and re-encodes, it moves to / is expressed against the real encoder (the old test used
-  `StreamingOnlyImage`, whose body is undecodable, and asserted `refute_received :stream_encoder_called`,
-  which no longer holds — encode now runs).
-- `processor_test.exs` "process_source rejects final images wider…" → **deleted** (the function is gone;
-  clamp behavior is covered by `clamp_test.exs` + wire tests).
+- `plug_test.exs` "rejects static result dimensions above configured limits before encoding" (~2051) → a
+  downscale assertion (200 + clamp). The new behavior decodes and re-encodes, so it is expressed against the
+  real encoder in the conformance file (the old test used `StreamingOnlyImage`, whose body is undecodable,
+  and asserted `refute_received :stream_encoder_called`, which no longer holds — encode now runs).
+- `processor_test.exs` "process_source rejects final images wider than configured result limit" (~181) →
+  **deleted** (the function is gone; clamp behavior is covered by `clamp_test.exs` + wire tests).
+- `processor_test.exs` "process_source accepts final images within configured result limits" (~197) →
+  **deleted** (it sets `max_result_*` and asserts a property `process_source` no longer owns — `max_result_*`
+  no longer participates there; keeping it would be a post-migration parity pin on a coincidental pass).
+- `plug_test.exs` "allows static result dimensions within configured limits" (~2069, `StreamingOnlyImage`,
+  asserts `:stream_encoder_called`) → **kept as a no-clamp control**: `max_result_width: 64` == realized
+  `w:64` so the producer's now-unconditional `Clamp.clamp` no-ops (no resize node) and the stub still streams
+  through. Verify it still passes unchanged after the wiring lands; it usefully exercises the no-op path on
+  the streaming stub.
 
 ## Docs
 
@@ -281,11 +358,18 @@ Real `ImagePipe.call/2` + real encode + body decode (the file already has `dimen
   - Row 113 (host result-dimension cap) ⚠️ → ✅, pointing at the `Output.Clamp` reuse with `min(host,
     encoder)`.
   - `limitScale` in the processing-pipeline section (a **stage/order** + **behavioral/pixel** change per the
-    compat-doc-sync rule).
+    compat-doc-sync rule), incl. the composited-vs-fold-back "Diverges" note (above) and the omitted 1px
+    floor.
+  - Update the stale `fixSize` row (~91) sentence "The `max_pixels`/sqrt branch … is deferred to #165" — #165
+    has landed, and it implements an **independent result-pixel sqrt cap**, *not* `fixGifSize`'s combined-sqrt
+    (which it deliberately avoids). Reword so the doc doesn't imply ImagePipe now mirrors `fixGifSize`.
   - "standing divergences" note (line ~124): drop the host-result-cap divergence; add the per-axis /
-    result-pixel superset divergence.
+    result-pixel / composited-clamp superset divergences.
   - Input/output safety-limits section (~426-437): reflect downscale-not-error for the result cap.
-- `docs/telemetry.md`: `[:output, :clamp]` metadata `limits` shape.
+- `docs/telemetry.md`: rewrite the "Output dimension clamp" section **prose** (not just the metadata bullet) —
+  it currently describes the event as *encoder*-only; after #165 the same event also fires for the **host**
+  cap (the common path). Update the metadata to the `limits` shape and describe the merged
+  `min(host, encoder)` semantics.
 - `docs/operational_notes.md`: the result-limit 413 mention → downscale behavior.
 
 ## Out of scope

--- a/docs/superpowers/specs/2026-06-08-host-max-result-downscale-design.md
+++ b/docs/superpowers/specs/2026-06-08-host-max-result-downscale-design.md
@@ -134,8 +134,12 @@ The `resize` helper applies a **per-axis 1px floor** — `hscale = max(scale, 1/
 — so no axis ever rounds below one realized pixel. This is needed because for an extreme aspect ratio with a
 tight cap the uniform `scale` can drive the *short* axis to 0 (e.g. `40000×1` with `max_width:100` →
 `round(1·0.0025)=0`); the floor pins the short axis at 1px while the long axis shrinks, and the verify-shrink
-loop then reduces the long axis until the product fits. This is the **equivalent of imgproxy's**
-`WScale ≥ 1/widthToScale` floor (`prepare.go:252-258`) — so ImagePipe matches rather than diverges here.
+loop then reduces the long axis until the product fits. This **mirrors imgproxy's** per-axis
+`WScale ≥ 1/widthToScale` floor (`prepare.go:252-258`). The floors are structurally equivalent (neither
+ever rounds an axis below 1px), but the denominators differ — imgproxy floors against the *source-relative*
+`widthToScale`, ImagePipe against the *composited* image dimension — so in the extreme-aspect 1px regime the
+two can still land on different realized pixels for the same composited-vs-fold-back reason as the
+padding/extend divergence above.
 
 **`clamp_info`** (returned only when a clamp actually occurs; `nil` otherwise) replaces `max_dimension` with
 the effective `limits` applied:

--- a/docs/superpowers/specs/2026-06-08-host-max-result-downscale-design.md
+++ b/docs/superpowers/specs/2026-06-08-host-max-result-downscale-design.md
@@ -130,9 +130,12 @@ enforce(original, resized, limits, max_iters):
   sizes, extreme aspect ratios, and small/large pixel caps including the 1px-floor regime, plus a
   termination self-check within the iteration bound.
 
-ImagePipe deliberately does **not** replicate imgproxy's explicit `WScale ≥ 1/widthToScale` floor
-(`prepare.go:252-258`): for dimension caps (always ≥ 1) a downscale of a ≥1px image never yields a sub-1px
-axis, and the pixel-enforce loop handles the short-axis-floored regime directly.
+The `resize` helper applies a **per-axis 1px floor** — `hscale = max(scale, 1/w)`, `vscale = max(scale, 1/h)`
+— so no axis ever rounds below one realized pixel. This is needed because for an extreme aspect ratio with a
+tight cap the uniform `scale` can drive the *short* axis to 0 (e.g. `40000×1` with `max_width:100` →
+`round(1·0.0025)=0`); the floor pins the short axis at 1px while the long axis shrinks, and the verify-shrink
+loop then reduces the long axis until the product fits. This is the **equivalent of imgproxy's**
+`WScale ≥ 1/widthToScale` floor (`prepare.go:252-258`) — so ImagePipe matches rather than diverges here.
 
 **`clamp_info`** (returned only when a clamp actually occurs; `nil` otherwise) replaces `max_dimension` with
 the effective `limits` applied:
@@ -285,9 +288,9 @@ Verified against `local/imgproxy-master/processing/prepare.go:222-265`:
     content-to-padding composition differs (ImagePipe scales the composite as one unit; imgproxy scales
     content then re-applies scaled padding). This is documented as a deliberate "Diverges" note in the
     conformance doc.
-  - ImagePipe omits imgproxy's explicit `WScale ≥ 1/widthToScale` sub-1px floor (`prepare.go:252-258`): for
-    dimension caps (≥ 1) a downscale never produces a sub-1px axis, and the pixel-enforce loop handles the
-    floored-short-axis regime directly. Functionally covered; no separate floor needed.
+  - ImagePipe **matches** imgproxy's sub-1px floor (`prepare.go:252-258`): the `resize` helper pins each axis
+    at ≥ 1 realized pixel (`hscale = max(scale, 1/w)`, `vscale = max(scale, 1/h)`), the equivalent of
+    imgproxy's `WScale ≥ 1/widthToScale`. (Not a divergence — listed for completeness.)
 - **Input gate stays a hard error:** `max_input_pixels` ↔ `MaxSrcResolution` (checked on the loaded source at
   `processing.go:114`, *before* `transformImage`/`limitScale`) — mirrors imgproxy's split (downscale the
   output cap, hard-error the input gate). ✅

--- a/docs/superpowers/specs/2026-06-08-host-max-result-downscale-design.md
+++ b/docs/superpowers/specs/2026-06-08-host-max-result-downscale-design.md
@@ -1,0 +1,299 @@
+# Host `max_result_*` error→downscale (imgproxy `limitScale` parity) — Design
+
+**Issue:** #165. **Builds on:** #150 / #166 (the generic `ImagePipe.Output.Clamp` seam, merged to `main`).
+**Verified imgproxy reference:** `local/imgproxy-master/processing/prepare.go:222-265` (`limitScale`).
+
+## Summary
+
+Today the host result-dimension cap is an **error**: `ImagePipe.Request.Processor.validate_result_image/2`
+(`check_result_width/height/pixels`) returns `{:error, {:result_limit, …}}` → **413** when the realized
+image exceeds `max_result_width` / `max_result_height` / `max_result_pixels`. This change makes the cap a
+**uniform downscale-to-fit and serve**, matching imgproxy's `limitScale`, by **reusing #150's
+`ImagePipe.Output.Clamp`** at the producer seam: the host caps fold into the same clamp call via
+`min(host_cap, encoder_limit(format))`. The error path (`check_result_*`, the `{:result_limit, …}` tag, and
+its 413) is **deleted**. `max_input_pixels` (the decode-time image-bomb gate) remains the only hard error —
+mirroring imgproxy's split (it downscales the output cap but hard-errors `MaxSrcResolution`).
+
+This is the same mechanism as #150 with a different *limit source* (host config, format-independent, rather
+than the output encoder, format-dependent). The clamp does not care which source won the `min`.
+
+## Resolved decisions (from brainstorming)
+
+| Decision | Resolution | Rationale |
+|---|---|---|
+| **Cap geometry** | **Per-axis (independent)** width/height + pixels | imgproxy's `limitScale` has a single `MaxResultDimension`; ImagePipe exposes *separate* `max_result_width`/`max_result_height`/`max_result_pixels`. Collapsing to one square cap would **over-shrink** (a behavior change) when caps are asymmetric — e.g. `max_w=10000, max_h=4000`, an `8000x4000` image passes untouched today but a square `min(10000,4000)=4000` clamp would reduce it. Per-axis preserves the no-op boundary. |
+| **Hard ceiling** | **None** — pure downscale | The output cap purely downscales; `max_input_pixels` remains the only hard error. Matches imgproxy (`limitScale` never errors; only `MaxSrcResolution` does). Removes `check_result_*` + 413 entirely. |
+| **Observability** | **Telemetry only** | Reuse/extend the existing `[:output, :clamp]` one-shot (the #150 mechanism). imgproxy only `slog.Warn`-logs the downscale and sets **no** response header. No new public response surface. |
+| **Decode fold** | **Split to follow-up** | Land the post-hoc clamp (the correctness path) now; defer the shrink-on-load decode-work optimization (extend `DecodePlanner` toward `min(resize_target, host_limit)`, declining under trim) to its own issue/PR. The issue explicitly permits this split. |
+
+## Architecture
+
+### Single encode path (verified)
+
+`ImagePipe.Output.Clamp.clamp/3` is called **only** at
+`lib/image_pipe/request/source_session/producer.ex:127`, and
+`Processor.process_decoded_source/3` is reached **only** through the producer
+(`producer.ex:117`). The producer is the sole encode path, so moving the result-dimension policy out of
+`Processor.validate_result_image/2` and into the `Output.Clamp` seam loses no coverage: there is no second
+path that encodes an un-clamped image.
+
+### Clamp seam — widen to per-axis + pixels
+
+`ImagePipe.Output.Clamp.clamp/3` keeps **arity 3**, but its second argument becomes a **limits descriptor**
+instead of a single square `max_dimension`. This honors ImagePipe's three independent host options and folds
+in the encoder's per-format limit.
+
+```elixir
+@type limits :: %{
+        max_width: pos_integer() | :infinity,
+        max_height: pos_integer() | :infinity,
+        max_pixels: pos_integer() | :infinity
+      }
+
+@spec clamp(VixImage.t(), limits(), keyword()) ::
+        {:ok, VixImage.t(), clamp_info() | nil}
+        | {:error, {:encode, Exception.t(), list()}}
+```
+
+The descriptor is a plain map (not a struct): it is constructed by the producer and consumed by the clamp,
+both in-repo — no external boundary, so no validation is needed (per the *Validation guidelines*: trust what
+another module in this codebase just produced). A struct would force either a nested module (banned —
+"Avoid nesting multiple modules in the same file") or a new file for three fields; a typed map is lighter and
+matches `Encoder.encoder_limit/1`'s existing map return.
+
+**Scale math — dimension linear (per-axis), pixels sqrt, take the most-aggressive scale.** This is exactly
+the #150 hand-off note. It is deliberately **not** imgproxy's `fixGifSize` combined-sqrt
+(`fix_size.go:65-72`), which `sqrt`s the dimension component too and can leave a result over the dimension
+limit when the dimension constraint binds.
+
+```
+w = Image.width(image); h = Image.height(image); px = w * h
+
+wscale = (max_width  == :infinity) or (w  <= max_width)  -> 1.0 ; else max_width  / w
+hscale = (max_height == :infinity) or (h  <= max_height) -> 1.0 ; else max_height / h
+pscale = (max_pixels == :infinity) or (px <= max_pixels) -> 1.0 ; else :math.sqrt(max_pixels / px)
+
+scale = min(1.0, wscale, hscale, pscale)            # most-aggressive constraint wins
+
+scale >= 1.0  ->  {:ok, image, nil}                 # no-op: image unchanged, NO resize node (stays lazy)
+else          ->  resize by scale, enforce caps, return {:ok, resized, clamp_info}
+```
+
+When all three caps are `:infinity` (or non-binding) the no-op path is taken — preserving the existing
+JPEG/PNG behavior. When `max_width == max_height` (the default 8192/8192) and only dimension binds, the math
+reduces to `max_dimension / max(w, h)` — byte-intent identical to imgproxy's `limitScale` linear downscale.
+
+**≤-cap guarantee (defensive — generalizes #150's `enforce_limit`).** After the resize, measure realized
+`rw`, `rh`, `rw*rh`. If **any** cap is exceeded (libvips rounding quirk), re-resize the **original** by a
+floor-biased corrected factor that is the `min` across the binding caps:
+
+```
+dim_c(:infinity, _)      = 1.0
+dim_c(maxd, dim)         = (maxd - 0.5) / dim          # floor-bias: round() cannot bump back over
+
+px_c(:infinity, _, _)    = 1.0
+px_c(maxp, w, h)         = :math.sqrt((maxp - 0.5) / (w * h))
+
+corrected = min(dim_c(max_width, w), dim_c(max_height, h), px_c(max_pixels, w, h))
+```
+
+Single corrective pass on the **original** (not the already-resized image, to avoid compounding rounding),
+matching the established #150 pattern. In practice this branch never fires; it exists so a rounding
+regression cannot silently re-introduce an over-cap result. The unit and wire tests assert realized
+dimensions/pixels ≤ caps, catching any regression here.
+
+**`clamp_info`** (returned only when a clamp actually occurs; `nil` otherwise) replaces `max_dimension` with
+the effective `limits` applied:
+
+```elixir
+%{
+  scale: float(),                                     # realized rw / w
+  source_dimensions: {pos_integer(), pos_integer()},  # {w, h} before
+  dimensions: {pos_integer(), pos_integer()},         # {w, h} after (realized, ≤ all caps)
+  limits: limits()                                     # the effective caps applied
+}
+```
+
+`opts` continues to carry only `:image_module` (defaults to `Image`), matching the existing convention;
+measurement uses the real `Image.width/1`/`Image.height/1` accessors (O(1) header reads), the resize goes
+through `image_module.resize/2`. The resize-error contract is **unchanged** from #150: a resize failure maps
+to `{:error, {:encode, exception, stacktrace}}` (the 3-tuple the response layer routes to 500).
+
+### Producer wiring — effective limits
+
+`ImagePipe.Output.Encoder.encoder_limit/1` gains a `:max_pixels` key (`:infinity` for all four current
+formats — now live, per the #150 placeholder note). The producer computes the per-axis effective caps by
+intersecting host config with the encoder limit:
+
+```elixir
+defp effective_limits(format, opts) do
+  %{max_dimension: enc_dim, max_pixels: enc_px} = Encoder.encoder_limit(format)
+
+  %{
+    max_width:  min_limit(Keyword.fetch!(opts, :max_result_width),  enc_dim),
+    max_height: min_limit(Keyword.fetch!(opts, :max_result_height), enc_dim),
+    max_pixels: min_limit(Keyword.fetch!(opts, :max_result_pixels), enc_px)
+  }
+end
+
+# `:infinity` means "no encoder limit"; host caps are always integers (NimbleOptions
+# pos_integer defaults), so today every effective cap resolves to the host integer.
+defp min_limit(a, :infinity), do: a
+defp min_limit(:infinity, b), do: b
+defp min_limit(a, b), do: min(a, b)
+```
+
+The producer's `with` chain replaces the two `max_dimension` lines:
+
+```elixir
+# before (#150):
+#   %{max_dimension: max_dimension} = Encoder.encoder_limit(resolved_output.format),
+#   {:ok, image, clamp_info} <- Clamp.clamp(final_state.image, max_dimension, request.opts),
+# after (#165):
+     limits = effective_limits(resolved_output.format, request.opts),
+     {:ok, image, clamp_info} <- Clamp.clamp(final_state.image, limits, request.opts),
+```
+
+`effective_limits/2` and `min_limit/2` live in the producer (the request boundary, which legitimately reads
+`opts` and calls `Output`). `Clamp` and `Encoder` stay pure, format/host-agnostic functions.
+
+With the default `max_result_*` = 8192/8192/40M, the clamp now triggers at the **host** cap — the commonly
+hit path, unlike #150's encoder-only niche (which only fired when an admin raised the host cap above the
+encoder limit).
+
+### Removals (the error path)
+
+| Location | Removed |
+|---|---|
+| `lib/image_pipe/request/processor.ex` | `validate_result_image/2` (and its call in `process_decoded_source`'s `with`), `check_result_width/2`, `check_result_height/2`, `check_result_pixels/2` |
+| `lib/image_pipe/response/sender.ex` | the `{:result_limit, error}` `handle_processing_error` clause and `send_result_limit_error/3` (413 "result image is too large") |
+| `test/image_pipe/processor_test.exs` | "process_source rejects final images wider than configured result limit" (asserts `{:result_limit, …}`) |
+| `test/image_pipe/plug_test.exs` | "rejects static result dimensions above configured limits before encoding" (asserts 413 + `refute_received :stream_encoder_called`) — replaced by a downscale wire test (see Tests) |
+
+`max_input_pixels` 413 handling (`{:input_limit, …}` → `send_input_limit_error/3`) is **untouched**, as are
+its tests (`plug_test.exs` "source image is too large", `telemetry_test.exs` input-pixel limit,
+`shrink_on_load_test.exs` oversized-JPEG).
+
+### Telemetry — reuse `[:output, :clamp]`
+
+The single existing `[:output, :clamp]` one-shot is kept. Only the metadata changes: `max_dimension:`
+(scalar) → `limits:` (the effective caps map). The event fires once per request when a clamp occurs,
+regardless of whether the host cap or the encoder limit bound — the event does **not** distinguish the source
+of the `min`. (The issue floated distinguishing host-cap vs encoder-cap "if useful"; we judge it not worth
+the extra branch — the effective caps and the before/after dimensions are the observable facts a host needs.)
+
+- **measurements:** `%{scale: scale}` (unchanged).
+- **metadata:** `%{format: format, source_dimensions: {w, h}, dimensions: {w', h'}, limits: limits}`.
+
+All metadata stays non-sensitive (dimensions, format atom, integer/`:infinity` caps).
+
+**Default Logger sync** (`telemetry/logger.ex`, per the *Telemetry guidelines*): update the existing
+`message/3` clause for `[:output, :clamp | _]` to render the new `limits` shape, e.g.
+`"image_pipe output clamp: 18000x9000 -> 8192x4096 for webp (caps w:8192 h:8192 px:40000000)"`. Level stays
+`:warning`. Update the `logger_test.exs` assertion and `docs/telemetry.md` to the `limits` metadata.
+
+### Cache / ETag — no change
+
+`max_result_*` stays out of **both** the cache key (`ImagePipe.Cache.Key`) and the ETag
+(`ImagePipe.Request.HttpCache`, `"ip{schema}-{hash}"`). Confirmed: `max_result_*` appears in `lib/` only in
+the (to-be-deleted) `check_result_*` code — absent from `cache/key.ex` and `http_cache.ex`.
+
+**Subtlety flagged for the compat/cache reviewer:** #165 turns `max_result_*` from a *pure generation gate*
+(decides whether a miss may generate) into something that *shapes the output bytes* (downscales them). It is
+still **not storage identity**:
+
+- It is **deployment config**, not a request input. Output stays canonical per `(source identity + plan +
+  negotiated format)` for a given deployment — there is still exactly one output variant per request, so
+  `max_result_*` is not a selector among variants.
+- This matches **#150 exactly**: the encoder limit also shapes output bytes (downscales) and is also unkeyed
+  — it derives from the negotiated format, already in the key.
+- It matches CLAUDE.md's *Cache guidelines*: "Keep safety limits (`max_body_bytes`, `max_input_pixels`,
+  static result dimension limits) out of both … those decide whether a cache miss may generate a response."
+- A config change is out-of-band: an operator who lowers `max_result_*` and wants old (larger) entries gone
+  bumps the cachebuster / data-version — the same posture already in effect for `max_input_pixels` changes,
+  which likewise don't bust the cache.
+
+The ETag still returns `304` before any source fetch/decode/encode/clamp; the clamp never participates in
+validator derivation.
+
+## imgproxy parity & deliberate divergences (compat)
+
+Verified against `local/imgproxy-master/processing/prepare.go:222-265`:
+
+- **Dimension, equal caps:** `limitScale` computes `downScale = maxResultDim / max(outWidth, outHeight)`
+  (`prepare.go:245-247`) — a uniform linear downscale on the longest axis. ImagePipe's per-axis math reduces
+  to exactly this when `max_width == max_height` and dimension binds. ✅ byte-intent identical.
+- **Deliberate divergences — ImagePipe is a strict superset:**
+  - imgproxy's `limitScale` has a **single** `MaxResultDimension` applied to both axes; ImagePipe honors
+    **independent** `max_result_width` / `max_result_height`. More granular; strictly safer (never exceeds
+    either axis cap, never over-shrinks within them).
+  - imgproxy's `limitScale` has **no pixel/resolution cap** — its resolution gate (`MaxSrcResolution`) is
+    *input*-side only. ImagePipe additionally honors a **result** pixel cap (`max_result_pixels`, sqrt
+    shrink). This has no `limitScale` counterpart; it is an ImagePipe-specific output safety knob. The sqrt
+    choice (dimension linear, pixels sqrt, most-aggressive) is the #150 hand-off recommendation, **not**
+    `fixGifSize`'s combined-sqrt.
+- **Input gate stays a hard error:** `max_input_pixels` ↔ `MaxSrcResolution` — mirrors imgproxy's split
+  (downscale the output cap, hard-error the input gate). ✅
+
+These divergences are documented in `docs/imgproxy_support_matrix.md` as more-granular, strictly-safe
+choices, in the same spirit as #150's linear-dimension divergence from `fixGifSize`.
+
+## Tests (per CLAUDE.md)
+
+### Direct unit tests — `test/image_pipe/output/clamp_test.exs`
+
+Extend the existing file. Every case uses a producer-constructible shape (realized image + a limits map of
+integers/`:infinity`):
+
+- width binds (per-axis): `max_width` small, `max_height`/`max_pixels` large → scale = `max_width/w`.
+- height binds (per-axis): symmetric.
+- pixels bind (sqrt): dims within `max_width`/`max_height` but `w*h > max_pixels` → scale = `sqrt(max_pixels/(w*h))`, dimensions reduced, realized `w'*h' <= max_pixels`.
+- most-aggressive: a shape where pixel and dimension constraints disagree → the smaller scale wins.
+- no-op: within all caps (and all-`:infinity`) → `{:ok, image, nil}`, no resize node.
+- ≤-cap guarantee: realized longest axis == cap and realized pixels ≤ pixel cap.
+
+### Wire conformance — `test/image_pipe/imgproxy_wire_conformance_test.exs`
+
+Real `ImagePipe.call/2` + real encode + body decode (the file already has `dimensions/1`/`content_type/1`):
+
+- **Default-cap downscale:** a request that realizes above 8192 on an axis (e.g. `el:1`/`w:` enlarge),
+  `f:jpeg`, **default** host caps → `200`, decode body, longest axis ≤ 8192 and strictly reduced,
+  `[:output, :clamp]` fired with matching `source_dimensions`/`dimensions`/`limits`.
+- **Asymmetric caps (per-axis):** raise one axis cap, lower the other; assert the result fits both and is not
+  over-shrunk (a case that the square-collapse alternative would get wrong).
+- **Pixel-cap downscale:** dims within width/height caps but over `max_result_pixels` → decoded `w*h ≤
+  max_result_pixels`, `[:output, :clamp]` fired.
+- **No-clamp control:** a request under all caps → no `[:output, :clamp]` event, unchanged dimensions.
+- Update #150's existing encoder-clamp conformance tests if they assert `max_dimension` metadata → `limits`.
+
+### Converted error tests
+
+- `plug_test.exs` "rejects static result dimensions…" → a downscale assertion (200 + clamp). Because the new
+  behavior decodes and re-encodes, it moves to / is expressed against the real encoder (the old test used
+  `StreamingOnlyImage`, whose body is undecodable, and asserted `refute_received :stream_encoder_called`,
+  which no longer holds — encode now runs).
+- `processor_test.exs` "process_source rejects final images wider…" → **deleted** (the function is gone;
+  clamp behavior is covered by `clamp_test.exs` + wire tests).
+
+## Docs
+
+- `docs/imgproxy_support_matrix.md`:
+  - Row 113 (host result-dimension cap) ⚠️ → ✅, pointing at the `Output.Clamp` reuse with `min(host,
+    encoder)`.
+  - `limitScale` in the processing-pipeline section (a **stage/order** + **behavioral/pixel** change per the
+    compat-doc-sync rule).
+  - "standing divergences" note (line ~124): drop the host-result-cap divergence; add the per-axis /
+    result-pixel superset divergence.
+  - Input/output safety-limits section (~426-437): reflect downscale-not-error for the result cap.
+- `docs/telemetry.md`: `[:output, :clamp]` metadata `limits` shape.
+- `docs/operational_notes.md`: the result-limit 413 mention → downscale behavior.
+
+## Out of scope
+
+- Shrink-on-load decode fold (`DecodePlanner`) — split to a follow-up; the post-hoc clamp is the correctness
+  path.
+- #164 look-ahead pre-clamp — untouched.
+- Native strict-error policy — no native caller exists; default everything to downscale (per the *Validation
+  guidelines*: add the policy when the future caller appears, with a test that exercises it).
+- Demo UI — `max_result_*` are host config, not URL/transform knobs; no demo control exists.
+- Cache key/ETag data-version bump — no key shape change.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -347,12 +347,14 @@ values.
 
 ## Output dimension clamp (`[:output, :clamp]`)
 
-When the realized final image exceeds the negotiated output encoder's hard
-dimension limit, ImagePipe uniformly downscales it to fit before encoding and
-emits a one-shot (non-span) marker. The limit is format-aware: WebP caps each
-dimension at 16383 and AVIF at 16384, while JPEG and PNG are effectively
-unbounded. This lets a host observe that a served image was downscaled to fit
-the encoder rather than delivered at the requested size.
+When the realized final image exceeds the effective result caps — the tighter of
+the host `max_result_width`/`max_result_height`/`max_result_pixels` config and the
+negotiated output encoder's hard limit (`min(host, encoder)`) — ImagePipe
+uniformly downscales it to fit before encoding and emits a one-shot (non-span)
+marker. This both keeps encoding from failing (WebP caps each dimension at 16383,
+AVIF at 16384; JPEG/PNG effectively unbounded) and serves the host result cap as a
+downscale rather than an error (imgproxy `limitScale` parity). The common trigger
+is the host cap (default 8192 per axis), which is below the encoder limits.
 
 ```text
 [:image_pipe, :output, :clamp]
@@ -367,7 +369,7 @@ Metadata:
 - `:format` — the negotiated output format atom (e.g. `:webp`, `:avif`).
 - `:source_dimensions` — `{w, h}` before the clamp.
 - `:dimensions` — `{w, h}` after the clamp.
-- `:max_dimension` — the per-dimension limit that bound the result.
+- `:limits` — the effective caps applied: `%{max_width, max_height, max_pixels}` (each a `pos_integer` or `:infinity`).
 
 This metadata is product-neutral and non-sensitive (no URLs, secrets, or PII).
 
@@ -375,7 +377,7 @@ The opt-in default Logger attaches to this event and renders it at `:warning`,
 matching imgproxy's `slog.Warn` for the same condition, e.g.:
 
 ```text
-output clamp: 18000x9000 -> 16383x8191 for webp (max 16383)
+image_pipe output clamp: 18000x9000 -> 8192x4096 for webp (caps w:8192 h:8192 px:40000000)
 ```
 
 ## Attaching handlers

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -352,7 +352,7 @@ the host `max_result_width`/`max_result_height`/`max_result_pixels` config and t
 negotiated output encoder's hard limit (`min(host, encoder)`) — ImagePipe
 uniformly downscales it to fit before encoding and emits a one-shot (non-span)
 marker. This both keeps encoding from failing (WebP caps each dimension at 16383,
-AVIF at 16384; JPEG/PNG effectively unbounded) and serves the host result cap as a
+AVIF at 16384, JPEG at 65535; PNG effectively unbounded) and serves the host result cap as a
 downscale rather than an error (imgproxy `limitScale` parity). The common trigger
 is the host cap (default 8192 per axis), which is below the encoder limits.
 

--- a/lib/image_pipe/output/clamp.ex
+++ b/lib/image_pipe/output/clamp.ex
@@ -1,77 +1,146 @@
 defmodule ImagePipe.Output.Clamp do
   @moduledoc false
   # Generic, product-neutral uniform downscale of a realized image so it fits a
-  # maximum dimension. Used by the producer with the output encoder's per-format
-  # limit (`ImagePipe.Output.Encoder.encoder_limit/1`) so encoding cannot fail.
-  # Knows nothing about formats or hosts: it takes a raw `max_dimension`. #165
-  # widens this to also accept a `max_pixels` budget.
+  # set of result caps: per-axis dimensions (`:max_width`/`:max_height`) and a
+  # total pixel budget (`:max_pixels`). The producer passes the EFFECTIVE caps =
+  # min(host max_result_*, encoder limit), so encoding cannot fail AND the host
+  # result cap downscales rather than errors (imgproxy `limitScale` parity).
+  # Knows nothing about formats or hosts.
   #
-  # Reads/resizes the image via the `image` library directly (no Transform or
-  # Telemetry dependency, per the Output boundary). Resize is lazy; measuring
-  # width/height reads libvips header fields (O(1), no pixel realization).
+  # Reads/resizes via the `image` library directly (no Transform/Telemetry dep).
+  # Resize is lazy; measuring width/height reads libvips header fields (O(1)).
 
   alias Vix.Vips.Image, as: VixImage
+
+  @type limit :: pos_integer() | :infinity
+  @type limits :: %{max_width: limit(), max_height: limit(), max_pixels: limit()}
 
   @type clamp_info :: %{
           scale: float(),
           source_dimensions: {pos_integer(), pos_integer()},
           dimensions: {pos_integer(), pos_integer()},
-          max_dimension: pos_integer()
+          limits: limits()
         }
 
-  @spec clamp(VixImage.t(), pos_integer() | :infinity, keyword()) ::
+  # Bounded escape for the pixel verify-and-shrink loop. Realistic caps converge
+  # in one iteration; the bound only guards an adversarially tiny pixel cap (a
+  # few hundred px) that needs several geometric steps.
+  @max_pixel_iterations 16
+
+  @spec clamp(VixImage.t(), limits(), keyword()) ::
           {:ok, VixImage.t(), clamp_info() | nil}
           | {:error, {:encode, Exception.t(), list()}}
-  def clamp(%VixImage{} = image, :infinity, _opts), do: {:ok, image, nil}
-
-  def clamp(%VixImage{} = image, max_dimension, opts) when is_integer(max_dimension) do
+  def clamp(%VixImage{} = image, %{} = limits, opts) do
     w = Image.width(image)
     h = Image.height(image)
-    longest = max(w, h)
+    scale = primary_scale(limits, w, h)
 
-    if longest <= max_dimension do
+    if scale >= 1.0 do
       {:ok, image, nil}
     else
       image_module = Keyword.get(opts, :image_module, Image)
-      scale = max_dimension / longest
 
       with {:ok, resized} <- resize(image_module, image, scale),
-           {:ok, resized} <- enforce_limit(image_module, image, resized, max_dimension) do
+           {:ok, resized} <- enforce(image_module, image, resized, limits, @max_pixel_iterations) do
         rw = Image.width(resized)
         rh = Image.height(resized)
 
         {:ok, resized,
          %{
-           # Derived from the realized result so it stays consistent with
-           # `dimensions` even on the defensive corrective path.
            scale: rw / w,
            source_dimensions: {w, h},
            dimensions: {rw, rh},
-           max_dimension: max_dimension
+           limits: limits
          }}
       end
     end
   end
 
-  # Defensive ≤-limit guarantee: `scale = limit/longest` lands the longest axis
-  # on `limit`, but if a libvips rounding quirk overshoots we re-resize the
-  # ORIGINAL by a slightly smaller (`limit - 0.5`) factor so the corrected
-  # longest axis lands at or below the limit. In practice this never fires.
-  defp enforce_limit(image_module, original, resized, max_dimension) do
-    realized = max(Image.width(resized), Image.height(resized))
+  # Most-aggressive scale across the per-axis dimension caps (linear) and the
+  # pixel budget (sqrt). Each `*_scale` helper returns exactly 1.0 when its cap
+  # does not bind, else a value < 1.0, so the minimum is always <= 1.0; a result
+  # of 1.0 means no cap binds -> no-op.
+  defp primary_scale(%{max_width: mw, max_height: mh, max_pixels: mp}, w, h) do
+    Enum.min([axis_scale(mw, w), axis_scale(mh, h), pixel_scale(mp, w * h)])
+  end
 
-    if realized <= max_dimension do
-      {:ok, resized}
-    else
-      longest = max(Image.width(original), Image.height(original))
-      # floor-bias: subtract a hair so round() cannot bump back to the overshoot
-      corrected = (max_dimension - 0.5) / longest
-      resize(image_module, original, corrected)
+  defp axis_scale(:infinity, _dim), do: 1.0
+  defp axis_scale(max_dim, dim) when dim <= max_dim, do: 1.0
+  defp axis_scale(max_dim, dim), do: max_dim / dim
+
+  defp pixel_scale(:infinity, _px), do: 1.0
+  defp pixel_scale(max_px, px) when px <= max_px, do: 1.0
+  defp pixel_scale(max_px, px), do: :math.sqrt(max_px / px)
+
+  # Dimension caps are satisfied by the primary resize's construction; only the
+  # pixel budget can overshoot (a product of two independently rounded axes), so
+  # this loop verifies the realized result and shrinks the dominant axis toward
+  # the aspect-preserving pixel budget until it fits. Always resizes from the
+  # ORIGINAL (never the already-resized image) to avoid compounding rounding;
+  # only ever shrinks, so dimension caps stay satisfied. Checks ALL caps each
+  # iteration (defensive). Exhausting the bound is a tagged encode error.
+  defp enforce(image_module, original, resized, limits, iters_left) do
+    rw = Image.width(resized)
+    rh = Image.height(resized)
+
+    cond do
+      within_caps?(rw, rh, limits) ->
+        {:ok, resized}
+
+      iters_left == 0 ->
+        {:error, encode_error(:pixel_enforce_exhausted)}
+
+      true ->
+        target_long = shrink_target(rw, rh, limits)
+        long_orig = max(Image.width(original), Image.height(original))
+        # round-to target_long on the long axis; +0.49 lands on target_long, not target_long+1.
+        scale = (target_long + 0.49) / long_orig
+
+        with {:ok, resized} <- resize(image_module, original, scale) do
+          enforce(image_module, original, resized, limits, iters_left - 1)
+        end
     end
   end
 
+  defp within_caps?(w, h, %{max_width: mw, max_height: mh, max_pixels: mp}) do
+    within?(w, mw) and within?(h, mh) and within?(w * h, mp)
+  end
+
+  defp within?(_value, :infinity), do: true
+  defp within?(value, limit), do: value <= limit
+
+  # Largest dominant-axis length that fits the long axis's own dimension cap and
+  # (aspect-preserving) the pixel budget, with a strict -1 progress floor so the
+  # loop always advances at least one pixel and therefore terminates. The
+  # :infinity terms are naturally ignored by Enum.min (an atom sorts above the
+  # always-present `long - 1` integer).
+  defp shrink_target(rw, rh, %{max_width: mw, max_height: mh, max_pixels: mp}) do
+    long = max(rw, rh)
+    short = min(rw, rh)
+    long_dim_cap = if rw >= rh, do: mw, else: mh
+
+    Enum.min([long - 1, dim_target(long_dim_cap), pixel_target(mp, long, short)])
+  end
+
+  defp dim_target(:infinity), do: :infinity
+  defp dim_target(max_dim), do: max_dim
+
+  defp pixel_target(:infinity, _long, _short), do: :infinity
+  # long' * (long' * short / long) <= max_px  =>  long' = floor(sqrt(max_px * long / short)).
+  # The sqrt is non-negative, so `trunc` is `floor` here.
+  defp pixel_target(max_px, long, short), do: trunc(:math.sqrt(max_px * long / short))
+
+  # Per-axis 1px floor: never scale an axis below one realized pixel. This is the
+  # equivalent of imgproxy's `WScale >= 1/widthToScale` (prepare.go:252-258) and
+  # is what keeps an extreme aspect ratio (e.g. 40000x1) from rounding the short
+  # axis to 0 under a tight cap.
   defp resize(image_module, image, scale) do
-    case image_module.resize(image, scale, vertical_scale: scale) do
+    w = Image.width(image)
+    h = Image.height(image)
+    hscale = max(scale, 1.0 / w)
+    vscale = max(scale, 1.0 / h)
+
+    case image_module.resize(image, hscale, vertical_scale: vscale) do
       {:ok, resized} -> {:ok, resized}
       {:error, reason} -> {:error, encode_error(reason)}
     end

--- a/lib/image_pipe/output/encoder.ex
+++ b/lib/image_pipe/output/encoder.ex
@@ -7,17 +7,21 @@ defmodule ImagePipe.Output.Encoder do
   alias Vix.Vips.MutableImage, as: VixMutableImage
 
   @doc """
-  The output encoder's hard per-dimension limit for `format`, used by
-  `ImagePipe.Output.Clamp` to keep encoding from failing. `:infinity` means no
+  The output encoder's hard per-format limits, used by `ImagePipe.Output.Clamp`
+  to keep encoding from failing. `:max_dimension` is the hard per-axis pixel
+  limit; `:max_pixels` is a total-resolution budget. `:infinity` means no
   practical limit. Sourced from libvips encoder constraints (cf. imgproxy
-  `processing/fix_size.go`). #150 uses only `:max_dimension`; #165 will extend
-  the returned map with a `:max_pixels` budget when its caller makes that live.
+  `processing/fix_size.go`). #165 folds these with the host `max_result_*` caps
+  via `min/2` at the producer before calling `Clamp.clamp/3`.
   """
-  @spec encoder_limit(Format.output_format()) :: %{max_dimension: pos_integer() | :infinity}
-  def encoder_limit(:webp), do: %{max_dimension: 16_383}
-  def encoder_limit(:avif), do: %{max_dimension: 16_384}
-  def encoder_limit(:jpeg), do: %{max_dimension: 65_535}
-  def encoder_limit(:png), do: %{max_dimension: :infinity}
+  @spec encoder_limit(Format.output_format()) :: %{
+          max_dimension: pos_integer() | :infinity,
+          max_pixels: pos_integer() | :infinity
+        }
+  def encoder_limit(:webp), do: %{max_dimension: 16_383, max_pixels: :infinity}
+  def encoder_limit(:avif), do: %{max_dimension: 16_384, max_pixels: :infinity}
+  def encoder_limit(:jpeg), do: %{max_dimension: 65_535, max_pixels: :infinity}
+  def encoder_limit(:png), do: %{max_dimension: :infinity, max_pixels: :infinity}
 
   @spec stream_output(VixImage.t(), Resolved.t(), keyword()) ::
           {:ok, Enumerable.t(), String.t()}

--- a/lib/image_pipe/request/processor.ex
+++ b/lib/image_pipe/request/processor.ex
@@ -138,11 +138,8 @@ defmodule ImagePipe.Request.Processor do
       execute_start_meta,
       fn ->
         result =
-          with {:ok, final_state} <-
-                 execute_transform_plan(initial_state, plan, opts),
-               {:ok, final_state} <-
-                 materialize_before_delivery(final_state, opts, source_response) do
-            {:ok, final_state}
+          with {:ok, final_state} <- execute_transform_plan(initial_state, plan, opts) do
+            materialize_before_delivery(final_state, opts, source_response)
           end
 
         {result, transform_stop_metadata(result)}

--- a/lib/image_pipe/request/processor.ex
+++ b/lib/image_pipe/request/processor.ex
@@ -141,8 +141,7 @@ defmodule ImagePipe.Request.Processor do
           with {:ok, final_state} <-
                  execute_transform_plan(initial_state, plan, opts),
                {:ok, final_state} <-
-                 materialize_before_delivery(final_state, opts, source_response),
-               :ok <- validate_result_image(final_state.image, opts) do
+                 materialize_before_delivery(final_state, opts, source_response) do
             {:ok, final_state}
           end
 
@@ -287,32 +286,6 @@ defmodule ImagePipe.Request.Processor do
 
   defp wrap_input_limit_error(:ok), do: :ok
   defp wrap_input_limit_error({:error, error}), do: {:error, {:input_limit, error}}
-
-  defp validate_result_image(image, opts) do
-    width = Image.width(image)
-    height = Image.height(image)
-    pixels = width * height
-
-    with :ok <- check_result_width(width, Keyword.fetch!(opts, :max_result_width)),
-         :ok <- check_result_height(height, Keyword.fetch!(opts, :max_result_height)) do
-      check_result_pixels(pixels, Keyword.fetch!(opts, :max_result_pixels))
-    end
-  end
-
-  defp check_result_width(width, max_width) when width <= max_width, do: :ok
-
-  defp check_result_width(width, max_width),
-    do: {:error, {:result_limit, {:result_width_too_large, width, max_width}}}
-
-  defp check_result_height(height, max_height) when height <= max_height, do: :ok
-
-  defp check_result_height(height, max_height),
-    do: {:error, {:result_limit, {:result_height_too_large, height, max_height}}}
-
-  defp check_result_pixels(pixels, max_pixels) when pixels <= max_pixels, do: :ok
-
-  defp check_result_pixels(pixels, max_pixels),
-    do: {:error, {:result_limit, {:too_many_result_pixels, pixels, max_pixels}}}
 
   defp fetch_decode_stop_metadata(
          {:ok, %{image: image, decode_options: decode_options} = decoded}

--- a/lib/image_pipe/request/source_session/producer.ex
+++ b/lib/image_pipe/request/source_session/producer.ex
@@ -122,9 +122,9 @@ defmodule ImagePipe.Request.SourceSession.Producer do
                final_state.image,
                request.opts
              ),
-           %{max_dimension: max_dimension} = Encoder.encoder_limit(resolved_output.format),
+           limits = effective_limits(resolved_output.format, request.opts),
            {:ok, image, clamp_info} <-
-             Clamp.clamp(final_state.image, max_dimension, request.opts),
+             Clamp.clamp(final_state.image, limits, request.opts),
            :ok <- emit_clamp_telemetry(clamp_info, resolved_output.format, request.opts),
            {:ok, stream, content_type} <-
              Encoder.stream_output(image, resolved_output, request.opts),
@@ -154,6 +154,24 @@ defmodule ImagePipe.Request.SourceSession.Producer do
     end)
   end
 
+  # Effective per-axis + pixel result caps: the tighter of the host `max_result_*`
+  # config and the chosen encoder's hard limit. The clamp does not care which
+  # source won the `min`.
+  defp effective_limits(format, opts) do
+    %{max_dimension: enc_dim, max_pixels: enc_px} = Encoder.encoder_limit(format)
+
+    %{
+      max_width: min_limit(Keyword.fetch!(opts, :max_result_width), enc_dim),
+      max_height: min_limit(Keyword.fetch!(opts, :max_result_height), enc_dim),
+      max_pixels: min_limit(Keyword.fetch!(opts, :max_result_pixels), enc_px)
+    }
+  end
+
+  # The host cap (`a`) is always an integer (NimbleOptions `:pos_integer`); only
+  # the encoder limit (`b`) can be `:infinity` ("no limit from the encoder").
+  defp min_limit(a, :infinity), do: a
+  defp min_limit(a, b), do: min(a, b)
+
   defp emit_clamp_telemetry(nil, _format, _opts), do: :ok
 
   defp emit_clamp_telemetry(%{} = info, format, opts) do
@@ -165,7 +183,7 @@ defmodule ImagePipe.Request.SourceSession.Producer do
         format: format,
         source_dimensions: info.source_dimensions,
         dimensions: info.dimensions,
-        max_dimension: info.max_dimension
+        limits: info.limits
       }
     )
 

--- a/lib/image_pipe/response/sender.ex
+++ b/lib/image_pipe/response/sender.ex
@@ -126,9 +126,6 @@ defmodule ImagePipe.Response.Sender do
   defp handle_processing_error(conn, {:input_limit, error}, response_headers),
     do: send_input_limit_error(conn, error, response_headers)
 
-  defp handle_processing_error(conn, {:result_limit, error}, response_headers),
-    do: send_result_limit_error(conn, error, response_headers)
-
   defp handle_processing_error(conn, {:encode, exception, stacktrace}, response_headers),
     do: handle_encode_exception(exception, stacktrace, conn, response_headers)
 
@@ -191,15 +188,6 @@ defmodule ImagePipe.Response.Sender do
     |> put_resp_headers(response_headers)
     |> put_resp_content_type("text/plain")
     |> send_resp(413, "source image is too large")
-  end
-
-  defp send_result_limit_error(%Plug.Conn{} = conn, error, response_headers) do
-    Logger.info("result_limit_error: #{inspect(error)}")
-
-    conn
-    |> put_resp_headers(response_headers)
-    |> put_resp_content_type("text/plain")
-    |> send_resp(413, "result image is too large")
   end
 
   defp send_transform_error(%Plug.Conn{} = conn, response_headers) do

--- a/lib/image_pipe/telemetry/logger.ex
+++ b/lib/image_pipe/telemetry/logger.ex
@@ -166,13 +166,18 @@ defmodule ImagePipe.Telemetry.Logger do
   defp message([:output, :clamp | _], _m, meta) do
     {sw, sh} = meta[:source_dimensions]
     {w, h} = meta[:dimensions]
+    %{max_width: mw, max_height: mh, max_pixels: mp} = meta[:limits]
 
-    "image_pipe output clamp: #{sw}x#{sh} -> #{w}x#{h} for #{meta[:format]} (max #{meta[:max_dimension]})"
+    "image_pipe output clamp: #{sw}x#{sh} -> #{w}x#{h} for #{meta[:format]} " <>
+      "(caps w:#{cap(mw)} h:#{cap(mh)} px:#{cap(mp)})"
   end
 
   defp message(suffix, _m, meta) do
     "image_pipe #{label(suffix)}: #{outcome(meta)}"
   end
+
+  defp cap(:infinity), do: "inf"
+  defp cap(value), do: value
 
   defp exception_message(suffix, meta) do
     "image_pipe #{label(suffix)}: exception (#{meta[:kind]} #{inspect(meta[:reason])})"

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -2401,6 +2401,118 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
     end
   end
 
+  describe "host result cap downscale (#165, limitScale parity)" do
+    # Default host caps: max_result_width/height = 8192, max_result_pixels = 40M.
+    @host_default_opts [
+      parser: ImagePipe.Parser.Imgproxy,
+      sources: [
+        path: {RootHTTPAdapter, root_url: "http://origin.test", req_options: [plug: OriginImage]}
+      ],
+      output_capabilities: %{avif: true, webp: true}
+    ]
+
+    test "downscales a result above the default 8192 host cap and serves 200" do
+      attach_clamp_telemetry()
+
+      conn =
+        call_imgproxy(
+          "/_/el:1/rs:force:12000:200/f:jpeg/plain/images/beach.jpg",
+          @host_default_opts
+        )
+
+      assert conn.status == 200
+      assert content_type(conn) == ["image/jpeg"]
+
+      {w, h} = dimensions(conn)
+      # Parity, not just safety: when the width cap binds on a non-degenerate
+      # aspect, the long axis lands EXACTLY on 8192 — byte-intent identical to
+      # imgproxy's linear `downScale = maxResultDim/max(outW,outH)`.
+      assert w == 8192
+
+      assert_received {:telemetry_event, [:image_pipe, :output, :clamp], %{scale: scale}, meta}
+      assert scale < 1.0
+      assert meta.limits.max_width == 8192
+      assert meta.limits.max_height == 8192
+      assert meta.dimensions == {w, h}
+      {sw, _sh} = meta.source_dimensions
+      assert sw > 8192
+    end
+
+    # The one place ImagePipe and imgproxy observably diverge: a PADDED request
+    # whose composited frame exceeds the cap. imgproxy folds the downscale into
+    # the resize scale before re-applying padding (prepare.go:233-263); ImagePipe
+    # clamps the already-composited frame. Both land <= cap; the framing differs.
+    # This test pins ImagePipe's contract (status 200, composite <= cap, clamp
+    # fired) so a future change to the clamp point can't silently alter padded
+    # behavior with a green suite.
+    test "clamps a padded result whose composited frame exceeds the host cap" do
+      attach_clamp_telemetry()
+
+      # w:100 then pad 5000px each side -> composited width ~10100 > 8192.
+      conn =
+        call_imgproxy("/_/w:100/pd:5000/f:jpeg/plain/images/beach.jpg", @host_default_opts)
+
+      assert conn.status == 200
+      {w, h} = dimensions(conn)
+      assert max(w, h) <= 8192
+
+      assert_received {:telemetry_event, [:image_pipe, :output, :clamp], %{scale: scale}, _meta}
+      assert scale < 1.0
+    end
+
+    test "honors asymmetric per-axis caps without over-shrinking" do
+      attach_clamp_telemetry()
+
+      # Realize ~6000x200, raise width cap above it, keep height cap slack:
+      # both axes within caps -> NO clamp, served at full requested size.
+      conn =
+        call_imgproxy(
+          "/_/el:1/rs:force:6000:200/f:jpeg/plain/images/beach.jpg",
+          Keyword.merge(@host_default_opts, max_result_width: 10_000, max_result_height: 8192)
+        )
+
+      assert conn.status == 200
+      {w, h} = dimensions(conn)
+      assert w == 6000
+      assert h == 200
+      refute_received {:telemetry_event, [:image_pipe, :output, :clamp], _m, _meta}
+    end
+
+    test "downscales on the host pixel cap with dims within the per-axis caps" do
+      attach_clamp_telemetry()
+
+      # ~5000x5000 = 25M px. Per-axis caps slack (8000), pixel cap 4M -> clamp on pixels.
+      conn =
+        call_imgproxy(
+          "/_/el:1/rs:force:5000:5000/f:jpeg/plain/images/beach.jpg",
+          Keyword.merge(@host_default_opts,
+            max_result_width: 8000,
+            max_result_height: 8000,
+            max_result_pixels: 4_000_000
+          )
+        )
+
+      assert conn.status == 200
+      {w, h} = dimensions(conn)
+      assert w <= 8000 and h <= 8000
+      assert w * h <= 4_000_000
+
+      assert_received {:telemetry_event, [:image_pipe, :output, :clamp], %{scale: scale}, _meta}
+      assert scale < 1.0
+    end
+
+    test "does not clamp or emit when the result is within all default caps" do
+      attach_clamp_telemetry()
+
+      conn = call_imgproxy("/_/w:300/f:jpeg/plain/images/beach.jpg", @host_default_opts)
+
+      assert conn.status == 200
+      {w, _h} = dimensions(conn)
+      assert w == 300
+      refute_received {:telemetry_event, [:image_pipe, :output, :clamp], _m, _meta}
+    end
+  end
+
   defp cached_opts(overrides \\ []) do
     cache_root =
       Path.join(

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -2358,7 +2358,8 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
 
       assert scale < 1.0
       assert meta.format == :webp
-      assert meta.max_dimension == 16_383
+      assert meta.limits.max_width == 16_383
+      assert meta.limits.max_height == 16_383
       assert meta.dimensions == {w, h}
       {sw, sh} = meta.source_dimensions
       assert max(sw, sh) > 16_383
@@ -2381,7 +2382,8 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
 
       assert scale < 1.0
       assert meta.format == :avif
-      assert meta.max_dimension == 16_384
+      assert meta.limits.max_width == 16_384
+      assert meta.limits.max_height == 16_384
       assert meta.dimensions == {w, h}
     end
 

--- a/test/image_pipe/output/clamp_test.exs
+++ b/test/image_pipe/output/clamp_test.exs
@@ -14,14 +14,14 @@ defmodule ImagePipe.Output.ClampTest do
   end
 
   describe "encoder_limit/1" do
-    test "returns the WebP and AVIF hard dimension limits" do
-      assert Encoder.encoder_limit(:webp) == %{max_dimension: 16_383}
-      assert Encoder.encoder_limit(:avif) == %{max_dimension: 16_384}
+    test "returns the WebP and AVIF hard dimension limits with unbounded pixels" do
+      assert Encoder.encoder_limit(:webp) == %{max_dimension: 16_383, max_pixels: :infinity}
+      assert Encoder.encoder_limit(:avif) == %{max_dimension: 16_384, max_pixels: :infinity}
     end
 
     test "returns the documented JPEG limit and unbounded PNG" do
-      assert Encoder.encoder_limit(:jpeg) == %{max_dimension: 65_535}
-      assert Encoder.encoder_limit(:png) == %{max_dimension: :infinity}
+      assert Encoder.encoder_limit(:jpeg) == %{max_dimension: 65_535, max_pixels: :infinity}
+      assert Encoder.encoder_limit(:png) == %{max_dimension: :infinity, max_pixels: :infinity}
     end
   end
 

--- a/test/image_pipe/output/clamp_test.exs
+++ b/test/image_pipe/output/clamp_test.exs
@@ -1,17 +1,8 @@
 defmodule ImagePipe.Output.ClampTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias ImagePipe.Output.Encoder
-
-  # Stub whose first (more aggressive) resize overshoots the limit by 1px and
-  # whose floor-biased corrective resize lands within it. Models a libvips
-  # rounding quirk so the defensive `enforce_limit` re-resize is exercised.
-  # Injected via the `:image_module` opt; the primary call uses the larger
-  # `max_dimension / longest` factor, the corrective uses `(max_dimension - 0.5) / longest`.
-  defmodule OvershootOnceImage do
-    def resize(_image, scale, _opts) when scale >= 0.5, do: Image.new(101, 50)
-    def resize(_image, _scale, _opts), do: Image.new(100, 50)
-  end
 
   describe "encoder_limit/1" do
     test "returns the WebP and AVIF hard dimension limits with unbounded pixels" do
@@ -28,64 +19,160 @@ defmodule ImagePipe.Output.ClampTest do
   describe "clamp/3" do
     alias ImagePipe.Output.Clamp
 
-    # A blank image of exact dimensions; cheap and lazy.
+    @inf %{max_width: :infinity, max_height: :infinity, max_pixels: :infinity}
+
     defp image(width, height) do
       {:ok, image} = Image.new(width, height)
       image
     end
 
-    test "returns the image unchanged with nil info when within the limit" do
-      img = image(200, 50)
-      assert {:ok, ^img, nil} = Clamp.clamp(img, 1000, [])
+    defp limits(opts) do
+      %{
+        max_width: Keyword.get(opts, :max_width, :infinity),
+        max_height: Keyword.get(opts, :max_height, :infinity),
+        max_pixels: Keyword.get(opts, :max_pixels, :infinity)
+      }
     end
 
-    test "is a no-op for an :infinity limit" do
+    test "no-op (unchanged image, nil info) when within all caps" do
       img = image(200, 50)
-      assert {:ok, ^img, nil} = Clamp.clamp(img, :infinity, [])
+      assert {:ok, ^img, nil} = Clamp.clamp(img, limits(max_width: 1000, max_height: 1000), [])
     end
 
-    test "uniformly downscales when the longest axis exceeds the limit" do
+    test "no-op for an all-:infinity limits map" do
       img = image(200, 50)
-      assert {:ok, resized, info} = Clamp.clamp(img, 100, [])
+      assert {:ok, ^img, nil} = Clamp.clamp(img, @inf, [])
+    end
+
+    test "no-op when a cap exactly equals a dimension (no degenerate resize)" do
+      img = image(200, 50)
+      assert {:ok, ^img, nil} = Clamp.clamp(img, limits(max_width: 200, max_height: 50), [])
+    end
+
+    test "downscales linearly when the width cap binds" do
+      img = image(200, 50)
+      assert {:ok, resized, info} = Clamp.clamp(img, limits(max_width: 100), [])
 
       assert Image.width(resized) == 100
       assert Image.height(resized) == 25
       assert info.source_dimensions == {200, 50}
       assert info.dimensions == {100, 25}
-      assert info.max_dimension == 100
+      assert info.limits == limits(max_width: 100)
       assert_in_delta info.scale, 0.5, 1.0e-6
     end
 
-    test "guarantees the realized longest axis is at most the limit (rounding)" do
-      # 333 * (100/333) = 100.0 -> round 100; this also exercises the
-      # measure-and-verify path that keeps a rounding quirk from exceeding it.
-      img = image(333, 10)
-      assert {:ok, resized, info} = Clamp.clamp(img, 100, [])
-
-      assert Image.width(resized) <= 100
-      assert max(Image.width(resized), Image.height(resized)) <= 100
-      assert info.dimensions == {Image.width(resized), Image.height(resized)}
-    end
-
-    test "downscales when the longest axis is the height" do
+    test "downscales when the height cap binds" do
       img = image(50, 200)
-      assert {:ok, resized, info} = Clamp.clamp(img, 100, [])
+      assert {:ok, resized, info} = Clamp.clamp(img, limits(max_height: 100), [])
 
       assert Image.width(resized) == 25
       assert Image.height(resized) == 100
       assert info.dimensions == {25, 100}
     end
 
-    test "re-resizes when the first resize overshoots the limit" do
-      img = image(200, 100)
+    test "respects asymmetric caps without over-shrinking (per-axis)" do
+      # 8000x4000, caps w<=10000 (slack), h<=4000 (exactly met) -> no clamp.
+      img = image(8000, 4000)
+      assert {:ok, ^img, nil} = Clamp.clamp(img, limits(max_width: 10_000, max_height: 4000), [])
+    end
 
-      assert {:ok, resized, info} =
-               Clamp.clamp(img, 100, image_module: OvershootOnceImage)
+    test "downscales on the pixel budget, preserving aspect, realized product <= cap" do
+      # 2000x2000 = 4_000_000 px; cap 1_000_000 -> scale 0.5 -> 1000x1000.
+      img = image(2000, 2000)
+      assert {:ok, resized, info} = Clamp.clamp(img, limits(max_pixels: 1_000_000), [])
 
-      # The corrective re-resize brought the overshooting 101px result back to
-      # the limit, and the reported dimensions reflect the realized result.
-      assert max(Image.width(resized), Image.height(resized)) <= 100
-      assert info.dimensions == {100, 50}
+      w = Image.width(resized)
+      h = Image.height(resized)
+      assert w * h <= 1_000_000
+      assert_in_delta w / 2000, h / 2000, 1.0e-6
+      assert info.dimensions == {w, h}
+    end
+
+    test "takes the most-aggressive scale when pixel and dimension caps disagree" do
+      # 4000x1000 = 4_000_000 px. max_width 2000 -> dim scale 0.5 (-> 2000x500=1_000_000).
+      # max_pixels 250_000 -> sqrt(250000/4e6)=0.25 (-> 1000x250=250_000). Pixels win.
+      img = image(4000, 1000)
+
+      assert {:ok, resized, _info} =
+               Clamp.clamp(img, limits(max_width: 2000, max_pixels: 250_000), [])
+
+      assert Image.width(resized) <= 2000
+      assert Image.width(resized) * Image.height(resized) <= 250_000
+    end
+
+    test "keeps each axis >= 1px for an extreme aspect ratio with a tight cap" do
+      img = image(40_000, 1)
+      assert {:ok, resized, _info} = Clamp.clamp(img, limits(max_width: 100), [])
+
+      assert Image.width(resized) <= 100
+      assert Image.height(resized) >= 1
+    end
+
+    # Deterministic cover for the deep pixel verify-and-shrink loop — the exact
+    # path the bounded loop, the `long - 1` floor, and the 1px floor exist for.
+    # (Traced: ~8 and ~10 iterations respectively, both well under the bound.)
+    test "pixel cap on an extreme aspect ratio converges and fits (deep loop, 1px floor)" do
+      img = image(40_000, 1)
+      assert {:ok, resized, _info} = Clamp.clamp(img, limits(max_pixels: 100), [])
+
+      w = Image.width(resized)
+      h = Image.height(resized)
+      assert h >= 1
+      assert w * h <= 100
+    end
+
+    test "pixel cap on a tall sliver converges and fits (deep loop)" do
+      img = image(1, 6000)
+      assert {:ok, resized, _info} = Clamp.clamp(img, limits(max_pixels: 1300), [])
+
+      w = Image.width(resized)
+      h = Image.height(resized)
+      assert w >= 1
+      assert w * h <= 1300
+    end
+  end
+
+  describe "clamp/3 pixel ≤-cap property" do
+    alias ImagePipe.Output.Clamp
+
+    # Bias the generator toward the regimes that actually drive the pixel loop
+    # deep: extreme aspect ratios (one axis tiny) and small pixel caps. A uniform
+    # square generator almost never reaches the >1-iteration path (~72% no-op),
+    # leaving the loop the test exists to protect essentially unexercised.
+    defp dim_gen do
+      StreamData.frequency([
+        {3, StreamData.integer(1..6000)},
+        {2, StreamData.integer(1..8)}
+      ])
+    end
+
+    property "realized dims and pixel product never exceed the caps" do
+      check all(
+              w <- dim_gen(),
+              h <- dim_gen(),
+              max_w <- StreamData.integer(1..6000),
+              max_h <- StreamData.integer(1..6000),
+              max_px <-
+                StreamData.frequency([
+                  {2, StreamData.integer(64..5000)},
+                  {1, StreamData.integer(5001..2_000_000)}
+                ]),
+              max_runs: 400
+            ) do
+        {:ok, image} = Image.new(w, h)
+        lim = %{max_width: max_w, max_height: max_h, max_pixels: max_px}
+
+        # A `{:error, {:encode, ...}}` here would mean the bounded loop exhausted
+        # (non-termination within the bound) — the pattern-match failure surfaces it.
+        assert {:ok, resized, _info} = Clamp.clamp(image, lim, [])
+        rw = Image.width(resized)
+        rh = Image.height(resized)
+
+        assert rw >= 1 and rh >= 1
+        assert rw <= max_w
+        assert rh <= max_h
+        assert rw * rh <= max_px
+      end
     end
   end
 end

--- a/test/image_pipe/plug_test.exs
+++ b/test/image_pipe/plug_test.exs
@@ -2044,28 +2044,6 @@ defmodule ImagePipe.PlugTest do
     assert conn.resp_body == "source image is too large"
   end
 
-  test "rejects static result dimensions above configured limits before encoding" do
-    conn =
-      conn(:get, "/_/el:1/w:64/f:jpeg/plain/images/beach.jpg")
-      |> call_image_pipe(
-        root_url: "http://origin.test",
-        parser: ImagePipe.Parser.Imgproxy,
-        max_result_width: 32,
-        max_result_height: 8_192,
-        max_result_pixels: 40_000_000,
-        image_module: StreamingOnlyImage,
-        cache: {CacheProbe, message_target: self()},
-        origin_req_options: [plug: {CountingOriginImage, test_pid: self()}]
-      )
-
-    assert conn.status == 413
-    assert conn.resp_body == "result image is too large"
-    assert_received {:cache_get, _key}
-    assert_received :origin_was_called
-    refute_received :stream_encoder_called
-    refute_received {:cache_put, _key, _entry}
-  end
-
   test "allows static result dimensions within configured limits" do
     conn =
       conn(:get, "/_/el:1/w:64/f:jpeg/plain/images/beach.jpg")

--- a/test/image_pipe/processor_test.exs
+++ b/test/image_pipe/processor_test.exs
@@ -178,41 +178,6 @@ defmodule ImagePipe.Request.ProcessorTest do
     assert pixel_count > 1
   end
 
-  test "process_source rejects final images wider than configured result limit" do
-    {:ok, operation} = Operation.resize(:fit, {:px, 21}, :auto, enlargement: :allow)
-
-    plan = %Plan{plan() | pipelines: [%Pipeline{operations: [operation]}]}
-
-    assert {:error, {:result_limit, {:result_width_too_large, 21, 20}}} =
-             Processor.process_source(
-               plan,
-               resolved_source(),
-               opts()
-               |> Keyword.put(:max_result_width, 20)
-               |> Keyword.put(:max_result_height, 10_000)
-               |> Keyword.put(:max_result_pixels, 10_000)
-             )
-  end
-
-  test "process_source accepts final images within configured result limits" do
-    {:ok, operation} = Operation.resize(:fit, {:px, 20}, :auto, enlargement: :allow)
-
-    plan = %Plan{plan() | pipelines: [%Pipeline{operations: [operation]}]}
-
-    assert {:ok, %State{} = state} =
-             Processor.process_source(
-               plan,
-               resolved_source(),
-               opts()
-               |> Keyword.put(:max_result_width, 20)
-               |> Keyword.put(:max_result_height, 20)
-               |> Keyword.put(:max_result_pixels, 400)
-             )
-
-    assert Image.width(state.image) <= 20
-    assert Image.height(state.image) <= 20
-  end
-
   test "decode_validate_source_response rejects SVG after decode" do
     if svg_supported?() do
       source_response = %Response{stream: [svg_body(20, 20)]}

--- a/test/image_pipe/telemetry/logger_test.exs
+++ b/test/image_pipe/telemetry/logger_test.exs
@@ -124,14 +124,16 @@ defmodule ImagePipe.Telemetry.LoggerTest do
           %{
             format: :webp,
             source_dimensions: {18_000, 9_000},
-            dimensions: {16_383, 8_191},
-            max_dimension: 16_383
+            dimensions: {8_192, 4_096},
+            limits: %{max_width: 8_192, max_height: 8_192, max_pixels: 40_000_000}
           }
         )
       end)
 
     assert log =~ "[warning]"
-    assert log =~ "output clamp: 18000x9000 -> 16383x8191 for webp (max 16383)"
+
+    assert log =~
+             "output clamp: 18000x9000 -> 8192x4096 for webp (caps w:8192 h:8192 px:40000000)"
   end
 
   test "logs a normal no-face detect fallback at the base level, not warning" do


### PR DESCRIPTION
Closes #165.

## Summary

Changes ImagePipe's **host result-dimension cap** (`max_result_width` / `max_result_height` / `max_result_pixels`) from a **413 error** to a **uniform downscale-and-serve**, matching imgproxy's `limitScale` (verified against `local/imgproxy-master/processing/prepare.go:222-265`). It **reuses #150's `ImagePipe.Output.Clamp`** seam: the producer feeds the clamp `min(host max_result_*, encoder_limit(format))`, so the host cap downscales the realized image to fit instead of erroring. `max_input_pixels` (the decode-time image-bomb gate) stays a hard 413 — mirroring imgproxy's split (it downscales the output cap, hard-errors `MaxSrcResolution`).

The default host cap (8192) is hit far more often than the encoder cap (16383/16384), so this is the limit users actually trip.

## What changed

- **`ImagePipe.Output.Clamp.clamp/3`** — second arg widened from a scalar `max_dimension` to a per-axis + pixel **limits map** `%{max_width, max_height, max_pixels}`. Dimension caps use a linear per-axis scale (most-aggressive `min`); the **pixel cap** uses a bounded verify-and-shrink loop (a closed form can't guarantee a *rounded product* ≤ cap under independent two-axis rounding — caught in design review). A per-axis 1px floor (`max(scale, 1/dim)`) mirrors imgproxy's `WScale ≥ 1/widthToScale`.
- **`ImagePipe.Output.Encoder.encoder_limit/1`** — gains a `:max_pixels` budget (`:infinity` for all current formats).
- **Producer seam** — `effective_limits/2` folds `min(host max_result_*, encoder_limit)` per axis + pixels; the clamp is source-agnostic about which won the `min`. Reuses the existing `[:output, :clamp]` telemetry (metadata `:max_dimension` → `:limits`).
- **Deleted** the obsolete error path: `check_result_*` / `validate_result_image` (`processor.ex`) and the `{:result_limit, _}` → 413 handling (`response/sender.ex`).
- **Cache/ETag unchanged** — `max_result_*` stays out of both (deployment config, not a request input; output stays canonical per source+plan+format).

## imgproxy parity & deliberate divergences

- **Linear dimension, equal caps:** byte-intent identical to `limitScale`'s `downScale = maxResultDim/max(outW,outH)` (`prepare.go:247`). The wire test asserts the binding axis lands **exactly** on 8192.
- **Superset (strictly safer):** ImagePipe honors *independent* `max_result_width`/`max_result_height` and a *result* `max_result_pixels` cap (sqrt), where imgproxy's `limitScale` has a single `MaxResultDimension` and no result-pixel cap. The pixel rule is linear-dimension + sqrt-pixel, deliberately **not** `fixGifSize`'s combined-sqrt.
- **Composition divergence:** ImagePipe clamps the *composited* final image; imgproxy folds the downscale into the resize scale and re-applies padding/extend at the reduced scale (`prepare.go:233-263`). Both land ≤ cap; padded/extended frames differ in content-to-padding ratio. Pinned by a dedicated wire test and documented in `docs/imgproxy_support_matrix.md`.

## Test plan

- [x] `mise run precommit` — `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix test` (**1527 passed**, 52 properties; credo clean)
- [x] `Clamp.clamp/3` unit tests: per-axis width/height bind, pixel bind, most-aggressive, no-op boundary (incl. cap == dimension), 1px floor, deep-loop convergence
- [x] **Pixel ≤-cap property test** (the gate that would have caught the closed-form overshoot): realized `w ≤ max_w`, `h ≤ max_h`, `w*h ≤ max_px`, `≥1px`, biased toward extreme aspect ratios + tiny caps
- [x] Wire-level imgproxy conformance (real `call/2` + decode): default-cap downscale (exact 8192), asymmetric per-axis no-over-shrink, pixel-cap, padded-composite divergence, no-clamp control; #150 encoder-clamp tests updated to `meta.limits`

## Out of scope

- Shrink-on-load decode fold (`DecodePlanner` toward `min(resize_target, host_limit)`) — split to a follow-up; the post-hoc clamp is the correctness path.
- #164 look-ahead pre-clamp — untouched.

## Process

Design → parallel disjoint-reviewer cycle (incl. imgproxy-compat lens vs `prepare.go`) → reviewed design committed → implementation plan → parallel plan review → reviewed plan committed → subagent-driven implementation (fresh subagent + spec→quality review pair per task) → final 3-reviewer parallel review (all Approve). The design-review's clamp-math lens caught and fixed a pixel ≤-cap blocker (closed form → bounded verify-shrink loop) before any code was written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Result images exceeding configured size limits are now downscaled-to-fit instead of being rejected, aligning with imgproxy's behavior.
  * Independent per-axis width/height and total-pixel result caps now apply uniformly across all output formats.

* **Documentation**
  * Updated compatibility guides and operational notes to reflect downscale behavior for oversized results.
  * Enhanced telemetry documentation with clearer limit-tracking semantics.

* **Tests**
  * Added conformance tests verifying downscale behavior for host result limits.
  * Removed obsolete tests asserting prior error-rejection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->