### PR TITLE
feat(telemetry): opt-in span capture/tracing layer

### DIFF
--- a/docs/superpowers/plans/2026-06-09-telemetry-span-tracer.md
+++ b/docs/superpowers/plans/2026-06-09-telemetry-span-tracer.md
@@ -1,0 +1,1989 @@
+# Telemetry Span Tracer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in layer that consumes ImagePipe's existing `:telemetry.span/3` events, reconstructs correctly-nested distributed-trace-shaped spans, and hands each finished span to a pluggable exporter.
+
+**Architecture:** A per-process active-span stack (process dictionary) reconstructs nesting within a process; `Trace.Context` is threaded as data across the request→SourceSession and request→Producer hops; a new `[:transform, :materialize]` span gives honest libvips flush timing; an opt-in plug edge extracts inbound W3C `traceparent`; Req/Finch get logical + physical client spans. Everything lives under `ImagePipe.Telemetry.Trace.*` (telemetry boundary), attaches only on `ImagePipe.Telemetry.attach_tracer/1`, and ships a stdlib `LogExporter`.
+
+**Tech Stack:** Elixir, `:telemetry` 1.x, Req 0.5 / Finch 0.22, Plug, NimbleOptions, Boundary, ExUnit + StreamData.
+
+**Design spec:** `docs/superpowers/specs/2026-06-09-telemetry-span-tracer-design.md` — read it before starting; this plan implements it.
+
+**Run commands with `mise exec -- …`** (project rule). Focused test: `mise exec -- mix test test/path_test.exs:LINE`. Gate before finishing a phase: `mise run precommit`.
+
+---
+
+## File structure
+
+**New (telemetry boundary, `lib/image_pipe/telemetry/trace/`):**
+- `context.ex` — `Trace.Context` immutable serializable context struct
+- `span.ex` — `Trace.Span` captured-span struct
+- `id.ex` — `Trace.Id` random id generation
+- `w3c.ex` — `Trace.W3C` traceparent encode/decode
+- `stack.ex` — `Trace.Stack` process-dictionary active-span stack
+- `capture.ex` — `Trace.Capture` attach_many handler for `[:image_pipe, …]`
+- `finch_capture.ex` — `Trace.FinchCapture` attach_many handler for `[:finch, …]`
+- `req_step.ex` — `Trace.ReqStep` Req request/response/error steps
+- `exporter.ex` — `Trace.Exporter` behaviour
+- `log_exporter.ex` — `Trace.LogExporter` stdlib default
+
+**Modified:**
+- `lib/image_pipe/telemetry.ex` — add `attach_tracer/1` / `detach_tracer/0`; boundary `exports:`
+- `lib/image_pipe/transform/materializer.ex` — wrap flush in `[:transform, :materialize]` span
+- `lib/image_pipe/telemetry/logger.ex` — subscribe + level-escalate the materialize event
+- `lib/image_pipe/plug.ex` — opt-in inbound `traceparent` extraction before the `[:request]` span
+- `lib/image_pipe/request/runner.ex` — capture `Trace.Stack.context()` at `start_session`
+- `lib/image_pipe/request/source_session_supervisor.ex` + `source_session.ex` — thread + adopt context (hop A)
+- `lib/image_pipe/request/source_session/producer.ex` — adopt context (hop B)
+- `lib/image_pipe/source/req_stream.ex` (or the Req-client build site) — attach `Trace.ReqStep`
+- `docs/telemetry.md` — materialize subsection + `## Tracing (opt-in)` section
+
+**New test files:** mirror under `test/image_pipe/telemetry/trace/` plus a shared `test/support/trace_test_exporter.ex`.
+
+---
+
+# Phase 1 — Core capture + materialize barrier + Logger/doc sync
+
+Self-contained: produces a working in-process tracer (single-process subtree) plus the honest materialize span and its full Logger/doc sync. Reviewable and committable on its own.
+
+## Task 1: `Trace.Id` — random trace/span ids
+
+**Files:**
+- Create: `lib/image_pipe/telemetry/trace/id.ex`
+- Test: `test/image_pipe/telemetry/trace/id_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+# test/image_pipe/telemetry/trace/id_test.exs
+defmodule ImagePipe.Telemetry.Trace.IdTest do
+  use ExUnit.Case, async: true
+  alias ImagePipe.Telemetry.Trace.Id
+
+  test "trace_id is 32 lowercase hex chars and unique" do
+    a = Id.trace_id()
+    b = Id.trace_id()
+    assert a =~ ~r/\A[0-9a-f]{32}\z/
+    assert a != b
+  end
+
+  test "span_id is 16 lowercase hex chars and unique" do
+    a = Id.span_id()
+    assert a =~ ~r/\A[0-9a-f]{16}\z/
+    assert a != Id.span_id()
+  end
+end
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/id_test.exs`
+Expected: FAIL — `ImagePipe.Telemetry.Trace.Id is undefined`.
+
+- [ ] **Step 3: Implement**
+
+```elixir
+# lib/image_pipe/telemetry/trace/id.ex
+defmodule ImagePipe.Telemetry.Trace.Id do
+  @moduledoc false
+
+  @spec trace_id() :: String.t()
+  def trace_id, do: 16 |> :crypto.strong_rand_bytes() |> Base.encode16(case: :lower)
+
+  @spec span_id() :: String.t()
+  def span_id, do: 8 |> :crypto.strong_rand_bytes() |> Base.encode16(case: :lower)
+end
+```
+
+- [ ] **Step 4: Run it, verify it passes**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/id_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/telemetry/trace/id.ex test/image_pipe/telemetry/trace/id_test.exs
+git commit -m "feat(telemetry): Trace.Id random trace/span ids"
+```
+
+## Task 2: `Trace.Context` struct
+
+**Files:**
+- Create: `lib/image_pipe/telemetry/trace/context.ex`
+- Test: covered via `W3C` round-trip (Task 3) — no standalone test (a bare struct has no behavior to assert; testing it alone would be a no-value test per CLAUDE.md).
+
+- [ ] **Step 1: Implement the struct**
+
+```elixir
+# lib/image_pipe/telemetry/trace/context.ex
+defmodule ImagePipe.Telemetry.Trace.Context do
+  @moduledoc """
+  Immutable, serializable trace context that crosses process/node/HTTP seams.
+
+  Carries the current span identity so a far-side process (or downstream service)
+  can attach children under it. `span_id` becomes the child's `parent_span_id`.
+  """
+
+  @enforce_keys [:trace_id, :span_id]
+  defstruct [:trace_id, :span_id, trace_flags: 1, baggage: %{}]
+
+  @type t :: %__MODULE__{
+          trace_id: String.t(),
+          span_id: String.t(),
+          trace_flags: non_neg_integer(),
+          baggage: %{optional(String.t()) => String.t()}
+        }
+end
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `mise exec -- mix compile --warnings-as-errors`
+Expected: clean compile.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/image_pipe/telemetry/trace/context.ex
+git commit -m "feat(telemetry): Trace.Context serializable trace context"
+```
+
+## Task 3: `Trace.W3C` — traceparent encode/decode
+
+**Files:**
+- Create: `lib/image_pipe/telemetry/trace/w3c.ex`
+- Test: `test/image_pipe/telemetry/trace/w3c_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+# test/image_pipe/telemetry/trace/w3c_test.exs
+defmodule ImagePipe.Telemetry.Trace.W3CTest do
+  use ExUnit.Case, async: true
+  alias ImagePipe.Telemetry.Trace.{Context, Id, W3C}
+
+  test "encode produces a valid W3C traceparent" do
+    tp = W3C.encode("0af7651916cd43dd8448eb211c80319c", "b7ad6b7169203331", 1)
+    assert tp == "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+  end
+
+  test "round-trips a freshly generated context" do
+    tid = Id.trace_id()
+    sid = Id.span_id()
+    assert {:ok, %Context{trace_id: ^tid, span_id: ^sid, trace_flags: 1}} =
+             tid |> W3C.encode(sid, 1) |> W3C.decode()
+  end
+
+  test "decode rejects malformed input" do
+    assert W3C.decode("garbage") == :error
+    assert W3C.decode("00-short-b7ad6b7169203331-01") == :error
+    assert W3C.decode("00-" <> String.duplicate("0", 32) <> "-b7ad6b7169203331-01") == :error
+    assert W3C.decode("") == :error
+  end
+end
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/w3c_test.exs`
+Expected: FAIL — `W3C is undefined`.
+
+- [ ] **Step 3: Implement**
+
+```elixir
+# lib/image_pipe/telemetry/trace/w3c.ex
+defmodule ImagePipe.Telemetry.Trace.W3C do
+  @moduledoc false
+  alias ImagePipe.Telemetry.Trace.Context
+
+  @all_zero_trace String.duplicate("0", 32)
+  @all_zero_span String.duplicate("0", 16)
+
+  @spec encode(String.t(), String.t(), non_neg_integer()) :: String.t()
+  def encode(trace_id, span_id, flags \\ 1) do
+    "00-" <> trace_id <> "-" <> span_id <> "-" <> flags_hex(flags)
+  end
+
+  @spec decode(String.t()) :: {:ok, Context.t()} | :error
+  def decode("00-" <> rest) do
+    with [t, s, f] <- String.split(rest, "-"),
+         true <- valid_trace?(t),
+         true <- valid_span?(s),
+         {:ok, flags} <- parse_flags(f) do
+      {:ok, %Context{trace_id: String.downcase(t), span_id: String.downcase(s), trace_flags: flags}}
+    else
+      _ -> :error
+    end
+  end
+
+  def decode(_), do: :error
+
+  defp valid_trace?(t), do: byte_size(t) == 32 and hex?(t) and String.downcase(t) != @all_zero_trace
+  defp valid_span?(s), do: byte_size(s) == 16 and hex?(s) and String.downcase(s) != @all_zero_span
+
+  defp parse_flags(f) when byte_size(f) == 2 do
+    case Integer.parse(f, 16) do
+      {n, ""} -> {:ok, n}
+      _ -> :error
+    end
+  end
+
+  defp parse_flags(_), do: :error
+
+  defp flags_hex(flags) do
+    flags |> Integer.to_string(16) |> String.downcase() |> String.pad_leading(2, "0")
+  end
+
+  defp hex?(s), do: String.match?(s, ~r/\A[0-9a-fA-F]+\z/)
+end
+```
+
+- [ ] **Step 4: Run it, verify it passes**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/w3c_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/telemetry/trace/w3c.ex test/image_pipe/telemetry/trace/w3c_test.exs
+git commit -m "feat(telemetry): Trace.W3C traceparent encode/decode"
+```
+
+## Task 4: `Trace.Span` struct
+
+**Files:**
+- Create: `lib/image_pipe/telemetry/trace/span.ex`
+- Test: none standalone (struct exercised by `Capture` tests in Task 6).
+
+- [ ] **Step 1: Implement**
+
+```elixir
+# lib/image_pipe/telemetry/trace/span.ex
+defmodule ImagePipe.Telemetry.Trace.Span do
+  @moduledoc """
+  A captured span handed to a `ImagePipe.Telemetry.Trace.Exporter`.
+
+  OTel-shaped so a Jaeger/Tempo/OTLP mapping is mechanical. `duration_native` is the
+  honest timing source (raw monotonic units from `:telemetry.span/3`); `start_time`/
+  `end_time` are wall-clock (`system_time`) for export.
+  """
+
+  @enforce_keys [:trace_id, :span_id, :name, :start_time]
+  defstruct [
+    :trace_id,
+    :span_id,
+    :parent_span_id,
+    :name,
+    :kind,
+    :start_time,
+    :end_time,
+    :duration_native,
+    :status,
+    :status_message,
+    :pid,
+    :node,
+    attributes: %{},
+    events: [],
+    links: []
+  ]
+
+  @type t :: %__MODULE__{
+          trace_id: String.t(),
+          span_id: String.t(),
+          parent_span_id: String.t() | nil,
+          name: String.t(),
+          kind: :internal | :server | :client | nil,
+          start_time: integer() | nil,
+          end_time: integer() | nil,
+          duration_native: integer() | nil,
+          status: :unset | :ok | :error | nil,
+          status_message: String.t() | nil,
+          pid: pid() | nil,
+          node: node() | nil,
+          attributes: map(),
+          events: [map()],
+          links: [map()]
+        }
+end
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `mise exec -- mix compile --warnings-as-errors`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/image_pipe/telemetry/trace/span.ex
+git commit -m "feat(telemetry): Trace.Span captured-span struct"
+```
+
+## Task 5: `Trace.Stack` — process-dictionary active-span stack
+
+**Files:**
+- Create: `lib/image_pipe/telemetry/trace/stack.ex`
+- Test: `test/image_pipe/telemetry/trace/stack_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+# test/image_pipe/telemetry/trace/stack_test.exs
+defmodule ImagePipe.Telemetry.Trace.StackTest do
+  use ExUnit.Case, async: true
+  alias ImagePipe.Telemetry.Trace.{Context, Span, Stack}
+
+  defp span(name), do: %Span{trace_id: "t", span_id: name, name: name, start_time: 0}
+
+  setup do
+    on_exit(fn -> Stack.clear() end)
+    Stack.clear()
+    :ok
+  end
+
+  test "push/current/pop are LIFO" do
+    assert Stack.current() == nil
+    Stack.push(span("a"))
+    Stack.push(span("b"))
+    assert Stack.current().span_id == "b"
+    assert Stack.pop().span_id == "b"
+    assert Stack.current().span_id == "a"
+    assert Stack.pop().span_id == "a"
+    assert Stack.pop() == nil
+  end
+
+  test "nested-then-sibling preserves parentage order" do
+    Stack.push(span("root"))
+    Stack.push(span("child1"))
+    assert Stack.pop().span_id == "child1"
+    # sibling: parent is root again
+    assert Stack.current().span_id == "root"
+    Stack.push(span("child2"))
+    assert Stack.current().span_id == "child2"
+  end
+
+  test "context/0 snapshots the current span identity" do
+    assert Stack.context() == nil
+    Stack.push(%Span{trace_id: "abc", span_id: "def", name: "x", start_time: 0})
+    assert %Context{trace_id: "abc", span_id: "def"} = Stack.context()
+  end
+
+  test "adopt/1 seeds a remote-parent frame; next span inherits it" do
+    Stack.adopt(%Context{trace_id: "rt", span_id: "rs", trace_flags: 1})
+    assert %Context{trace_id: "rt", span_id: "rs"} = Stack.context()
+    # a child pushed now would read current() as its parent
+    assert Stack.current().span_id == "rs"
+  end
+
+  test "adopt(nil) is a no-op" do
+    Stack.adopt(nil)
+    assert Stack.current() == nil
+  end
+end
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/stack_test.exs`
+Expected: FAIL — `Stack is undefined`.
+
+- [ ] **Step 3: Implement**
+
+```elixir
+# lib/image_pipe/telemetry/trace/stack.ex
+defmodule ImagePipe.Telemetry.Trace.Stack do
+  @moduledoc false
+  alias ImagePipe.Telemetry.Trace.{Context, Span}
+
+  @key :"$image_pipe_trace_stack"
+
+  @spec current() :: Span.t() | nil
+  def current, do: List.first(stack())
+
+  @spec push(Span.t()) :: :ok
+  def push(%Span{} = span), do: put([span | stack()])
+
+  @spec pop() :: Span.t() | nil
+  def pop do
+    case stack() do
+      [top | rest] ->
+        put(rest)
+        top
+
+      [] ->
+        nil
+    end
+  end
+
+  @spec context() :: Context.t() | nil
+  def context do
+    case current() do
+      nil -> nil
+      %Span{trace_id: t, span_id: s} -> %Context{trace_id: t, span_id: s}
+    end
+  end
+
+  @doc "Seed the far side of a process hop with a synthetic remote-parent frame."
+  @spec adopt(Context.t() | nil) :: :ok
+  def adopt(nil), do: :ok
+
+  def adopt(%Context{trace_id: t, span_id: s}) do
+    push(%Span{trace_id: t, span_id: s, name: "remote_parent", start_time: nil})
+  end
+
+  @doc false
+  @spec clear() :: :ok
+  def clear, do: put([])
+
+  defp stack, do: Process.get(@key, [])
+  defp put(stack), do: (Process.put(@key, stack); :ok)
+end
+```
+
+- [ ] **Step 4: Run it, verify it passes**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/stack_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/telemetry/trace/stack.ex test/image_pipe/telemetry/trace/stack_test.exs
+git commit -m "feat(telemetry): Trace.Stack per-process active-span stack"
+```
+
+## Task 6: `Trace.Exporter` behaviour + `Trace.Capture` handler + `TestExporter`
+
+This is the heart of Phase 1: subscribe to `[:image_pipe, …]` span events, reconstruct nesting via the stack, fold one-shots, finalize status, export. Inbound-context read (Task in Phase 2) is stubbed to `nil` here.
+
+**Files:**
+- Create: `lib/image_pipe/telemetry/trace/exporter.ex`
+- Create: `lib/image_pipe/telemetry/trace/capture.ex`
+- Create: `test/support/trace_test_exporter.ex`
+- Test: `test/image_pipe/telemetry/trace/capture_test.exs`
+
+- [ ] **Step 1: Define the Exporter behaviour**
+
+```elixir
+# lib/image_pipe/telemetry/trace/exporter.ex
+defmodule ImagePipe.Telemetry.Trace.Exporter do
+  @moduledoc """
+  Behaviour a host implements to receive captured spans, one per completed span.
+
+  `export/1` is called synchronously in the process that emitted the span's `:stop`/
+  `:exception`. Keep it cheap and non-blocking — hand off to a batch processor for any
+  real I/O. It must return `:ok` and should not raise. Attributes are pre-filtered for
+  sensitivity (`ImagePipe.Telemetry.Trace.Capture` allowlists them), but exporters that
+  fan out to third parties remain responsible for their own egress policy.
+  """
+  alias ImagePipe.Telemetry.Trace.Span
+
+  @callback export(Span.t()) :: :ok
+end
+```
+
+- [ ] **Step 2: Add the TestExporter support module**
+
+```elixir
+# test/support/trace_test_exporter.ex
+defmodule ImagePipe.Telemetry.Trace.TestExporter do
+  @moduledoc """
+  Test-only exporter. Spans are exported from MULTIPLE processes (Producer,
+  SourceSession), so the receiver pid must be reachable globally — we use
+  :persistent_term. REQUIREMENT: every test module using this must be `async: false`
+  (ExUnit runs async:false modules with no concurrent test), and must clear the
+  receiver in on_exit to keep the global key from leaking across modules.
+  """
+  @behaviour ImagePipe.Telemetry.Trace.Exporter
+
+  @key {__MODULE__, :receiver}
+
+  @doc "Attach the tracer with this exporter and route spans to `test_pid`."
+  def attach(test_pid, opts \\ []) do
+    set_receiver(test_pid)
+    ImagePipe.Telemetry.attach_tracer(Keyword.merge([exporter: __MODULE__], opts))
+  end
+
+  def set_receiver(pid), do: :persistent_term.put(@key, pid)
+  def clear_receiver, do: :persistent_term.put(@key, nil)
+
+  @impl true
+  def export(span) do
+    case :persistent_term.get(@key, nil) do
+      nil -> :ok
+      pid -> send(pid, {:span, span})
+    end
+
+    :ok
+  end
+end
+```
+
+Ensure `test/support` is compiled: confirm `elixirc_paths(:test)` includes `"test/support"` in `mix.exs` (it commonly does; if not, add it in this step).
+
+**Every trace test setup must be symmetric** — clear the receiver and detach on exit:
+
+```elixir
+  setup do
+    ImagePipe.Telemetry.Trace.TestExporter.set_receiver(self())
+    :ok = ImagePipe.Telemetry.Trace.TestExporter.attach(self())
+
+    on_exit(fn ->
+      ImagePipe.Telemetry.detach_tracer()
+      ImagePipe.Telemetry.Trace.TestExporter.clear_receiver()
+    end)
+
+    :ok
+  end
+```
+
+Use this exact `on_exit` shape in **all** trace test modules below (replacing the shorter `on_exit(fn -> Telemetry.detach_tracer() end)` shown in individual tasks).
+
+- [ ] **Step 3: Write the failing capture test (single-process tree)**
+
+```elixir
+# test/image_pipe/telemetry/trace/capture_test.exs
+defmodule ImagePipe.Telemetry.Trace.CaptureTest do
+  use ExUnit.Case, async: false
+  alias ImagePipe.Telemetry
+  alias ImagePipe.Telemetry.Trace.{Span, TestExporter}
+
+  setup do
+    TestExporter.set_receiver(self())
+    :ok = TestExporter.attach(self())
+    on_exit(fn -> Telemetry.detach_tracer() end)
+    :ok
+  end
+
+  defp emit_nested do
+    Telemetry.span([], [:request], %{}, fn ->
+      Telemetry.span([], [:transform, :execute], %{operation_count: 1}, fn ->
+        {:ok, %{result: :ok}}
+      end)
+
+      {:ok, %{result: :ok, status: 200}}
+    end)
+  end
+
+  test "captures a nested tree with one trace_id and correct parentage" do
+    emit_nested()
+
+    assert_receive {:span, %Span{name: "image_pipe.transform.execute"} = child}
+    assert_receive {:span, %Span{name: "image_pipe.request"} = root}
+
+    assert root.parent_span_id == nil
+    assert child.parent_span_id == root.span_id
+    assert child.trace_id == root.trace_id
+    assert root.status == :ok
+    assert is_integer(child.duration_native)
+  end
+
+  test "maps an error result to :error status" do
+    Telemetry.span([], [:request], %{}, fn -> {:ok, %{result: :processing_error}} end)
+    assert_receive {:span, %Span{name: "image_pipe.request", status: :error}}
+  end
+
+  test "captures an exception as :error with a folded exception event" do
+    assert_raise RuntimeError, fn ->
+      Telemetry.span([], [:request], %{}, fn -> raise "boom" end)
+    end
+
+    assert_receive {:span, %Span{name: "image_pipe.request", status: :error} = s}
+    assert Enum.any?(s.events, &(&1.name == "exception"))
+  end
+end
+```
+
+- [ ] **Step 4: Run it, verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/capture_test.exs`
+Expected: FAIL — `attach_tracer/1 undefined` / `Capture undefined`. (Task 6 Step 5 adds `Capture`; the `attach_tracer` glue minimal form is added here too so the test can run; the full validated version lands in Phase 3 Task 12 — keep them consistent.)
+
+- [ ] **Step 5: Implement `Trace.Capture`**
+
+```elixir
+# lib/image_pipe/telemetry/trace/capture.ex
+defmodule ImagePipe.Telemetry.Trace.Capture do
+  @moduledoc false
+  alias ImagePipe.Telemetry.Trace.{Id, Span, Stack}
+
+  @handler_id {__MODULE__, :spans}
+
+  # Span stages emitted under the image_pipe prefix.
+  @span_stages [
+    [:request], [:parse], [:send],
+    [:source, :resolve], [:source, :fetch], [:source, :fetch_decode],
+    [:output, :negotiate],
+    [:transform, :execute], [:transform, :operation], [:transform, :materialize],
+    [:transform, :detect], [:transform, :detect, :model],
+    [:cache, :lookup], [:cache, :write], [:cache, :admission], [:cache, :warm_start]
+  ]
+
+  # One-shot (terminal) events — folded as annotations onto the current span.
+  @oneshot_stages [
+    [:cache, :stage], [:cache, :eviction, :stop], [:cache, :flush, :stop],
+    [:cache, :cleanup, :stop], [:output, :clamp],
+    [:transform, :detect, :skipped], [:transform, :detect, :blend],
+    [:http_cache, :prepare], [:http_cache, :conditional, :match],
+    [:http_cache, :fallback, :no_store], [:http_cache, :cache_hit, :headers]
+  ]
+
+  # Keys safe to copy into span attributes (allowlist; everything else dropped).
+  @safe_keys [
+    :operation, :index, :operation_count, :operations, :result, :cache,
+    :output_mode, :source_kind, :source_adapter_kind, :detector, :model,
+    :classes, :regions, :scale, :width, :height, :format, :params
+  ]
+
+  @spec attach(map()) :: :ok
+  def attach(%{prefix: prefix, exporter: exporter} = config) do
+    events =
+      (for stage <- @span_stages, suffix <- [:start, :stop, :exception], do: prefix ++ stage ++ [suffix]) ++
+        (for stage <- @oneshot_stages, do: prefix ++ stage)
+
+    _ = :telemetry.detach(@handler_id)
+
+    :telemetry.attach_many(
+      @handler_id,
+      events,
+      &__MODULE__.handle_event/4,
+      Map.put(config, :plen, length(prefix))
+    )
+  end
+
+  @spec detach() :: :ok
+  def detach, do: (_ = :telemetry.detach(@handler_id); :ok)
+
+  def handle_event(event, measurements, meta, config) do
+    case classify(event, config.plen) do
+      {:start, name} -> on_start(name, meta, config)
+      {:stop, _name} -> on_stop(measurements, meta, config)
+      {:exception, _name} -> on_exception(measurements, meta, config)
+      {:oneshot, name} -> on_oneshot(name, meta)
+    end
+  rescue
+    # A tracer must never crash the request path; drop the event on any internal error.
+    _ -> :ok
+  end
+
+  # ---- classification --------------------------------------------------------
+
+  defp classify(event, plen) do
+    stage = Enum.drop(event, plen)
+
+    # CRITICAL: one-shots whose last atom is :stop (e.g. [:cache, :flush, :stop],
+    # [:cache, :eviction, :stop], [:cache, :cleanup, :stop]) are terminal events, NOT
+    # span stops. Check membership in @oneshot_stages BEFORE the suffix dispatch, or
+    # they would wrongly pop and export an unrelated span.
+    if stage in @oneshot_stages do
+      {:oneshot, name(stage)}
+    else
+      case List.last(stage) do
+        :start -> {:start, name(stage_without_suffix(stage))}
+        :stop -> {:stop, name(stage_without_suffix(stage))}
+        :exception -> {:exception, name(stage_without_suffix(stage))}
+        _ -> {:oneshot, name(stage)}
+      end
+    end
+  end
+
+  defp stage_without_suffix(stage), do: Enum.drop(stage, -1)
+
+  defp name(stage), do: "image_pipe." <> Enum.map_join(stage, ".", &Atom.to_string/1)
+
+  # ---- handlers --------------------------------------------------------------
+
+  defp on_start(name, meta, config) do
+    {trace_id, parent_id, flags} =
+      case Stack.current() do
+        nil -> root_ids(config)
+        %Span{trace_id: t, span_id: s} -> {t, s, nil}
+      end
+
+    Stack.push(%Span{
+      trace_id: trace_id,
+      span_id: Id.span_id(),
+      parent_span_id: parent_id,
+      name: name,
+      kind: :internal,
+      start_time: meta[:system_time],
+      attributes: safe_attrs(meta) |> maybe_flags(flags),
+      pid: self(),
+      node: node()
+    })
+  end
+
+  defp on_stop(measurements, meta, %{exporter: exporter}) do
+    case Stack.pop() do
+      nil -> :ok
+      span -> span |> finalize(measurements, status_from(meta)) |> export(exporter)
+    end
+  end
+
+  defp on_exception(measurements, meta, %{exporter: exporter}) do
+    case Stack.pop() do
+      nil ->
+        :ok
+
+      span ->
+        span
+        |> Map.update!(:events, &[exception_event(meta) | &1])
+        |> finalize(measurements, :error)
+        |> Map.put(:status_message, exception_message(meta))
+        |> export(exporter)
+    end
+  end
+
+  defp on_oneshot(name, meta) do
+    case Stack.current() do
+      nil ->
+        :ok
+
+      span ->
+        event = %{name: name, time: meta[:monotonic_time], attributes: safe_attrs(meta)}
+        Stack.pop()
+        Stack.push(%{span | events: [event | span.events]})
+    end
+  end
+
+  # ---- helpers ---------------------------------------------------------------
+
+  # Inbound root context is read here in Phase 2 (Trace.Inbound.take/0); for now mint.
+  defp root_ids(_config), do: {Id.trace_id(), nil, 1}
+
+  defp finalize(span, measurements, status) do
+    %{
+      span
+      | duration_native: measurements[:duration],
+        end_time: end_time(span.start_time, measurements),
+        status: status
+    }
+  end
+
+  # start_time is native system_time (wall-clock); duration is a native monotonic
+  # delta. Both native → the sum is a valid native end_time. Exporters convert to
+  # ms/µs as needed; we keep native here (and duration_native) as the source of truth.
+  defp end_time(nil, _), do: nil
+  defp end_time(start, %{duration: d}) when is_integer(d), do: start + d
+  defp end_time(start, _), do: start
+
+  defp status_from(meta) do
+    case meta[:result] do
+      :ok -> :ok
+      nil -> :ok
+      _other -> :error
+    end
+  end
+
+  defp exception_event(meta) do
+    %{name: "exception", attributes: %{kind: meta[:kind], reason: inspect(meta[:reason])}}
+  end
+
+  defp exception_message(meta), do: inspect(meta[:reason])
+
+  defp safe_attrs(meta) do
+    meta
+    |> Map.take(@safe_keys)
+    |> Map.new(fn {k, v} -> {k, v} end)
+  end
+
+  defp maybe_flags(attrs, nil), do: attrs
+  defp maybe_flags(attrs, flags), do: Map.put(attrs, :trace_flags, flags)
+
+  defp export(span, exporter), do: exporter.export(span)
+end
+```
+
+- [ ] **Step 6: Add the `Trace` facade + minimal `attach_tracer`/`detach_tracer` glue**
+
+Create the facade now (it gains `maybe_extract_inbound/1` in Phase 2 Task 12 and is the boundary-exported public entry); it owns the active-exporter persistent_term that `ReqStep`/`FinchCapture` read later:
+
+```elixir
+# lib/image_pipe/telemetry/trace.ex
+defmodule ImagePipe.Telemetry.Trace do
+  @moduledoc "Public facade for the opt-in span tracer."
+
+  @exporter_key {__MODULE__, :exporter}
+
+  @doc false
+  def set_exporter(mod), do: :persistent_term.put(@exporter_key, mod)
+
+  @doc "The active exporter module, or nil when no tracer is attached."
+  def exporter, do: :persistent_term.get(@exporter_key, nil)
+end
+```
+
+Add to `lib/image_pipe/telemetry.ex` (full validation lands in Phase 3 Task 17; this minimal form must stay signature-compatible and **must set the active exporter** so later HTTP steps resolve it):
+
+```elixir
+  @doc "Attach the opt-in span tracer. See `ImagePipe.Telemetry.Trace`."
+  @spec attach_tracer(keyword()) :: :ok
+  def attach_tracer(opts) do
+    exporter = Keyword.fetch!(opts, :exporter)
+    prefix = Keyword.get(opts, :prefix, default_prefix())
+
+    ImagePipe.Telemetry.Trace.set_exporter(exporter)
+    ImagePipe.Telemetry.Trace.Capture.attach(%{prefix: prefix, exporter: exporter})
+  end
+
+  @spec detach_tracer() :: :ok
+  def detach_tracer do
+    ImagePipe.Telemetry.Trace.Capture.detach()
+    ImagePipe.Telemetry.Trace.set_exporter(nil)
+    :ok
+  end
+```
+
+- [ ] **Step 7: Run the capture test, verify it passes**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/capture_test.exs`
+Expected: PASS (all three tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/image_pipe/telemetry/trace/exporter.ex lib/image_pipe/telemetry/trace/capture.ex \
+        lib/image_pipe/telemetry.ex test/support/trace_test_exporter.ex \
+        test/image_pipe/telemetry/trace/capture_test.exs
+git commit -m "feat(telemetry): Trace.Capture nesting reconstruction + Exporter behaviour"
+```
+
+## Task 7: Attribute safety — drop URLs/paths/secrets, store structs opaque
+
+**Files:**
+- Modify: `lib/image_pipe/telemetry/trace/capture.ex` (already allowlist-based; add the regression test and confirm uniform application)
+- Test: `test/image_pipe/telemetry/trace/attr_safety_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+# test/image_pipe/telemetry/trace/attr_safety_test.exs
+defmodule ImagePipe.Telemetry.Trace.AttrSafetyTest do
+  use ExUnit.Case, async: false
+  alias ImagePipe.Telemetry
+  alias ImagePipe.Telemetry.Trace.{Span, TestExporter}
+
+  setup do
+    TestExporter.set_receiver(self())
+    :ok = TestExporter.attach(self())
+    on_exit(fn -> Telemetry.detach_tracer() end)
+    :ok
+  end
+
+  test "a signed source URL in metadata never reaches span attributes" do
+    signed = "https://cdn.example.com/img.jpg?sig=SECRET123&exp=999"
+
+    Telemetry.span([], [:source, :fetch], %{source_url: signed, source_path: "/img.jpg?sig=SECRET123", source_kind: :http}, fn ->
+      {:ok, %{result: :ok}}
+    end)
+
+    assert_receive {:span, %Span{name: "image_pipe.source.fetch"} = span}
+    flat = inspect(span.attributes)
+    refute flat =~ "SECRET123"
+    refute flat =~ "cdn.example.com"
+    # product-neutral key is allowed through
+    assert span.attributes[:source_kind] == :http
+  end
+
+  property "no secret-bearing key ever reaches attributes, for any value" do
+    check all secret <- StreamData.string(:alphanumeric, min_length: 1),
+              key <- StreamData.member_of([:source_url, :source_path, :signature, :token, :authorization]) do
+      Telemetry.span([], [:source, :fetch], %{key => secret, :source_kind => :http}, fn -> {:ok, %{result: :ok}} end)
+      assert_receive {:span, %Span{name: "image_pipe.source.fetch"} = span}
+      refute inspect(span.attributes) =~ secret
+    end
+  end
+end
+```
+
+Add `use ExUnitProperties` to the test module for the `property`/`check all` macros.
+
+- [ ] **Step 2: Run it, verify it fails or passes**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/attr_safety_test.exs`
+Expected: PASS already (allowlist drops `:source_url`/`:source_path` since they are not in `@safe_keys`). If it FAILS, a non-allowlisted key leaked — fix `safe_attrs/1`. The test exists to lock the guarantee against future `@safe_keys` edits.
+
+- [ ] **Step 3: Add a module doc note pinning the contract**
+
+In `capture.ex`, above `@safe_keys`, add:
+
+```elixir
+  # SENSITIVITY: allowlist only. Never add :source_url, :source_path, request paths,
+  # signatures, tokens, or any secret-bearing key. Operation structs (:params) are
+  # stored opaque (inspected by exporters) and MUST NOT be pattern-matched against
+  # ImagePipe.Transform.Operation.* here — that would invert the telemetry boundary.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/image_pipe/telemetry/trace/capture.ex test/image_pipe/telemetry/trace/attr_safety_test.exs
+git commit -m "test(telemetry): lock attribute allowlist against URL/secret leakage"
+```
+
+## Task 8: `[:transform, :materialize]` barrier span
+
+**Files:**
+- Modify: `lib/image_pipe/transform/materializer.ex` (wrap the flush in a span using `state.telemetry_opts`)
+- Test: `test/image_pipe/telemetry/trace/materialize_span_test.exs`
+
+First **read** `lib/image_pipe/transform/materializer.ex`, `lib/image_pipe/transform/state.ex` (confirm `telemetry_opts` field), and `lib/image_pipe/transform/orientation_flush.ex` to see the exact `materialize/1` body and return contract before editing.
+
+- [ ] **Step 1: Write the failing wire-level test (three nesting cases)**
+
+```elixir
+# test/image_pipe/telemetry/trace/materialize_span_test.exs
+defmodule ImagePipe.Telemetry.Trace.MaterializeSpanTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  alias ImagePipe.Telemetry
+  alias ImagePipe.Telemetry.Trace.{Span, TestExporter}
+
+  # NOTE: replace `build_opts/0` and the request paths with the project's
+  # established imgproxy wire-test fixtures (see test/image_pipe/imgproxy_wire_conformance_test.exs).
+  # The materializing request must trigger a right-angle rotate / vertical flip / smart-crop;
+  # the negative request must be resize-only on an orientation-1 source.
+
+  setup do
+    TestExporter.set_receiver(self())
+    :ok = TestExporter.attach(self())
+    on_exit(fn -> Telemetry.detach_tracer() end)
+    :ok
+  end
+
+  defp collect_spans(timeout \\ 200) do
+    receive do
+      {:span, %Span{} = s} -> [s | collect_spans(timeout)]
+    after
+      timeout -> []
+    end
+  end
+
+  test "mid-chain materializing op yields a materialize span nested under an operation" do
+    conn = conn(:get, materializing_request_path()) |> ImagePipe.call(build_opts())
+    assert conn.status == 200
+
+    spans = collect_spans()
+    mat = Enum.find(spans, &(&1.name == "image_pipe.transform.materialize"))
+    op = Enum.find(spans, &(&1.name == "image_pipe.transform.operation"))
+
+    assert mat, "expected a materialize span"
+    assert is_integer(mat.duration_native) and mat.duration_native >= 0
+    assert mat.parent_span_id == op.span_id
+  end
+
+  test "delivery-only EXIF-3-8 flush yields a materialize span under the request root" do
+    # No-geometry request on an orientation-6 source: the only flush is the delivery
+    # backstop (materialize_for_delivery/2), AFTER [:transform, :execute] closes — so
+    # the span parents to the request root, not an operation span. (Spec §7/§12.)
+    conn = conn(:get, exif_oriented_no_geometry_path()) |> ImagePipe.call(exif_oriented_opts())
+    assert conn.status == 200
+
+    spans = collect_spans()
+    mat = Enum.find(spans, &(&1.name == "image_pipe.transform.materialize"))
+    root = Enum.find(spans, &(&1.name == "image_pipe.request"))
+
+    assert mat && root
+    assert mat.parent_span_id == root.span_id
+  end
+
+  test "pure-lazy orientation-1 request yields no materialize span" do
+    conn = conn(:get, resize_only_orientation1_path()) |> ImagePipe.call(build_opts())
+    assert conn.status == 200
+
+    spans = collect_spans()
+    refute Enum.any?(spans, &(&1.name == "image_pipe.transform.materialize"))
+  end
+
+  # Fixtures — fill from test/image_pipe/imgproxy_wire_conformance_test.exs (these
+  # helpers EXIST there; this is wiring, not logic):
+  #   build_opts / exif_oriented_opts  -> @default_opts / sharp_oriented_opts(6)
+  #   materializing_request_path       -> a g:sm smart-crop or rt:force rotate URL
+  #   exif_oriented_no_geometry_path   -> a /_/plain/... no-geometry URL on SharpOrientedOrigin (orientation 6)
+  #   resize_only_orientation1_path    -> a resize-only URL on an orientation-1 source
+  defp build_opts, do: raise("TODO: @default_opts from the wire test")
+  defp exif_oriented_opts, do: raise("TODO: sharp_oriented_opts(6) from the wire test")
+  defp materializing_request_path, do: raise("TODO: g:sm or rt:force request path")
+  defp exif_oriented_no_geometry_path, do: raise("TODO: no-geometry path on orientation-6 source")
+  defp resize_only_orientation1_path, do: raise("TODO: resize-only orientation-1 path")
+end
+```
+
+> Implementer note: the `raise("TODO …")` helpers are wiring placeholders for real fixtures that already exist in `test/image_pipe/imgproxy_wire_conformance_test.exs` (`@default_opts`, `sharp_oriented_opts/1`, `SharpOrientedOrigin`, `g:sm`/`rt:force` URLs). Lift them into a shared `test/support` helper if convenient. The test is not done until all resolve to real requests.
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/materialize_span_test.exs`
+Expected: FAIL — no `image_pipe.transform.materialize` span emitted yet.
+
+- [ ] **Step 3: Wrap the flush in a span**
+
+In `lib/image_pipe/transform/materializer.ex`, wrap the existing flush body. **Read the real file first** — there are TWO arities: `materialize/1` (used by `chain.ex`) and the `@callback materialize/2` delivery-backstop (used by `processor.ex`), and the arity-2 currently delegates to arity-1. Wrap the **shared inner body once** so a single span covers both entry points (do not wrap each arity independently — that would double-emit).
+
+```elixir
+  alias ImagePipe.Telemetry
+
+  # Arity-1 (chain) and arity-2 (delivery backstop) both route through here.
+  def materialize(%ImagePipe.Transform.State{telemetry_opts: telemetry_opts} = state) do
+    Telemetry.span(telemetry_opts, [:transform, :materialize], %{}, fn ->
+      case do_materialize(state) do
+        {:ok, new_state} -> {{:ok, new_state}, %{result: :ok}}
+        {:error, reason} -> {{:error, reason}, %{result: :materialize_error}}
+      end
+    end)
+  end
+
+  # Keep arity-2 delegating to the wrapped arity-1 (it currently ignores opts) — do
+  # not add a second span here.
+  def materialize(state, _opts), do: materialize(state)
+
+  # do_materialize/1 is the EXISTING arity-1 body, renamed — OrientationFlush.flush.
+  # Do not change its behavior.
+  defp do_materialize(state), do: ImagePipe.Transform.OrientationFlush.flush(state)
+```
+
+**Return contract (corrected):** `materialize/1` returns a **bare** `{:ok, state} | {:error, reason}` — `OrientationFlush.flush/1` does NOT wrap `:materialize_error`; the `{:materialize_error, reason}` wrapping is done by the **callers** (`chain.ex:82`, `plan_executor.ex:133`). The wrapper above preserves the bare return (`{:error, reason}` passes through unchanged) and only tags the *span's* stop metadata `result: :materialize_error`. **Do NOT** return `{:error, {:materialize_error, reason}}` from the Materializer — that would double-wrap at the callers. A raise inside `do_materialize` surfaces as a `[:transform, :materialize, :exception]` event (telemetry re-raises); a tagged `{:error, _}` surfaces as a `:stop` carrying `result: :materialize_error`.
+
+- [ ] **Step 4: Run materialize + full transform suites, verify pass**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/materialize_span_test.exs test/image_pipe/transform`
+Expected: PASS, and no transform regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/transform/materializer.ex test/image_pipe/telemetry/trace/materialize_span_test.exs
+git commit -m "feat(transform): [:transform, :materialize] barrier span for honest flush timing"
+```
+
+## Task 9: Logger sync for the materialize event (all four points)
+
+**Files:**
+- Modify: `lib/image_pipe/telemetry/logger.ex`
+- Test: `test/image_pipe/telemetry/logger_test.exs` (extend)
+
+First **read** `logger.ex:12-19` (`@group_span_events`), `logger.ex:106-125` (`level_for/3`), `logger.ex:175-186` (generic `message/3` + `outcome/1`), and the existing detect/clamp assertions in `logger_test.exs`.
+
+- [ ] **Step 1: Write failing logger tests**
+
+```elixir
+# add to test/image_pipe/telemetry/logger_test.exs
+  describe "materialize event" do
+    setup do
+      :ok = ImagePipe.Telemetry.Logger.attach(level: :info)
+      on_exit(fn -> ImagePipe.Telemetry.Logger.detach() end)
+      :ok
+    end
+
+    test "successful flush logs at base level, no warning" do
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          :telemetry.execute([:image_pipe, :transform, :materialize, :stop], %{duration: 10}, %{result: :ok})
+        end)
+
+      assert log =~ "materialize"
+      refute log =~ "[warning]"
+    end
+
+    test "stop carrying materialize_error escalates to warning" do
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          :telemetry.execute([:image_pipe, :transform, :materialize, :stop], %{duration: 10}, %{result: :materialize_error})
+        end)
+
+      assert log =~ "[warning]"
+    end
+
+    test "exception escalates to warning" do
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          :telemetry.execute(
+            [:image_pipe, :transform, :materialize, :exception],
+            %{duration: 5},
+            %{kind: :error, reason: %RuntimeError{message: "x"}, stacktrace: []}
+          )
+        end)
+
+      assert log =~ "[warning]"
+    end
+  end
+```
+
+(Match the project's actual `Logger.attach/detach` test setup — copy the existing describe-block setup verbatim if it differs.)
+
+- [ ] **Step 2: Run, verify the stop-error test fails**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/logger_test.exs`
+Expected: the success + exception tests pass (exception auto-escalates via the generic `:exception` arm at `logger.ex:111`); the **stop-error** test FAILS (materialize_error logs at base level).
+
+- [ ] **Step 3: Implement the three sync points**
+
+In `logger.ex`:
+
+1. **Subscription** — add `[:transform, :materialize]` to the `transform` list in `@group_span_events` (`logger.ex:16`).
+2. **Levels** — escalate a materialize stop-error. **Read `logger.ex:106-115` first**: the generic `level_for/3` is a `cond` (the `[:output, :clamp]`-style heads come before it). Add a branch **inside that `cond`**, beside the existing `:cache_error` branch (~`logger.ex:111`) — do NOT add a new wildcard function head (it would swallow clamp/exception cases):
+
+```elixir
+      # inside the existing cond in level_for/3, next to the :cache_error branch:
+      metadata[:result] == :materialize_error -> :warning
+```
+
+The materialize `:exception` path needs no new code — the generic `:exception` arm (`logger.ex:111`-ish, `List.last(suffix) == :exception -> :warning`) already escalates it. Confirm this by reading the clause; the test in Step 1 asserts it.
+
+3. **Rendering** — none; the generic `message/3` fallback (`logger.ex:175`) prints `label` + `outcome/1`. Confirm no specific clause is added.
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/logger_test.exs`
+Expected: PASS (all three).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/telemetry/logger.ex test/image_pipe/telemetry/logger_test.exs
+git commit -m "feat(telemetry): Logger subscribe + escalate [:transform, :materialize]"
+```
+
+## Task 10: `telemetry.md` — materialize subsection (Phase 1 doc sync)
+
+**Files:**
+- Modify: `docs/telemetry.md`
+
+- [ ] **Step 1: Add the subsection**
+
+Add `### Materialization barrier span (`[:transform, :materialize]`)` near the per-operation-spans section. Document: emitted from `Materializer.materialize/1`; `:stop` metadata `result: :ok | :materialize_error`; duration is the real flush cost (the honest per-barrier timing the per-op spans deliberately lack); parenting nuance (mid-chain under `[:transform, :operation]`, boundary flush under `[:transform, :execute]`, delivery flush under the request root). Update the result-atoms list to include `:materialize_error`.
+
+- [ ] **Step 2: Verify prose builds / no broken references**
+
+Run: `mise exec -- mix docs` (if configured) or visually confirm Markdown.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/telemetry.md
+git commit -m "docs(telemetry): document [:transform, :materialize] barrier span"
+```
+
+## Phase 1 gate
+
+- [ ] Run the full gate: `mise run precommit`
+- [ ] Expected: format clean, `--warnings-as-errors` clean, credo strict clean, all tests pass.
+
+---
+
+# Phase 2 — Cross-process propagation + inbound edge
+
+Threads `Trace.Context` across hop A (request→SourceSession, for `[:cache, :write]`) and hop B (SourceSession→Producer, for the bulk), keeps Admission spans as separate roots (§8.1), and adds opt-in inbound `traceparent` extraction. Depends on Phase 1.
+
+## Task 11: Inbound context plumbing (`Trace.Inbound`) wired into Capture root
+
+**Files:**
+- Create: `lib/image_pipe/telemetry/trace/inbound.ex`
+- Modify: `lib/image_pipe/telemetry/trace/capture.ex` (`root_ids/1` reads inbound)
+- Test: `test/image_pipe/telemetry/trace/inbound_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+# test/image_pipe/telemetry/trace/inbound_test.exs
+defmodule ImagePipe.Telemetry.Trace.InboundTest do
+  use ExUnit.Case, async: false
+  alias ImagePipe.Telemetry
+  alias ImagePipe.Telemetry.Trace.{Context, Inbound, Span, TestExporter}
+
+  setup do
+    TestExporter.set_receiver(self())
+    :ok = TestExporter.attach(self())
+    on_exit(fn -> Telemetry.detach_tracer() end)
+    :ok
+  end
+
+  test "root span adopts an inbound context when present" do
+    Inbound.put(%Context{trace_id: "0af7651916cd43dd8448eb211c80319c", span_id: "b7ad6b7169203331", trace_flags: 1})
+    Telemetry.span([], [:request], %{}, fn -> {:ok, %{result: :ok}} end)
+
+    assert_receive {:span, %Span{name: "image_pipe.request"} = root}
+    assert root.trace_id == "0af7651916cd43dd8448eb211c80319c"
+    assert root.parent_span_id == "b7ad6b7169203331"
+  end
+
+  test "root mints fresh when no inbound context" do
+    Telemetry.span([], [:request], %{}, fn -> {:ok, %{result: :ok}} end)
+    assert_receive {:span, %Span{name: "image_pipe.request"} = root}
+    assert root.trace_id =~ ~r/\A[0-9a-f]{32}\z/
+    assert root.parent_span_id == nil
+  end
+end
+```
+
+- [ ] **Step 2: Run, verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/inbound_test.exs`
+Expected: FAIL — `Inbound` undefined.
+
+- [ ] **Step 3: Implement `Trace.Inbound` + wire `root_ids/1`**
+
+```elixir
+# lib/image_pipe/telemetry/trace/inbound.ex
+defmodule ImagePipe.Telemetry.Trace.Inbound do
+  @moduledoc false
+  alias ImagePipe.Telemetry.Trace.Context
+
+  @key :"$image_pipe_trace_inbound"
+
+  @spec put(Context.t()) :: :ok
+  def put(%Context{} = ctx), do: (Process.put(@key, ctx); :ok)
+
+  @doc "Read and clear the inbound context (consumed once by the root span)."
+  @spec take() :: Context.t() | nil
+  def take, do: Process.delete(@key)
+end
+```
+
+Update `capture.ex` `root_ids/1`:
+
+```elixir
+  defp root_ids(_config) do
+    case ImagePipe.Telemetry.Trace.Inbound.take() do
+      %ImagePipe.Telemetry.Trace.Context{trace_id: t, span_id: s, trace_flags: f} -> {t, s, f}
+      nil -> {Id.trace_id(), nil, 1}
+    end
+  end
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/inbound_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/telemetry/trace/inbound.ex lib/image_pipe/telemetry/trace/capture.ex \
+        test/image_pipe/telemetry/trace/inbound_test.exs
+git commit -m "feat(telemetry): inbound trace context adopted by the root span"
+```
+
+## Task 12: Plug edge — extract `traceparent` when `extract_inbound: true`
+
+**Files:**
+- Modify: `lib/image_pipe/plug.ex` (before the `[:request]` span at `plug.ex:43`)
+- Modify: `lib/image_pipe/telemetry.ex` (`attach_tracer` records `extract_inbound`; expose it to the plug via the request opts or application env — see Step 3)
+- Test: `test/image_pipe/telemetry/trace/inbound_plug_test.exs`
+
+First **read** `plug.ex:40-115` to see how `opts`/`telemetry_opts` flow and where request options live.
+
+- [ ] **Step 1: Write the failing wire test**
+
+```elixir
+# test/image_pipe/telemetry/trace/inbound_plug_test.exs
+defmodule ImagePipe.Telemetry.Trace.InboundPlugTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  alias ImagePipe.Telemetry
+  alias ImagePipe.Telemetry.Trace.{Span, TestExporter}
+
+  @tp "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+
+  setup do
+    TestExporter.set_receiver(self())
+    on_exit(fn -> Telemetry.detach_tracer() end)
+    :ok
+  end
+
+  test "adopts inbound traceparent when extract_inbound: true" do
+    :ok = TestExporter.attach(self(), extract_inbound: true)
+    conn(:get, valid_request_path()) |> put_req_header("traceparent", @tp) |> ImagePipe.call(build_opts())
+
+    assert_receive {:span, %Span{name: "image_pipe.request"} = root}
+    assert root.trace_id == "0af7651916cd43dd8448eb211c80319c"
+  end
+
+  test "ignores traceparent by default (opt-in)" do
+    :ok = TestExporter.attach(self())
+    conn(:get, valid_request_path()) |> put_req_header("traceparent", @tp) |> ImagePipe.call(build_opts())
+
+    assert_receive {:span, %Span{name: "image_pipe.request"} = root}
+    assert root.trace_id != "0af7651916cd43dd8448eb211c80319c"
+  end
+
+  test "malformed traceparent falls back to a fresh root" do
+    :ok = TestExporter.attach(self(), extract_inbound: true)
+    conn(:get, valid_request_path()) |> put_req_header("traceparent", "garbage") |> ImagePipe.call(build_opts())
+
+    assert_receive {:span, %Span{name: "image_pipe.request"} = root}
+    assert root.trace_id =~ ~r/\A[0-9a-f]{32}\z/
+  end
+
+  defp build_opts, do: raise("TODO: project ImagePipe.call/2 opts")
+  defp valid_request_path, do: raise("TODO: a 200-status request path")
+end
+```
+
+- [ ] **Step 2: Run, verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/inbound_plug_test.exs`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement extraction in the plug**
+
+The plug must know whether extraction is enabled. Simplest: `attach_tracer` stores `extract_inbound` in `:persistent_term` keyed `{ImagePipe.Telemetry.Trace, :extract_inbound}`; `plug.call` reads it. In `plug.ex`, before the `[:request]` span:
+
+```elixir
+  def call(%Plug.Conn{} = conn, opts) do
+    telemetry_opts = Telemetry.telemetry_opts(opts)
+    ImagePipe.Telemetry.Trace.maybe_extract_inbound(conn)
+
+    Telemetry.span(telemetry_opts, [:request], request_metadata(conn, opts), fn ->
+      {conn, metadata} = do_call(conn, opts)
+      {conn, Map.put(metadata, :status, conn.status)}
+    end)
+  end
+```
+
+Extend the existing facade `lib/image_pipe/telemetry/trace.ex` (created in Task 6) with `maybe_extract_inbound/1` + the `extract_inbound` flag:
+
+```elixir
+  alias ImagePipe.Telemetry.Trace.{Inbound, W3C}
+
+  @extract_key {__MODULE__, :extract_inbound}
+
+  @doc false
+  def set_extract_inbound(flag), do: :persistent_term.put(@extract_key, flag == true)
+
+  @doc false
+  def maybe_extract_inbound(conn) do
+    if :persistent_term.get(@extract_key, false) do
+      case Plug.Conn.get_req_header(conn, "traceparent") do
+        [tp | _] ->
+          case W3C.decode(tp) do
+            {:ok, ctx} -> Inbound.put(ctx)
+            :error -> :ok
+          end
+
+        [] ->
+          :ok
+      end
+    end
+
+    :ok
+  end
+```
+
+Wire the flag into the (still-minimal) `attach_tracer` in `lib/image_pipe/telemetry.ex` now — add `ImagePipe.Telemetry.Trace.set_extract_inbound(Keyword.get(opts, :extract_inbound, false))` to its body, and `ImagePipe.Telemetry.Trace.set_extract_inbound(false)` to `detach_tracer`. (Task 17 replaces this with the validated version that keeps the same wiring.) Without this, the minimal `attach_tracer` ignores `extract_inbound: true` and this task's test fails.
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/inbound_plug_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/plug.ex lib/image_pipe/telemetry.ex lib/image_pipe/telemetry/trace.ex \
+        test/image_pipe/telemetry/trace/inbound_plug_test.exs
+git commit -m "feat(telemetry): opt-in inbound traceparent extraction at the plug edge"
+```
+
+## Task 13: Hop B — request context → Producer
+
+**Files:**
+- Modify: `lib/image_pipe/request/runner.ex` (capture `Trace.Stack.context()` at `start_session`)
+- Modify: `lib/image_pipe/request/source_session_supervisor.ex` (pass context through `start_child` opts)
+- Modify: `lib/image_pipe/request/source_session.ex` (stash + forward to `Producer.start_link`)
+- Modify: `lib/image_pipe/request/source_session/producer.ex` (`Trace.Stack.adopt/1` in the spawn)
+- Test: `test/image_pipe/telemetry/trace/cross_process_test.exs`
+
+First **read** `runner.ex:30-40,128-160`, `source_session_supervisor.ex:31-37`, `source_session.ex:80-90,244-250`, `producer.ex:26-36`.
+
+- [ ] **Step 1: Write the failing cross-process test**
+
+```elixir
+# test/image_pipe/telemetry/trace/cross_process_test.exs
+defmodule ImagePipe.Telemetry.Trace.CrossProcessTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  alias ImagePipe.Telemetry
+  alias ImagePipe.Telemetry.Trace.{Span, TestExporter}
+
+  setup do
+    TestExporter.set_receiver(self())
+    :ok = TestExporter.attach(self())
+    on_exit(fn -> Telemetry.detach_tracer() end)
+    :ok
+  end
+
+  defp collect(timeout \\ 300) do
+    receive do
+      {:span, %Span{} = s} -> [s | collect(timeout)]
+    after
+      timeout -> []
+    end
+  end
+
+  test "producer-process spans share the request trace_id and parent under it" do
+    conn(:get, valid_request_path()) |> ImagePipe.call(build_opts())
+
+    spans = collect()
+    root = Enum.find(spans, &(&1.name == "image_pipe.request"))
+    fetch = Enum.find(spans, &(&1.name == "image_pipe.source.fetch_decode"))
+
+    assert root && fetch
+    assert fetch.trace_id == root.trace_id
+    refute fetch.parent_span_id == nil
+  end
+
+  defp build_opts, do: raise("TODO: project ImagePipe.call/2 opts (cache miss, decodes a real image)")
+  defp valid_request_path, do: raise("TODO: a request that fetches+decodes a source")
+end
+```
+
+- [ ] **Step 2: Run, verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/cross_process_test.exs`
+Expected: FAIL — `fetch.trace_id != root.trace_id` (producer orphans without threading).
+
+- [ ] **Step 3: Thread the context (data, not process-local)**
+
+1. In `runner.ex` at the `start_session` call: capture `ctx = ImagePipe.Telemetry.Trace.Stack.context()` and pass it as an option/field alongside `owner`.
+2. In `source_session_supervisor.ex` `start_session/…`: forward the `trace_context` into the child spec args (the same path `owner` travels at `:35`).
+3. In `source_session.ex` `init/1` (~`:84`): stash `trace_context` in state; in `start_producer/1` (~`:244`) pass `trace_context: state.trace_context` to `Producer.start_link`.
+4. In `producer.ex` `start_link/2` spawn body (~`:31`), beside `Process.put(:"$callers", caller_chain)`:
+
+```elixir
+      Process.put(:"$callers", caller_chain)
+      ImagePipe.Telemetry.Trace.Stack.adopt(trace_context)
+```
+
+(`trace_context` read from opts: `trace_context = Keyword.get(opts, :trace_context)`.)
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/cross_process_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/request/runner.ex lib/image_pipe/request/source_session_supervisor.ex \
+        lib/image_pipe/request/source_session.ex lib/image_pipe/request/source_session/producer.ex \
+        test/image_pipe/telemetry/trace/cross_process_test.exs
+git commit -m "feat(telemetry): thread trace context request->producer (hop B)"
+```
+
+## Task 14: Hop A — request context → SourceSession for `[:cache, :write]`
+
+**Files:**
+- Modify: `lib/image_pipe/request/source_session.ex` (`Trace.Stack.adopt/1` in `init/1`, beside the `$callers` put at `:84`)
+- Test: extend `test/image_pipe/telemetry/trace/cross_process_test.exs`
+
+- [ ] **Step 1: Add the failing assertion**
+
+Add to `cross_process_test.exs`:
+
+```elixir
+  test "cache write parents under the request (hop A)" do
+    conn(:get, cache_miss_request_path()) |> ImagePipe.call(build_opts())
+
+    spans = collect()
+    root = Enum.find(spans, &(&1.name == "image_pipe.request"))
+    write = Enum.find(spans, &(&1.name == "image_pipe.cache.write"))
+
+    assert root && write, "expected request + cache.write spans"
+    assert write.trace_id == root.trace_id
+  end
+
+  test "cache admission is a separate root, not under the request (§8.1)" do
+    conn(:get, cache_miss_request_path()) |> ImagePipe.call(build_opts())
+
+    spans = collect()
+    root = Enum.find(spans, &(&1.name == "image_pipe.request"))
+    admission = Enum.find(spans, &(&1.name == "image_pipe.cache.admission"))
+
+    # Admission runs in the shared Admission GenServer with no request context
+    # threaded (spec §8.1): it must NOT share the request trace.
+    if admission do
+      assert admission.parent_span_id == nil
+      assert admission.trace_id != root.trace_id
+    end
+  end
+
+  defp cache_miss_request_path, do: raise("TODO: request path that writes to cache on miss")
+```
+
+- [ ] **Step 2: Run, verify the new test fails**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/cross_process_test.exs`
+Expected: the cache-write test FAILS (`[:cache, :write]` emitted from SourceSession with an empty stack → different trace_id).
+
+- [ ] **Step 3: Adopt the context in SourceSession.init**
+
+The context already travels to SourceSession for hop B (Task 13). In `init/1` (~`source_session.ex:84`), beside the `$callers` put:
+
+```elixir
+    Process.put(:"$callers", [owner | Process.get(:"$callers", [])])
+    ImagePipe.Telemetry.Trace.Stack.adopt(state.trace_context)
+```
+
+(Read `trace_context` from the init args/state as threaded in Task 13.)
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/cross_process_test.exs`
+Expected: PASS (both producer and cache-write assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/request/source_session.ex test/image_pipe/telemetry/trace/cross_process_test.exs
+git commit -m "feat(telemetry): thread trace context request->SourceSession for cache.write (hop A)"
+```
+
+## Phase 2 gate
+
+- [ ] `mise run precommit` — all green.
+
+---
+
+# Phase 3 — Outbound HTTP + public glue + docs
+
+Adds logical + physical Finch client spans, the validated public `attach_tracer/1`, the `LogExporter`, and the boundary/architecture enforcement + remaining docs. Depends on Phases 1–2.
+
+## Task 15: `Trace.ReqStep` — logical client span + traceparent inject + finch_private stamp
+
+**Files:**
+- Create: `lib/image_pipe/telemetry/trace/req_step.ex`
+- Modify: the source Req-client build site (find via `grep -rl "Req.new\|Req.Request" lib/image_pipe/source`)
+- Test: `test/image_pipe/telemetry/trace/req_step_test.exs`
+
+First **read** the source Req-client construction to see where to attach steps and how `source` already uses Req.
+
+- [ ] **Step 1: Write the failing test (a logical client span is emitted with status)**
+
+```elixir
+# test/image_pipe/telemetry/trace/req_step_test.exs
+defmodule ImagePipe.Telemetry.Trace.ReqStepTest do
+  use ExUnit.Case, async: false
+  alias ImagePipe.Telemetry
+  alias ImagePipe.Telemetry.Trace.{ReqStep, Span, TestExporter}
+
+  setup do
+    TestExporter.set_receiver(self())
+    :ok = TestExporter.attach(self())
+    on_exit(fn -> Telemetry.detach_tracer() end)
+    :ok
+  end
+
+  test "injects traceparent and emits a logical client span with status" do
+    # Open a parent span so the client span has a trace to attach to.
+    Telemetry.span([], [:request], %{}, fn ->
+      req =
+        Req.new(adapter: fn req ->
+          assert [tp] = Req.Request.get_header(req, "traceparent")
+          assert tp =~ ~r/\A00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]\z/
+          {req, Req.Response.new(status: 200, body: "ok")}
+        end)
+        |> ReqStep.attach()
+
+      {:ok, _} = Req.request(req)
+      {:ok, %{result: :ok}}
+    end)
+
+    assert_receive {:span, %Span{name: "image_pipe.http.client", kind: :client} = s}
+    assert s.attributes[:"http.status_code"] == 200
+  end
+end
+```
+
+- [ ] **Step 2: Run, verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/req_step_test.exs`
+Expected: FAIL — `ReqStep` undefined.
+
+- [ ] **Step 3: Implement `Trace.ReqStep`**
+
+```elixir
+# lib/image_pipe/telemetry/trace/req_step.ex
+defmodule ImagePipe.Telemetry.Trace.ReqStep do
+  @moduledoc """
+  Req steps that trace an outbound HTTP call as a logical client span, inject a W3C
+  `traceparent` header, and stamp `finch_private` so `Trace.FinchCapture` can attach
+  wire spans. Apply where the source builds its Req client.
+  """
+  alias ImagePipe.Telemetry.Trace.{Id, Span, Stack, W3C}
+
+  @priv :image_pipe_trace
+
+  @spec attach(Req.Request.t()) :: Req.Request.t()
+  def attach(%Req.Request{} = req) do
+    req
+    |> Req.Request.append_request_steps(image_pipe_trace_start: &start/1)
+    |> Req.Request.prepend_response_steps(image_pipe_trace_stop: &stop/1)
+    |> Req.Request.append_error_steps(image_pipe_trace_error: &error/1)
+  end
+
+  defp start(req) do
+    span_id = Id.span_id()
+    {trace_id, flags} =
+      case Stack.context() do
+        %{trace_id: t, trace_flags: f} -> {t, f || 1}
+        _ -> {Id.trace_id(), 1}
+      end
+
+    req
+    |> Req.Request.put_header("traceparent", W3C.encode(trace_id, span_id, flags))
+    |> Req.Request.put_private(@priv, {trace_id, span_id, System.system_time(), Stack.context()})
+    |> Req.merge(finch_private: %{@priv => {trace_id, span_id}})
+  end
+
+  defp stop({req, %Req.Response{status: status} = resp}) do
+    emit(req, %{"http.status_code" => status}, :ok)
+    {req, resp}
+  end
+
+  defp error({req, exception}) do
+    emit(req, %{"http.error" => inspect(exception)}, :error)
+    {req, exception}
+  end
+
+  defp emit(req, attrs, status) do
+    case Req.Request.get_private(req, @priv) do
+      {trace_id, span_id, start_time, parent_ctx} ->
+        exporter().export(%Span{
+          trace_id: trace_id,
+          span_id: span_id,
+          parent_span_id: parent_ctx && parent_ctx.span_id,
+          name: "image_pipe.http.client",
+          kind: :client,
+          start_time: start_time,
+          end_time: System.system_time(),
+          status: status,
+          attributes: attrs,
+          pid: self(),
+          node: node()
+        })
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp exporter, do: ImagePipe.Telemetry.Trace.exporter() || NoopExporter
+end
+```
+
+Add `ImagePipe.Telemetry.Trace.exporter/0` returning the active exporter module (store it in `:persistent_term` in `attach_tracer`); `ReqStep` uses it directly because the response/error steps may run in a process boundary where the active span stack differs. Define a private `NoopExporter` or guard `nil` to skip emission when no tracer is attached.
+
+- [ ] **Step 4: Attach `ReqStep` at the source Req-client build site (NON-TRIVIAL — read first)**
+
+`lib/image_pipe/source/req_stream.ex` currently calls `Req.get(keyword_opts, …)` — it never builds a `%Req.Request{}` struct, so there is nothing to pipe through `attach/1`. You must restructure the call to build a request, attach the steps, then run it:
+
+```elixir
+# before (conceptually): Req.get(request_options(req_options), url: url, into: :self)
+# after:
+Req.new(request_options(req_options))
+|> ImagePipe.Telemetry.Trace.ReqStep.attach()
+|> Req.request(url: url, into: :self)
+```
+
+This touches the redirect-follow loop (`follow/5` / `request_and_route/6` in `req_stream.ex`). Keep the existing redirect/timeout/limit options intact; only the build-and-run shape changes. Gate cheaply: `ReqStep.attach/1` is a no-op-at-runtime when `ImagePipe.Telemetry.Trace.exporter()` is nil (the steps emit nothing), so it's safe to always attach.
+
+**Timing caveat (document in the `ReqStep` `@moduledoc`):** `req_stream.ex` uses `into: :self`, so the response step (and the logical client span `:stop`) fires when **status + headers** arrive, not when the body finishes downloading. The span duration covers connect + TTFB, not full transfer. Status is captured correctly.
+
+- [ ] **Step 5: Run, verify pass**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/req_step_test.exs`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/image_pipe/telemetry/trace/req_step.ex lib/image_pipe/source/ test/image_pipe/telemetry/trace/req_step_test.exs
+git commit -m "feat(telemetry): Trace.ReqStep logical client span + traceparent injection"
+```
+
+## Task 16: `Trace.FinchCapture` — physical wire spans via finch_private
+
+**Files:**
+- Create: `lib/image_pipe/telemetry/trace/finch_capture.ex`
+- Modify: `lib/image_pipe/telemetry.ex` (`attach_tracer` attaches FinchCapture when `finch_spans: true`)
+- Test: `test/image_pipe/telemetry/trace/finch_capture_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+# test/image_pipe/telemetry/trace/finch_capture_test.exs
+defmodule ImagePipe.Telemetry.Trace.FinchCaptureTest do
+  use ExUnit.Case, async: false
+  alias ImagePipe.Telemetry.Trace.{FinchCapture, Span}
+
+  test "builds a wire span parented from finch_private" do
+    FinchCapture.set_exporter(fn s -> send(self(), {:span, s}) end)
+
+    request = %{private: %{image_pipe_trace: {"trace123", "parentspan"}}}
+    FinchCapture.handle_event(
+      [:finch, :request, :stop],
+      %{duration: 10, system_time: 1},
+      %{name: TestFinch, request: request, result: {:ok, %{status: 200}}},
+      %{exporter_ref: self()}
+    )
+
+    assert_receive {:span, %Span{name: "finch.request", trace_id: "trace123", parent_span_id: "parentspan"}}
+  end
+end
+```
+
+(Adapt to the real FinchCapture API you implement; the contract: read `meta.request.private[:image_pipe_trace]`, build a `finch.*` span parented to that span_id.)
+
+- [ ] **Step 2: Run, verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/finch_capture_test.exs`
+Expected: FAIL — `FinchCapture` undefined.
+
+- [ ] **Step 3: Implement `Trace.FinchCapture`**
+
+```elixir
+# lib/image_pipe/telemetry/trace/finch_capture.ex
+defmodule ImagePipe.Telemetry.Trace.FinchCapture do
+  @moduledoc false
+  alias ImagePipe.Telemetry.Trace.Span
+
+  @handler_id {__MODULE__, :finch}
+  @events [
+    [:finch, :request, :stop], [:finch, :request, :exception],
+    [:finch, :queue, :stop], [:finch, :connect, :stop],
+    [:finch, :send, :stop], [:finch, :recv, :stop], [:finch, :recv, :exception]
+  ]
+
+  def attach(%{exporter: exporter}) do
+    _ = :telemetry.detach(@handler_id)
+    :telemetry.attach_many(@handler_id, @events, &__MODULE__.handle_event/4, %{exporter: exporter})
+  end
+
+  def detach, do: (_ = :telemetry.detach(@handler_id); :ok)
+
+  def handle_event([:finch | rest] = _event, measurements, meta, config) do
+    with %{} = request <- Map.get(meta, :request),
+         %{image_pipe_trace: {trace_id, parent_span_id}} <- Map.get(request, :private, %{}) do
+      config.exporter.export(%Span{
+        trace_id: trace_id,
+        span_id: ImagePipe.Telemetry.Trace.Id.span_id(),
+        parent_span_id: parent_span_id,
+        name: "finch." <> Enum.map_join(Enum.drop(rest, -1), ".", &Atom.to_string/1),
+        kind: :client,
+        start_time: meta[:system_time],
+        duration_native: measurements[:duration],
+        status: finch_status(meta),
+        attributes: finch_attrs(meta),
+        pid: self(),
+        node: node()
+      })
+    else
+      _ -> :ok
+    end
+  end
+
+  defp finch_status(%{result: {:error, _}}), do: :error
+  defp finch_status(%{kind: _}), do: :error
+  defp finch_status(_), do: :ok
+
+  defp finch_attrs(meta), do: Map.take(meta, [:status]) |> Map.new(fn {_k, v} -> {:"http.status_code", v} end)
+end
+```
+
+(The test's `set_exporter` shim: expose a test seam, or rewrite the test to call `handle_event/4` with a `%{exporter: SomeMod}` config that sends to `self()`. Keep the production path config-driven.)
+
+In `attach_tracer`, when `finch_spans` is true, call `FinchCapture.attach(%{exporter: exporter})`; in `detach_tracer`, `FinchCapture.detach()`.
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/finch_capture_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/telemetry/trace/finch_capture.ex lib/image_pipe/telemetry.ex \
+        test/image_pipe/telemetry/trace/finch_capture_test.exs
+git commit -m "feat(telemetry): Trace.FinchCapture physical wire spans via finch_private"
+```
+
+## Task 17: `Trace.LogExporter` + validated `attach_tracer/1`
+
+**Files:**
+- Create: `lib/image_pipe/telemetry/trace/log_exporter.ex`
+- Modify: `lib/image_pipe/telemetry.ex` (replace the minimal `attach_tracer` with a NimbleOptions-validated, raising version that wires Capture + FinchCapture + extract_inbound + exporter persistent_term)
+- Test: `test/image_pipe/telemetry/trace/log_exporter_test.exs`, extend an attach validation test
+
+- [ ] **Step 1: Write the failing tests**
+
+```elixir
+# test/image_pipe/telemetry/trace/log_exporter_test.exs
+defmodule ImagePipe.Telemetry.Trace.LogExporterTest do
+  use ExUnit.Case, async: false
+  import ExUnit.CaptureLog
+  alias ImagePipe.Telemetry.Trace.{LogExporter, Span}
+
+  test "logs one flat line with ids, name, duration, status" do
+    span = %Span{
+      trace_id: "t", span_id: "s", parent_span_id: "p", name: "image_pipe.request",
+      start_time: 0, duration_native: 1234, status: :ok
+    }
+
+    log = capture_log(fn -> LogExporter.export(span) end)
+    assert log =~ "image_pipe.request"
+    assert log =~ "t"
+    assert log =~ "status=ok"
+  end
+end
+```
+
+```elixir
+# add to test/image_pipe/telemetry/trace/capture_test.exs (or a new attach_test.exs)
+  test "attach_tracer raises on unknown option" do
+    assert_raise ArgumentError, fn ->
+      ImagePipe.Telemetry.attach_tracer(exporter: ImagePipe.Telemetry.Trace.LogExporter, bogus: 1)
+    end
+  end
+
+  test "attach_tracer raises when exporter is missing or not loadable" do
+    assert_raise ArgumentError, fn -> ImagePipe.Telemetry.attach_tracer([]) end
+    assert_raise ArgumentError, fn -> ImagePipe.Telemetry.attach_tracer(exporter: NotARealModule) end
+  end
+```
+
+- [ ] **Step 2: Run, verify they fail**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/log_exporter_test.exs test/image_pipe/telemetry/trace/capture_test.exs`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `LogExporter` + validated `attach_tracer`**
+
+```elixir
+# lib/image_pipe/telemetry/trace/log_exporter.ex
+defmodule ImagePipe.Telemetry.Trace.LogExporter do
+  @moduledoc "Stdlib Logger exporter: one flat structured line per span. No buffering."
+  @behaviour ImagePipe.Telemetry.Trace.Exporter
+  require Logger
+  alias ImagePipe.Telemetry.Trace.Span
+
+  @impl true
+  def export(%Span{} = s) do
+    Logger.info(fn ->
+      "image_pipe.trace " <>
+        "trace=#{s.trace_id} span=#{s.span_id} parent=#{s.parent_span_id || "-"} " <>
+        "#{s.name} dur=#{s.duration_native || "-"} status=#{s.status || "unset"}"
+    end)
+
+    :ok
+  end
+end
+```
+
+```elixir
+# lib/image_pipe/telemetry.ex — replace the minimal attach_tracer
+  @tracer_schema NimbleOptions.new!(
+    exporter: [type: :atom, required: true],
+    prefix: [type: {:list, :atom}, default: ImagePipe.Telemetry.default_prefix()],
+    extract_inbound: [type: :boolean, default: false],
+    finch_spans: [type: :boolean, default: true]
+  )
+
+  @spec attach_tracer(keyword()) :: :ok
+  def attach_tracer(opts) do
+    opts = NimbleOptions.validate!(opts, @tracer_schema)
+    exporter = opts[:exporter]
+
+    unless Code.ensure_loaded?(exporter) and function_exported?(exporter, :export, 1) do
+      raise ArgumentError, "exporter #{inspect(exporter)} must export export/1"
+    end
+
+    ImagePipe.Telemetry.Trace.set_exporter(exporter)
+    ImagePipe.Telemetry.Trace.set_extract_inbound(opts[:extract_inbound])
+    ImagePipe.Telemetry.Trace.Capture.attach(%{prefix: opts[:prefix], exporter: exporter})
+    if opts[:finch_spans], do: ImagePipe.Telemetry.Trace.FinchCapture.attach(%{exporter: exporter})
+    :ok
+  end
+
+  @spec detach_tracer() :: :ok
+  def detach_tracer do
+    ImagePipe.Telemetry.Trace.Capture.detach()
+    ImagePipe.Telemetry.Trace.FinchCapture.detach()
+    ImagePipe.Telemetry.Trace.set_extract_inbound(false)
+    ImagePipe.Telemetry.Trace.set_exporter(nil)
+    :ok
+  end
+```
+
+Note: `NimbleOptions.validate!` raises on unknown/invalid options (satisfies the raising contract). Add `set_exporter/1` + `exporter/0` to `ImagePipe.Telemetry.Trace` (persistent_term), used by `ReqStep`/`FinchCapture` default-exporter lookups.
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `mise exec -- mix test test/image_pipe/telemetry/trace/log_exporter_test.exs test/image_pipe/telemetry/trace/capture_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/telemetry/trace/log_exporter.ex lib/image_pipe/telemetry.ex lib/image_pipe/telemetry/trace.ex \
+        test/image_pipe/telemetry/trace/log_exporter_test.exs test/image_pipe/telemetry/trace/capture_test.exs
+git commit -m "feat(telemetry): LogExporter + validated raising attach_tracer/1"
+```
+
+## Task 18: Boundary exports + architecture test + `## Tracing (opt-in)` docs
+
+**Files:**
+- Modify: `lib/image_pipe/telemetry.ex` (Boundary `exports:`)
+- Modify: `test/image_pipe/architecture_boundary_test.exs`
+- Modify: `docs/telemetry.md`
+
+- [ ] **Step 1: Set the boundary exports**
+
+In the telemetry boundary declaration, add `exports:` for exactly: `ImagePipe.Telemetry.Trace.Context`, `…Trace.Stack`, `…Trace.Span`, `…Trace.Exporter`, `…Trace.ReqStep`, and `…Trace` (the facade with `maybe_extract_inbound/1`). Do **not** export `Capture`, `FinchCapture`, `Id`, `W3C`, `LogExporter`, `Inbound`.
+
+- [ ] **Step 2: Add the architecture test**
+
+```elixir
+# add to test/image_pipe/architecture_boundary_test.exs
+  test "telemetry trace capture does not reference concrete transform/source modules" do
+    source = File.read!("lib/image_pipe/telemetry/trace/capture.ex")
+    refute source =~ "ImagePipe.Transform.Operation"
+    refute source =~ "ImagePipe.Source."
+    refute source =~ "ImagePipe.Request."
+  end
+```
+
+(Follow the existing architecture-test style; source-text scanning is permitted only in this file per CLAUDE.md.)
+
+- [ ] **Step 3: Run, verify pass**
+
+Run: `mise exec -- mix test test/image_pipe/architecture_boundary_test.exs`
+Expected: PASS. If Boundary reports a violation at compile, fix the `deps:`/`exports:` per the spec §11.
+
+- [ ] **Step 4: Add the `## Tracing (opt-in)` docs section**
+
+In `docs/telemetry.md`, add a section parallel to `## Attaching handlers` documenting `attach_tracer/1`/`detach_tracer/0`, all four options (`exporter`, `prefix`, `extract_inbound`, `finch_spans`), the `Trace.Exporter` `export/1` contract, and a `LogExporter` example. Note inbound extraction is opt-in and sampling is deferred to the host.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/telemetry.ex test/image_pipe/architecture_boundary_test.exs docs/telemetry.md
+git commit -m "feat(telemetry): boundary exports, architecture test, tracing docs"
+```
+
+## Phase 3 gate
+
+- [ ] `mise run precommit` — all green.
+- [ ] Manual smoke: attach `LogExporter`, issue one `ImagePipe.call/2`, confirm a flat trace tree in the log; detach.
+
+---
+
+## Self-review checklist (run before handing off to execution)
+
+- Spec coverage: every spec section (§3 layout, §4 model, §5 capture, §6 attr safety, §7 materialize, §8/§8.1 hops + Admission roots, §9 Finch, §10 inbound + sampling-deferred, §11 docs/boundary, §12 tests) maps to a task above.
+- The `raise("TODO …")` fixtures in Tasks 8/12/13/14 are **wiring placeholders for real project test fixtures**, called out explicitly for the implementer to fill from `imgproxy_wire_conformance_test.exs`; they are not logic gaps.
+- Type consistency: `Trace.Span` field names (`duration_native`, `parent_span_id`, `attributes`, `events`) are used identically across Capture/ReqStep/FinchCapture/LogExporter.
+- Sampling: no sampling code anywhere (deferred); `trace_flags` only propagated.

--- a/docs/superpowers/specs/2026-06-09-telemetry-span-tracer-design.md
+++ b/docs/superpowers/specs/2026-06-09-telemetry-span-tracer-design.md
@@ -1,0 +1,423 @@
+# Telemetry Span Capture & Tracing Layer — Design
+
+- **Date:** 2026-06-09
+- **Status:** Approved design (reviewed), pre-implementation
+- **Scope:** Three phased implementation plans / PRs along the §14 seams
+
+## 1. Problem & goals
+
+ImagePipe already emits a clean tree of `:telemetry.span/3` spans rooted at
+`[:image_pipe, :request]` (see `docs/telemetry.md`). We want an **opt-in capture
+layer** that consumes those events, reconstructs distributed-trace-shaped spans
+with correct parent/child nesting, and hands each finished span to a pluggable
+exporter so a host can render its own UI/format or map to Jaeger/Tempo/OTLP.
+
+This is **not** an OpenTelemetry export task. OTel is the reference model for the
+span shape and W3C `traceparent` wire format; the deliverable is our own capture +
+correlation + propagation + export contract.
+
+### Goals
+
+- Reconstruct correct span nesting within each process and across ImagePipe's
+  request-scoped process hops (request → SourceSession, request → Producer), while
+  keeping shared-process cache-maintenance spans out of the request trace (§8.1).
+- OTel-shaped internal span model so a later Jaeger/Tempo/OTLP map is mechanical.
+- Logical **and** physical (Finch wire) spans for outbound source fetches.
+- Opt-in inbound `traceparent` extraction so ImagePipe can be a middle hop.
+- Honest timing for libvips' lazy pipeline: explicit materialization-barrier spans.
+- Ship the same way as the default Logger: opt-in, stdlib-only default exporter,
+  third-party backends attached by the host.
+
+### Non-goals
+
+- No sampling logic in our layer (defer to the host SDK; we only propagate the
+  inbound sampled flag).
+- No third-party backend integration in the library (host attaches OTel/APM).
+- No tree-buffering / pretty-tree rendering in the default exporter (flat, stateless).
+- No demo UI change (host observability only, no transform/parser option added).
+
+## 2. Confirmed facts the design relies on (verified in code)
+
+- `:telemetry.span/3` runs its handler **synchronously, inline** in the emitting
+  process, and adds `telemetry_span_context` (an `make_ref()`) to start/stop/
+  exception. That context **matches a single span's events only — it carries no
+  parentage**.
+- **Process topology (corrected after review — there are FOUR live processes, not
+  one hop):**
+  - **Plug request process** emits `[:request]`, `[:parse]`, `[:cache, :lookup]`
+    (`runner.ex:66`), `[:send]`; holds the inbound `Conn`.
+  - It blocks on `GenServer.call` → **SourceSession GenServer process**, which is
+    **not** a pure coordinator: it emits `[:cache, :write]` from
+    `handle_producer_result` (`sink.ex:161` via `source_session.ex:298`).
+  - SourceSession `spawn_link`s the **Producer process**, which emits
+    `[:source, :fetch_decode]`, `[:source, :fetch]`, `[:transform, :execute]`,
+    `[:transform, :operation]`, `[:transform, :materialize]` (new), `[:transform,
+    :detect[, :model]]`, `[:output, :negotiate]`.
+  - A long-lived **Admission GenServer** (separate process, reached via
+    `GenServer.call` at `file_system.ex:265`) emits `[:cache, :admission]`
+    (`admission.ex:505`), `[:cache, :warm_start]` (`admission.ex:140`, in `init/1`,
+    outside any request), and the ticker one-shots `[:cache, :flush|:cleanup, :stop]`
+    (timer-driven, no request context).
+
+  So there are **two request-scoped hops to thread** (request → SourceSession for
+  `[:cache, :write]`; request → Producer for the bulk), plus the Admission process
+  whose spans are **deliberately not part of the request trace** (§8.1).
+- **Detection is fully synchronous** (`Composite.detect/3` uses `Enum.map`, no
+  `Task`/`spawn`) — no fan-out propagation needed; the stack covers detect spans.
+- **Materialization runs inside the operation span:** `chain.ex` wraps
+  `run_operation` in `[:transform, :operation]`; `run_operation` →
+  `maybe_materialize` → `Materializer.materialize/1` (`copy_memory`). Only the
+  first materializing op flushes (`materialized?: true` short-circuits). The flush
+  is real pixel work but is a **barrier cost** (accumulated upstream lazy work), not
+  an op cost, and whether it fires is runtime state invisible from the op name.
+- Finch (Req's adapter) emits `[:finch, :request|queue|connect|send|recv, …]` in
+  the **caller** process; Req itself emits no telemetry. `meta.request` is the full
+  `%Finch.Request{}`; Req's `:finch_private` populates `Finch.Request.private`.
+
+## 3. Architecture
+
+All modules under `ImagePipe.Telemetry.Trace.*` (telemetry boundary). Nothing
+attaches automatically; with no tracer attached, zero events match → zero cost.
+
+```
+inbound traceparent (opt-in) ─┐
+                              ▼
+:telemetry [:image_pipe,…] ─▶ Trace.Capture.handle_event/4  (sync, in-proc)
+                                  │  push/pop Trace.Stack (process dictionary)
+:telemetry [:finch,…]      ─▶ Trace.FinchCapture.handle_event/4
+                                  │  parent via finch_private (no stack)
+                                  ▼
+                              Trace.Span ──▶ Exporter.export/1
+                                                ├─ Trace.LogExporter (stdlib, flat)
+                                                └─ host OTLP/APM exporter (host-wired)
+```
+
+### Module layout
+
+| Module | Purpose |
+|---|---|
+| `Trace.Context` | immutable, serializable `{trace_id, span_id, trace_flags, baggage}` crossing seams |
+| `Trace.Span` | captured span handed to the exporter |
+| `Trace.Id` | id generation (`:crypto.strong_rand_bytes`) |
+| `Trace.W3C` | `traceparent` encode/decode |
+| `Trace.Stack` | per-process active-span stack (process dictionary) |
+| `Trace.Capture` | `attach_many` handler for `[:image_pipe, …]` span + one-shot events |
+| `Trace.FinchCapture` | `attach_many` handler for `[:finch, …]` events, parented via `finch_private` |
+| `Trace.ReqStep` | Req request/response/error steps: inject `traceparent`, open logical client span, stamp `finch_private` |
+| `Trace.Exporter` (behaviour) | `@callback export(Trace.Span.t()) :: :ok` |
+| `Trace.LogExporter` | stdlib `Logger` default, one flat structured line per span |
+
+Plus host-facing entry points on `ImagePipe.Telemetry`:
+`attach_tracer/1`, `detach_tracer/0`.
+
+### Public API
+
+```elixir
+ImagePipe.Telemetry.attach_tracer(
+  exporter: MyApp.OTLPExporter,   # required; module implementing Trace.Exporter
+  prefix: [:image_pipe],          # default: configured prefix
+  extract_inbound: false,         # opt-in inbound traceparent extraction
+  finch_spans: true               # physical wire spans via FinchCapture
+)
+ImagePipe.Telemetry.detach_tracer()
+```
+
+Options validated with `NimbleOptions`; unknown options rejected. `exporter` must
+be a loaded module exporting `export/1`. Like its sibling `attach_default_logger/1`,
+`attach_tracer/1` **raises `ArgumentError`** on invalid options (host-startup config
+boundary — raise, not a tagged return).
+
+## 4. Span model
+
+`Trace.Span` (OTel-shaped):
+
+- `trace_id` (16 bytes, 32 hex), `span_id` (8 bytes, 16 hex), `parent_span_id`
+  (`nil` = root)
+- `name` (e.g. `"image_pipe.transform.materialize"`), `kind`
+  (`:internal | :server | :client`)
+- `start_time` (wall-clock from `system_time`), `end_time`,
+  `duration_native` (raw monotonic — the honest timing source)
+- `status` (`:unset | :ok | :error`), `status_message`
+- `attributes` (filtered; see §6), `events` (one-shots + exceptions), `links`
+- `pid`, `node`
+
+## 5. Capture mechanism
+
+`Trace.Capture` is one `attach_many` (module fn; `:telemetry.detach` before
+re-attach), dispatching on the event suffix.
+
+- **`:start`** — parent = `Stack.current()`. If stack empty: use an inbound context
+  if `Trace.put_inbound/1` left one in the process dict (§9), else mint a fresh
+  `trace_id` (root). Otherwise inherit parent's `trace_id` and use its `span_id` as
+  `parent_span_id`. Push the new span (stashing `telemetry_span_context` for the
+  pairing check).
+- **`:stop` / `:exception`** — `:telemetry.span/3` emits exactly one of these (never
+  both), so the terminator pops once. Within a correct single-process stack the LIFO
+  discipline alone gives right parentage; the stashed `telemetry_span_context` is
+  **only** a corruption guard for a dropped/un-propagated event (mismatch ⇒ log +
+  skip rather than mis-nest), not load-bearing for nesting. Pop, check the ref,
+  finalize duration + status, `exporter.export/1`.
+- **One-shots** (`[:cache, :stage]`, `[:output, :clamp]`, `[:http_cache, …]`) — no
+  span context; fold as timestamped `events` onto `Stack.current()`. **Guard the
+  empty stack:** if `Stack.current()` is `nil` (e.g. a ticker-driven cache one-shot
+  fired on a process with no open span), drop the one-shot — never invent a parent.
+  `:exception` also folds an `exception` event before finalizing `:error`.
+
+**Status mapping:** stop metadata `result: :ok` → `:ok`; an error atom
+(`:cache_error`, `:processing_error`, …) or an `:exception` → `:error` +
+`status_message`.
+
+**Honesty tags:** `[:transform, :operation]` spans get `timing: :construction`
+(libvips lazy — duration is construction structure, not compute). The materialize
+barrier span (§7) carries real flush timing.
+
+## 6. Attribute safety (allowlist, day one)
+
+`safe_attrs/1` copies only known-safe keys (operation structs, dimensions, class
+names, cache keys, model-artifact names, result atoms, `output_mode`, `operation`,
+`index`). It **drops** full source URLs, request paths, signatures, tokens — any
+secret-bearing value. Cardinality is irrelevant; *sensitivity* is the bar
+(CLAUDE.md telemetry guideline). Allowlist-by-default means anything unenumerated
+(incl. PII / secret-embedding strings) is dropped automatically. Constraints:
+
+- Applied **uniformly** to start metadata, stop metadata, **and** one-shot event
+  metadata before folding — not just operation spans.
+- Operation structs are stored as **opaque `term()`** (store/inspect only); the
+  telemetry boundary must **not** alias `ImagePipe.Transform.Operation.*` — that
+  would invert the dependency (telemetry `deps: []` stays empty).
+- Confirm the URL/path carriers — `request_metadata` (`plug.ex:43,115`) and
+  `source_metadata` (`source.ex:63,85`) — expose no key on the allowlist.
+
+Locked by a test asserting a signed source URL never reaches `attributes`.
+
+## 7. Materialization-barrier span (transform enrichment)
+
+Emit a `[:transform, :materialize]` span **inside
+`ImagePipe.Transform.Materializer.materialize/1`** — the single flush site, so it
+covers the chain's `maybe_materialize`, the `PlanExecutor` orientation-flush
+boundary, and the delivery backstop `materialize_for_delivery/2`. The span's
+duration is the real `copy_memory` flush cost.
+
+**Failure mapping (corrected):** `materialize/1` returns tagged
+`{:error, {:materialize_error, _}}` as a *value*, not a raise (see `chain.ex:73,82`).
+So a flush failure arrives as a `:stop` with an error result → mapped to `:error`
+status (§5), **not** an `exception` event. An `exception` event only fires if
+`copy_memory` actually *raises*. Both must be handled.
+
+**Nesting is not always under an operation span:** mid-chain materialize nests under
+`[:transform, :operation]`; the `PlanExecutor` boundary flush nests under
+`[:transform, :execute]`; the delivery backstop (`processor.ex:33`, after the
+`execute` span has closed) and an EXIF-only-no-op flush nest under the **producer
+root** (`[:request]` via the adopted context). All three are honest about where the
+flush fired; the tests (§12) assert each case separately.
+
+`telemetry_opts` is already on `State` (`state.ex:41`, populated at
+`plan_executor.ex:62`, read at `crop.ex:175`) and both flush call sites pass a full
+`State` — so use `state.telemetry_opts`; **no threading and no arity change** to
+`materialize/1`. This is a **new telemetry event** on the transform boundary and
+carries doc-sync obligations (§11).
+
+## 8. Cross-process propagation
+
+Thread a `Trace.Context` **as data** alongside the existing `$callers` chain. The
+context cannot ride the process dictionary across `DynamicSupervisor.start_child` or
+`spawn_link` — it must travel through the call/opts and be re-adopted in the child's
+entry, exactly like `owner`/`$callers` do today.
+
+1. **Capture (Plug process).** The `[:request]` span is open on the Plug stack
+   throughout `do_call` → `Runner.run` → `start_session` (confirmed: `plug.ex:43`
+   wraps everything). Capture `Trace.Stack.context()` at the `start_session` call
+   (`runner.ex` ~L35). It's an immutable value, so the parent id is stable even
+   though the Plug process then blocks on `GenServer.call` while the child runs.
+2. **Hop A — request → SourceSession (for `[:cache, :write]`).** `start_session`
+   goes through `DynamicSupervisor.start_child` (`source_session_supervisor.ex:31-37`),
+   so the context must travel as a field in the per-session opts/`Request` that
+   `SourceSession.init/1` reads (the same path `owner` takes at
+   `source_session_supervisor.ex:35`). In `init/1`, beside
+   `Process.put(:"$callers", …)` (`source_session.ex:84`), `Trace.Stack.adopt(ctx)`.
+   The `[:cache, :write]` span (emitted from `handle_producer_result`) then nests
+   under `[:request]`.
+3. **Hop B — SourceSession → Producer (for the bulk).** SourceSession forwards the
+   context to `Producer.start_link` (already passing `caller_chain`); in the Producer
+   `spawn_link`, beside `Process.put(:"$callers", caller_chain)` (`producer.ex:31`),
+   `Trace.Stack.adopt(ctx)`. Every producer-process span nests under `[:request]`.
+
+`Trace.Stack.adopt/1` seeds the empty far-side stack with a synthetic remote-parent
+frame carrying the context's `trace_id` + `span_id`. Both hops adopt the **same**
+request context, so SourceSession's `[:cache, :write]` and the Producer subtree are
+siblings under `[:request]` — matching the real causal structure.
+
+### 8.1 Admission GenServer spans — deliberately not in the request trace
+
+`[:cache, :admission]` is behind a `GenServer.call` into a shared, long-lived
+Admission process (`file_system.ex:265` → `admission.ex:505`); `[:cache, :warm_start]`
+fires in that process's `init/1` (cache startup, no request); the ticker one-shots
+`[:cache, :flush|:cleanup, :stop]` fire on its timers. These are **shared-process /
+lifecycle** events, not part of any one request's causal chain. Decision: do **not**
+thread request context into the Admission process. Each such span becomes its own
+fresh root (stack empty ⇒ mint a `trace_id`); the ticker one-shots hit the empty-stack
+guard (§5) and are dropped. This is documented behavior, not a gap — threading a
+per-request context into a multiplexed shared GenServer would mis-attribute it.
+
+## 9. Finch + Req (logical + physical)
+
+- `Trace.ReqStep` (applied where `source` builds its Req client):
+  - **request step** — open a logical client span (kind `:client`), inject
+    `traceparent` header from its ids, stamp
+    `finch_private: %{image_pipe_trace: {trace_id, span_id}}`.
+  - **response step** — close with `http.status_code`; fold redirects/retries as
+    `events` (each hop/attempt with its status + `location`).
+  - **error step** — close `:error` for transport errors (Req surfaces these via
+    error steps, not exceptions).
+- `Trace.FinchCapture` — second `attach_many` on `[:finch, …]`. Events fire in the
+  Producer process, but parent is taken from `meta.request.private[:image_pipe_trace]`
+  (**not** the stack) — robust across retries/redirects/concurrency. Builds wire
+  spans (`request`/`queue`/`connect`/`send`/`recv`) under the logical Req span.
+  Gated by `finch_spans: true`.
+
+The logical Req span opens in the request step and closes in the response/error
+step. If the Producer is hard-killed mid-fetch (`Process.exit`, e.g. owner-down at
+`source_session.ex:391`), neither closing step runs: the span is **dropped** (never
+exported), not leaked (the dead Producer's process dict is discarded). A killed
+fetch losing its in-flight client span is acceptable; documented here so it isn't
+mistaken for a bug.
+
+## 10. Inbound edge (opt-in) & sampling
+
+- When `extract_inbound: true`, `plug.call` reads `traceparent`/`tracestate` off the
+  `Conn` and calls `Trace.put_inbound(ctx)` **before** the `[:request]` span opens;
+  the capture root `on_start` adopts `trace_id` + `parent_span_id` + the sampled
+  flag. Malformed/absent header → ignored, fresh root minted (fail-safe). Default
+  (disabled) always mints our own root.
+- **Sampling is deferred to the host SDK.** We always build the span and call
+  `export/1`. The inbound sampled bit rides in `trace_flags` and propagates onward
+  (into outbound `traceparent`) but does not gate recording.
+
+## 11. Docs / demo / boundary sync (CLAUDE.md rules)
+
+- `docs/telemetry.md`:
+  - A dedicated `### Materialization barrier span ([:transform, :materialize])`
+    subsection (not a bare list entry): stop metadata, the `:error`/`materialize_error`
+    result on failure, and the parenting nuance (mid-chain under an op span; boundary
+    flush under `[:transform, :execute]`; delivery flush under the request root).
+    Keep the result-atom list (`telemetry.md` ~L196-219) non-stale.
+  - A dedicated `## Tracing (opt-in)` section parallel to `## Attaching handlers`:
+    `attach_tracer/1` / `detach_tracer/0`, **every** option (`exporter`, `prefix`,
+    `extract_inbound`, `finch_spans`), the `prefix` default reusing `default_prefix/0`,
+    and the `Trace.Exporter` `export/1` contract (returns `:ok`; attribute-sensitivity
+    expectations mirroring the custom-detector note).
+- `ImagePipe.Telemetry.Logger` — all four sync points:
+  - **Subscription:** add `[:transform, :materialize]` to `@group_span_events.transform`
+    (`logger.ex:16`); the machinery auto-derives `:stop` + `:exception`.
+  - **Rendering:** rely on the generic `message/3` fallback (`logger.ex:175`) which
+    prints `label` + `outcome/1` — no new clause (a custom clause would risk swallowing
+    the outcome). State this choice explicitly.
+  - **Levels (the blocking point):** a materialize **`:exception`** is already
+    escalated to `:warning` by the generic `:exception` arm (`logger.ex:111`) — record
+    that we checked. But a materialize **`:stop` carrying an error result**
+    (`{:materialize_error, _}` returned as a value, not raised) would log at **base
+    level silently** — so add a `level_for/3` arm escalating a materialize stop-error
+    (mirroring the `:cache_error` special-case at `logger.ex:111`).
+  - **Coverage:** `logger_test` assertions for both — `refute log =~ "[warning]"` on a
+    successful flush stop, `assert log =~ "[warning]"` on the stop-error and on the
+    exception (synthetic `:telemetry.execute`, matching the detect/clamp test style).
+- **Demo UI: no change** (observability only; no transform/parser option changed).
+- **imgproxy conformance: no change** — the materialize span *observes* the existing
+  pipeline; it adds no processing behavior, knob, or pixel/stage divergence
+  (confirmed by the compatibility reviewer; the flush itself is already documented at
+  stage 7 `rotateAndFlip` and the `fixSize`/`limitScale` notes in
+  `docs/imgproxy_support_matrix.md`). Optional nicety (non-blocking): a one-line
+  mention in the stage-7 note that the barrier now emits `[:transform, :materialize]`,
+  paralleling how `[:output, :clamp]` is named there.
+- **Boundary:** tracer in the telemetry boundary (`deps: []` stays empty).
+  `source → telemetry`, `request → telemetry`, `transform → telemetry` deps **already
+  exist** (`source.ex:6`, `request.ex:14`, `transform.ex:13`) — no facade needed; drop
+  that fallback. Add to the telemetry boundary's `exports:` exactly: `Trace.Context`,
+  `Trace.Stack`, `Trace.Span`, `Trace.Exporter`, `Trace.ReqStep`. Keep `Trace.Capture`,
+  `Trace.FinchCapture`, `Trace.Id`, `Trace.W3C`, `Trace.LogExporter` **unexported**.
+  The architecture test asserts this export set and that `Trace.Capture`/`FinchCapture`
+  subscribe by event-name only (never aliasing emitter modules).
+
+## 12. Testing strategy
+
+Wire-level via real `ImagePipe.call/2` + a `TestExporter` that sends spans to the
+test pid:
+
+- Full-tree: one `trace_id`; `[:source, :fetch]` and the transform subtree parented
+  under `[:request]` across hop B; `[:cache, :write]` parented under `[:request]`
+  across hop A (sibling to the Producer subtree); error → `status: :error`; exception
+  folded as an event.
+- Materialize nesting, **three separate cases** (the span isn't always under an op):
+  - mid-chain materializing op (e.g. smart-crop / right-angle rotate) → `materialize`
+    span nested under `[:transform, :operation]`, nonzero duration;
+  - delivery-only flush (an EXIF orientation 3–8 source with no other random-access
+    op) → `materialize` span present, parented to the **request root**, not an op span;
+  - pure-lazy + orientation-1 pipeline (resize/scale only, no deferred EXIF) → **no**
+    `materialize` span (negative control; the orientation-1 source ensures the delivery
+    flush doesn't fire).
+- `[:cache, :admission]` / `[:cache, :warm_start]` appear as their own roots, not
+  under `[:request]` (asserts §8.1).
+- Attr safety: a signed source URL never appears in any span's `attributes`
+  (property + example).
+- Inbound: `traceparent` + enabled → root adopts `trace_id`; malformed → fresh;
+  default (disabled) → fresh.
+- Finch wire spans parented to the logical Req span via `finch_private`.
+- Unit: `Id`/`W3C` round-trip and sizes; `Stack` push/pop/adopt incl. a
+  nested-then-sibling sequence; status mapping.
+- `logger_test` assertion for the new `materialize` line.
+
+**Tests not to write** (CLAUDE.md): no impossible-internal-misuse structs, no
+name/existence policing, no post-migration parity pins, no private-error-string
+assertions, no source-text scanning outside the architecture test.
+
+## 13. Risks & tradeoffs
+
+- **Process-dictionary leak** if a span opens without a matching stop (a hop that
+  bypasses `:telemetry.span/3`, or `Process.exit`). Mitigation: process death
+  discards the dict; pairing-ref check catches mismatches; depth cap + warn. A
+  hard-killed Producer drops its in-flight logical Req span (§9) — acceptable.
+- **Forgettable propagation** — a future spawn/Task that doesn't thread context
+  orphans. Mitigation: two request hops today (§8), both threaded; `bind/async`
+  helpers + an architecture test guard; orphan-root detection in tests.
+- **Cache topology is the subtle part** — `[:cache, :write]` (SourceSession) needs
+  hop A; admission/warm_start/ticker spans are intentionally separate roots (§8.1).
+  Getting this wrong silently orphans cache spans; covered by the §12 assertions.
+- **Finch span volume** — `finch_spans: true` multiplies spans; it's gated and the
+  default can be reconsidered if noisy.
+- **Sensitive-data regression** is the highest-stakes failure — locked by the
+  attr-safety test; every new attribute is guideline-reviewed; operation structs
+  stored opaque (no `Transform.Operation.*` alias in telemetry).
+
+Resolved during review (no longer open): `source → telemetry` dep already exists;
+`State.telemetry_opts` is already reachable at the flush site.
+
+## 14. Build order — three phased plans (each its own review + PR)
+
+The test surface spans five boundaries; per review it decomposes into three plans
+along natural seams. The materialize span + its **full** Logger/doc-sync stay in
+Phase 1 (the only piece with CLAUDE.md doc-sync teeth — don't let the Levels arm slip
+under Finch/inbound review fatigue).
+
+**Phase 1 — core capture + materialize barrier + Logger/doc sync:**
+1. `Trace.Id`, `Trace.W3C` (+ unit tests).
+2. `Trace.Context`, `Trace.Span`, `Trace.Stack` (+ unit tests incl. nested-then-sibling).
+3. `Trace.Capture` + `Trace.Exporter` + a `TestExporter`; single-process wire-level
+   tree test via real `ImagePipe.call/2`.
+4. `safe_attrs/1` (opaque structs, uniform application) + attr-safety test.
+5. `[:transform, :materialize]` span in `Materializer` (use `state.telemetry_opts`) +
+   the four Logger-sync points (incl. the stop-error `level_for/3` arm) +
+   `telemetry.md` materialize subsection + the three-case materialize tests.
+
+**Phase 2 — cross-process propagation + inbound edge:**
+6. Hop A (request → SourceSession, threaded as data through `start_child` opts →
+   `init/1`) and Hop B (SourceSession → Producer); §8.1 Admission-as-separate-root;
+   cross-process tree test (`[:cache, :write]` + Producer subtree under `[:request]`).
+7. Inbound edge (`extract_inbound`, `put_inbound`, plug extraction, malformed→fresh) +
+   tests.
+
+**Phase 3 — outbound HTTP + public glue + docs:**
+8. `Trace.ReqStep` + `Trace.FinchCapture` (logical + physical via `finch_private`) +
+   Finch tests.
+9. `Trace.LogExporter` + `logger_test`; `ImagePipe.Telemetry.attach_tracer/1` (raising
+   validation) + `detach_tracer/0`; `telemetry.md` `## Tracing (opt-in)` section.
+10. Boundary defs + `exports:` set + architecture test; full `mise run precommit`.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -470,3 +470,82 @@ end
 
 When customizing `telemetry_prefix`, attach to that same prefix instead of
 `[:image_pipe]`.
+
+## Tracing (opt-in)
+
+The events above are raw `:telemetry` events. ImagePipe also ships an **opt-in
+span tracer** that consumes those events, reconstructs correctly-nested
+distributed-trace-shaped spans (one `trace_id` per request, parent/child
+relationships preserved across the `[:transform, :execute]` /
+`[:transform, :operation]` / `[:transform, :materialize]` nesting and across the
+request → `SourceSession` → `Producer` process seams), and hands each finished
+span to a pluggable exporter as an `ImagePipe.Telemetry.Trace.Span`.
+
+The tracer is **not** attached automatically. A host opts in with
+`ImagePipe.Telemetry.attach_tracer/1` and removes it with
+`ImagePipe.Telemetry.detach_tracer/0`. Both are host-startup configuration, so
+`attach_tracer/1` **raises** `ArgumentError` on invalid options rather than
+returning a tagged error.
+
+```elixir
+# Attach the bundled stdlib-Logger exporter:
+ImagePipe.Telemetry.attach_tracer(exporter: ImagePipe.Telemetry.Trace.LogExporter)
+
+# ... later ...
+ImagePipe.Telemetry.detach_tracer()
+```
+
+### Options
+
+| Option            | Type            | Default                   | Meaning                                                                 |
+| ----------------- | --------------- | ------------------------- | ----------------------------------------------------------------------- |
+| `:exporter`       | module (atom)   | — (required)              | Module implementing the `ImagePipe.Telemetry.Trace.Exporter` behaviour. |
+| `:prefix`         | list of atoms   | `[:image_pipe]`           | Telemetry event prefix to subscribe to. Reuses `ImagePipe.Telemetry.default_prefix()`; match your configured `telemetry_prefix`. |
+| `:extract_inbound`| boolean         | `false`                   | Extract an inbound W3C `traceparent` header so the root span continues an upstream trace. Off by default — only enable behind a trusted edge. |
+| `:finch_spans`    | boolean         | `true`                    | Also capture physical Finch wire spans for outbound source fetches.     |
+
+`attach_tracer/1` raises `ArgumentError` when an option is unknown, has the wrong
+type, `:exporter` is missing, or the exporter module is not loaded / does not
+export `export/1`.
+
+### The exporter contract
+
+A host implements `ImagePipe.Telemetry.Trace.Exporter`:
+
+```elixir
+@callback export(ImagePipe.Telemetry.Trace.Span.t()) :: :ok
+```
+
+- `export/1` is called **synchronously** in the process that emitted the span's
+  `:stop` / `:exception`. Keep it cheap and non-blocking — hand real I/O off to a
+  batch processor. It must return `:ok` and should not raise.
+- Span **attributes are pre-filtered for sensitivity** by the capture layer
+  (allowlist only — source URLs, request paths, signatures, and tokens are never
+  copied in). Exporters that fan out to third parties remain responsible for
+  their own egress policy.
+
+### `LogExporter`
+
+`ImagePipe.Telemetry.Trace.LogExporter` is the bundled default. It is
+**stateless and flat by design**: it logs one structured `Logger.info` line per
+completed span as that span closes, in the process that emitted it. It does
+**not** buffer spans into a tree or wait for a root to close — parentage is
+carried in the `parent=` field so a downstream log pipeline can reconstruct
+nesting.
+
+```
+image_pipe.trace trace=<trace_id> span=<span_id> parent=<parent_span_id|-> <name> dur=<duration_native|-> status=<ok|error|unset>
+```
+
+### Inbound extraction and sampling
+
+Inbound `traceparent` extraction is **opt-in** (`extract_inbound: true`) because
+trusting an inbound trace header from an untrusted client lets a caller pin your
+`trace_id`; enable it only behind a gateway you control. When enabled and a valid
+W3C `traceparent` is present, the request root span continues that trace and
+parents to the inbound span; otherwise it mints a fresh root.
+
+**Sampling is deferred to the host.** ImagePipe propagates `trace_flags` but does
+not implement a sampler. A host that wants head- or tail-based sampling does it in
+its exporter (e.g. drop spans whose `trace_flags` indicate "not sampled", or
+batch and sample in the downstream collector).

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -57,6 +57,7 @@ transform execution, output negotiation, encoding, and send streaming spans.
 [:image_pipe, :source, :fetch_decode, ...]
 [:image_pipe, :transform, :execute, ...]
 [:image_pipe, :transform, :operation, ...]
+[:image_pipe, :transform, :materialize, ...]
 [:image_pipe, :encode, ...]
 [:image_pipe, :cache, :stage, ...]
 [:image_pipe, :cache, :write, ...]
@@ -140,6 +141,41 @@ Start metadata:
 
 Stop metadata: `:result` (`:ok` or `:error`).
 
+### Materialization barrier span (`[:transform, :materialize]`)
+
+Each time the pipeline flushes the lazy libvips state to a RAM-resident buffer it
+emits a `[:image_pipe, :transform, :materialize]` span from
+`ImagePipe.Transform.Materializer.materialize/1`. This is the **honest
+per-barrier timing the per-operation spans deliberately lack**: libvips defers
+and fuses pixel work until materialization, so a materialize span's duration is
+real flush cost (orientation pixels written, `copy_memory`), not construction
+time.
+
+A flush also applies any deferred EXIF/user orientation before copying, so a
+materialize span can mark where the displayed frame changes, not only where
+pixels reach RAM.
+
+Stop metadata: `:result` (`:ok` or `:materialize_error`). A failed flush surfaces
+as a `:stop` carrying `result: :materialize_error` (the callers map it to a decode
+error → `415`); a raise inside the flush surfaces as a `[:transform, :materialize,
+:exception]` event.
+
+Parenting depends on where the flush happens — there are three cases:
+
+- **mid-chain**, before the first operation that needs random access (right-angle
+  rotate, vertical/both flip, smart/object-detect crop): nested under that
+  operation's `[:transform, :operation]` span;
+- **pipeline-boundary**, when a still-pending EXIF orientation is flushed by the
+  plan executor: nested under `[:transform, :execute]` (not under any single
+  operation);
+- **delivery backstop**, when a chain streamed through without ever materializing
+  and the late delivery flush runs after `[:transform, :execute]` has closed:
+  nested under the request root.
+
+Every successful request materializes at least once (a chain that never
+materializes mid-pipeline hits the delivery backstop), so there is no
+"zero materialize spans" outcome.
+
 ## Measurements
 
 ImagePipe uses the measurements provided by `:telemetry.span/3`:
@@ -201,6 +237,7 @@ Request and stage spans use narrow result atoms:
 - `:plan_error`
 - `:source_error`
 - `:cache_error`
+- `:materialize_error`
 - `:processing_error`
 - `:error`
 
@@ -213,6 +250,7 @@ Representative stage → result mappings:
 - `[:source, :fetch_decode]` → `:ok`, `:source_error` (e.g. `error: :body_too_large`),
   or `:processing_error` (e.g. `error: :input_limit`, `:decode`).
 - `[:transform, :execute]` → `:ok` or `:processing_error`.
+- `[:transform, :materialize]` → `:ok` or `:materialize_error`.
 - `[:output, :negotiate]` → `:ok` or a negotiation failure category.
 
 The `:error` field is a stable category atom (`ImagePipe.Error.tag/1`), never a
@@ -399,6 +437,7 @@ defmodule MyApp.ImagePipeTelemetry do
     [:source, :fetch_decode],
     [:transform, :execute],
     [:transform, :operation],
+    [:transform, :materialize],
     [:encode],
     [:cache, :stage],
     [:cache, :write],

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -63,9 +63,6 @@ transform execution, output negotiation, encoding, and send streaming spans.
 [:image_pipe, :send, ...]
 ```
 
-(`[:cache, :stage]` and the HTTP-cache decisions are one-shot `Telemetry.execute/4`
-events, not spans — see [Measurements](#measurements).)
-
 For example, the cache lookup stop event with the default prefix is:
 
 ```text

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -171,9 +171,11 @@ Parenting depends on where the flush happens — there are three cases:
   and the late delivery flush runs after `[:transform, :execute]` has closed:
   nested under the request root.
 
-Every successful request materializes at least once (a chain that never
-materializes mid-pipeline hits the delivery backstop), so there is no
-"zero materialize spans" outcome.
+Every request that decodes and runs the transform pipeline (a cache miss)
+materializes at least once: a chain that never materializes mid-pipeline hits the
+delivery backstop. Requests served from cache (cache hits, conditional `304`s) skip
+decode and transform entirely, so they emit no `[:transform, :materialize]` span
+(nor any other transform span).
 
 ## Measurements
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -59,10 +59,12 @@ transform execution, output negotiation, encoding, and send streaming spans.
 [:image_pipe, :transform, :operation, ...]
 [:image_pipe, :transform, :materialize, ...]
 [:image_pipe, :encode, ...]
-[:image_pipe, :cache, :stage, ...]
 [:image_pipe, :cache, :write, ...]
 [:image_pipe, :send, ...]
 ```
+
+(`[:cache, :stage]` and the HTTP-cache decisions are one-shot `Telemetry.execute/4`
+events, not spans — see [Measurements](#measurements).)
 
 For example, the cache lookup stop event with the default prefix is:
 
@@ -353,7 +355,8 @@ Cache-related metadata may also include:
 - `cache: :stage_abandoned`
 - `cache: :stage_cleanup_error`
 
-Streamed cache misses may also emit `[:cache, :stage, :stop]` with:
+Streamed cache misses may also emit the one-shot `[:cache, :stage]` event (sent
+with `Telemetry.execute/4`, not a span) with:
 
 - `cache: :stage_skipped` and `reason: :too_large` when the staging sink crosses
   `:max_body_bytes`.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -525,6 +525,11 @@ A host implements `ImagePipe.Telemetry.Trace.Exporter`:
   (allowlist only — source URLs, request paths, signatures, and tokens are never
   copied in). Exporters that fan out to third parties remain responsible for
   their own egress policy.
+- The allowlist covers **attributes only**. A span's `status_message` and the
+  `reason` on a folded `exception` event carry the raw exception reason
+  (`inspect/1`, standard tracing behavior) and are **not** allowlist-filtered,
+  so an exporter that renders them to third parties should be aware they may
+  embed an exception message. (The bundled `LogExporter` renders neither.)
 
 ### `LogExporter`
 

--- a/lib/image_pipe/plug.ex
+++ b/lib/image_pipe/plug.ex
@@ -39,6 +39,7 @@ defmodule ImagePipe.Plug do
   @impl Plug
   def call(%Plug.Conn{} = conn, opts) do
     telemetry_opts = Telemetry.telemetry_opts(opts)
+    Telemetry.Trace.maybe_extract_inbound(conn)
 
     Telemetry.span(telemetry_opts, [:request], request_metadata(conn, opts), fn ->
       {conn, metadata} = do_call(conn, opts)

--- a/lib/image_pipe/request/runner.ex
+++ b/lib/image_pipe/request/runner.ex
@@ -16,6 +16,7 @@ defmodule ImagePipe.Request.Runner do
   alias ImagePipe.Response.PreparedStream
   alias ImagePipe.Source
   alias ImagePipe.Telemetry
+  alias ImagePipe.Telemetry.Trace
   alias ImagePipe.Transform
 
   @type delivery() ::
@@ -127,7 +128,7 @@ defmodule ImagePipe.Request.Runner do
 
         # Capture the active trace context from THIS (request) process and pass it as
         # data: the SourceSession/Producer spawn does not inherit our process stack.
-        trace_context = ImagePipe.Telemetry.Trace.Stack.context()
+        trace_context = Trace.Stack.context()
 
         case SourceSessionSupervisor.start_session(supervisor, request,
                trace_context: trace_context

--- a/lib/image_pipe/request/runner.ex
+++ b/lib/image_pipe/request/runner.ex
@@ -125,7 +125,13 @@ defmodule ImagePipe.Request.Runner do
 
         supervisor = Keyword.get(opts, :source_session_supervisor, SourceSessionSupervisor)
 
-        case SourceSessionSupervisor.start_session(supervisor, request) do
+        # Capture the active trace context from THIS (request) process and pass it as
+        # data: the SourceSession/Producer spawn does not inherit our process stack.
+        trace_context = ImagePipe.Telemetry.Trace.Stack.context()
+
+        case SourceSessionSupervisor.start_session(supervisor, request,
+               trace_context: trace_context
+             ) do
           {:ok, session} ->
             prepare_supervised_session(
               session,

--- a/lib/image_pipe/request/source_session.ex
+++ b/lib/image_pipe/request/source_session.ex
@@ -8,6 +8,7 @@ defmodule ImagePipe.Request.SourceSession do
   alias ImagePipe.Request.SourceSession.Producer
   alias ImagePipe.Request.SourceSession.Request
   alias ImagePipe.Source.StreamError
+  alias ImagePipe.Telemetry.Trace
 
   # Backstop for a wedged producer, not an input-safety bound (real liveness is
   # bounded by origin_receive_timeout and the decoded-pixel limit). `prepare`/`next`
@@ -84,6 +85,9 @@ defmodule ImagePipe.Request.SourceSession do
     Process.flag(:trap_exit, true)
     # Preserve request ownership for Tasks spawned by downstream image/source code.
     Process.put(:"$callers", [owner | Process.get(:"$callers", [])])
+    # Hop A: adopt the request's trace context so spans emitted from THIS process
+    # (e.g. [:cache, :write] during commit) nest under the request root.
+    Trace.Stack.adopt(trace_context)
 
     {:ok,
      %__MODULE__{
@@ -253,6 +257,7 @@ defmodule ImagePipe.Request.SourceSession do
         caller_chain: caller_chain,
         trace_context: state.trace_context
       )
+
     ref = Process.monitor(producer)
     %{state | producer: producer, producer_monitor: ref, fetch_started_at: fetch_started_at}
   end

--- a/lib/image_pipe/request/source_session.ex
+++ b/lib/image_pipe/request/source_session.ex
@@ -24,6 +24,7 @@ defmodule ImagePipe.Request.SourceSession do
     :owner,
     :owner_monitor,
     :parent,
+    :trace_context,
     :producer,
     :producer_monitor,
     :producer_request_ref,
@@ -70,15 +71,16 @@ defmodule ImagePipe.Request.SourceSession do
   defp start_server(kind, %Request{} = request, opts, default_parent) do
     owner = Keyword.get(opts, :owner, self())
     parent = Keyword.get(opts, :parent, default_parent)
+    trace_context = Keyword.get(opts, :trace_context)
 
     case kind do
-      :start -> GenServer.start(__MODULE__, {request, owner, parent})
-      :start_link -> GenServer.start_link(__MODULE__, {request, owner, parent})
+      :start -> GenServer.start(__MODULE__, {request, owner, parent, trace_context})
+      :start_link -> GenServer.start_link(__MODULE__, {request, owner, parent, trace_context})
     end
   end
 
   @impl GenServer
-  def init({%Request{} = request, owner, parent}) when is_pid(owner) do
+  def init({%Request{} = request, owner, parent, trace_context}) when is_pid(owner) do
     Process.flag(:trap_exit, true)
     # Preserve request ownership for Tasks spawned by downstream image/source code.
     Process.put(:"$callers", [owner | Process.get(:"$callers", [])])
@@ -88,7 +90,8 @@ defmodule ImagePipe.Request.SourceSession do
        request: request,
        owner: owner,
        owner_monitor: Process.monitor(owner),
-       parent: parent
+       parent: parent,
+       trace_context: trace_context
      }}
   end
 
@@ -244,7 +247,12 @@ defmodule ImagePipe.Request.SourceSession do
   defp start_producer(%{request: %Request{} = request} = state) do
     caller_chain = Process.get(:"$callers", [])
     fetch_started_at = System.monotonic_time(:microsecond)
-    {:ok, producer} = Producer.start_link(request, caller_chain: caller_chain)
+
+    {:ok, producer} =
+      Producer.start_link(request,
+        caller_chain: caller_chain,
+        trace_context: state.trace_context
+      )
     ref = Process.monitor(producer)
     %{state | producer: producer, producer_monitor: ref, fetch_started_at: fetch_started_at}
   end

--- a/lib/image_pipe/request/source_session/producer.ex
+++ b/lib/image_pipe/request/source_session/producer.ex
@@ -25,10 +25,15 @@ defmodule ImagePipe.Request.SourceSession.Producer do
   @spec start_link(Request.t(), keyword()) :: {:ok, pid()}
   def start_link(%Request{} = request, opts \\ []) do
     caller_chain = Keyword.get(opts, :caller_chain, Process.get(:"$callers", []))
+    trace_context = Keyword.get(opts, :trace_context)
 
     pid =
       spawn_link(fn ->
         Process.put(:"$callers", caller_chain)
+        # Hop B: adopt the request's trace context (passed as data, since the spawned
+        # process does not inherit the caller's trace stack) so producer-process spans
+        # (source.fetch_decode, transform.execute, …) nest under the request root.
+        ImagePipe.Telemetry.Trace.Stack.adopt(trace_context)
         loop(%__MODULE__{request: request})
       end)
 

--- a/lib/image_pipe/request/source_session/producer.ex
+++ b/lib/image_pipe/request/source_session/producer.ex
@@ -10,6 +10,7 @@ defmodule ImagePipe.Request.SourceSession.Producer do
   alias ImagePipe.Request.SourceSession.Request
   alias ImagePipe.Source.StreamError
   alias ImagePipe.Telemetry
+  alias ImagePipe.Telemetry.Trace
   alias ImagePipe.Transform.State
 
   defstruct [
@@ -33,7 +34,7 @@ defmodule ImagePipe.Request.SourceSession.Producer do
         # Hop B: adopt the request's trace context (passed as data, since the spawned
         # process does not inherit the caller's trace stack) so producer-process spans
         # (source.fetch_decode, transform.execute, …) nest under the request root.
-        ImagePipe.Telemetry.Trace.Stack.adopt(trace_context)
+        Trace.Stack.adopt(trace_context)
         loop(%__MODULE__{request: request})
       end)
 

--- a/lib/image_pipe/source/req_stream.ex
+++ b/lib/image_pipe/source/req_stream.ex
@@ -49,12 +49,13 @@ defmodule ImagePipe.Source.ReqStream do
   end
 
   defp request_and_route(req_options, runtime_opts, validate, redirects_left, redirects_allowed?) do
-    case Req.get(request_options(req_options),
-           receive_timeout:
-             timeout(req_options, runtime_opts, :receive_timeout, @default_receive_timeout),
-           pool_timeout: timeout(req_options, runtime_opts, :pool_timeout, @default_pool_timeout),
-           connect_options: connect_options(req_options, runtime_opts)
-         ) do
+    request =
+      req_options
+      |> request_options(runtime_opts)
+      |> Req.new()
+      |> ImagePipe.Telemetry.Trace.ReqStep.attach()
+
+    case Req.request(request) do
       {:ok, %Req.Response{status: status} = response} when status in 200..299 ->
         %{
           response: response,
@@ -158,11 +159,15 @@ defmodule ImagePipe.Source.ReqStream do
     end
   end
 
-  defp request_options(req_options) do
+  defp request_options(req_options, runtime_opts) do
     Keyword.merge(req_options,
       into: :self,
       retry: false,
-      redirect: false
+      redirect: false,
+      receive_timeout:
+        timeout(req_options, runtime_opts, :receive_timeout, @default_receive_timeout),
+      pool_timeout: timeout(req_options, runtime_opts, :pool_timeout, @default_pool_timeout),
+      connect_options: connect_options(req_options, runtime_opts)
     )
   end
 

--- a/lib/image_pipe/source/req_stream.ex
+++ b/lib/image_pipe/source/req_stream.ex
@@ -2,6 +2,7 @@ defmodule ImagePipe.Source.ReqStream do
   @moduledoc false
 
   alias ImagePipe.Source.StreamError
+  alias ImagePipe.Telemetry.Trace.ReqStep
 
   @default_receive_timeout 5_000
   @default_pool_timeout 5_000
@@ -53,7 +54,7 @@ defmodule ImagePipe.Source.ReqStream do
       req_options
       |> request_options(runtime_opts)
       |> Req.new()
-      |> ImagePipe.Telemetry.Trace.ReqStep.attach()
+      |> ReqStep.attach()
 
     case Req.request(request) do
       {:ok, %Req.Response{status: status} = response} when status in 200..299 ->

--- a/lib/image_pipe/telemetry.ex
+++ b/lib/image_pipe/telemetry.ex
@@ -15,6 +15,7 @@ defmodule ImagePipe.Telemetry do
   alias ImagePipe.Telemetry.Logger, as: DefaultLogger
   alias ImagePipe.Telemetry.Trace
   alias ImagePipe.Telemetry.Trace.Capture
+  alias ImagePipe.Telemetry.Trace.FinchCapture
 
   @default_prefix [:image_pipe]
 
@@ -107,11 +108,18 @@ defmodule ImagePipe.Telemetry do
     Trace.set_exporter(exporter)
     Trace.set_extract_inbound(Keyword.get(opts, :extract_inbound, false))
     Capture.attach(%{prefix: prefix, exporter: exporter})
+
+    if Keyword.get(opts, :finch_spans, true) do
+      FinchCapture.attach(%{exporter: exporter})
+    end
+
+    :ok
   end
 
   @spec detach_tracer() :: :ok
   def detach_tracer do
     Capture.detach()
+    FinchCapture.detach()
     Trace.set_exporter(nil)
     Trace.set_extract_inbound(false)
     :ok

--- a/lib/image_pipe/telemetry.ex
+++ b/lib/image_pipe/telemetry.ex
@@ -10,7 +10,7 @@ defmodule ImagePipe.Telemetry do
   use Boundary,
     top_level?: true,
     deps: [],
-    exports: [Trace, Trace.Stack, Trace.Context, Trace.ReqStep]
+    exports: [Trace, Trace.Stack, Trace.Context, Trace.Span, Trace.Exporter, Trace.ReqStep]
 
   alias ImagePipe.Telemetry.Logger, as: DefaultLogger
   alias ImagePipe.Telemetry.Trace
@@ -133,7 +133,8 @@ defmodule ImagePipe.Telemetry do
     exporter = opts[:exporter]
 
     unless Code.ensure_loaded?(exporter) and function_exported?(exporter, :export, 1) do
-      raise ArgumentError, "exporter #{inspect(exporter)} must be a loaded module exporting export/1"
+      raise ArgumentError,
+            "exporter #{inspect(exporter)} must be a loaded module exporting export/1"
     end
 
     Trace.set_exporter(exporter)

--- a/lib/image_pipe/telemetry.ex
+++ b/lib/image_pipe/telemetry.ex
@@ -10,7 +10,7 @@ defmodule ImagePipe.Telemetry do
   use Boundary,
     top_level?: true,
     deps: [],
-    exports: [Trace]
+    exports: [Trace, Trace.Stack, Trace.Context]
 
   alias ImagePipe.Telemetry.Logger, as: DefaultLogger
   alias ImagePipe.Telemetry.Trace

--- a/lib/image_pipe/telemetry.ex
+++ b/lib/image_pipe/telemetry.ex
@@ -13,6 +13,8 @@ defmodule ImagePipe.Telemetry do
     exports: []
 
   alias ImagePipe.Telemetry.Logger, as: DefaultLogger
+  alias ImagePipe.Telemetry.Trace
+  alias ImagePipe.Telemetry.Trace.Capture
 
   @default_prefix [:image_pipe]
 
@@ -95,6 +97,23 @@ defmodule ImagePipe.Telemetry do
 
   defp validate_prefix(other),
     do: raise(ArgumentError, ":prefix must be a non-empty list of atoms, got: #{inspect(other)}")
+
+  @doc "Attach the opt-in span tracer. See `ImagePipe.Telemetry.Trace`."
+  @spec attach_tracer(keyword()) :: :ok
+  def attach_tracer(opts) do
+    exporter = Keyword.fetch!(opts, :exporter)
+    prefix = Keyword.get(opts, :prefix, default_prefix())
+
+    Trace.set_exporter(exporter)
+    Capture.attach(%{prefix: prefix, exporter: exporter})
+  end
+
+  @spec detach_tracer() :: :ok
+  def detach_tracer do
+    Capture.detach()
+    Trace.set_exporter(nil)
+    :ok
+  end
 
   @spec span(keyword(), [atom()], map() | keyword(), (-> term())) :: term()
   def span(telemetry_opts, stage, start_metadata, fun) when is_function(fun, 0) do

--- a/lib/image_pipe/telemetry.ex
+++ b/lib/image_pipe/telemetry.ex
@@ -10,7 +10,7 @@ defmodule ImagePipe.Telemetry do
   use Boundary,
     top_level?: true,
     deps: [],
-    exports: []
+    exports: [Trace]
 
   alias ImagePipe.Telemetry.Logger, as: DefaultLogger
   alias ImagePipe.Telemetry.Trace
@@ -105,6 +105,7 @@ defmodule ImagePipe.Telemetry do
     prefix = Keyword.get(opts, :prefix, default_prefix())
 
     Trace.set_exporter(exporter)
+    Trace.set_extract_inbound(Keyword.get(opts, :extract_inbound, false))
     Capture.attach(%{prefix: prefix, exporter: exporter})
   end
 
@@ -112,6 +113,7 @@ defmodule ImagePipe.Telemetry do
   def detach_tracer do
     Capture.detach()
     Trace.set_exporter(nil)
+    Trace.set_extract_inbound(false)
     :ok
   end
 

--- a/lib/image_pipe/telemetry.ex
+++ b/lib/image_pipe/telemetry.ex
@@ -148,6 +148,7 @@ defmodule ImagePipe.Telemetry do
     :ok
   end
 
+  @doc "Remove the opt-in span tracer attached with `attach_tracer/1`."
   @spec detach_tracer() :: :ok
   def detach_tracer do
     Capture.detach()

--- a/lib/image_pipe/telemetry.ex
+++ b/lib/image_pipe/telemetry.ex
@@ -148,6 +148,11 @@ defmodule ImagePipe.Telemetry do
     :ok
   end
 
+  def attach_tracer(other) do
+    raise ArgumentError,
+          "attach_tracer/1 expects a keyword list, got: #{inspect(other)}"
+  end
+
   @doc "Remove the opt-in span tracer attached with `attach_tracer/1`."
   @spec detach_tracer() :: :ok
   def detach_tracer do

--- a/lib/image_pipe/telemetry.ex
+++ b/lib/image_pipe/telemetry.ex
@@ -10,7 +10,7 @@ defmodule ImagePipe.Telemetry do
   use Boundary,
     top_level?: true,
     deps: [],
-    exports: [Trace, Trace.Stack, Trace.Context]
+    exports: [Trace, Trace.Stack, Trace.Context, Trace.ReqStep]
 
   alias ImagePipe.Telemetry.Logger, as: DefaultLogger
   alias ImagePipe.Telemetry.Trace

--- a/lib/image_pipe/telemetry.ex
+++ b/lib/image_pipe/telemetry.ex
@@ -99,17 +99,48 @@ defmodule ImagePipe.Telemetry do
   defp validate_prefix(other),
     do: raise(ArgumentError, ":prefix must be a non-empty list of atoms, got: #{inspect(other)}")
 
-  @doc "Attach the opt-in span tracer. See `ImagePipe.Telemetry.Trace`."
+  @tracer_schema NimbleOptions.new!(
+                   exporter: [type: :atom, required: true],
+                   prefix: [type: {:list, :atom}, default: @default_prefix],
+                   extract_inbound: [type: :boolean, default: false],
+                   finch_spans: [type: :boolean, default: true]
+                 )
+
+  @doc """
+  Attach the opt-in span tracer. See `ImagePipe.Telemetry.Trace`.
+
+  Host-startup configuration, so it raises `ArgumentError` on invalid options
+  (unknown keys, wrong types, or an exporter module that is not loadable or does
+  not export `export/1`) rather than returning a tagged error.
+
+  Options:
+    * `:exporter` — required; a module implementing `ImagePipe.Telemetry.Trace.Exporter`.
+    * `:prefix` — telemetry event prefix list (default `#{inspect(@default_prefix)}`).
+    * `:extract_inbound` — extract a W3C `traceparent` from inbound requests (default `false`).
+    * `:finch_spans` — also capture physical Finch wire spans (default `true`).
+  """
   @spec attach_tracer(keyword()) :: :ok
-  def attach_tracer(opts) do
-    exporter = Keyword.fetch!(opts, :exporter)
-    prefix = Keyword.get(opts, :prefix, default_prefix())
+  def attach_tracer(opts) when is_list(opts) do
+    opts =
+      case NimbleOptions.validate(opts, @tracer_schema) do
+        {:ok, validated} ->
+          validated
+
+        {:error, %NimbleOptions.ValidationError{} = error} ->
+          raise ArgumentError, "invalid attach_tracer options: #{Exception.message(error)}"
+      end
+
+    exporter = opts[:exporter]
+
+    unless Code.ensure_loaded?(exporter) and function_exported?(exporter, :export, 1) do
+      raise ArgumentError, "exporter #{inspect(exporter)} must be a loaded module exporting export/1"
+    end
 
     Trace.set_exporter(exporter)
-    Trace.set_extract_inbound(Keyword.get(opts, :extract_inbound, false))
-    Capture.attach(%{prefix: prefix, exporter: exporter})
+    Trace.set_extract_inbound(opts[:extract_inbound])
+    Capture.attach(%{prefix: opts[:prefix], exporter: exporter})
 
-    if Keyword.get(opts, :finch_spans, true) do
+    if opts[:finch_spans] do
       FinchCapture.attach(%{exporter: exporter})
     end
 

--- a/lib/image_pipe/telemetry/logger.ex
+++ b/lib/image_pipe/telemetry/logger.ex
@@ -13,7 +13,12 @@ defmodule ImagePipe.Telemetry.Logger do
     request: [[:request], [:send]],
     parse: [[:parse]],
     source: [[:source, :resolve], [:source, :fetch], [:source, :fetch_decode]],
-    transform: [[:transform, :execute], [:transform, :operation], [:transform, :detect]],
+    transform: [
+      [:transform, :execute],
+      [:transform, :operation],
+      [:transform, :materialize],
+      [:transform, :detect]
+    ],
     cache: [[:cache, :lookup], [:cache, :write], [:cache, :admission], [:cache, :warm_start]],
     output: []
   }
@@ -109,6 +114,7 @@ defmodule ImagePipe.Telemetry.Logger do
     cond do
       List.last(suffix) == :exception -> :warning
       metadata[:result] == :cache_error -> :warning
+      metadata[:result] == :materialize_error -> :warning
       detect_fallback_warning?(suffix, metadata) -> :warning
       true -> base
     end

--- a/lib/image_pipe/telemetry/trace.ex
+++ b/lib/image_pipe/telemetry/trace.ex
@@ -13,15 +13,17 @@ defmodule ImagePipe.Telemetry.Trace do
   def exporter, do: :persistent_term.get(@exporter_key, nil)
 
   @doc false
+  @spec set_extract_inbound(boolean()) :: :ok
   def set_extract_inbound(flag), do: :persistent_term.put(@extract_key, flag == true)
 
   @doc false
+  @spec maybe_extract_inbound(Plug.Conn.t()) :: :ok
   def maybe_extract_inbound(conn) do
     if :persistent_term.get(@extract_key, false) do
       conn |> Plug.Conn.get_req_header("traceparent") |> adopt_traceparent()
+    else
+      :ok
     end
-
-    :ok
   end
 
   defp adopt_traceparent([tp | _]) do

--- a/lib/image_pipe/telemetry/trace.ex
+++ b/lib/image_pipe/telemetry/trace.ex
@@ -1,11 +1,35 @@
 defmodule ImagePipe.Telemetry.Trace do
   @moduledoc "Public facade for the opt-in span tracer."
 
+  alias ImagePipe.Telemetry.Trace.{Inbound, W3C}
+
   @exporter_key {__MODULE__, :exporter}
+  @extract_key {__MODULE__, :extract_inbound}
 
   @doc false
   def set_exporter(mod), do: :persistent_term.put(@exporter_key, mod)
 
   @doc "The active exporter module, or nil when no tracer is attached."
   def exporter, do: :persistent_term.get(@exporter_key, nil)
+
+  @doc false
+  def set_extract_inbound(flag), do: :persistent_term.put(@extract_key, flag == true)
+
+  @doc false
+  def maybe_extract_inbound(conn) do
+    if :persistent_term.get(@extract_key, false) do
+      conn |> Plug.Conn.get_req_header("traceparent") |> adopt_traceparent()
+    end
+
+    :ok
+  end
+
+  defp adopt_traceparent([tp | _]) do
+    case W3C.decode(tp) do
+      {:ok, ctx} -> Inbound.put(ctx)
+      :error -> :ok
+    end
+  end
+
+  defp adopt_traceparent([]), do: :ok
 end

--- a/lib/image_pipe/telemetry/trace.ex
+++ b/lib/image_pipe/telemetry/trace.ex
@@ -1,0 +1,11 @@
+defmodule ImagePipe.Telemetry.Trace do
+  @moduledoc "Public facade for the opt-in span tracer."
+
+  @exporter_key {__MODULE__, :exporter}
+
+  @doc false
+  def set_exporter(mod), do: :persistent_term.put(@exporter_key, mod)
+
+  @doc "The active exporter module, or nil when no tracer is attached."
+  def exporter, do: :persistent_term.get(@exporter_key, nil)
+end

--- a/lib/image_pipe/telemetry/trace/capture.ex
+++ b/lib/image_pipe/telemetry/trace/capture.ex
@@ -234,9 +234,7 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
   defp exception_message(meta), do: inspect(meta[:reason])
 
   defp safe_attrs(meta) do
-    meta
-    |> Map.take(@safe_keys)
-    |> Map.new(fn {k, v} -> {k, v} end)
+    Map.take(meta, @safe_keys)
   end
 
   defp maybe_flags(attrs, nil), do: attrs

--- a/lib/image_pipe/telemetry/trace/capture.ex
+++ b/lib/image_pipe/telemetry/trace/capture.ex
@@ -80,12 +80,15 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
 
     _ = :telemetry.detach(@handler_id)
 
-    :telemetry.attach_many(
-      @handler_id,
-      events,
-      &__MODULE__.handle_event/4,
-      Map.put(config, :plen, length(prefix))
-    )
+    _ =
+      :telemetry.attach_many(
+        @handler_id,
+        events,
+        &__MODULE__.handle_event/4,
+        Map.put(config, :plen, length(prefix))
+      )
+
+    :ok
   end
 
   @spec detach() :: :ok
@@ -137,7 +140,7 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
     {trace_id, parent_id, flags} =
       case Stack.current() do
         nil -> root_ids(config)
-        %Span{trace_id: t, span_id: s} -> {t, s, nil}
+        %Span{trace_id: t, span_id: s, trace_flags: pf} -> {t, s, pf}
       end
 
     Stack.push(%Span{
@@ -147,7 +150,8 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
       name: name,
       kind: :internal,
       start_time: measurements[:system_time],
-      attributes: meta |> safe_attrs() |> maybe_flags(flags),
+      trace_flags: flags,
+      attributes: safe_attrs(meta),
       pid: self(),
       node: node()
     })
@@ -244,9 +248,6 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
   defp safe_attrs(meta) do
     Map.take(meta, @safe_keys)
   end
-
-  defp maybe_flags(attrs, nil), do: attrs
-  defp maybe_flags(attrs, flags), do: Map.put(attrs, :trace_flags, flags)
 
   defp export(span, exporter), do: exporter.export(span)
 end

--- a/lib/image_pipe/telemetry/trace/capture.ex
+++ b/lib/image_pipe/telemetry/trace/capture.ex
@@ -44,7 +44,8 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
   # SENSITIVITY: allowlist only. Never add :source_url, :source_path, request paths,
   # signatures, tokens, or any secret-bearing key. Operation structs (:params) are
   # stored opaque (inspected by exporters) and MUST NOT be pattern-matched against
-  # ImagePipe.Transform.Operation.* here — that would invert the telemetry boundary.
+  # concrete transform operation structs here — that would invert the telemetry
+  # boundary (enforced by the capture-no-concrete-modules architecture test).
   @safe_keys [
     :operation,
     :index,

--- a/lib/image_pipe/telemetry/trace/capture.ex
+++ b/lib/image_pipe/telemetry/trace/capture.ex
@@ -40,6 +40,11 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
   ]
 
   # Keys safe to copy into span attributes (allowlist; everything else dropped).
+  #
+  # SENSITIVITY: allowlist only. Never add :source_url, :source_path, request paths,
+  # signatures, tokens, or any secret-bearing key. Operation structs (:params) are
+  # stored opaque (inspected by exporters) and MUST NOT be pattern-matched against
+  # ImagePipe.Transform.Operation.* here — that would invert the telemetry boundary.
   @safe_keys [
     :operation,
     :index,

--- a/lib/image_pipe/telemetry/trace/capture.ex
+++ b/lib/image_pipe/telemetry/trace/capture.ex
@@ -94,7 +94,7 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
 
   def handle_event(event, measurements, meta, config) do
     case classify(event, config.plen) do
-      {:start, name} -> on_start(name, meta, config)
+      {:start, name} -> on_start(name, measurements, meta, config)
       {:stop, _name} -> on_stop(measurements, meta, config)
       {:exception, _name} -> on_exception(measurements, meta, config)
       {:oneshot, name} -> on_oneshot(name, meta)
@@ -131,7 +131,7 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
 
   # ---- handlers --------------------------------------------------------------
 
-  defp on_start(name, meta, config) do
+  defp on_start(name, measurements, meta, config) do
     {trace_id, parent_id, flags} =
       case Stack.current() do
         nil -> root_ids(config)
@@ -144,7 +144,7 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
       parent_span_id: parent_id,
       name: name,
       kind: :internal,
-      start_time: meta[:system_time],
+      start_time: measurements[:system_time],
       attributes: meta |> safe_attrs() |> maybe_flags(flags),
       pid: self(),
       node: node()

--- a/lib/image_pipe/telemetry/trace/capture.ex
+++ b/lib/image_pipe/telemetry/trace/capture.ex
@@ -1,0 +1,241 @@
+defmodule ImagePipe.Telemetry.Trace.Capture do
+  @moduledoc false
+  alias ImagePipe.Telemetry.Trace.{Id, Span, Stack}
+
+  @handler_id {__MODULE__, :spans}
+
+  # Span stages emitted under the image_pipe prefix.
+  @span_stages [
+    [:request],
+    [:parse],
+    [:send],
+    [:source, :resolve],
+    [:source, :fetch],
+    [:source, :fetch_decode],
+    [:output, :negotiate],
+    [:transform, :execute],
+    [:transform, :operation],
+    [:transform, :materialize],
+    [:transform, :detect],
+    [:transform, :detect, :model],
+    [:cache, :lookup],
+    [:cache, :write],
+    [:cache, :admission],
+    [:cache, :warm_start]
+  ]
+
+  # One-shot (terminal) events — folded as annotations onto the current span.
+  @oneshot_stages [
+    [:cache, :stage],
+    [:cache, :eviction, :stop],
+    [:cache, :flush, :stop],
+    [:cache, :cleanup, :stop],
+    [:output, :clamp],
+    [:transform, :detect, :skipped],
+    [:transform, :detect, :blend],
+    [:http_cache, :prepare],
+    [:http_cache, :conditional, :match],
+    [:http_cache, :fallback, :no_store],
+    [:http_cache, :cache_hit, :headers]
+  ]
+
+  # Keys safe to copy into span attributes (allowlist; everything else dropped).
+  @safe_keys [
+    :operation,
+    :index,
+    :operation_count,
+    :operations,
+    :result,
+    :cache,
+    :output_mode,
+    :source_kind,
+    :source_adapter_kind,
+    :detector,
+    :model,
+    :classes,
+    :regions,
+    :scale,
+    :width,
+    :height,
+    :format,
+    :params
+  ]
+
+  @spec attach(map()) :: :ok
+  def attach(%{prefix: prefix, exporter: _exporter} = config) do
+    events =
+      for(
+        stage <- @span_stages,
+        suffix <- [:start, :stop, :exception],
+        do: prefix ++ stage ++ [suffix]
+      ) ++
+        for(stage <- @oneshot_stages, do: prefix ++ stage)
+
+    _ = :telemetry.detach(@handler_id)
+
+    :telemetry.attach_many(
+      @handler_id,
+      events,
+      &__MODULE__.handle_event/4,
+      Map.put(config, :plen, length(prefix))
+    )
+  end
+
+  @spec detach() :: :ok
+  def detach do
+    _ = :telemetry.detach(@handler_id)
+    :ok
+  end
+
+  def handle_event(event, measurements, meta, config) do
+    case classify(event, config.plen) do
+      {:start, name} -> on_start(name, meta, config)
+      {:stop, _name} -> on_stop(measurements, meta, config)
+      {:exception, _name} -> on_exception(measurements, meta, config)
+      {:oneshot, name} -> on_oneshot(name, meta)
+    end
+  rescue
+    # A tracer must never crash the request path; drop the event on any internal error.
+    _ -> :ok
+  end
+
+  # ---- classification --------------------------------------------------------
+
+  defp classify(event, plen) do
+    stage = Enum.drop(event, plen)
+
+    # CRITICAL: one-shots whose last atom is :stop (e.g. [:cache, :flush, :stop],
+    # [:cache, :eviction, :stop], [:cache, :cleanup, :stop]) are terminal events, NOT
+    # span stops. Check membership in @oneshot_stages BEFORE the suffix dispatch, or
+    # they would wrongly pop and export an unrelated span.
+    if stage in @oneshot_stages do
+      {:oneshot, name(stage)}
+    else
+      case List.last(stage) do
+        :start -> {:start, name(stage_without_suffix(stage))}
+        :stop -> {:stop, name(stage_without_suffix(stage))}
+        :exception -> {:exception, name(stage_without_suffix(stage))}
+        _ -> {:oneshot, name(stage)}
+      end
+    end
+  end
+
+  defp stage_without_suffix(stage), do: Enum.drop(stage, -1)
+
+  defp name(stage), do: "image_pipe." <> Enum.map_join(stage, ".", &Atom.to_string/1)
+
+  # ---- handlers --------------------------------------------------------------
+
+  defp on_start(name, meta, config) do
+    {trace_id, parent_id, flags} =
+      case Stack.current() do
+        nil -> root_ids(config)
+        %Span{trace_id: t, span_id: s} -> {t, s, nil}
+      end
+
+    Stack.push(%Span{
+      trace_id: trace_id,
+      span_id: Id.span_id(),
+      parent_span_id: parent_id,
+      name: name,
+      kind: :internal,
+      start_time: meta[:system_time],
+      attributes: meta |> safe_attrs() |> maybe_flags(flags),
+      pid: self(),
+      node: node()
+    })
+  end
+
+  defp on_stop(measurements, meta, %{exporter: exporter}) do
+    case Stack.pop() do
+      nil ->
+        :ok
+
+      # A synthetic remote-parent frame must never be finalized/exported: it belongs to
+      # the upstream process. If a stray :stop pops it, re-push and no-op.
+      %Span{name: "remote_parent", start_time: nil} = parent ->
+        Stack.push(parent)
+        :ok
+
+      span ->
+        span |> finalize(measurements, status_from(meta)) |> export(exporter)
+    end
+  end
+
+  defp on_exception(measurements, meta, %{exporter: exporter}) do
+    case Stack.pop() do
+      nil ->
+        :ok
+
+      # See on_stop: never finalize/export the synthetic cross-process parent frame.
+      %Span{name: "remote_parent", start_time: nil} = parent ->
+        Stack.push(parent)
+        :ok
+
+      span ->
+        span
+        |> Map.update!(:events, &[exception_event(meta) | &1])
+        |> finalize(measurements, :error)
+        |> Map.put(:status_message, exception_message(meta))
+        |> export(exporter)
+    end
+  end
+
+  defp on_oneshot(name, meta) do
+    case Stack.current() do
+      nil ->
+        :ok
+
+      span ->
+        event = %{name: name, time: meta[:monotonic_time], attributes: safe_attrs(meta)}
+        Stack.pop()
+        Stack.push(%{span | events: [event | span.events]})
+    end
+  end
+
+  # ---- helpers ---------------------------------------------------------------
+
+  # Inbound root context is read here in Phase 2 (Trace.Inbound.take/0); for now mint.
+  defp root_ids(_config), do: {Id.trace_id(), nil, 1}
+
+  defp finalize(span, measurements, status) do
+    %{
+      span
+      | duration_native: measurements[:duration],
+        end_time: end_time(span.start_time, measurements),
+        status: status
+    }
+  end
+
+  # start_time is native system_time (wall-clock); duration is a native monotonic
+  # delta. Both native → the sum is a valid native end_time. Exporters convert to
+  # ms/µs as needed; we keep native here (and duration_native) as the source of truth.
+  defp end_time(nil, _), do: nil
+  defp end_time(start, %{duration: d}) when is_integer(d), do: start + d
+  defp end_time(start, _), do: start
+
+  defp status_from(meta) do
+    case meta[:result] do
+      :ok -> :ok
+      nil -> :ok
+      _other -> :error
+    end
+  end
+
+  defp exception_event(meta) do
+    %{name: "exception", attributes: %{kind: meta[:kind], reason: inspect(meta[:reason])}}
+  end
+
+  defp exception_message(meta), do: inspect(meta[:reason])
+
+  defp safe_attrs(meta) do
+    meta
+    |> Map.take(@safe_keys)
+    |> Map.new(fn {k, v} -> {k, v} end)
+  end
+
+  defp maybe_flags(attrs, nil), do: attrs
+  defp maybe_flags(attrs, flags), do: Map.put(attrs, :trace_flags, flags)
+
+  defp export(span, exporter), do: exporter.export(span)
+end

--- a/lib/image_pipe/telemetry/trace/capture.ex
+++ b/lib/image_pipe/telemetry/trace/capture.ex
@@ -1,6 +1,6 @@
 defmodule ImagePipe.Telemetry.Trace.Capture do
   @moduledoc false
-  alias ImagePipe.Telemetry.Trace.{Id, Span, Stack}
+  alias ImagePipe.Telemetry.Trace.{Context, Id, Inbound, Span, Stack}
 
   @handler_id {__MODULE__, :spans}
 
@@ -203,8 +203,8 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
   # Inbound root context (W3C traceparent) is consumed once at the root span; falls
   # back to minting a fresh trace when no inbound context is present.
   defp root_ids(_config) do
-    case ImagePipe.Telemetry.Trace.Inbound.take() do
-      %ImagePipe.Telemetry.Trace.Context{trace_id: t, span_id: s, trace_flags: f} -> {t, s, f}
+    case Inbound.take() do
+      %Context{trace_id: t, span_id: s, trace_flags: f} -> {t, s, f}
       nil -> {Id.trace_id(), nil, 1}
     end
   end

--- a/lib/image_pipe/telemetry/trace/capture.ex
+++ b/lib/image_pipe/telemetry/trace/capture.ex
@@ -200,8 +200,14 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
 
   # ---- helpers ---------------------------------------------------------------
 
-  # Inbound root context is read here in Phase 2 (Trace.Inbound.take/0); for now mint.
-  defp root_ids(_config), do: {Id.trace_id(), nil, 1}
+  # Inbound root context (W3C traceparent) is consumed once at the root span; falls
+  # back to minting a fresh trace when no inbound context is present.
+  defp root_ids(_config) do
+    case ImagePipe.Telemetry.Trace.Inbound.take() do
+      %ImagePipe.Telemetry.Trace.Context{trace_id: t, span_id: s, trace_flags: f} -> {t, s, f}
+      nil -> {Id.trace_id(), nil, 1}
+    end
+  end
 
   defp finalize(span, measurements, status) do
     %{

--- a/lib/image_pipe/telemetry/trace/capture.ex
+++ b/lib/image_pipe/telemetry/trace/capture.ex
@@ -9,6 +9,7 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
     [:request],
     [:parse],
     [:send],
+    [:encode],
     [:source, :resolve],
     [:source, :fetch],
     [:source, :fetch_decode],

--- a/lib/image_pipe/telemetry/trace/context.ex
+++ b/lib/image_pipe/telemetry/trace/context.ex
@@ -1,0 +1,18 @@
+defmodule ImagePipe.Telemetry.Trace.Context do
+  @moduledoc """
+  Immutable, serializable trace context that crosses process/node/HTTP seams.
+
+  Carries the current span identity so a far-side process (or downstream service)
+  can attach children under it. `span_id` becomes the child's `parent_span_id`.
+  """
+
+  @enforce_keys [:trace_id, :span_id]
+  defstruct [:trace_id, :span_id, trace_flags: 1, baggage: %{}]
+
+  @type t :: %__MODULE__{
+          trace_id: String.t(),
+          span_id: String.t(),
+          trace_flags: non_neg_integer(),
+          baggage: %{optional(String.t()) => String.t()}
+        }
+end

--- a/lib/image_pipe/telemetry/trace/exporter.ex
+++ b/lib/image_pipe/telemetry/trace/exporter.ex
@@ -1,0 +1,14 @@
+defmodule ImagePipe.Telemetry.Trace.Exporter do
+  @moduledoc """
+  Behaviour a host implements to receive captured spans, one per completed span.
+
+  `export/1` is called synchronously in the process that emitted the span's `:stop`/
+  `:exception`. Keep it cheap and non-blocking — hand off to a batch processor for any
+  real I/O. It must return `:ok` and should not raise. Attributes are pre-filtered for
+  sensitivity (`ImagePipe.Telemetry.Trace.Capture` allowlists them), but exporters that
+  fan out to third parties remain responsible for their own egress policy.
+  """
+  alias ImagePipe.Telemetry.Trace.Span
+
+  @callback export(Span.t()) :: :ok
+end

--- a/lib/image_pipe/telemetry/trace/finch_capture.ex
+++ b/lib/image_pipe/telemetry/trace/finch_capture.ex
@@ -49,7 +49,8 @@ defmodule ImagePipe.Telemetry.Trace.FinchCapture do
   # parent identity is carried on the request struct rather than read off the stack.
   def handle_event([:finch | rest], measurements, meta, config) do
     with %{} = request <- Map.get(meta, :request),
-         %{@finch_private_key => {trace_id, parent_span_id}} <- Map.get(request, :private, %{}) do
+         %{@finch_private_key => {trace_id, parent_span_id, flags}} <-
+           Map.get(request, :private, %{}) do
       config.exporter.export(%Span{
         trace_id: trace_id,
         span_id: Id.span_id(),
@@ -58,6 +59,7 @@ defmodule ImagePipe.Telemetry.Trace.FinchCapture do
         kind: :client,
         start_time: measurements[:system_time],
         duration_native: measurements[:duration],
+        trace_flags: flags,
         status: status(meta),
         attributes: attributes(meta),
         pid: self(),

--- a/lib/image_pipe/telemetry/trace/finch_capture.ex
+++ b/lib/image_pipe/telemetry/trace/finch_capture.ex
@@ -23,16 +23,19 @@ defmodule ImagePipe.Telemetry.Trace.FinchCapture do
     [:finch, :recv, :exception]
   ]
 
-  @spec attach(%{exporter: module()}) :: :ok | {:error, :already_exists}
+  @spec attach(%{exporter: module()}) :: :ok
   def attach(%{exporter: exporter}) do
     _ = :telemetry.detach(@handler_id)
 
-    :telemetry.attach_many(
-      @handler_id,
-      @events,
-      &__MODULE__.handle_event/4,
-      %{exporter: exporter}
-    )
+    _ =
+      :telemetry.attach_many(
+        @handler_id,
+        @events,
+        &__MODULE__.handle_event/4,
+        %{exporter: exporter}
+      )
+
+    :ok
   end
 
   @spec detach() :: :ok

--- a/lib/image_pipe/telemetry/trace/finch_capture.ex
+++ b/lib/image_pipe/telemetry/trace/finch_capture.ex
@@ -1,0 +1,76 @@
+defmodule ImagePipe.Telemetry.Trace.FinchCapture do
+  @moduledoc false
+  alias ImagePipe.Telemetry.Trace.{Id, Span}
+
+  @handler_id {__MODULE__, :finch}
+
+  # Finch span events worth a physical wire span. We attach to the stop/exception
+  # boundaries (durations are meaningful there). The logical client span comes from
+  # ReqStep; these are the Finch-level children.
+  @events [
+    [:finch, :request, :stop],
+    [:finch, :request, :exception],
+    [:finch, :queue, :stop],
+    [:finch, :queue, :exception],
+    [:finch, :connect, :stop],
+    [:finch, :connect, :exception],
+    [:finch, :send, :stop],
+    [:finch, :send, :exception],
+    [:finch, :recv, :stop],
+    [:finch, :recv, :exception]
+  ]
+
+  @spec attach(%{exporter: module()}) :: :ok | {:error, :already_exists}
+  def attach(%{exporter: exporter}) do
+    _ = :telemetry.detach(@handler_id)
+
+    :telemetry.attach_many(
+      @handler_id,
+      @events,
+      &__MODULE__.handle_event/4,
+      %{exporter: exporter}
+    )
+  end
+
+  @spec detach() :: :ok
+  def detach do
+    _ = :telemetry.detach(@handler_id)
+    :ok
+  end
+
+  # FinchCapture parents via finch_private (NOT the active span stack): Finch events
+  # fire in the Producer/caller process and may interleave across retries, so the
+  # parent identity is carried on the request struct rather than read off the stack.
+  def handle_event([:finch | rest], measurements, meta, config) do
+    with %{} = request <- Map.get(meta, :request),
+         %{image_pipe_trace: {trace_id, parent_span_id}} <- Map.get(request, :private, %{}) do
+      config.exporter.export(%Span{
+        trace_id: trace_id,
+        span_id: Id.span_id(),
+        parent_span_id: parent_span_id,
+        name: "finch." <> Enum.map_join(Enum.drop(rest, -1), ".", &Atom.to_string/1),
+        kind: :client,
+        start_time: meta[:system_time],
+        duration_native: measurements[:duration],
+        status: status(meta),
+        attributes: attributes(meta),
+        pid: self(),
+        node: node()
+      })
+
+      :ok
+    else
+      _ -> :ok
+    end
+  rescue
+    # A tracer must never crash the request path; drop the event on any internal error.
+    _ -> :ok
+  end
+
+  defp status(%{result: {:error, _reason}}), do: :error
+  defp status(%{kind: _kind}), do: :error
+  defp status(_meta), do: :ok
+
+  defp attributes(%{result: {:ok, %{status: status}}}), do: %{"http.status_code": status}
+  defp attributes(_meta), do: %{}
+end

--- a/lib/image_pipe/telemetry/trace/finch_capture.ex
+++ b/lib/image_pipe/telemetry/trace/finch_capture.ex
@@ -4,6 +4,9 @@ defmodule ImagePipe.Telemetry.Trace.FinchCapture do
 
   @handler_id {__MODULE__, :finch}
 
+  # Shared finch_private key — must match @priv in ReqStep (both stamp/read this atom).
+  @finch_private_key :image_pipe_trace
+
   # Finch span events worth a physical wire span. We attach to the stop/exception
   # boundaries (durations are meaningful there). The logical client span comes from
   # ReqStep; these are the Finch-level children.
@@ -43,14 +46,14 @@ defmodule ImagePipe.Telemetry.Trace.FinchCapture do
   # parent identity is carried on the request struct rather than read off the stack.
   def handle_event([:finch | rest], measurements, meta, config) do
     with %{} = request <- Map.get(meta, :request),
-         %{image_pipe_trace: {trace_id, parent_span_id}} <- Map.get(request, :private, %{}) do
+         %{@finch_private_key => {trace_id, parent_span_id}} <- Map.get(request, :private, %{}) do
       config.exporter.export(%Span{
         trace_id: trace_id,
         span_id: Id.span_id(),
         parent_span_id: parent_span_id,
         name: "finch." <> Enum.map_join(Enum.drop(rest, -1), ".", &Atom.to_string/1),
         kind: :client,
-        start_time: meta[:system_time],
+        start_time: measurements[:system_time],
         duration_native: measurements[:duration],
         status: status(meta),
         attributes: attributes(meta),

--- a/lib/image_pipe/telemetry/trace/id.ex
+++ b/lib/image_pipe/telemetry/trace/id.ex
@@ -1,0 +1,9 @@
+defmodule ImagePipe.Telemetry.Trace.Id do
+  @moduledoc false
+
+  @spec trace_id() :: String.t()
+  def trace_id, do: 16 |> :crypto.strong_rand_bytes() |> Base.encode16(case: :lower)
+
+  @spec span_id() :: String.t()
+  def span_id, do: 8 |> :crypto.strong_rand_bytes() |> Base.encode16(case: :lower)
+end

--- a/lib/image_pipe/telemetry/trace/inbound.ex
+++ b/lib/image_pipe/telemetry/trace/inbound.ex
@@ -1,0 +1,16 @@
+defmodule ImagePipe.Telemetry.Trace.Inbound do
+  @moduledoc false
+  alias ImagePipe.Telemetry.Trace.Context
+
+  @key :"$image_pipe_trace_inbound"
+
+  @spec put(Context.t()) :: :ok
+  def put(%Context{} = ctx) do
+    Process.put(@key, ctx)
+    :ok
+  end
+
+  @doc "Read and clear the inbound context (consumed once by the root span)."
+  @spec take() :: Context.t() | nil
+  def take, do: Process.delete(@key)
+end

--- a/lib/image_pipe/telemetry/trace/log_exporter.ex
+++ b/lib/image_pipe/telemetry/trace/log_exporter.ex
@@ -1,0 +1,26 @@
+defmodule ImagePipe.Telemetry.Trace.LogExporter do
+  @moduledoc """
+  Stdlib `Logger` exporter: one flat structured line per completed span.
+
+  Stateless by design — it does NOT buffer spans into a tree or wait for a root
+  to close. Each span is logged on its own as `:stop`/`:exception` fires, in the
+  process that emitted it. Parentage is carried in the `parent=` field so a
+  downstream log pipeline can reconstruct nesting; this exporter never holds
+  state between spans.
+  """
+  @behaviour ImagePipe.Telemetry.Trace.Exporter
+  require Logger
+  alias ImagePipe.Telemetry.Trace.Span
+
+  @impl true
+  @spec export(Span.t()) :: :ok
+  def export(%Span{} = span) do
+    Logger.info(fn ->
+      "image_pipe.trace " <>
+        "trace=#{span.trace_id} span=#{span.span_id} parent=#{span.parent_span_id || "-"} " <>
+        "#{span.name} dur=#{span.duration_native || "-"} status=#{span.status || "unset"}"
+    end)
+
+    :ok
+  end
+end

--- a/lib/image_pipe/telemetry/trace/log_exporter.ex
+++ b/lib/image_pipe/telemetry/trace/log_exporter.ex
@@ -16,9 +16,15 @@ defmodule ImagePipe.Telemetry.Trace.LogExporter do
   @spec export(Span.t()) :: :ok
   def export(%Span{} = span) do
     Logger.info(fn ->
+      status =
+        case span.status do
+          nil -> "unset"
+          other -> to_string(other)
+        end
+
       "image_pipe.trace " <>
         "trace=#{span.trace_id} span=#{span.span_id} parent=#{span.parent_span_id || "-"} " <>
-        "#{span.name} dur=#{span.duration_native || "-"} status=#{span.status || "unset"}"
+        "#{span.name} dur=#{span.duration_native || "-"} status=#{status}"
     end)
 
     :ok

--- a/lib/image_pipe/telemetry/trace/req_step.ex
+++ b/lib/image_pipe/telemetry/trace/req_step.ex
@@ -30,6 +30,8 @@ defmodule ImagePipe.Telemetry.Trace.ReqStep do
   alias ImagePipe.Telemetry.Trace
   alias ImagePipe.Telemetry.Trace.{Context, Id, Span, Stack, W3C}
 
+  # Finch-private key: shared contract with FinchCapture, which reads this atom from
+  # request.private to parent wire spans under the logical client span we stamp here.
   @priv :image_pipe_trace
 
   @spec attach(Req.Request.t()) :: Req.Request.t()
@@ -47,6 +49,7 @@ defmodule ImagePipe.Telemetry.Trace.ReqStep do
     {trace_id, flags} =
       case parent do
         %Context{trace_id: trace_id, trace_flags: flags} -> {trace_id, flags}
+        # No parent: mint a fresh trace, default sampled (flags=1).
         nil -> {Id.trace_id(), 1}
       end
 

--- a/lib/image_pipe/telemetry/trace/req_step.ex
+++ b/lib/image_pipe/telemetry/trace/req_step.ex
@@ -65,9 +65,12 @@ defmodule ImagePipe.Telemetry.Trace.ReqStep do
   end
 
   defp error({%Req.Request{} = req, exception}) do
-    emit(req, %{"http.error": inspect(exception)}, :error)
+    emit(req, %{"error.type": error_type(exception)}, :error)
     {req, exception}
   end
+
+  defp error_type(%{__struct__: mod}) when is_atom(mod), do: inspect(mod)
+  defp error_type(_), do: "unknown"
 
   defp emit(%Req.Request{} = req, attributes, status) do
     case {Trace.exporter(), Req.Request.get_private(req, @priv)} do

--- a/lib/image_pipe/telemetry/trace/req_step.ex
+++ b/lib/image_pipe/telemetry/trace/req_step.ex
@@ -1,0 +1,95 @@
+defmodule ImagePipe.Telemetry.Trace.ReqStep do
+  @moduledoc """
+  Req steps that trace an outbound HTTP call as a logical client span, inject a W3C
+  `traceparent` header, and stamp `finch_private` so `ImagePipe.Telemetry.Trace.FinchCapture`
+  can attach physical wire spans under the same parent. Apply where the source builds
+  its Req client (`req |> ReqStep.attach() |> Req.request(...)`).
+
+  ## Active-exporter coupling (not the stack)
+
+  The request step reads `ImagePipe.Telemetry.Trace.Stack.context/0` for its parent, but the
+  response/error steps emit through the *active exporter* (`ImagePipe.Telemetry.Trace.exporter/0`)
+  directly, NOT through the per-process span stack. Req's response/error steps may run in a
+  different process (or with a different active span) than the request step, so the parent
+  identity is carried in the request's private state rather than read back off the stack.
+
+  ## No-op when no tracer is attached
+
+  When `ImagePipe.Telemetry.Trace.exporter/0` is `nil` (no tracer attached), the steps emit
+  nothing. The header injection and `finch_private` stamp are cheap and harmless, so attaching
+  `ReqStep` is safe to do unconditionally at the build site — a source fetch behaves identically
+  whether or not a tracer is attached.
+
+  ## `into: :self` timing caveat
+
+  The source streams the body with `into: :self`, so Req's response step (and thus this span's
+  stop) fires at **status + headers received**, not when the body finishes downloading. The
+  logical client span's duration therefore covers connect + TTFB, not the full transfer. The
+  captured status is correct.
+  """
+  alias ImagePipe.Telemetry.Trace
+  alias ImagePipe.Telemetry.Trace.{Context, Id, Span, Stack, W3C}
+
+  @priv :image_pipe_trace
+
+  @spec attach(Req.Request.t()) :: Req.Request.t()
+  def attach(%Req.Request{} = req) do
+    req
+    |> Req.Request.append_request_steps(image_pipe_trace_start: &start/1)
+    |> Req.Request.prepend_response_steps(image_pipe_trace_stop: &stop/1)
+    |> Req.Request.append_error_steps(image_pipe_trace_error: &error/1)
+  end
+
+  defp start(%Req.Request{} = req) do
+    span_id = Id.span_id()
+    parent = Stack.context()
+
+    {trace_id, flags} =
+      case parent do
+        %Context{trace_id: trace_id, trace_flags: flags} -> {trace_id, flags}
+        nil -> {Id.trace_id(), 1}
+      end
+
+    req
+    |> Req.Request.put_header("traceparent", W3C.encode(trace_id, span_id, flags))
+    |> Req.Request.put_private(@priv, {trace_id, span_id, System.system_time(), parent})
+    |> Req.merge(finch_private: %{@priv => {trace_id, span_id}})
+  end
+
+  defp stop({%Req.Request{} = req, %Req.Response{status: status} = resp}) do
+    emit(req, %{"http.status_code": status}, :ok)
+    {req, resp}
+  end
+
+  defp error({%Req.Request{} = req, exception}) do
+    emit(req, %{"http.error": inspect(exception)}, :error)
+    {req, exception}
+  end
+
+  defp emit(%Req.Request{} = req, attributes, status) do
+    case {Trace.exporter(), Req.Request.get_private(req, @priv)} do
+      {nil, _private} ->
+        :ok
+
+      {_exporter, nil} ->
+        :ok
+
+      {exporter, {trace_id, span_id, start_time, parent}} ->
+        exporter.export(%Span{
+          trace_id: trace_id,
+          span_id: span_id,
+          parent_span_id: parent && parent.span_id,
+          name: "image_pipe.http.client",
+          kind: :client,
+          start_time: start_time,
+          end_time: System.system_time(),
+          status: status,
+          attributes: attributes,
+          pid: self(),
+          node: node()
+        })
+
+        :ok
+    end
+  end
+end

--- a/lib/image_pipe/telemetry/trace/req_step.ex
+++ b/lib/image_pipe/telemetry/trace/req_step.ex
@@ -55,8 +55,8 @@ defmodule ImagePipe.Telemetry.Trace.ReqStep do
 
     req
     |> Req.Request.put_header("traceparent", W3C.encode(trace_id, span_id, flags))
-    |> Req.Request.put_private(@priv, {trace_id, span_id, System.system_time(), parent})
-    |> Req.merge(finch_private: %{@priv => {trace_id, span_id}})
+    |> Req.Request.put_private(@priv, {trace_id, span_id, System.system_time(), parent, flags})
+    |> Req.merge(finch_private: %{@priv => {trace_id, span_id, flags}})
   end
 
   defp stop({%Req.Request{} = req, %Req.Response{status: status} = resp}) do
@@ -80,7 +80,7 @@ defmodule ImagePipe.Telemetry.Trace.ReqStep do
       {_exporter, nil} ->
         :ok
 
-      {exporter, {trace_id, span_id, start_time, parent}} ->
+      {exporter, {trace_id, span_id, start_time, parent, flags}} ->
         exporter.export(%Span{
           trace_id: trace_id,
           span_id: span_id,
@@ -89,6 +89,7 @@ defmodule ImagePipe.Telemetry.Trace.ReqStep do
           kind: :client,
           start_time: start_time,
           end_time: System.system_time(),
+          trace_flags: flags,
           status: status,
           attributes: attributes,
           pid: self(),

--- a/lib/image_pipe/telemetry/trace/req_step.ex
+++ b/lib/image_pipe/telemetry/trace/req_step.ex
@@ -94,5 +94,8 @@ defmodule ImagePipe.Telemetry.Trace.ReqStep do
 
         :ok
     end
+  rescue
+    # A tracer must never crash the request path; drop the span on any exporter error.
+    _ -> :ok
   end
 end

--- a/lib/image_pipe/telemetry/trace/span.ex
+++ b/lib/image_pipe/telemetry/trace/span.ex
@@ -1,0 +1,46 @@
+defmodule ImagePipe.Telemetry.Trace.Span do
+  @moduledoc """
+  A captured span handed to a `ImagePipe.Telemetry.Trace.Exporter`.
+
+  OTel-shaped so a Jaeger/Tempo/OTLP mapping is mechanical. `duration_native` is the
+  honest timing source (raw monotonic units from `:telemetry.span/3`); `start_time`/
+  `end_time` are wall-clock (`system_time`) for export.
+  """
+
+  @enforce_keys [:trace_id, :span_id, :name, :start_time]
+  defstruct [
+    :trace_id,
+    :span_id,
+    :parent_span_id,
+    :name,
+    :kind,
+    :start_time,
+    :end_time,
+    :duration_native,
+    :status,
+    :status_message,
+    :pid,
+    :node,
+    attributes: %{},
+    events: [],
+    links: []
+  ]
+
+  @type t :: %__MODULE__{
+          trace_id: String.t(),
+          span_id: String.t(),
+          parent_span_id: String.t() | nil,
+          name: String.t(),
+          kind: :internal | :server | :client | nil,
+          start_time: integer() | nil,
+          end_time: integer() | nil,
+          duration_native: integer() | nil,
+          status: :unset | :ok | :error | nil,
+          status_message: String.t() | nil,
+          pid: pid() | nil,
+          node: node() | nil,
+          attributes: map(),
+          events: [map()],
+          links: [map()]
+        }
+end

--- a/lib/image_pipe/telemetry/trace/span.ex
+++ b/lib/image_pipe/telemetry/trace/span.ex
@@ -21,6 +21,7 @@ defmodule ImagePipe.Telemetry.Trace.Span do
     :status_message,
     :pid,
     :node,
+    trace_flags: 1,
     attributes: %{},
     events: [],
     links: []
@@ -39,6 +40,7 @@ defmodule ImagePipe.Telemetry.Trace.Span do
           status_message: String.t() | nil,
           pid: pid() | nil,
           node: node() | nil,
+          trace_flags: non_neg_integer(),
           attributes: map(),
           events: [map()],
           links: [map()]

--- a/lib/image_pipe/telemetry/trace/span.ex
+++ b/lib/image_pipe/telemetry/trace/span.ex
@@ -1,6 +1,6 @@
 defmodule ImagePipe.Telemetry.Trace.Span do
   @moduledoc """
-  A captured span handed to a `ImagePipe.Telemetry.Trace.Exporter`.
+  A captured span handed to an `ImagePipe.Telemetry.Trace.Exporter`.
 
   OTel-shaped so a Jaeger/Tempo/OTLP mapping is mechanical. `duration_native` is the
   honest timing source (raw monotonic units from `:telemetry.span/3`); `start_time`/

--- a/lib/image_pipe/telemetry/trace/stack.ex
+++ b/lib/image_pipe/telemetry/trace/stack.ex
@@ -25,8 +25,11 @@ defmodule ImagePipe.Telemetry.Trace.Stack do
   @spec context() :: Context.t() | nil
   def context do
     case current() do
-      nil -> nil
-      %Span{trace_id: t, span_id: s} -> %Context{trace_id: t, span_id: s}
+      nil ->
+        nil
+
+      %Span{trace_id: t, span_id: s, trace_flags: f} ->
+        %Context{trace_id: t, span_id: s, trace_flags: f}
     end
   end
 
@@ -34,8 +37,8 @@ defmodule ImagePipe.Telemetry.Trace.Stack do
   @spec adopt(Context.t() | nil) :: :ok
   def adopt(nil), do: :ok
 
-  def adopt(%Context{trace_id: t, span_id: s}) do
-    push(%Span{trace_id: t, span_id: s, name: "remote_parent", start_time: nil})
+  def adopt(%Context{trace_id: t, span_id: s, trace_flags: f}) do
+    push(%Span{trace_id: t, span_id: s, name: "remote_parent", start_time: nil, trace_flags: f})
   end
 
   @spec clear() :: :ok

--- a/lib/image_pipe/telemetry/trace/stack.ex
+++ b/lib/image_pipe/telemetry/trace/stack.ex
@@ -1,0 +1,47 @@
+defmodule ImagePipe.Telemetry.Trace.Stack do
+  @moduledoc false
+  alias ImagePipe.Telemetry.Trace.{Context, Span}
+
+  @key :"$image_pipe_trace_stack"
+
+  @spec current() :: Span.t() | nil
+  def current, do: List.first(stack())
+
+  @spec push(Span.t()) :: :ok
+  def push(%Span{} = span), do: put([span | stack()])
+
+  @spec pop() :: Span.t() | nil
+  def pop do
+    case stack() do
+      [top | rest] ->
+        put(rest)
+        top
+
+      [] ->
+        nil
+    end
+  end
+
+  @spec context() :: Context.t() | nil
+  def context do
+    case current() do
+      nil -> nil
+      %Span{trace_id: t, span_id: s} -> %Context{trace_id: t, span_id: s}
+    end
+  end
+
+  @doc "Seed the far side of a process hop with a synthetic remote-parent frame."
+  @spec adopt(Context.t() | nil) :: :ok
+  def adopt(nil), do: :ok
+
+  def adopt(%Context{trace_id: t, span_id: s}) do
+    push(%Span{trace_id: t, span_id: s, name: "remote_parent", start_time: nil})
+  end
+
+  @doc false
+  @spec clear() :: :ok
+  def clear, do: put([])
+
+  defp stack, do: Process.get(@key, [])
+  defp put(stack), do: (Process.put(@key, stack); :ok)
+end

--- a/lib/image_pipe/telemetry/trace/stack.ex
+++ b/lib/image_pipe/telemetry/trace/stack.ex
@@ -30,7 +30,7 @@ defmodule ImagePipe.Telemetry.Trace.Stack do
     end
   end
 
-  @doc "Seed the far side of a process hop with a synthetic remote-parent frame."
+  # Seed the far side of a process hop with a synthetic remote-parent frame.
   @spec adopt(Context.t() | nil) :: :ok
   def adopt(nil), do: :ok
 
@@ -38,10 +38,13 @@ defmodule ImagePipe.Telemetry.Trace.Stack do
     push(%Span{trace_id: t, span_id: s, name: "remote_parent", start_time: nil})
   end
 
-  @doc false
   @spec clear() :: :ok
   def clear, do: put([])
 
   defp stack, do: Process.get(@key, [])
-  defp put(stack), do: (Process.put(@key, stack); :ok)
+
+  defp put(stack) do
+    Process.put(@key, stack)
+    :ok
+  end
 end

--- a/lib/image_pipe/telemetry/trace/w3c.ex
+++ b/lib/image_pipe/telemetry/trace/w3c.ex
@@ -1,0 +1,44 @@
+defmodule ImagePipe.Telemetry.Trace.W3C do
+  @moduledoc false
+  alias ImagePipe.Telemetry.Trace.Context
+
+  @all_zero_trace String.duplicate("0", 32)
+  @all_zero_span String.duplicate("0", 16)
+
+  @spec encode(String.t(), String.t(), non_neg_integer()) :: String.t()
+  def encode(trace_id, span_id, flags \\ 1) do
+    "00-" <> trace_id <> "-" <> span_id <> "-" <> flags_hex(flags)
+  end
+
+  @spec decode(String.t()) :: {:ok, Context.t()} | :error
+  def decode("00-" <> rest) do
+    with [t, s, f] <- String.split(rest, "-"),
+         true <- valid_trace?(t),
+         true <- valid_span?(s),
+         {:ok, flags} <- parse_flags(f) do
+      {:ok, %Context{trace_id: String.downcase(t), span_id: String.downcase(s), trace_flags: flags}}
+    else
+      _ -> :error
+    end
+  end
+
+  def decode(_), do: :error
+
+  defp valid_trace?(t), do: byte_size(t) == 32 and hex?(t) and String.downcase(t) != @all_zero_trace
+  defp valid_span?(s), do: byte_size(s) == 16 and hex?(s) and String.downcase(s) != @all_zero_span
+
+  defp parse_flags(f) when byte_size(f) == 2 do
+    case Integer.parse(f, 16) do
+      {n, ""} -> {:ok, n}
+      _ -> :error
+    end
+  end
+
+  defp parse_flags(_), do: :error
+
+  defp flags_hex(flags) do
+    flags |> Integer.to_string(16) |> String.downcase() |> String.pad_leading(2, "0")
+  end
+
+  defp hex?(s), do: String.match?(s, ~r/\A[0-9a-fA-F]+\z/)
+end

--- a/lib/image_pipe/telemetry/trace/w3c.ex
+++ b/lib/image_pipe/telemetry/trace/w3c.ex
@@ -16,7 +16,8 @@ defmodule ImagePipe.Telemetry.Trace.W3C do
          true <- valid_trace?(t),
          true <- valid_span?(s),
          {:ok, flags} <- parse_flags(f) do
-      {:ok, %Context{trace_id: String.downcase(t), span_id: String.downcase(s), trace_flags: flags}}
+      {:ok,
+       %Context{trace_id: String.downcase(t), span_id: String.downcase(s), trace_flags: flags}}
     else
       _ -> :error
     end
@@ -24,7 +25,9 @@ defmodule ImagePipe.Telemetry.Trace.W3C do
 
   def decode(_), do: :error
 
-  defp valid_trace?(t), do: byte_size(t) == 32 and hex?(t) and String.downcase(t) != @all_zero_trace
+  defp valid_trace?(t),
+    do: byte_size(t) == 32 and hex?(t) and String.downcase(t) != @all_zero_trace
+
   defp valid_span?(s), do: byte_size(s) == 16 and hex?(s) and String.downcase(s) != @all_zero_span
 
   defp parse_flags(f) when byte_size(f) == 2 do

--- a/lib/image_pipe/transform/materializer.ex
+++ b/lib/image_pipe/transform/materializer.ex
@@ -16,18 +16,34 @@ defmodule ImagePipe.Transform.Materializer do
   mid-pipeline.
   """
 
+  alias ImagePipe.Telemetry
   alias ImagePipe.Transform.{OrientationFlush, State}
 
   @callback materialize(State.t(), keyword()) ::
               {:ok, State.t()} | {:error, term()}
 
+  # Arity-1 (chain mid-pipeline) and arity-2 (delivery backstop) both route through
+  # here, so a single [:transform, :materialize] span covers both entry points.
   @spec materialize(State.t()) :: {:ok, State.t()} | {:error, term()}
-  def materialize(%State{} = state) do
-    OrientationFlush.flush(state)
+  def materialize(%State{telemetry_opts: telemetry_opts} = state) do
+    Telemetry.span(telemetry_opts, [:transform, :materialize], %{}, fn ->
+      case do_materialize(state) do
+        {:ok, new_state} -> {{:ok, new_state}, %{result: :ok}}
+        {:error, reason} -> {{:error, reason}, %{result: :materialize_error}}
+      end
+    end)
   end
 
+  # Delivery backstop delegates to the wrapped arity-1; it ignores opts (telemetry
+  # metadata rides on the State). Do not add a second span here.
   @spec materialize(State.t(), keyword()) :: {:ok, State.t()} | {:error, term()}
   def materialize(%State{} = state, _opts) do
     materialize(state)
   end
+
+  # The flush itself returns a BARE {:ok, state} | {:error, reason}. The
+  # {:materialize_error, reason} tagging is owned by the callers (Chain, PlanExecutor);
+  # the span wrapper must preserve the bare error and only label the span's stop
+  # metadata, never re-wrap.
+  defp do_materialize(%State{} = state), do: OrientationFlush.flush(state)
 end

--- a/lib/image_pipe/transform/materializer.ex
+++ b/lib/image_pipe/transform/materializer.ex
@@ -14,6 +14,10 @@ defmodule ImagePipe.Transform.Materializer do
   access. `Request.Processor.materialize_for_delivery/2` also calls the arity-2
   callback form once before delivery for any chain that never materialized
   mid-pipeline.
+
+  `materialize/1` emits a `[:transform, :materialize]` telemetry span around the
+  flush, giving honest per-barrier timing regardless of which call site triggered
+  the materialization.
   """
 
   alias ImagePipe.Telemetry
@@ -41,9 +45,9 @@ defmodule ImagePipe.Transform.Materializer do
     materialize(state)
   end
 
-  # The flush itself returns a BARE {:ok, state} | {:error, reason}. The
-  # {:materialize_error, reason} tagging is owned by the callers (Chain, PlanExecutor);
-  # the span wrapper must preserve the bare error and only label the span's stop
-  # metadata, never re-wrap.
+  # The flush returns a BARE {:ok, state} | {:error, reason}. The
+  # {:materialize_error, reason} TUPLE wrapping is owned by callers (Chain,
+  # PlanExecutor); the :materialize_error SPAN metadata label is set in the wrapper
+  # above only to drive Logger level escalation. Never re-wrap the error tuple here.
   defp do_materialize(%State{} = state), do: OrientationFlush.flush(state)
 end

--- a/test/image_pipe/architecture_boundary_test.exs
+++ b/test/image_pipe/architecture_boundary_test.exs
@@ -280,13 +280,25 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
     # request->SourceSession (hop A) and request->Producer (hop B) process seams (it
     # calls only these generic Trace.* modules, never concrete transform ops).
     # Trace.ReqStep is exported because the source Req-client build site attaches it to
-    # trace outbound fetches as a logical client span. The boundary stays dependency-free.
+    # trace outbound fetches as a logical client span. Trace.Span and Trace.Exporter are
+    # exported because a host implements the exporter behaviour (Trace.Exporter) and
+    # receives captured spans (Trace.Span) — that is the public exporter contract. The
+    # boundary stays dependency-free.
     assert_boundary_exports(telemetry, [
       ImagePipe.Telemetry.Trace,
       ImagePipe.Telemetry.Trace.Stack,
       ImagePipe.Telemetry.Trace.Context,
+      ImagePipe.Telemetry.Trace.Span,
+      ImagePipe.Telemetry.Trace.Exporter,
       ImagePipe.Telemetry.Trace.ReqStep
     ])
+  end
+
+  test "telemetry trace capture does not reference concrete transform/source/request modules" do
+    source = File.read!("lib/image_pipe/telemetry/trace/capture.ex")
+    refute source =~ "ImagePipe.Transform.Operation"
+    refute source =~ "ImagePipe.Source."
+    refute source =~ "ImagePipe.Request."
   end
 
   test "error boundary remains a dependency-free helper" do

--- a/test/image_pipe/architecture_boundary_test.exs
+++ b/test/image_pipe/architecture_boundary_test.exs
@@ -275,8 +275,16 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
 
     assert_boundary_deps(telemetry, [])
     # ImagePipe.Telemetry.Trace is the opt-in span-tracer facade; the Plug edge calls
-    # Trace.maybe_extract_inbound/1, so it is exported. The boundary stays dependency-free.
-    assert_boundary_exports(telemetry, [ImagePipe.Telemetry.Trace])
+    # Trace.maybe_extract_inbound/1, so it is exported. Trace.Stack/Trace.Context are
+    # exported because request/source code threads + adopts the trace context across the
+    # request->SourceSession (hop A) and request->Producer (hop B) process seams (it
+    # calls only these generic Trace.* modules, never concrete transform ops). The
+    # boundary stays dependency-free.
+    assert_boundary_exports(telemetry, [
+      ImagePipe.Telemetry.Trace,
+      ImagePipe.Telemetry.Trace.Stack,
+      ImagePipe.Telemetry.Trace.Context
+    ])
   end
 
   test "error boundary remains a dependency-free helper" do

--- a/test/image_pipe/architecture_boundary_test.exs
+++ b/test/image_pipe/architecture_boundary_test.exs
@@ -278,12 +278,14 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
     # Trace.maybe_extract_inbound/1, so it is exported. Trace.Stack/Trace.Context are
     # exported because request/source code threads + adopts the trace context across the
     # request->SourceSession (hop A) and request->Producer (hop B) process seams (it
-    # calls only these generic Trace.* modules, never concrete transform ops). The
-    # boundary stays dependency-free.
+    # calls only these generic Trace.* modules, never concrete transform ops).
+    # Trace.ReqStep is exported because the source Req-client build site attaches it to
+    # trace outbound fetches as a logical client span. The boundary stays dependency-free.
     assert_boundary_exports(telemetry, [
       ImagePipe.Telemetry.Trace,
       ImagePipe.Telemetry.Trace.Stack,
-      ImagePipe.Telemetry.Trace.Context
+      ImagePipe.Telemetry.Trace.Context,
+      ImagePipe.Telemetry.Trace.ReqStep
     ])
   end
 

--- a/test/image_pipe/architecture_boundary_test.exs
+++ b/test/image_pipe/architecture_boundary_test.exs
@@ -274,7 +274,9 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
     telemetry = boundary_declaration(ImagePipe.Telemetry)
 
     assert_boundary_deps(telemetry, [])
-    assert_boundary_exports(telemetry, [])
+    # ImagePipe.Telemetry.Trace is the opt-in span-tracer facade; the Plug edge calls
+    # Trace.maybe_extract_inbound/1, so it is exported. The boundary stays dependency-free.
+    assert_boundary_exports(telemetry, [ImagePipe.Telemetry.Trace])
   end
 
   test "error boundary remains a dependency-free helper" do

--- a/test/image_pipe/telemetry/logger_test.exs
+++ b/test/image_pipe/telemetry/logger_test.exs
@@ -254,4 +254,52 @@ defmodule ImagePipe.Telemetry.LoggerTest do
     assert_raise ArgumentError, fn -> Telemetry.attach_default_logger(prefix: "nope") end
     assert_raise ArgumentError, fn -> Telemetry.attach_default_logger(debug: :yes) end
   end
+
+  test "successful materialize flush logs at base level, no warning" do
+    Telemetry.attach_default_logger(level: :info)
+
+    log =
+      capture_log(fn ->
+        :telemetry.execute(
+          [:image_pipe, :transform, :materialize, :stop],
+          %{duration: 10},
+          %{result: :ok}
+        )
+      end)
+
+    assert log =~ "transform materialize"
+    refute log =~ "[warning]"
+  end
+
+  test "materialize stop carrying materialize_error escalates to warning" do
+    Telemetry.attach_default_logger(level: :info)
+
+    log =
+      capture_log(fn ->
+        :telemetry.execute(
+          [:image_pipe, :transform, :materialize, :stop],
+          %{duration: 10},
+          %{result: :materialize_error}
+        )
+      end)
+
+    assert log =~ "[warning]"
+    assert log =~ "transform materialize"
+  end
+
+  test "materialize exception escalates to warning" do
+    Telemetry.attach_default_logger(level: :info)
+
+    log =
+      capture_log(fn ->
+        :telemetry.execute(
+          [:image_pipe, :transform, :materialize, :exception],
+          %{duration: 5},
+          %{kind: :error, reason: %RuntimeError{message: "x"}, stacktrace: []}
+        )
+      end)
+
+    assert log =~ "[warning]"
+    assert log =~ "transform materialize"
+  end
 end

--- a/test/image_pipe/telemetry/trace/admission_root_test.exs
+++ b/test/image_pipe/telemetry/trace/admission_root_test.exs
@@ -1,0 +1,86 @@
+defmodule ImagePipe.Telemetry.Trace.AdmissionRootTest do
+  # Positive coverage for spec §8.1: a [:cache, :admission] span emitted from the
+  # long-lived Admission GenServer becomes its OWN trace root (parent_span_id == nil,
+  # fresh trace_id) EVEN WHEN the caller of Admission.admit/2 carries a request trace
+  # context on its stack. The GenServer process boundary severs the trace: the Capture
+  # handler runs in the GenServer process (empty Stack), never the caller's.
+  #
+  # async: false is required by TestExporter (it routes spans through a global
+  # :persistent_term receiver).
+  use ExUnit.Case, async: false
+
+  alias ImagePipe.Cache.FileSystem.Admission
+  alias ImagePipe.Telemetry
+  alias ImagePipe.Telemetry.Trace.{Context, Span, Stack, TestExporter}
+
+  # A request context the CALLER carries on its stack. If admission inherited the
+  # caller's context, the emitted span would reuse this trace_id / parent under it.
+  @caller_trace_id "deadbeefdeadbeefdeadbeefdeadbeef"
+  @caller_span_id "1111111111111111"
+
+  setup do
+    registry = :"#{__MODULE__}.Registry.#{System.unique_integer([:positive])}"
+    start_supervised!({Registry, keys: :unique, name: registry})
+
+    tmp_dir = Path.join(System.tmp_dir!(), "admission_root_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp_dir)
+    on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+    # The Admission GenServer emits under this custom prefix; the Capture handler
+    # subscribes per-prefix, so the tracer must be attached with the SAME prefix.
+    prefix = [:"admission_root_#{System.unique_integer([:positive])}"]
+
+    TestExporter.set_receiver(self())
+    :ok = TestExporter.attach(self(), prefix: prefix)
+
+    on_exit(fn ->
+      Telemetry.detach_tracer()
+      TestExporter.clear_receiver()
+      # Drop the adopted caller frame so it doesn't leak into other tests.
+      Stack.clear()
+    end)
+
+    %{registry: registry, tmp_dir: tmp_dir, prefix: prefix}
+  end
+
+  defp opts(ctx) do
+    [
+      registry: ctx.registry,
+      root: ctx.tmp_dir,
+      node_id: "tel-node",
+      state_dir: Path.join(ctx.tmp_dir, ".cache_state"),
+      telemetry_prefix: ctx.prefix,
+      max_size_bytes: 1_000_000,
+      window_ratio: 0.01,
+      sketch_depth: 4,
+      sketch_width: 256,
+      doorkeeper_cardinality: 1024,
+      doorkeeper_fpr: 0.01
+    ]
+  end
+
+  test "cache.admission becomes its own trace root despite an adopted caller context (§8.1)",
+       ctx do
+    pid = start_supervised!({Admission, opts(ctx)})
+
+    # The TEST process (the caller of admit/2) genuinely carries a request context.
+    Stack.adopt(%Context{
+      trace_id: @caller_trace_id,
+      span_id: @caller_span_id,
+      trace_flags: 1
+    })
+
+    descriptor = %{key_hash: "h1", size_bytes: 5_000, body_sha256: "s", cost_us: 1_000}
+    assert {:admit, []} = Admission.admit(pid, descriptor)
+
+    # Capture strips the configured prefix and re-roots the name under "image_pipe.",
+    # so the [:cache, :admission] stage always surfaces as this name regardless of the
+    # custom telemetry prefix the GenServer uses.
+    assert_receive {:span, %Span{name: "image_pipe.cache.admission"} = span}
+
+    # The GenServer process boundary severed the trace: the span did NOT inherit the
+    # caller's adopted context.
+    assert span.parent_span_id == nil
+    assert span.trace_id != @caller_trace_id
+  end
+end

--- a/test/image_pipe/telemetry/trace/attach_test.exs
+++ b/test/image_pipe/telemetry/trace/attach_test.exs
@@ -29,4 +29,8 @@ defmodule ImagePipe.Telemetry.Trace.AttachTest do
   test "attach_tracer raises when module is loadable but does not export export/1" do
     assert_raise ArgumentError, fn -> Telemetry.attach_tracer(exporter: Enum) end
   end
+
+  test "attach_tracer raises ArgumentError on a non-list argument" do
+    assert_raise ArgumentError, fn -> Telemetry.attach_tracer(:not_a_list) end
+  end
 end

--- a/test/image_pipe/telemetry/trace/attach_test.exs
+++ b/test/image_pipe/telemetry/trace/attach_test.exs
@@ -1,0 +1,32 @@
+defmodule ImagePipe.Telemetry.Trace.AttachTest do
+  use ExUnit.Case, async: false
+  alias ImagePipe.Telemetry
+  alias ImagePipe.Telemetry.Trace.LogExporter
+
+  setup do
+    on_exit(fn -> Telemetry.detach_tracer() end)
+    :ok
+  end
+
+  test "attach_tracer succeeds with a valid exporter" do
+    assert Telemetry.attach_tracer(exporter: LogExporter) == :ok
+  end
+
+  test "attach_tracer raises on unknown option" do
+    assert_raise ArgumentError, fn ->
+      Telemetry.attach_tracer(exporter: LogExporter, bogus: 1)
+    end
+  end
+
+  test "attach_tracer raises when exporter is missing" do
+    assert_raise ArgumentError, fn -> Telemetry.attach_tracer([]) end
+  end
+
+  test "attach_tracer raises when exporter module is not loadable" do
+    assert_raise ArgumentError, fn -> Telemetry.attach_tracer(exporter: NotARealModule) end
+  end
+
+  test "attach_tracer raises when module is loadable but does not export export/1" do
+    assert_raise ArgumentError, fn -> Telemetry.attach_tracer(exporter: Enum) end
+  end
+end

--- a/test/image_pipe/telemetry/trace/attr_safety_test.exs
+++ b/test/image_pipe/telemetry/trace/attr_safety_test.exs
@@ -1,0 +1,66 @@
+defmodule ImagePipe.Telemetry.Trace.AttrSafetyTest do
+  use ExUnit.Case, async: false
+  use ExUnitProperties
+  alias ImagePipe.Telemetry
+  alias ImagePipe.Telemetry.Trace.{Span, TestExporter}
+
+  setup do
+    TestExporter.set_receiver(self())
+    :ok = TestExporter.attach(self())
+
+    on_exit(fn ->
+      Telemetry.detach_tracer()
+      TestExporter.clear_receiver()
+    end)
+
+    :ok
+  end
+
+  test "a signed source URL in metadata never reaches span attributes" do
+    signed = "https://cdn.example.com/img.jpg?sig=SECRET123&exp=999"
+
+    Telemetry.span(
+      [],
+      [:source, :fetch],
+      %{source_url: signed, source_path: "/img.jpg?sig=SECRET123", source_kind: :http},
+      fn ->
+        {:ok, %{result: :ok}}
+      end
+    )
+
+    assert_receive {:span, %Span{name: "image_pipe.source.fetch"} = span}
+    flat = inspect(span.attributes)
+    refute flat =~ "SECRET123"
+    refute flat =~ "cdn.example.com"
+    # product-neutral key is allowed through
+    assert span.attributes[:source_kind] == :http
+  end
+
+  property "no secret-bearing key ever reaches attributes, for any value" do
+    check all(
+            body <- StreamData.string(:alphanumeric, min_length: 1),
+            key <-
+              StreamData.member_of([
+                :source_url,
+                :source_path,
+                :signature,
+                :token,
+                :authorization
+              ])
+          ) do
+      # A distinctive marker prefix so the substring check tests the secret VALUE
+      # leaking through, not incidental collisions with allowlisted values
+      # (e.g. ":http" contains "p") or the synthetic trace_flags annotation.
+      secret = "SECRET_" <> body
+
+      Telemetry.span([], [:source, :fetch], %{key => secret, :source_kind => :http}, fn ->
+        {:ok, %{result: :ok}}
+      end)
+
+      assert_receive {:span, %Span{name: "image_pipe.source.fetch"} = span}
+      refute inspect(span.attributes) =~ secret
+      # The secret-bearing key itself must never be present in attributes.
+      refute Map.has_key?(span.attributes, key)
+    end
+  end
+end

--- a/test/image_pipe/telemetry/trace/attr_safety_test.exs
+++ b/test/image_pipe/telemetry/trace/attr_safety_test.exs
@@ -50,7 +50,7 @@ defmodule ImagePipe.Telemetry.Trace.AttrSafetyTest do
           ) do
       # A distinctive marker prefix so the substring check tests the secret VALUE
       # leaking through, not incidental collisions with allowlisted values
-      # (e.g. ":http" contains "p") or the synthetic trace_flags annotation.
+      # (e.g. ":http" contains "p").
       secret = "SECRET_" <> body
 
       Telemetry.span([], [:source, :fetch], %{key => secret, :source_kind => :http}, fn ->

--- a/test/image_pipe/telemetry/trace/capture_test.exs
+++ b/test/image_pipe/telemetry/trace/capture_test.exs
@@ -1,0 +1,54 @@
+defmodule ImagePipe.Telemetry.Trace.CaptureTest do
+  use ExUnit.Case, async: false
+  alias ImagePipe.Telemetry
+  alias ImagePipe.Telemetry.Trace.{Span, TestExporter}
+
+  setup do
+    TestExporter.set_receiver(self())
+    :ok = TestExporter.attach(self())
+
+    on_exit(fn ->
+      Telemetry.detach_tracer()
+      TestExporter.clear_receiver()
+    end)
+
+    :ok
+  end
+
+  defp emit_nested do
+    Telemetry.span([], [:request], %{}, fn ->
+      Telemetry.span([], [:transform, :execute], %{operation_count: 1}, fn ->
+        {:ok, %{result: :ok}}
+      end)
+
+      {:ok, %{result: :ok, status: 200}}
+    end)
+  end
+
+  test "captures a nested tree with one trace_id and correct parentage" do
+    emit_nested()
+
+    assert_receive {:span, %Span{name: "image_pipe.transform.execute"} = child}
+    assert_receive {:span, %Span{name: "image_pipe.request"} = root}
+
+    assert root.parent_span_id == nil
+    assert child.parent_span_id == root.span_id
+    assert child.trace_id == root.trace_id
+    assert root.status == :ok
+    assert is_integer(child.duration_native)
+  end
+
+  test "maps an error result to :error status" do
+    Telemetry.span([], [:request], %{}, fn -> {:ok, %{result: :processing_error}} end)
+    assert_receive {:span, %Span{name: "image_pipe.request", status: :error}}
+  end
+
+  test "captures an exception as :error with a folded exception event" do
+    assert_raise RuntimeError, fn ->
+      Telemetry.span([], [:request], %{}, fn -> raise "boom" end)
+    end
+
+    assert_receive {:span, %Span{name: "image_pipe.request", status: :error} = s}
+    assert Enum.any?(s.events, &(&1.name == "exception"))
+  end
+end

--- a/test/image_pipe/telemetry/trace/capture_test.exs
+++ b/test/image_pipe/telemetry/trace/capture_test.exs
@@ -36,6 +36,9 @@ defmodule ImagePipe.Telemetry.Trace.CaptureTest do
     assert child.trace_id == root.trace_id
     assert root.status == :ok
     assert is_integer(child.duration_native)
+    assert is_integer(root.start_time)
+    assert is_integer(root.end_time)
+    assert root.end_time >= root.start_time
   end
 
   test "maps an error result to :error status" do

--- a/test/image_pipe/telemetry/trace/cross_process_test.exs
+++ b/test/image_pipe/telemetry/trace/cross_process_test.exs
@@ -86,7 +86,11 @@ defmodule ImagePipe.Telemetry.Trace.CrossProcessTest do
 
     # Admission runs in the shared Admission GenServer with no request context
     # threaded (spec §8.1): it must NOT share the request trace. CacheProbe does
-    # not run an admission GenServer, so the span may be absent here — guard it.
+    # not run an admission GenServer, so the span is typically absent here and this
+    # guard is effectively a no-op. The real POSITIVE coverage — a [:cache, :admission]
+    # span emitted from a live Admission GenServer staying a separate root even with a
+    # caller context adopted on the stack — lives in
+    # ImagePipe.Telemetry.Trace.AdmissionRootTest.
     if admission do
       assert admission.parent_span_id == nil
       assert admission.trace_id != root.trace_id

--- a/test/image_pipe/telemetry/trace/cross_process_test.exs
+++ b/test/image_pipe/telemetry/trace/cross_process_test.exs
@@ -84,6 +84,8 @@ defmodule ImagePipe.Telemetry.Trace.CrossProcessTest do
     root = Enum.find(spans, &(&1.name == "image_pipe.request"))
     admission = Enum.find(spans, &(&1.name == "image_pipe.cache.admission"))
 
+    assert root, "expected request root span"
+
     # Admission runs in the shared Admission GenServer with no request context
     # threaded (spec §8.1): it must NOT share the request trace. CacheProbe does
     # not run an admission GenServer, so the span is typically absent here and this

--- a/test/image_pipe/telemetry/trace/cross_process_test.exs
+++ b/test/image_pipe/telemetry/trace/cross_process_test.exs
@@ -63,4 +63,33 @@ defmodule ImagePipe.Telemetry.Trace.CrossProcessTest do
     assert fetch.trace_id == root.trace_id
     refute fetch.parent_span_id == nil
   end
+
+  test "cache write parents under the request (hop A)" do
+    conn = call(request_path(), miss_opts())
+    assert conn.status == 200
+
+    spans = collect()
+    root = Enum.find(spans, &(&1.name == "image_pipe.request"))
+    write = Enum.find(spans, &(&1.name == "image_pipe.cache.write"))
+
+    assert root && write, "expected request + cache.write spans"
+    assert write.trace_id == root.trace_id
+  end
+
+  test "cache admission is a separate root, not under the request (§8.1)" do
+    conn = call(request_path(), miss_opts())
+    assert conn.status == 200
+
+    spans = collect()
+    root = Enum.find(spans, &(&1.name == "image_pipe.request"))
+    admission = Enum.find(spans, &(&1.name == "image_pipe.cache.admission"))
+
+    # Admission runs in the shared Admission GenServer with no request context
+    # threaded (spec §8.1): it must NOT share the request trace. CacheProbe does
+    # not run an admission GenServer, so the span may be absent here — guard it.
+    if admission do
+      assert admission.parent_span_id == nil
+      assert admission.trace_id != root.trace_id
+    end
+  end
 end

--- a/test/image_pipe/telemetry/trace/cross_process_test.exs
+++ b/test/image_pipe/telemetry/trace/cross_process_test.exs
@@ -1,0 +1,66 @@
+defmodule ImagePipe.Telemetry.Trace.CrossProcessTest do
+  use ExUnit.Case, async: false
+
+  import Plug.Test
+
+  alias ImagePipe.SourceTest.RootHTTPAdapter
+  alias ImagePipe.Telemetry
+  alias ImagePipe.Telemetry.Trace.{Span, TestExporter}
+  alias ImgproxyWireConformanceTest.CacheProbe
+
+  setup do
+    TestExporter.set_receiver(self())
+    :ok = TestExporter.attach(self())
+
+    on_exit(fn ->
+      Telemetry.detach_tracer()
+      TestExporter.clear_receiver()
+    end)
+
+    :ok
+  end
+
+  defp collect(timeout \\ 300) do
+    receive do
+      {:span, %Span{} = s} -> [s | collect(timeout)]
+    after
+      timeout -> []
+    end
+  end
+
+  defp call(path, opts) do
+    conn = conn(:get, path)
+    ImagePipe.Plug.call(conn, ImagePipe.Plug.init(opts))
+  end
+
+  # A cache-miss request that fetches + decodes a real source and writes to cache.
+  # CacheProbe(result: :miss) drives open_sink -> write_chunk -> commit_sink, so the
+  # [:cache, :write] span fires from the SourceSession process (hop A target).
+  defp miss_opts do
+    [
+      parser: ImagePipe.Parser.Imgproxy,
+      sources: [
+        path:
+          {RootHTTPAdapter,
+           root_url: "http://origin.test",
+           req_options: [plug: ImgproxyWireConformanceTest.OriginImage]}
+      ],
+      cache: {CacheProbe, result: :miss}
+    ]
+  end
+
+  defp request_path, do: "/_/rs:fit:120:90/f:jpeg/plain/images/beach.jpg"
+
+  test "producer-process spans share the request trace_id and parent under it (hop B)" do
+    conn = call(request_path(), miss_opts())
+    assert conn.status == 200
+
+    spans = collect()
+    root = Enum.find(spans, &(&1.name == "image_pipe.request"))
+    fetch = Enum.find(spans, &(&1.name == "image_pipe.source.fetch_decode"))
+
+    assert root && fetch, "expected request + source.fetch_decode spans"
+    assert fetch.trace_id == root.trace_id
+    refute fetch.parent_span_id == nil
+  end
+end

--- a/test/image_pipe/telemetry/trace/encode_span_test.exs
+++ b/test/image_pipe/telemetry/trace/encode_span_test.exs
@@ -1,0 +1,78 @@
+defmodule ImagePipe.Telemetry.Trace.EncodeSpanTest do
+  use ExUnit.Case, async: false
+
+  import Plug.Test
+
+  alias ImagePipe.SourceTest.RootHTTPAdapter
+  alias ImagePipe.Telemetry
+  alias ImagePipe.Telemetry.Trace.{Span, TestExporter}
+
+  # [:encode] is emitted by ImagePipe.Response.Sender.send_prepared_stream/5 around
+  # the prepared-stream materialize+send. It is a real Telemetry.span stage and must
+  # be captured by the tracer, nested under the request trace.
+
+  setup do
+    TestExporter.set_receiver(self())
+    :ok = TestExporter.attach(self())
+
+    on_exit(fn ->
+      Telemetry.detach_tracer()
+      TestExporter.clear_receiver()
+    end)
+
+    :ok
+  end
+
+  defp collect_spans(timeout \\ 200) do
+    receive do
+      {:span, %Span{} = s} -> [s | collect_spans(timeout)]
+    after
+      timeout -> []
+    end
+  end
+
+  defp call(path, opts) do
+    conn = conn(:get, path)
+    ImagePipe.Plug.call(conn, ImagePipe.Plug.init(opts))
+  end
+
+  defp parent_of(spans, %Span{parent_span_id: pid}),
+    do: Enum.find(spans, &(&1.span_id == pid))
+
+  defp beach_opts do
+    [
+      parser: ImagePipe.Parser.Imgproxy,
+      sources: [
+        path:
+          {RootHTTPAdapter,
+           root_url: "http://origin.test",
+           req_options: [plug: ImgproxyWireConformanceTest.OriginImage]}
+      ]
+    ]
+  end
+
+  test "the encode span is captured and nested under the request trace" do
+    conn = call("/_/rs:fit:120:90/f:jpeg/plain/images/beach.jpg", beach_opts())
+    assert conn.status == 200
+
+    spans = collect_spans()
+    root = Enum.find(spans, &(&1.name == "image_pipe.request"))
+    assert root, "expected a request root span"
+
+    assert [encode] = Enum.filter(spans, &(&1.name == "image_pipe.encode"))
+
+    assert encode.trace_id == root.trace_id
+    refute encode.parent_span_id == nil, "encode span must not be an orphan"
+
+    # Sender.send_prepared_stream/5 emits [:encode] synchronously in the Plug request
+    # process, inside Sender.send_result, which runs inside the [:send] span
+    # (Plug.send_response/4). So encode nests under [:send], which nests under [:request].
+    parent = parent_of(spans, encode)
+    assert parent, "encode span must have a captured parent"
+    assert parent.name == "image_pipe.send"
+    assert parent.pid == encode.pid, "encode and its [:send] parent run in the same process"
+
+    grandparent = parent_of(spans, parent)
+    assert grandparent && grandparent.name == "image_pipe.request"
+  end
+end

--- a/test/image_pipe/telemetry/trace/finch_capture_test.exs
+++ b/test/image_pipe/telemetry/trace/finch_capture_test.exs
@@ -24,10 +24,12 @@ defmodule ImagePipe.Telemetry.Trace.FinchCaptureTest do
 
   test "builds a wire span parented from finch_private" do
     request = %{private: %{image_pipe_trace: {"trace123", "parentspan"}}}
+    start_time = System.system_time()
 
     FinchCapture.handle_event(
       [:finch, :request, :stop],
-      %{duration: 10, system_time: 1},
+      # system_time is in measurements (matching real Finch events), not metadata.
+      %{duration: 10, system_time: start_time},
       %{name: TestFinch, request: request, result: {:ok, %{status: 200}}},
       %{exporter: SendExporter}
     )
@@ -43,6 +45,7 @@ defmodule ImagePipe.Telemetry.Trace.FinchCaptureTest do
                     } = span}
 
     assert span.attributes[:"http.status_code"] == 200
+    assert is_integer(span.start_time) and span.start_time == start_time
   end
 
   test "maps a finch error result to :error status" do
@@ -50,7 +53,8 @@ defmodule ImagePipe.Telemetry.Trace.FinchCaptureTest do
 
     FinchCapture.handle_event(
       [:finch, :request, :exception],
-      %{duration: 3, system_time: 1},
+      # system_time in measurements, matching real Finch events.
+      %{duration: 3, system_time: System.system_time()},
       %{name: TestFinch, request: request, kind: :error, reason: %RuntimeError{message: "x"}},
       %{exporter: SendExporter}
     )
@@ -63,7 +67,7 @@ defmodule ImagePipe.Telemetry.Trace.FinchCaptureTest do
 
     FinchCapture.handle_event(
       [:finch, :request, :stop],
-      %{duration: 10, system_time: 1},
+      %{duration: 10, system_time: System.system_time()},
       %{name: TestFinch, request: request, result: {:ok, %{status: 200}}},
       %{exporter: SendExporter}
     )

--- a/test/image_pipe/telemetry/trace/finch_capture_test.exs
+++ b/test/image_pipe/telemetry/trace/finch_capture_test.exs
@@ -1,0 +1,73 @@
+defmodule ImagePipe.Telemetry.Trace.FinchCaptureTest do
+  use ExUnit.Case, async: false
+  alias ImagePipe.Telemetry.Trace.{FinchCapture, Span}
+
+  # A tiny in-test exporter module that forwards spans to the test process. The
+  # production path is config-driven (`%{exporter: module}`); the test supplies a
+  # module that sends to a pid stashed in :persistent_term so handle_event/4 can be
+  # called directly without attaching to the real :finch telemetry events.
+  defmodule SendExporter do
+    @behaviour ImagePipe.Telemetry.Trace.Exporter
+    @key {__MODULE__, :receiver}
+    def set_receiver(pid), do: :persistent_term.put(@key, pid)
+    @impl true
+    def export(span) do
+      send(:persistent_term.get(@key), {:span, span})
+      :ok
+    end
+  end
+
+  setup do
+    SendExporter.set_receiver(self())
+    :ok
+  end
+
+  test "builds a wire span parented from finch_private" do
+    request = %{private: %{image_pipe_trace: {"trace123", "parentspan"}}}
+
+    FinchCapture.handle_event(
+      [:finch, :request, :stop],
+      %{duration: 10, system_time: 1},
+      %{name: TestFinch, request: request, result: {:ok, %{status: 200}}},
+      %{exporter: SendExporter}
+    )
+
+    assert_receive {:span,
+                    %Span{
+                      name: "finch.request",
+                      kind: :client,
+                      trace_id: "trace123",
+                      parent_span_id: "parentspan",
+                      status: :ok,
+                      duration_native: 10
+                    } = span}
+
+    assert span.attributes[:"http.status_code"] == 200
+  end
+
+  test "maps a finch error result to :error status" do
+    request = %{private: %{image_pipe_trace: {"trace123", "parentspan"}}}
+
+    FinchCapture.handle_event(
+      [:finch, :request, :exception],
+      %{duration: 3, system_time: 1},
+      %{name: TestFinch, request: request, kind: :error, reason: %RuntimeError{message: "x"}},
+      %{exporter: SendExporter}
+    )
+
+    assert_receive {:span, %Span{name: "finch.request", status: :error}}
+  end
+
+  test "drops events with no image_pipe_trace in finch_private" do
+    request = %{private: %{}}
+
+    FinchCapture.handle_event(
+      [:finch, :request, :stop],
+      %{duration: 10, system_time: 1},
+      %{name: TestFinch, request: request, result: {:ok, %{status: 200}}},
+      %{exporter: SendExporter}
+    )
+
+    refute_receive {:span, _}
+  end
+end

--- a/test/image_pipe/telemetry/trace/finch_capture_test.exs
+++ b/test/image_pipe/telemetry/trace/finch_capture_test.exs
@@ -49,6 +49,19 @@ defmodule ImagePipe.Telemetry.Trace.FinchCaptureTest do
     assert is_integer(span.start_time) and span.start_time == start_time
   end
 
+  test "carries the unsampled trace_flag from finch_private onto the wire span" do
+    request = %{private: %{image_pipe_trace: {"trace123", "parentspan", 0}}}
+
+    FinchCapture.handle_event(
+      [:finch, :request, :stop],
+      %{duration: 10, system_time: System.system_time()},
+      %{name: TestFinch, request: request, result: {:ok, %{status: 200}}},
+      %{exporter: SendExporter}
+    )
+
+    assert_receive {:span, %Span{name: "finch.request", trace_flags: 0}}
+  end
+
   test "maps a finch error result to :error status" do
     request = %{private: %{image_pipe_trace: {"trace123", "parentspan", 1}}}
 

--- a/test/image_pipe/telemetry/trace/finch_capture_test.exs
+++ b/test/image_pipe/telemetry/trace/finch_capture_test.exs
@@ -23,7 +23,7 @@ defmodule ImagePipe.Telemetry.Trace.FinchCaptureTest do
   end
 
   test "builds a wire span parented from finch_private" do
-    request = %{private: %{image_pipe_trace: {"trace123", "parentspan"}}}
+    request = %{private: %{image_pipe_trace: {"trace123", "parentspan", 1}}}
     start_time = System.system_time()
 
     FinchCapture.handle_event(
@@ -41,7 +41,8 @@ defmodule ImagePipe.Telemetry.Trace.FinchCaptureTest do
                       trace_id: "trace123",
                       parent_span_id: "parentspan",
                       status: :ok,
-                      duration_native: 10
+                      duration_native: 10,
+                      trace_flags: 1
                     } = span}
 
     assert span.attributes[:"http.status_code"] == 200
