### PR TITLE
docs(imgproxy): clarify quality q:0 is the unset/default sentinel

### DIFF
--- a/docs/imgproxy_support_matrix.md
+++ b/docs/imgproxy_support_matrix.md
@@ -747,7 +747,7 @@ transforms or output encoding.
 
 | Imgproxy option | Aliases | Status | Notes |
 | --- | --- | --- | --- |
-| `quality` | `q` | Supported | `0` means configured default. Supports `1..100`. |
+| `quality` | `q` | Supported | `0` (the imgproxy "unset" sentinel) selects the configured/format default; explicit values are `1..100`. There is no per-request way to request a literal quality of `0`. |
 | `format_quality` | `fq` | Partial | One `<format>:<quality>` pair per option segment. Repeated segments merge. More than one pair in one segment isn't supported. |
 | `autoquality` | `aq` | Missing | Pro multi-encode quality search. |
 | `max_bytes` | `mb` | Missing | No iterative encode degradation. |


### PR DESCRIPTION
## What

Tightens the `quality` / `q` row in `docs/imgproxy_support_matrix.md`.

The row previously read:

> `0` means configured default. Supports `1..100`.

That's correct but ambiguous — it doesn't make clear whether a *literal* quality of 0 is accepted. It now reads:

> `0` (the imgproxy "unset" sentinel) selects the configured/format default; explicit values are `1..100`. There is no per-request way to request a literal quality of `0`.

## Why

This matches the actual parser behavior in `lib/image_pipe/parser/imgproxy/option_grammar.ex`:

```elixir
defp parse_quality("0"), do: {:ok, :default}

defp parse_quality(value) do
  case Integer.parse(value) do
    {integer, ""} when integer in 1..100 -> {:ok, {:quality, integer}}
    _other -> {:error, {:invalid_option, :quality, value}}
  end
end
```

`q:0` parses to the `:default` sentinel (encoder omits the quality option, letting libvips / format-quality config decide), `1..100` are explicit, and anything else (negatives, `>100`, empty) is rejected. This is imgproxy parity — `q:0` / `IMGPROXY_QUALITY=0` means "unset", not a real zero. Surface-axis only; no behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)