### PR TITLE
chore(mise): add worktrees:clean task to prune regenerable dirs

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -34,7 +34,7 @@ run = [
 ]
 
 [tasks."worktrees:clean"]
-description = "Remove regenerable dirs (deps, fiddle/deps, .dexter, .expert) from every worktree under .worktrees and .claude/worktrees"
+description = "Remove regenerable dirs (deps, _build, fiddle deps/_build/node_modules, .dexter, .expert) from every worktree under .worktrees and .claude/worktrees"
 run = """
 set -eu
 root=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")
@@ -53,7 +53,7 @@ for base in "$root/.worktrees" "$root/.claude/worktrees"; do
   [ -d "$base" ] || continue
   for wt in "$base"/*/; do
     [ -d "$wt" ] || continue
-    for target in deps fiddle/deps .dexter .expert; do
+    for target in deps _build fiddle/deps fiddle/_build fiddle/node_modules fiddle/assets/node_modules .dexter .expert; do
       path="$wt$target"
       [ -e "$path" ] || continue
       real=$(resolve "$path") || { echo "skip (unresolvable): $path" >&2; continue; }

--- a/mise.toml
+++ b/mise.toml
@@ -33,6 +33,43 @@ run = [
   "pnpm -C fiddle/assets run build",
 ]
 
+[tasks."worktrees:clean"]
+description = "Remove regenerable dirs (deps, fiddle/deps, .dexter, .expert) from every worktree under .worktrees and .claude/worktrees"
+run = """
+set -eu
+root=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")
+[ -n "$root" ] && [ -d "$root" ] || { echo "could not resolve git root" >&2; exit 1; }
+root=$(CDPATH= cd -- "$root" && pwd -P)
+
+# Canonical absolute path of an existing file/dir (resolves symlinks).
+resolve() {
+  d=$(CDPATH= cd -- "$(dirname -- "$1")" && pwd -P) || return 1
+  case "$d" in */) printf '%s%s\\n' "$d" "$(basename -- "$1")" ;;
+                *) printf '%s/%s\\n' "$d" "$(basename -- "$1")" ;; esac
+}
+
+removed=0
+for base in "$root/.worktrees" "$root/.claude/worktrees"; do
+  [ -d "$base" ] || continue
+  for wt in "$base"/*/; do
+    [ -d "$wt" ] || continue
+    for target in deps fiddle/deps .dexter .expert; do
+      path="$wt$target"
+      [ -e "$path" ] || continue
+      real=$(resolve "$path") || { echo "skip (unresolvable): $path" >&2; continue; }
+      case "$real" in
+        "$root"/*) ;;
+        *) echo "skip (outside git root): $real" >&2; continue ;;
+      esac
+      echo "rm -rf ${real#"$root/"}"
+      rm -rf "$real"
+      removed=$((removed + 1))
+    done
+  done
+done
+echo "Cleaned $removed director(ies)."
+"""
+
 [tasks.server]
 description = "Run the ImagePipe Fiddle dev server (Phoenix + Vite)"
 dir = "fiddle"


### PR DESCRIPTION
## What

Adds a `mise run worktrees:clean` task that removes regenerable directories from every worktree under `.worktrees` and `.claude/worktrees`:

- `deps`
- `_build`
- `fiddle/deps`
- `fiddle/_build`
- `fiddle/node_modules`
- `fiddle/assets/node_modules`
- `.dexter`
- `.expert`

All are caches/build output that get recreated by `mix deps.get` / `mix compile` / `pnpm install` (`mise run setup`). Across the current worktrees this reclaims roughly **32 GB**.

## How

- **Root resolution** — derives the main repo root via `git rev-parse --git-common-dir`, so the task works whether invoked from the main checkout or from inside any worktree (those worktree dirs only exist at the main root).
- **Targeted, not deep-recursive** — only the listed paths at each worktree root are removed. Nested copies inside `deps/` (e.g. `deps/telemetry/_build`) vanish with `deps` itself, and unlisted legacy dirs (e.g. `demo/`, `demo_new/`) are left alone.
- **Safety guard** — both the root and each target are canonicalized with `pwd -P` (resolving symlinks) and each removal is gated by a strict `"$root"/*` prefix check. Anything resolving outside the git root is printed as `skip (outside git root)` and never deleted. Aborts up front if the git root can't be resolved.
- Prints each `rm -rf` and a final count.

## Notes

The directories are removed wholesale rather than emptied, since they're all regenerable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)