@@ -49,7 +50,7 @@ defmodule ImagePipe.Telemetry.Trace.FinchCaptureTest do
   end
 
   test "maps a finch error result to :error status" do
-    request = %{private: %{image_pipe_trace: {"trace123", "parentspan"}}}
+    request = %{private: %{image_pipe_trace: {"trace123", "parentspan", 1}}}
 
     FinchCapture.handle_event(
       [:finch, :request, :exception],

--- a/test/image_pipe/telemetry/trace/id_test.exs
+++ b/test/image_pipe/telemetry/trace/id_test.exs
@@ -1,0 +1,17 @@
+defmodule ImagePipe.Telemetry.Trace.IdTest do
+  use ExUnit.Case, async: true
+  alias ImagePipe.Telemetry.Trace.Id
+
+  test "trace_id is 32 lowercase hex chars and unique" do
+    a = Id.trace_id()
+    b = Id.trace_id()
+    assert a =~ ~r/\A[0-9a-f]{32}\z/
+    assert a != b
+  end
+
+  test "span_id is 16 lowercase hex chars and unique" do
+    a = Id.span_id()
+    assert a =~ ~r/\A[0-9a-f]{16}\z/
+    assert a != Id.span_id()
+  end
+end

--- a/test/image_pipe/telemetry/trace/inbound_plug_test.exs
+++ b/test/image_pipe/telemetry/trace/inbound_plug_test.exs
@@ -8,6 +8,7 @@ defmodule ImagePipe.Telemetry.Trace.InboundPlugTest do
   alias ImagePipe.Telemetry.Trace.{Span, TestExporter}
 
   @tp "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+  @tp_unsampled "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00"
 
   setup do
     TestExporter.set_receiver(self())
@@ -51,6 +52,16 @@ defmodule ImagePipe.Telemetry.Trace.InboundPlugTest do
     assert_receive {:span, %Span{name: "image_pipe.request"} = root}
     assert root.trace_id == "0af7651916cd43dd8448eb211c80319c"
     assert root.parent_span_id == "b7ad6b7169203331"
+  end
+
+  test "propagates an inbound unsampled flag (flags=00) onto the root span" do
+    :ok = TestExporter.attach(self(), extract_inbound: true)
+    conn = call(valid_request_path(), [{"traceparent", @tp_unsampled}], build_opts())
+    assert conn.status == 200
+
+    assert_receive {:span, %Span{name: "image_pipe.request"} = root}
+    assert root.trace_id == "0af7651916cd43dd8448eb211c80319c"
+    assert root.trace_flags == 0
   end
 
   test "ignores traceparent by default (opt-in)" do

--- a/test/image_pipe/telemetry/trace/inbound_plug_test.exs
+++ b/test/image_pipe/telemetry/trace/inbound_plug_test.exs
@@ -1,0 +1,75 @@
+defmodule ImagePipe.Telemetry.Trace.InboundPlugTest do
+  use ExUnit.Case, async: false
+
+  import Plug.Test
+
+  alias ImagePipe.SourceTest.RootHTTPAdapter
+  alias ImagePipe.Telemetry
+  alias ImagePipe.Telemetry.Trace.{Span, TestExporter}
+
+  @tp "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+
+  setup do
+    TestExporter.set_receiver(self())
+
+    on_exit(fn ->
+      Telemetry.detach_tracer()
+      TestExporter.clear_receiver()
+    end)
+
+    :ok
+  end
+
+  defp build_opts do
+    [
+      parser: ImagePipe.Parser.Imgproxy,
+      sources: [
+        path:
+          {RootHTTPAdapter,
+           root_url: "http://origin.test",
+           req_options: [plug: ImgproxyWireConformanceTest.OriginImage]}
+      ]
+    ]
+  end
+
+  defp valid_request_path, do: "/_/rs:fit:120:90/f:jpeg/plain/images/beach.jpg"
+
+  defp call(path, headers, opts) do
+    conn =
+      Enum.reduce(headers, conn(:get, path), fn {k, v}, conn ->
+        Plug.Conn.put_req_header(conn, k, v)
+      end)
+
+    ImagePipe.Plug.call(conn, ImagePipe.Plug.init(opts))
+  end
+
+  test "adopts inbound traceparent when extract_inbound: true" do
+    :ok = TestExporter.attach(self(), extract_inbound: true)
+    conn = call(valid_request_path(), [{"traceparent", @tp}], build_opts())
+    assert conn.status == 200
+
+    assert_receive {:span, %Span{name: "image_pipe.request"} = root}
+    assert root.trace_id == "0af7651916cd43dd8448eb211c80319c"
+    assert root.parent_span_id == "b7ad6b7169203331"
+  end
+
+  test "ignores traceparent by default (opt-in)" do
+    :ok = TestExporter.attach(self())
+    conn = call(valid_request_path(), [{"traceparent", @tp}], build_opts())
+    assert conn.status == 200
+
+    assert_receive {:span, %Span{name: "image_pipe.request"} = root}
+    assert root.trace_id != "0af7651916cd43dd8448eb211c80319c"
+    assert root.parent_span_id == nil
+  end
+
+  test "malformed traceparent falls back to a fresh root" do
+    :ok = TestExporter.attach(self(), extract_inbound: true)
+    conn = call(valid_request_path(), [{"traceparent", "garbage"}], build_opts())
+    assert conn.status == 200
+
+    assert_receive {:span, %Span{name: "image_pipe.request"} = root}
+    assert root.trace_id =~ ~r/\A[0-9a-f]{32}\z/
+    assert root.parent_span_id == nil
+  end
+end

--- a/test/image_pipe/telemetry/trace/inbound_test.exs
+++ b/test/image_pipe/telemetry/trace/inbound_test.exs
@@ -1,0 +1,38 @@
+defmodule ImagePipe.Telemetry.Trace.InboundTest do
+  use ExUnit.Case, async: false
+  alias ImagePipe.Telemetry
+  alias ImagePipe.Telemetry.Trace.{Context, Inbound, Span, TestExporter}
+
+  setup do
+    TestExporter.set_receiver(self())
+    :ok = TestExporter.attach(self())
+
+    on_exit(fn ->
+      Telemetry.detach_tracer()
+      TestExporter.clear_receiver()
+    end)
+
+    :ok
+  end
+
+  test "root span adopts an inbound context when present" do
+    Inbound.put(%Context{
+      trace_id: "0af7651916cd43dd8448eb211c80319c",
+      span_id: "b7ad6b7169203331",
+      trace_flags: 1
+    })
+
+    Telemetry.span([], [:request], %{}, fn -> {:ok, %{result: :ok}} end)
+
+    assert_receive {:span, %Span{name: "image_pipe.request"} = root}
+    assert root.trace_id == "0af7651916cd43dd8448eb211c80319c"
+    assert root.parent_span_id == "b7ad6b7169203331"
+  end
+
+  test "root mints fresh when no inbound context" do
+    Telemetry.span([], [:request], %{}, fn -> {:ok, %{result: :ok}} end)
+    assert_receive {:span, %Span{name: "image_pipe.request"} = root}
+    assert root.trace_id =~ ~r/\A[0-9a-f]{32}\z/
+    assert root.parent_span_id == nil
+  end
+end

--- a/test/image_pipe/telemetry/trace/log_exporter_test.exs
+++ b/test/image_pipe/telemetry/trace/log_exporter_test.exs
@@ -1,0 +1,36 @@
+defmodule ImagePipe.Telemetry.Trace.LogExporterTest do
+  use ExUnit.Case, async: false
+  import ExUnit.CaptureLog
+  alias ImagePipe.Telemetry.Trace.{LogExporter, Span}
+
+  test "logs one flat line with ids, name, duration, status" do
+    span = %Span{
+      trace_id: "t",
+      span_id: "s",
+      parent_span_id: "p",
+      name: "image_pipe.request",
+      start_time: 0,
+      duration_native: 1234,
+      status: :ok
+    }
+
+    log = capture_log(fn -> assert LogExporter.export(span) == :ok end)
+    assert log =~ "image_pipe.request"
+    assert log =~ "trace=t"
+    assert log =~ "span=s"
+    assert log =~ "parent=p"
+    assert log =~ "dur=1234"
+    assert log =~ "status=ok"
+    # one flat line per span (no tree buffering)
+    assert log |> String.split("\n", trim: true) |> length() == 1
+  end
+
+  test "renders missing parent/duration/status as dashes/unset" do
+    span = %Span{trace_id: "t", span_id: "s", name: "image_pipe.request", start_time: 0}
+
+    log = capture_log(fn -> assert LogExporter.export(span) == :ok end)
+    assert log =~ "parent=-"
+    assert log =~ "dur=-"
+    assert log =~ "status=unset"
+  end
+end

--- a/test/image_pipe/telemetry/trace/materialize_span_test.exs
+++ b/test/image_pipe/telemetry/trace/materialize_span_test.exs
@@ -103,9 +103,8 @@ defmodule ImagePipe.Telemetry.Trace.MaterializeSpanTest do
     assert conn.status == 200
 
     spans = collect_spans()
-    mat = Enum.find(spans, &(&1.name == "image_pipe.transform.materialize"))
+    assert [mat] = Enum.filter(spans, &(&1.name == "image_pipe.transform.materialize"))
 
-    assert mat, "expected a materialize span"
     assert is_integer(mat.duration_native) and mat.duration_native >= 0
 
     parent = parent_of(spans, mat)
@@ -121,9 +120,7 @@ defmodule ImagePipe.Telemetry.Trace.MaterializeSpanTest do
     assert conn.status == 200
 
     spans = collect_spans()
-    mat = Enum.find(spans, &(&1.name == "image_pipe.transform.materialize"))
-
-    assert mat, "expected a materialize span"
+    assert [mat] = Enum.filter(spans, &(&1.name == "image_pipe.transform.materialize"))
 
     parent = parent_of(spans, mat)
     assert parent, "materialize span must have a captured parent"
@@ -138,9 +135,7 @@ defmodule ImagePipe.Telemetry.Trace.MaterializeSpanTest do
     assert conn.status == 200
 
     spans = collect_spans()
-    mat = Enum.find(spans, &(&1.name == "image_pipe.transform.materialize"))
-
-    assert mat, "expected a materialize span"
+    assert [mat] = Enum.filter(spans, &(&1.name == "image_pipe.transform.materialize"))
 
     # The delivery backstop runs after [:transform, :execute] has closed, so the
     # materialize span is not nested under any transform stage span.

--- a/test/image_pipe/telemetry/trace/materialize_span_test.exs
+++ b/test/image_pipe/telemetry/trace/materialize_span_test.exs
@@ -1,0 +1,152 @@
+defmodule ImagePipe.Telemetry.Trace.MaterializeSpanTest do
+  use ExUnit.Case, async: false
+
+  import Plug.Test
+
+  alias ImagePipe.SourceTest.RootHTTPAdapter
+  alias ImagePipe.Telemetry
+  alias ImagePipe.Telemetry.Trace.{Span, TestExporter}
+
+  # The [:transform, :materialize] barrier span fires once per flush, wherever the
+  # flush happens. There are THREE distinct nesting parents in practice, all covered
+  # below:
+  #
+  #   1. mid-chain, before a random-access op (e.g. a smart crop) -> parent is the
+  #      [:transform, :operation] span (Chain.maybe_materialize, inside run_operation);
+  #   2. a pipeline-boundary flush of a still-pending EXIF orientation (PlanExecutor),
+  #      which runs inside [:transform, :execute] but not under any single operation ->
+  #      parent is the [:transform, :execute] span;
+  #   3. the delivery backstop (Processor.materialize_for_delivery/2), which runs AFTER
+  #      [:transform, :execute] has closed -> parent is the request root.
+  #
+  # (Every successful request materializes at least once: a chain that never
+  # materializes mid-pipeline hits the delivery backstop, so there is no "zero
+  # materialize spans" outcome to assert.)
+
+  # EXIF-orientation-6 source (40x80 stored, displayed 80x40 after autorotate). A
+  # no-geometry request on it defers the EXIF orientation and flushes it at the
+  # pipeline boundary inside [:transform, :execute].
+  defmodule ExifOrientation6Origin do
+    @moduledoc false
+
+    def init(opts), do: opts
+
+    def call(conn, _opts) do
+      body =
+        40
+        |> Image.new!(80, color: :white)
+        |> Image.Draw.rect!(0, 0, 40, 40, color: :red)
+        |> Image.set_orientation!(6)
+        |> Image.write!(:memory, suffix: ".jpg")
+
+      conn
+      |> Plug.Conn.put_resp_content_type("image/jpeg")
+      |> Plug.Conn.send_resp(200, body)
+    end
+  end
+
+  setup do
+    TestExporter.set_receiver(self())
+    :ok = TestExporter.attach(self())
+
+    on_exit(fn ->
+      Telemetry.detach_tracer()
+      TestExporter.clear_receiver()
+    end)
+
+    :ok
+  end
+
+  defp collect_spans(timeout \\ 200) do
+    receive do
+      {:span, %Span{} = s} -> [s | collect_spans(timeout)]
+    after
+      timeout -> []
+    end
+  end
+
+  defp call(path, opts) do
+    conn = conn(:get, path)
+    ImagePipe.Plug.call(conn, ImagePipe.Plug.init(opts))
+  end
+
+  defp parent_of(spans, %Span{parent_span_id: pid}),
+    do: Enum.find(spans, &(&1.span_id == pid))
+
+  defp beach_opts do
+    [
+      parser: ImagePipe.Parser.Imgproxy,
+      sources: [
+        path:
+          {RootHTTPAdapter,
+           root_url: "http://origin.test",
+           req_options: [plug: ImgproxyWireConformanceTest.OriginImage]}
+      ]
+    ]
+  end
+
+  defp exif6_opts do
+    [
+      parser: ImagePipe.Parser.Imgproxy,
+      sources: [
+        path:
+          {RootHTTPAdapter,
+           root_url: "http://origin.test", req_options: [plug: ExifOrientation6Origin]}
+      ]
+    ]
+  end
+
+  test "mid-chain materializing op yields a materialize span nested under an operation" do
+    # A smart (attention) crop needs random pixel access, so the chain materializes
+    # mid-pipeline immediately before the crop operation, inside its operation span.
+    conn = call("/_/rs:fill:80:80/g:sm/f:jpeg/plain/images/beach.jpg", beach_opts())
+    assert conn.status == 200
+
+    spans = collect_spans()
+    mat = Enum.find(spans, &(&1.name == "image_pipe.transform.materialize"))
+
+    assert mat, "expected a materialize span"
+    assert is_integer(mat.duration_native) and mat.duration_native >= 0
+
+    parent = parent_of(spans, mat)
+    assert parent, "materialize span must have a captured parent"
+    assert parent.name == "image_pipe.transform.operation"
+  end
+
+  test "pipeline-boundary EXIF flush nests the materialize span under [:transform, :execute]" do
+    # No-geometry request on an orientation-6 source: the deferred EXIF orientation is
+    # flushed at the pipeline boundary inside the execute span (not under a single op,
+    # and before the execute span closes).
+    conn = call("/_/f:jpeg/plain/images/oriented.jpg", exif6_opts())
+    assert conn.status == 200
+
+    spans = collect_spans()
+    mat = Enum.find(spans, &(&1.name == "image_pipe.transform.materialize"))
+
+    assert mat, "expected a materialize span"
+
+    parent = parent_of(spans, mat)
+    assert parent, "materialize span must have a captured parent"
+    assert parent.name == "image_pipe.transform.execute"
+  end
+
+  test "delivery backstop flush nests the materialize span under the request root" do
+    # Resize-only on an orientation-1 source streams through the whole chain without
+    # materializing, so the only flush is the delivery backstop, AFTER the execute span
+    # closes — the materialize span parents to a request-level root span.
+    conn = call("/_/rs:fit:120:90/f:jpeg/plain/images/beach.jpg", beach_opts())
+    assert conn.status == 200
+
+    spans = collect_spans()
+    mat = Enum.find(spans, &(&1.name == "image_pipe.transform.materialize"))
+
+    assert mat, "expected a materialize span"
+
+    # The delivery backstop runs after [:transform, :execute] has closed, so the
+    # materialize span is not nested under any transform stage span.
+    refute Enum.any?(spans, fn s ->
+             s.span_id == mat.parent_span_id and
+               s.name in ["image_pipe.transform.execute", "image_pipe.transform.operation"]
+           end)
+  end
+end

--- a/test/image_pipe/telemetry/trace/req_step_test.exs
+++ b/test/image_pipe/telemetry/trace/req_step_test.exs
@@ -36,6 +36,25 @@ defmodule ImagePipe.Telemetry.Trace.ReqStepTest do
     assert s.attributes[:"http.status_code"] == 200
   end
 
+  test "emits a client span with status :error on transport error" do
+    Telemetry.span([], [:request], %{}, fn ->
+      req =
+        Req.new(
+          adapter: fn req ->
+            {req, %Mint.TransportError{reason: :timeout}}
+          end
+        )
+        |> ReqStep.attach()
+
+      {:error, _exception} = Req.request(req)
+      {:ok, %{result: :ok}}
+    end)
+
+    assert_receive {:span, %Span{name: "image_pipe.http.client", kind: :client} = s}
+    assert s.status == :error
+    assert Map.has_key?(s.attributes, :"http.error")
+  end
+
   test "is a harmless no-op when no tracer is attached" do
     Telemetry.detach_tracer()
 

--- a/test/image_pipe/telemetry/trace/req_step_test.exs
+++ b/test/image_pipe/telemetry/trace/req_step_test.exs
@@ -1,7 +1,16 @@
+defmodule ImagePipe.Telemetry.Trace.RaisingExporter do
+  @moduledoc false
+  @behaviour ImagePipe.Telemetry.Trace.Exporter
+
+  @impl true
+  def export(_span), do: raise("boom")
+end
+
 defmodule ImagePipe.Telemetry.Trace.ReqStepTest do
   use ExUnit.Case, async: false
   alias ImagePipe.Telemetry
-  alias ImagePipe.Telemetry.Trace.{ReqStep, Span, TestExporter}
+  alias ImagePipe.Telemetry.Trace
+  alias ImagePipe.Telemetry.Trace.{RaisingExporter, ReqStep, Span, TestExporter}
 
   setup do
     TestExporter.set_receiver(self())
@@ -74,5 +83,24 @@ defmodule ImagePipe.Telemetry.Trace.ReqStepTest do
     end)
 
     refute_receive {:span, %Span{name: "image_pipe.http.client"}}
+  end
+
+  test "a raising exporter does not break the request" do
+    Telemetry.detach_tracer()
+    Trace.set_exporter(RaisingExporter)
+
+    on_exit(fn ->
+      Trace.set_exporter(nil)
+    end)
+
+    req =
+      Req.new(
+        adapter: fn req ->
+          {req, Req.Response.new(status: 200, body: "ok")}
+        end
+      )
+      |> ReqStep.attach()
+
+    assert {:ok, %Req.Response{status: 200}} = Req.request(req)
   end
 end

--- a/test/image_pipe/telemetry/trace/req_step_test.exs
+++ b/test/image_pipe/telemetry/trace/req_step_test.exs
@@ -1,0 +1,59 @@
+defmodule ImagePipe.Telemetry.Trace.ReqStepTest do
+  use ExUnit.Case, async: false
+  alias ImagePipe.Telemetry
+  alias ImagePipe.Telemetry.Trace.{ReqStep, Span, TestExporter}
+
+  setup do
+    TestExporter.set_receiver(self())
+    :ok = TestExporter.attach(self())
+
+    on_exit(fn ->
+      Telemetry.detach_tracer()
+      TestExporter.clear_receiver()
+    end)
+
+    :ok
+  end
+
+  test "injects traceparent and emits a logical client span with status" do
+    # Open a parent span so the client span has a trace to attach to.
+    Telemetry.span([], [:request], %{}, fn ->
+      req =
+        Req.new(
+          adapter: fn req ->
+            assert [tp] = Req.Request.get_header(req, "traceparent")
+            assert tp =~ ~r/\A00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]\z/
+            {req, Req.Response.new(status: 200, body: "ok")}
+          end
+        )
+        |> ReqStep.attach()
+
+      {:ok, _} = Req.request(req)
+      {:ok, %{result: :ok}}
+    end)
+
+    assert_receive {:span, %Span{name: "image_pipe.http.client", kind: :client} = s}
+    assert s.attributes[:"http.status_code"] == 200
+  end
+
+  test "is a harmless no-op when no tracer is attached" do
+    Telemetry.detach_tracer()
+
+    Telemetry.span([], [:request], %{}, fn ->
+      req =
+        Req.new(
+          adapter: fn req ->
+            # traceparent is still injected (cheap, header only); span just is not emitted.
+            assert [_tp] = Req.Request.get_header(req, "traceparent")
+            {req, Req.Response.new(status: 200, body: "ok")}
+          end
+        )
+        |> ReqStep.attach()
+
+      {:ok, %Req.Response{status: 200}} = Req.request(req)
+      {:ok, %{result: :ok}}
+    end)
+
+    refute_receive {:span, %Span{name: "image_pipe.http.client"}}
+  end
+end

--- a/test/image_pipe/telemetry/trace/req_step_test.exs
+++ b/test/image_pipe/telemetry/trace/req_step_test.exs
@@ -61,7 +61,28 @@ defmodule ImagePipe.Telemetry.Trace.ReqStepTest do
 
     assert_receive {:span, %Span{name: "image_pipe.http.client", kind: :client} = s}
     assert s.status == :error
-    assert Map.has_key?(s.attributes, :"http.error")
+    assert is_binary(s.attributes[:"error.type"])
+  end
+
+  test "error span carries the exception type, never the inspected message" do
+    Telemetry.span([], [:request], %{}, fn ->
+      req =
+        Req.new(
+          adapter: fn req ->
+            # An exception whose message embeds a fake signed source URL.
+            {req, %RuntimeError{message: "boom https://secret.example/x?sig=LEAK"}}
+          end
+        )
+        |> ReqStep.attach()
+
+      {:error, _exception} = Req.request(req)
+      {:ok, %{result: :ok}}
+    end)
+
+    assert_receive {:span, %Span{name: "image_pipe.http.client", kind: :client} = s}
+    assert s.attributes[:"error.type"] == "RuntimeError"
+    refute Map.has_key?(s.attributes, :"http.error")
+    refute inspect(s.attributes) =~ "LEAK"
   end
 
   test "is a harmless no-op when no tracer is attached" do

--- a/test/image_pipe/telemetry/trace/req_step_test.exs
+++ b/test/image_pipe/telemetry/trace/req_step_test.exs
@@ -10,7 +10,7 @@ defmodule ImagePipe.Telemetry.Trace.ReqStepTest do
   use ExUnit.Case, async: false
   alias ImagePipe.Telemetry
   alias ImagePipe.Telemetry.Trace
-  alias ImagePipe.Telemetry.Trace.{RaisingExporter, ReqStep, Span, TestExporter}
+  alias ImagePipe.Telemetry.Trace.{Context, RaisingExporter, ReqStep, Span, Stack, TestExporter}
 
   setup do
     TestExporter.set_receiver(self())
@@ -31,7 +31,8 @@ defmodule ImagePipe.Telemetry.Trace.ReqStepTest do
         Req.new(
           adapter: fn req ->
             assert [tp] = Req.Request.get_header(req, "traceparent")
-            assert tp =~ ~r/\A00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]\z/
+            # Sampled (default mint) parent → outbound flags -01.
+            assert tp =~ ~r/\A00-[0-9a-f]{32}-[0-9a-f]{16}-01\z/
             {req, Req.Response.new(status: 200, body: "ok")}
           end
         )
@@ -43,6 +44,33 @@ defmodule ImagePipe.Telemetry.Trace.ReqStepTest do
 
     assert_receive {:span, %Span{name: "image_pipe.http.client", kind: :client} = s}
     assert s.attributes[:"http.status_code"] == 200
+  end
+
+  test "inbound unsampled flags=0 reaches the outbound traceparent and exported span" do
+    # Simulate a producer that adopted an unsampled remote request context.
+    Stack.adopt(%Context{
+      trace_id: "0af7651916cd43dd8448eb211c80319c",
+      span_id: "b7ad6b7169203331",
+      trace_flags: 0
+    })
+
+    on_exit(fn -> Stack.clear() end)
+
+    req =
+      Req.new(
+        adapter: fn req ->
+          assert [tp] = Req.Request.get_header(req, "traceparent")
+          # Unsampled parent → outbound flags -00.
+          assert tp =~ ~r/\A00-[0-9a-f]{32}-[0-9a-f]{16}-00\z/
+          {req, Req.Response.new(status: 200, body: "ok")}
+        end
+      )
+      |> ReqStep.attach()
+
+    {:ok, _} = Req.request(req)
+
+    assert_receive {:span, %Span{name: "image_pipe.http.client", kind: :client} = s}
+    assert s.trace_flags == 0
   end
 
   test "emits a client span with status :error on transport error" do

--- a/test/image_pipe/telemetry/trace/stack_test.exs
+++ b/test/image_pipe/telemetry/trace/stack_test.exs
@@ -1,0 +1,51 @@
+defmodule ImagePipe.Telemetry.Trace.StackTest do
+  use ExUnit.Case, async: true
+  alias ImagePipe.Telemetry.Trace.{Context, Span, Stack}
+
+  defp span(name), do: %Span{trace_id: "t", span_id: name, name: name, start_time: 0}
+
+  setup do
+    on_exit(fn -> Stack.clear() end)
+    Stack.clear()
+    :ok
+  end
+
+  test "push/current/pop are LIFO" do
+    assert Stack.current() == nil
+    Stack.push(span("a"))
+    Stack.push(span("b"))
+    assert Stack.current().span_id == "b"
+    assert Stack.pop().span_id == "b"
+    assert Stack.current().span_id == "a"
+    assert Stack.pop().span_id == "a"
+    assert Stack.pop() == nil
+  end
+
+  test "nested-then-sibling preserves parentage order" do
+    Stack.push(span("root"))
+    Stack.push(span("child1"))
+    assert Stack.pop().span_id == "child1"
+    # sibling: parent is root again
+    assert Stack.current().span_id == "root"
+    Stack.push(span("child2"))
+    assert Stack.current().span_id == "child2"
+  end
+
+  test "context/0 snapshots the current span identity" do
+    assert Stack.context() == nil
+    Stack.push(%Span{trace_id: "abc", span_id: "def", name: "x", start_time: 0})
+    assert %Context{trace_id: "abc", span_id: "def"} = Stack.context()
+  end
+
+  test "adopt/1 seeds a remote-parent frame; next span inherits it" do
+    Stack.adopt(%Context{trace_id: "rt", span_id: "rs", trace_flags: 1})
+    assert %Context{trace_id: "rt", span_id: "rs"} = Stack.context()
+    # a child pushed now would read current() as its parent
+    assert Stack.current().span_id == "rs"
+  end
+
+  test "adopt(nil) is a no-op" do
+    Stack.adopt(nil)
+    assert Stack.current() == nil
+  end
+end

--- a/test/image_pipe/telemetry/trace/w3c_test.exs
+++ b/test/image_pipe/telemetry/trace/w3c_test.exs
@@ -18,6 +18,7 @@ defmodule ImagePipe.Telemetry.Trace.W3CTest do
     assert W3C.decode("garbage") == :error
     assert W3C.decode("00-short-b7ad6b7169203331-01") == :error
     assert W3C.decode("00-" <> String.duplicate("0", 32) <> "-b7ad6b7169203331-01") == :error
+    assert W3C.decode("00-0af7651916cd43dd8448eb211c80319c-" <> String.duplicate("0", 16) <> "-01") == :error
     assert W3C.decode("") == :error
   end
 end

--- a/test/image_pipe/telemetry/trace/w3c_test.exs
+++ b/test/image_pipe/telemetry/trace/w3c_test.exs
@@ -10,6 +10,7 @@ defmodule ImagePipe.Telemetry.Trace.W3CTest do
   test "round-trips a freshly generated context" do
     tid = Id.trace_id()
     sid = Id.span_id()
+
     assert {:ok, %Context{trace_id: ^tid, span_id: ^sid, trace_flags: 1}} =
              tid |> W3C.encode(sid, 1) |> W3C.decode()
   end
@@ -18,7 +19,11 @@ defmodule ImagePipe.Telemetry.Trace.W3CTest do
     assert W3C.decode("garbage") == :error
     assert W3C.decode("00-short-b7ad6b7169203331-01") == :error
     assert W3C.decode("00-" <> String.duplicate("0", 32) <> "-b7ad6b7169203331-01") == :error
-    assert W3C.decode("00-0af7651916cd43dd8448eb211c80319c-" <> String.duplicate("0", 16) <> "-01") == :error
+
+    assert W3C.decode(
+             "00-0af7651916cd43dd8448eb211c80319c-" <> String.duplicate("0", 16) <> "-01"
+           ) == :error
+
     assert W3C.decode("") == :error
   end
 end

--- a/test/image_pipe/telemetry/trace/w3c_test.exs
+++ b/test/image_pipe/telemetry/trace/w3c_test.exs
@@ -1,0 +1,23 @@
+defmodule ImagePipe.Telemetry.Trace.W3CTest do
+  use ExUnit.Case, async: true
+  alias ImagePipe.Telemetry.Trace.{Context, Id, W3C}
+
+  test "encode produces a valid W3C traceparent" do
+    tp = W3C.encode("0af7651916cd43dd8448eb211c80319c", "b7ad6b7169203331", 1)
+    assert tp == "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+  end
+
+  test "round-trips a freshly generated context" do
+    tid = Id.trace_id()
+    sid = Id.span_id()
+    assert {:ok, %Context{trace_id: ^tid, span_id: ^sid, trace_flags: 1}} =
+             tid |> W3C.encode(sid, 1) |> W3C.decode()
+  end
+
+  test "decode rejects malformed input" do
+    assert W3C.decode("garbage") == :error
+    assert W3C.decode("00-short-b7ad6b7169203331-01") == :error
+    assert W3C.decode("00-" <> String.duplicate("0", 32) <> "-b7ad6b7169203331-01") == :error
+    assert W3C.decode("") == :error
+  end
+end

--- a/test/support/trace_test_exporter.ex
+++ b/test/support/trace_test_exporter.ex
@@ -1,0 +1,31 @@
+defmodule ImagePipe.Telemetry.Trace.TestExporter do
+  @moduledoc """
+  Test-only exporter. Spans are exported from MULTIPLE processes (Producer,
+  SourceSession), so the receiver pid must be reachable globally — we use
+  :persistent_term. REQUIREMENT: every test module using this must be `async: false`
+  (ExUnit runs async:false modules with no concurrent test), and must clear the
+  receiver in on_exit to keep the global key from leaking across modules.
+  """
+  @behaviour ImagePipe.Telemetry.Trace.Exporter
+
+  @key {__MODULE__, :receiver}
+
+  @doc "Attach the tracer with this exporter and route spans to `test_pid`."
+  def attach(test_pid, opts \\ []) do
+    set_receiver(test_pid)
+    ImagePipe.Telemetry.attach_tracer(Keyword.merge([exporter: __MODULE__], opts))
+  end
+
+  def set_receiver(pid), do: :persistent_term.put(@key, pid)
+  def clear_receiver, do: :persistent_term.put(@key, nil)
+
+  @impl true
+  def export(span) do
+    case :persistent_term.get(@key, nil) do
+      nil -> :ok
+      pid -> send(pid, {:span, span})
+    end
+
+    :ok
+  end
+end


### PR DESCRIPTION
## Summary

Adds an **opt-in telemetry span capture / tracing layer** (`ImagePipe.Telemetry.Trace.*`) that consumes ImagePipe's existing `:telemetry.span/3` events, reconstructs correctly-nested distributed-trace-shaped spans, and hands each finished span to a pluggable exporter. Ships the same way as the default Logger: nothing attaches automatically, stdlib-only default exporter, third-party backends attached by the host.

This is **not** an OpenTelemetry export task — OTel is the reference model (span shape, W3C `traceparent`); the deliverable is our own capture + correlation + propagation + export contract.

Design spec and implementation plan are included under `docs/superpowers/`.

## What it does

- **Nesting reconstruction** via a per-process active-span stack (process dictionary). `:telemetry.span/3` runs handlers synchronously inline, so top-of-stack at a child's `:start` is its parent — no per-span wiring.
- **Cross-process propagation** across ImagePipe's real topology (four live processes): the trace context is threaded as data alongside the existing `$callers` chain at the two hops — request → SourceSession (for `[:cache, :write]`) and request → Producer (for the transform/source subtree). Shared cache-maintenance spans (`[:cache, :admission]`, `[:cache, :warm_start]`, ticker events) are deliberately kept as separate roots.
- **`[:transform, :materialize]` barrier span** (new): wraps the existing libvips `copy_memory` flush in `Materializer.materialize/1` for honest per-barrier timing. Operations stay construction markers; the barrier owns the real flush cost. Purely observational — the flush behavior and return contract are byte-identical.
- **Opt-in inbound `traceparent` extraction** at the plug edge, so ImagePipe can be a middle hop in a distributed trace. Off by default; malformed headers fall back to a fresh root.
- **Logical + physical HTTP spans**: a `Trace.ReqStep` logical client span (injects `traceparent`, captures status) plus `Trace.FinchCapture` wire spans correlated via `finch_private`.
- **Pluggable `Trace.Exporter` behaviour** + a stdlib **`LogExporter`** (flat, one line per span, no tree-buffering). Hosts wire OTLP/APM/UI exporters themselves; sampling is deferred to the host SDK (we only propagate the inbound sampled flag).

## Safety & compatibility

- **No data leakage**: span attributes are allowlist-only (`safe_attrs/1`). Full source URLs, request paths, signatures, tokens, and auth never reach a span — verified by an example + StreamData property test, and re-verified end-to-end against every emitter's metadata.
- **Zero-cost when not attached**: no handlers, no spans built, `ReqStep` no-ops, `Stack.adopt(nil)` no-ops.
- **Never crashes the request path**: capture handlers and the ReqStep export call rescue to `:ok`; a buggy host exporter cannot fail a fetch.
- **imgproxy conformance unchanged**: the only processing-internals touch is the observational materialize span; `docs/imgproxy_support_matrix.md` is correctly untouched and the wire conformance suite passes.
- **Boundaries**: everything lives in the telemetry boundary (`deps: []`); only `Trace.{Context, Stack, Span, Exporter, ReqStep}` + the `Trace` facade are exported; an architecture test pins the export set and that the capture handler never references concrete transform/source/request modules.

## Process

Built via brainstorming → reviewed spec → reviewed plan → subagent-driven TDD implementation, with parallel disjoint-focus reviews (architecture, tracing correctness, security/sensitivity, tests/conventions, and an imgproxy-compatibility reviewer) at the spec, plan, per-task, and final stages.

## Test plan

- `mise run precommit` green: format, `--warnings-as-errors`, `credo --strict`, full suite — **1573 passed**, 5 `:image_vision` excluded.
- End-to-end span tree verified on a real `ImagePipe.Plug.call/2` request (one trace_id, correct four-process nesting, no orphans).
- imgproxy wire conformance suite: 84 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

## New Features
* Introduced opt-in distributed tracing with span capture and reconstruction across request lifecycle
* Added W3C traceparent support for inbound trace context propagation
* Integrated tracing with HTTP clients (Req and Finch)
* Added pluggable span exporter contract and bundled log-based exporter
* Enabled trace context propagation across process boundaries

## Documentation
* Added comprehensive tracing architecture and design specifications
* Expanded telemetry documentation with span event coverage and tracing behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->