### PR TITLE
feat(imgproxy): visual-diff HTML report task (gen_report) (#202)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ mise.local.toml
 # Generated benchmark output
 bench/results/
 tmp/
+
+# Generated imgproxy differential visual-diff report (regenerate on demand)
+test/support/image_pipe/test/imgproxy_differential/report.html

--- a/docs/superpowers/plans/2026-06-11-imgproxy-gen-report.md
+++ b/docs/superpowers/plans/2026-06-11-imgproxy-gen-report.md
@@ -1,0 +1,1299 @@
+# imgproxy Visual-Diff HTML Report — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `mix imgproxy.gen_report` task that renders ImagePipe live for every differential constellation and writes a single self-contained `report.html` putting imgproxy vs ImagePipe side by side with a comparison slider, two diff heatmaps, and the live-recomputed conformance metric/verdict/triage per case.
+
+**Architecture:** A `Mix.Task` (`check: [out: false]`, always compiled, no Docker) orchestrates: load the committed manifest → render each constellation through the *same* plug wiring the conformance test uses → compute the same per-group metric → build two libvips diff heatmaps → assemble card data → hand it to a pure HTML renderer. Two genuinely-pure pieces (opts→prose summary, HTML assembly) are isolated as `deps: []` support modules so they're unit-testable without the heavy render pass; the heatmap/render orchestration lives in the task. It reads only committed fixtures + live renders and writes nothing the test lane depends on.
+
+**Tech Stack:** Elixir, Mix.Task, Plug.Test, Req (via `RootHTTPAdapter`), Vix/libvips (`Vix.Vips.Operation`, `Vix.Vips.Image`), the `image` library (`Image.*`), `Boundary`, ExUnit.
+
+**Spec:** `docs/superpowers/specs/2026-06-11-imgproxy-gen-report-design.md`
+
+---
+
+## File structure
+
+- **Create** `test/support/image_pipe/test/imgproxy_differential/opts_summary.ex` — pure `opts`-string → human prose. `use Boundary, top_level?: true, deps: []`.
+- **Create** `test/support/image_pipe/test/imgproxy_differential/report_html.ex` — pure card-data + provenance → self-contained HTML string. `use Boundary, top_level?: true, deps: []`.
+- **Create** `test/support/mix/tasks/imgproxy.gen_report.ex` — the task: args, manifest, render, metric, heatmaps, card assembly, write. `use Boundary, top_level?: true, check: [out: false]`.
+- **Create** `test/image_pipe/imgproxy_gen_report_test.exs` — OptsSummary tests, ReportHtml tests, one full-task smoke test.
+- **Modify** `.gitignore` — ignore the default `report.html` output.
+- **Modify** `test/support/image_pipe/test/imgproxy_differential/README.md` — document the on-demand task.
+
+Card-data map shape (the contract between the task (producer) and `ReportHtml` (consumer); a plain map, documented in `ReportHtml`'s `@moduledoc`):
+
+```elixir
+%{
+  id: String.t(),
+  group: :transform | :diverges | :lossy,
+  verdict: :equal | :diverges,
+  url: String.t(),            # Constellations.imgproxy_path/1
+  summary: String.t(),        # OptsSummary.describe/1
+  status: :pass | :over_budget | :diverges_ok | :diverges_below_floor
+          | :dims_mismatch | :contract_ok | :contract_mismatch,
+  attention?: boolean(),
+  hash_drift?: boolean(),
+  triage: nil | %{reason: String.t(), issue: String.t()},
+  tol: nil | %{threshold: non_neg_integer(), budget: non_neg_integer()},
+  metric_text: String.t(),
+  imgproxy_img: nil | String.t(),   # data: URI (nil for lossy)
+  pipe_img: String.t(),             # data: URI
+  heat_banded: nil | String.t(),    # data: URI (nil for lossy / dims-mismatch)
+  heat_raw: nil | String.t(),       # data: URI (nil for lossy / dims-mismatch)
+  pipe_dims: {pos_integer(), pos_integer()},
+  fixture_dims: nil | {pos_integer(), pos_integer()}
+}
+```
+
+---
+
+## Task 1: OptsSummary — opts string → human prose
+
+**Files:**
+- Create: `test/support/image_pipe/test/imgproxy_differential/opts_summary.ex`
+- Test: `test/image_pipe/imgproxy_gen_report_test.exs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/image_pipe/imgproxy_gen_report_test.exs` with just the OptsSummary block for now:
+
+```elixir
+defmodule ImagePipe.ImgproxyGenReportTest do
+  use ExUnit.Case, async: true
+
+  alias ImagePipe.Test.ImgproxyDifferential.OptsSummary
+
+  describe "OptsSummary.describe/1" do
+    test "resize + gravity" do
+      assert OptsSummary.describe("rs:fill:240:180/g:ce") ==
+               "resize fill 240×180; gravity center"
+    end
+
+    test "compound gravity codes and absolute offset" do
+      assert OptsSummary.describe("c:120:90/g:nowe") == "crop 120×90; gravity north-west"
+      assert OptsSummary.describe("rs:fill:120:120/g:no:10:20") ==
+               "resize fill 120×120; gravity north +10,+20"
+    end
+
+    test "trim, min-dims, zoom, dpr" do
+      assert OptsSummary.describe("t:10") == "trim (threshold 10)"
+      assert OptsSummary.describe("rs:fit:300:300/mw:280/mh:280") ==
+               "resize fit 300×300; min-width 280; min-height 280"
+      assert OptsSummary.describe("z:0.5") == "zoom 0.5"
+      assert OptsSummary.describe("rs:fit:80:80/dpr:2") == "resize fit 80×80; dpr 2"
+    end
+
+    test "extend variants" do
+      assert OptsSummary.describe("rs:fit:300:200/ex:1") == "resize fit 300×200; extend"
+      assert OptsSummary.describe("rs:fit:300:200/ex:1:so") ==
+               "resize fit 300×200; extend (south)"
+      assert OptsSummary.describe("rs:fit:400:150/ex:1:we:5:0") ==
+               "resize fit 400×150; extend (west +5,+0)"
+      assert OptsSummary.describe("rs:fit:300:200/exar:1") ==
+               "resize fit 300×200; extend-aspect-ratio"
+    end
+
+    test "background, blur, sharpen, strip, format, quality" do
+      assert OptsSummary.describe("rs:fit:64:64/bg:255:0:0") ==
+               "resize fit 64×64; background rgb(255,0,0)"
+      assert OptsSummary.describe("rs:fit:240:240/bl:3") == "resize fit 240×240; blur 3"
+      assert OptsSummary.describe("rs:fit:240:240/sh:2") == "resize fit 240×240; sharpen 2"
+      assert OptsSummary.describe("rs:fit:120:120/sm:1") ==
+               "resize fit 120×120; strip-metadata on"
+      assert OptsSummary.describe("rs:fit:200:200/scp:0") ==
+               "resize fit 200×200; strip-color-profile off"
+      assert OptsSummary.describe("rs:fill:240:180/q:40/f:jpg") ==
+               "resize fill 240×180; quality 40; format jpg"
+    end
+
+    test "unknown segments echo verbatim" do
+      assert OptsSummary.describe("rs:fit:64:64/wat:9") == "resize fit 64×64; wat:9"
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_gen_report_test.exs`
+Expected: FAIL — `OptsSummary` is undefined.
+
+- [ ] **Step 3: Implement OptsSummary**
+
+Create `test/support/image_pipe/test/imgproxy_differential/opts_summary.ex`:
+
+```elixir
+defmodule ImagePipe.Test.ImgproxyDifferential.OptsSummary do
+  @moduledoc """
+  Renders an imgproxy `opts` string (as stored on a constellation) into a short
+  human-readable summary for the visual-diff report's card labels. Self-contained
+  on purpose — a tiny dedicated formatter, not a reach into the parser — covering
+  the option codes used in `constellations.ex`, with unknown segments echoed
+  verbatim so it never hides syntax it doesn't recognize.
+  """
+
+  use Boundary, top_level?: true, deps: []
+
+  @doc "Human-readable summary of a slash-separated imgproxy opts string."
+  @spec describe(String.t()) :: String.t()
+  def describe(opts) do
+    opts
+    |> String.split("/", trim: true)
+    |> Enum.map_join("; ", &segment/1)
+  end
+
+  defp segment(seg) do
+    case String.split(seg, ":") do
+      ["rs", mode, w, h] -> "resize #{mode} #{w}×#{h}"
+      ["rs", mode, w] -> "resize #{mode} #{w}"
+      ["c", w, h] -> "crop #{w}×#{h}"
+      ["t", n] -> "trim (threshold #{n})"
+      ["g" | rest] -> "gravity #{gravity(rest)}"
+      ["mw", n] -> "min-width #{n}"
+      ["mh", n] -> "min-height #{n}"
+      ["z", f] -> "zoom #{f}"
+      ["pd" | vals] -> "padding #{Enum.join(vals, ",")}"
+      ["ex" | rest] -> "extend#{extend_suffix(rest)}"
+      ["exar" | _] -> "extend-aspect-ratio"
+      ["dpr", n] -> "dpr #{n}"
+      ["bg", r, g, b] -> "background rgb(#{r},#{g},#{b})"
+      ["bl", n] -> "blur #{n}"
+      ["sh", n] -> "sharpen #{n}"
+      ["sm", f] -> "strip-metadata #{onoff(f)}"
+      ["scp", f] -> "strip-color-profile #{onoff(f)}"
+      ["el", f] -> "enlarge #{onoff(f)}"
+      ["q", n] -> "quality #{n}"
+      ["f", fmt] -> "format #{fmt}"
+      _ -> seg
+    end
+  end
+
+  defp gravity([code]), do: gravity_name(code)
+  defp gravity([code, x, y]), do: "#{gravity_name(code)} +#{x},+#{y}"
+  defp gravity(other), do: Enum.join(other, ":")
+
+  defp gravity_name("ce"), do: "center"
+  defp gravity_name("no"), do: "north"
+  defp gravity_name("so"), do: "south"
+  defp gravity_name("ea"), do: "east"
+  defp gravity_name("we"), do: "west"
+  defp gravity_name("noea"), do: "north-east"
+  defp gravity_name("nowe"), do: "north-west"
+  defp gravity_name("soea"), do: "south-east"
+  defp gravity_name("sowe"), do: "south-west"
+  defp gravity_name("sm"), do: "smart"
+  defp gravity_name(other), do: other
+
+  defp extend_suffix([_flag]), do: ""
+  defp extend_suffix([_flag, code]), do: " (#{gravity_name(code)})"
+  defp extend_suffix([_flag, code, x, y]), do: " (#{gravity_name(code)} +#{x},+#{y})"
+  defp extend_suffix(_), do: ""
+
+  defp onoff("0"), do: "off"
+  defp onoff("1"), do: "on"
+  defp onoff(x), do: x
+end
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_gen_report_test.exs`
+Expected: PASS (all OptsSummary tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/support/image_pipe/test/imgproxy_differential/opts_summary.ex test/image_pipe/imgproxy_gen_report_test.exs
+git commit -m "test(imgproxy): opts-string human summary for visual-diff report (#202)"
+```
+
+---
+
+## Task 2: Task skeleton — args, manifest, live render, stub HTML, gitignore
+
+This establishes the full pipeline end-to-end with a throwaway one-line HTML body (replaced in Task 5), proving renders work before any metric/heatmap/template work.
+
+**Files:**
+- Create: `test/support/mix/tasks/imgproxy.gen_report.ex`
+- Modify: `.gitignore`
+- Test: `test/image_pipe/imgproxy_gen_report_test.exs`
+
+- [ ] **Step 1: Add `.gitignore` entry**
+
+Append to `.gitignore` (the file ends with a `tmp/` line):
+
+```gitignore
+
+# Generated imgproxy differential visual-diff report (regenerate on demand)
+test/support/image_pipe/test/imgproxy_differential/report.html
+```
+
+- [ ] **Step 2: Write the failing smoke test**
+
+Append to `test/image_pipe/imgproxy_gen_report_test.exs`, inside the module, after the `describe` block:
+
+```elixir
+  alias ImagePipe.Test.ImgproxyDifferential.Constellations
+
+  test "gen_report renders every constellation to a self-contained file" do
+    out =
+      Path.join(System.tmp_dir!(), "imgproxy_report_#{System.unique_integer([:positive])}.html")
+
+    on_exit(fn -> File.rm_rf(out) end)
+
+    Mix.Tasks.Imgproxy.GenReport.run(["--out", out])
+
+    assert File.exists?(out)
+    html = File.read!(out)
+
+    for c <- Constellations.all() do
+      assert html =~ ~s(id="#{c.id}"), "report missing card anchor for #{c.id}"
+    end
+  end
+```
+
+Add `alias Mix.Tasks.Imgproxy.GenReport` is NOT needed (fully-qualified call used).
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_gen_report_test.exs:LINE` (the smoke test line)
+Expected: FAIL — `Mix.Tasks.Imgproxy.GenReport` is undefined.
+
+- [ ] **Step 4: Implement the task skeleton**
+
+Create `test/support/mix/tasks/imgproxy.gen_report.ex`:
+
+```elixir
+defmodule Mix.Tasks.Imgproxy.GenReport do
+  @shortdoc "Generate a self-contained visual-diff HTML report for the imgproxy differential suite"
+  @moduledoc """
+  Renders ImagePipe live for every constellation in `constellations.ex`, compares
+  against the committed imgproxy fixtures, and writes a single self-contained
+  `report.html` (images base64-inlined, slider + fonts from CDN). No Docker — the
+  imgproxy fixtures are already committed and ImagePipe renders are live. A DX /
+  inspection tool only: it touches no fixtures, manifest, or the `mix test` lane.
+
+      MIX_ENV=test mise exec -- mix imgproxy.gen_report [--out PATH]
+
+  `--out` defaults to `report.html` beside the harness (gitignored).
+  """
+  use Mix.Task
+  use Boundary, top_level?: true, check: [out: false]
+
+  import Plug.Test, only: [conn: 2]
+
+  alias ImagePipe.SourceTest.RootHTTPAdapter
+  alias ImagePipe.Test.ImgproxyDifferential.{Constellations, Manifest}
+
+  @base "test/support/image_pipe/test/imgproxy_differential"
+  @sources_dir "#{@base}/sources"
+  @fixtures_dir "#{@base}/fixtures"
+  @manifest_path "#{@base}/manifest.exs"
+  @default_out "#{@base}/report.html"
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _, _} = OptionParser.parse(args, strict: [out: :string])
+    out = Keyword.get(opts, :out, @default_out)
+
+    {:ok, _} = Application.ensure_all_started(:image)
+    {:ok, _} = Application.ensure_all_started(:req)
+
+    manifest = Manifest.load!(@manifest_path)
+    plug_opts = plug_opts()
+
+    cards = Enum.map(Constellations.all(), fn c -> build_card(c, manifest, plug_opts) end)
+
+    File.write!(out, stub_html(cards))
+    Mix.shell().info("Wrote visual-diff report (#{length(cards)} cards) to #{Path.expand(out)}")
+  end
+
+  # Throwaway placeholder body — replaced by ReportHtml.render/1 in Task 5.
+  defp stub_html(cards) do
+    body = Enum.map_join(cards, "\n", fn c -> ~s(<div id="#{c.id}">#{c.id}</div>) end)
+    "<!doctype html><meta charset=\"utf-8\"><body>#{body}</body>"
+  end
+
+  # Card assembly stub — fleshed out in Tasks 3 & 4. For now just render the pipe
+  # output so the end-to-end render path is exercised.
+  defp build_card(c, _manifest, plug_opts) do
+    {_body, _ct} = render(c, plug_opts)
+    %{id: c.id}
+  end
+
+  defp render(c, plug_opts) do
+    conn =
+      :get
+      |> conn(Constellations.imgproxy_path(c))
+      |> ImagePipe.Plug.call(plug_opts)
+
+    content_type =
+      conn
+      |> Plug.Conn.get_resp_header("content-type")
+      |> List.first()
+      |> then(fn ct -> ct && ct |> String.split(";") |> List.first() end)
+
+    {conn.resp_body, content_type}
+  end
+
+  defp plug_opts do
+    ImagePipe.Plug.init(
+      parser: ImagePipe.Parser.Imgproxy,
+      sources: [
+        path: {RootHTTPAdapter, root_url: "http://origin.test", req_options: [plug: &source_plug/1]}
+      ]
+    )
+  end
+
+  # Function plug mirroring the conformance test's inline SourceOrigin: serve the
+  # committed source bytes for the requested basename. RootHTTPAdapter forwards
+  # `req_options` straight into Req.get, so a function plug wires identically to
+  # the test's module plug.
+  defp source_plug(conn) do
+    file = Path.basename(conn.request_path)
+
+    conn
+    |> Plug.Conn.put_resp_content_type(content_type(file))
+    |> Plug.Conn.send_resp(200, File.read!(Path.join(@sources_dir, file)))
+  end
+
+  defp content_type(file) do
+    case Path.extname(file) do
+      ".jpg" -> "image/jpeg"
+      ".webp" -> "image/webp"
+      _ -> "image/png"
+    end
+  end
+end
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_gen_report_test.exs`
+Expected: PASS — all cards render; the file contains every constellation id anchor.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add test/support/mix/tasks/imgproxy.gen_report.ex .gitignore test/image_pipe/imgproxy_gen_report_test.exs
+git commit -m "feat(imgproxy): gen_report task skeleton + live render pipeline (#202)"
+```
+
+---
+
+## Task 3: Card computation — metric, status, dims guard, hash drift
+
+Fill in `build_card/3` with the real per-group computation, status/attention derivation, and authored-hash drift. No heatmaps yet (Task 4); image data URIs still absent.
+
+**Files:**
+- Modify: `test/support/mix/tasks/imgproxy.gen_report.ex`
+- Test: `test/image_pipe/imgproxy_gen_report_test.exs`
+
+- [ ] **Step 1: Extend the smoke test with status assertions**
+
+In the smoke test (Task 2), after the `for c <- ...` loop, append:
+
+```elixir
+    # The two quarantined cases must surface their live over-budget divergence
+    # (the triage badge annotates, it does not suppress the metric).
+    assert html =~ "extend_offset_east_marker"
+    assert html =~ "extend_ar_dpr_marker"
+
+    # A status atom is emitted for at least the known-divergence case.
+    assert html =~ "scp0_colorspace_124"
+```
+
+(These pass once cards carry status text rendered by the stub — see Step 3, which makes the stub echo status.)
+
+- [ ] **Step 2: Run to confirm current state**
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_gen_report_test.exs`
+Expected: PASS already (ids are present). This step just re-baselines before changing internals.
+
+- [ ] **Step 3: Implement real card computation**
+
+Replace `build_card/3` (and add helpers + the `alias`) in `imgproxy.gen_report.ex`. First extend the alias line:
+
+```elixir
+  alias ImagePipe.Test.ImgproxyDifferential.{Constellations, Manifest, OptsSummary, PixelCompare, Skew}
+```
+
+Add module attribute near the others:
+
+```elixir
+  @default_tol %{threshold: 2, budget: 64}
+```
+
+Replace `build_card/3` and the stub helpers. `group_fields/4` takes `content_type` (used only by the lossy clause; the others ignore it) and returns only `fixture_dims`, `status`, `metric_text` — no image structs (Task 4 reads images from locals/the entry, not the card):
+
+```elixir
+  defp build_card(c, manifest, plug_opts) do
+    entry = Map.fetch!(manifest.entries, c.id)
+    {body, content_type} = render(c, plug_opts)
+    pipe = Image.open!(body, access: :random, fail_on: :error)
+
+    %{
+      id: c.id,
+      group: display_group(c),
+      verdict: c.verdict,
+      url: Constellations.imgproxy_path(c),
+      summary: OptsSummary.describe(c.opts),
+      triage: c.triage,
+      tol: c.tol,
+      hash_drift?: Manifest.authored_sha256(c) != entry.authored_sha256,
+      pipe_dims: dims(pipe)
+    }
+    |> Map.merge(group_fields(c, entry, pipe, content_type))
+    |> finalize_attention()
+  end
+
+  # The `:diverges` constellation is stored as `group: :transform, verdict:
+  # :diverges` (it IS a fixture pixel comparison). For the report's display
+  # category/filter/counts it's its own bucket; the metric dispatch below still
+  # uses the constellation's real `group`/`verdict`, so this is display-only.
+  defp display_group(%{verdict: :diverges}), do: :diverges
+  defp display_group(%{group: group}), do: group
+
+  # transform / :diverges: compare against the committed fixture image.
+  defp group_fields(%{group: group} = c, entry, pipe, _content_type)
+       when group in [:transform, :diverges] do
+    fixture = fixture_image(entry)
+    fixture_dims = dims(fixture)
+
+    if fixture_dims != dims(pipe) do
+      %{
+        fixture_dims: fixture_dims,
+        status: :dims_mismatch,
+        metric_text: "dims #{fmt_dims(dims(pipe))} ≠ imgproxy #{fmt_dims(fixture_dims)}"
+      }
+    else
+      Map.put(metric_fields(c, pipe, fixture), :fixture_dims, fixture_dims)
+    end
+  end
+
+  defp group_fields(%{group: :lossy}, entry, pipe, content_type) do
+    ok? = dims(pipe) == {entry.width, entry.height} and content_type == entry.content_type
+
+    %{
+      fixture_dims: nil,
+      status: if(ok?, do: :contract_ok, else: :contract_mismatch),
+      metric_text:
+        "dims #{fmt_dims(dims(pipe))} (expected #{fmt_dims({entry.width, entry.height})}); " <>
+          "type #{inspect(content_type)} (expected #{inspect(entry.content_type)})"
+    }
+  end
+
+  defp metric_fields(%{verdict: :diverges} = c, pipe, fixture) do
+    %{metric: :fraction_over, threshold: threshold, floor: floor} = c.divergence
+    frac = PixelCompare.fraction_over(pipe, fixture, threshold)
+
+    %{
+      status: if(frac >= floor, do: :diverges_ok, else: :diverges_below_floor),
+      metric_text:
+        "#{Float.round(frac, 4)} fraction over Δ#{threshold} (floor #{floor})"
+    }
+  end
+
+  defp metric_fields(%{verdict: :equal} = c, pipe, fixture) do
+    tol = c.tol || @default_tol
+    outliers = PixelCompare.outliers(pipe, fixture, tol.threshold)
+
+    %{
+      status: if(outliers <= tol.budget, do: :pass, else: :over_budget),
+      metric_text:
+        "#{outliers} band-bytes over Δ#{tol.threshold} (budget #{tol.budget})"
+    }
+  end
+
+  defp finalize_attention(card) do
+    attention? =
+      card.hash_drift? or
+        card.status in [
+          :over_budget,
+          :diverges_below_floor,
+          :dims_mismatch,
+          :contract_mismatch
+        ]
+
+    Map.put(card, :attention?, attention?)
+  end
+
+  defp fixture_image(entry) do
+    Image.open!(File.read!(Path.join(@fixtures_dir, entry.fixture_filename)),
+      access: :random,
+      fail_on: :error
+    )
+  end
+
+  defp pipe_ct?(_pipe, entry), do: is_binary(entry.content_type)
+
+  defp dims(image), do: {Image.width(image), Image.height(image)}
+  defp fmt_dims({w, h}), do: "#{w}×#{h}"
+```
+
+Update the stub HTML to echo status so the in-progress report shows something meaningful and the smoke assertions hold:
+
+```elixir
+  defp stub_html(cards) do
+    body =
+      Enum.map_join(cards, "\n", fn c ->
+        ~s(<div id="#{c.id}">#{c.id} — #{c.status} — #{c.metric_text}</div>)
+      end)
+
+    "<!doctype html><meta charset=\"utf-8\"><body>#{body}</body>"
+  end
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_gen_report_test.exs`
+Expected: PASS. The stub now shows `id — status — metric`. The two triage cases appear as `over_budget` (their default-tol divergence), `scp0_colorspace_124` as `diverges_ok`.
+
+- [ ] **Step 5: Manually eyeball the statuses (sanity, optional)**
+
+Run: `MIX_ENV=test mise exec -- mix imgproxy.gen_report --out /tmp/r.html && grep -o 'extend_ar_dpr_marker — [a-z_]*' /tmp/r.html`
+Expected: `extend_ar_dpr_marker — over_budget` (its 1-column Δ255 blows the default budget). Confirms triage cards surface live divergence.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add test/support/mix/tasks/imgproxy.gen_report.ex test/image_pipe/imgproxy_gen_report_test.exs
+git commit -m "feat(imgproxy): per-group metric, status, dims-guard, hash-drift in gen_report (#202)"
+```
+
+---
+
+## Task 4: Heatmaps — RGB-aligned banded + raw amplified, base64 data URIs
+
+Add the two libvips heatmaps and convert every card image to a `data:` URI. Heatmaps only for transform/`:diverges` cards with matching dims.
+
+**Files:**
+- Modify: `test/support/mix/tasks/imgproxy.gen_report.ex`
+- Test: `test/image_pipe/imgproxy_gen_report_test.exs`
+
+- [ ] **Step 1: Extend the smoke test to assert inlined images + heatmaps**
+
+In the smoke test, after the existing assertions, append:
+
+```elixir
+    assert html =~ "data:image/png;base64,", "no inlined PNG images in report"
+    # alpha_resize / background_alpha exercise RGB band-alignment in the heatmap
+    # path; the run must not crash on a band-count mismatch.
+    assert html =~ "alpha_resize"
+    assert html =~ "background_alpha"
+```
+
+- [ ] **Step 2: Run to confirm it currently fails the new assertion**
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_gen_report_test.exs`
+Expected: FAIL on `data:image/png;base64,` (stub emits no images yet).
+
+- [ ] **Step 3: Implement heatmaps + data URIs**
+
+Add the alias for Vix Operation near the top:
+
+```elixir
+  alias Vix.Vips.Operation
+```
+
+Module attribute for the raw amplification factor:
+
+```elixir
+  @raw_amp 8
+```
+
+In `build_card/3`, after computing `base |> Map.merge(group_fields(...)) |> finalize_attention()`, pipe the card through image-attachment. Rename the existing terminal expression so it's bound, then attach images:
+
+```elixir
+  defp build_card(c, manifest, plug_opts) do
+    entry = Map.fetch!(manifest.entries, c.id)
+    {body, content_type} = render(c, plug_opts)
+    pipe = Image.open!(body, access: :random, fail_on: :error)
+
+    card =
+      %{
+        id: c.id,
+        group: c.group,
+        verdict: c.verdict,
+        url: Constellations.imgproxy_path(c),
+        summary: OptsSummary.describe(c.opts),
+        triage: c.triage,
+        tol: c.tol,
+        hash_drift?: Manifest.authored_sha256(c) != entry.authored_sha256,
+        pipe_dims: dims(pipe)
+      }
+      |> Map.merge(group_fields(c, entry, pipe, content_type))
+      |> finalize_attention()
+
+    attach_images(card, body, content_type, pipe, entry)
+  end
+```
+
+(The decoded `pipe` image and the fixture are locals — used only to build the metric/images, never stored on the card. `attach_images/5` re-reads the fixture via the entry. The card map already carries only `fixture_dims`/`status`/`metric_text` from Task 3's `group_fields/4`, so nothing needs stripping.)
+
+Add `attach_images/5` and the heatmap helpers:
+
+```elixir
+  # Attach base64 data URIs. Images are displayed from ORIGINAL bytes (no
+  # re-encode): the imgproxy fixture from its on-disk PNG, the pipe render from
+  # the response body. Decoded images feed the diff/heatmaps only.
+  defp attach_images(%{group: :lossy} = card, body, content_type, _pipe, _entry) do
+    Map.merge(card, %{
+      imgproxy_img: nil,
+      pipe_img: data_uri(content_type, body),
+      heat_banded: nil,
+      heat_raw: nil
+    })
+  end
+
+  defp attach_images(%{status: :dims_mismatch} = card, body, content_type, _pipe, entry) do
+    Map.merge(card, %{
+      imgproxy_img: data_uri("image/png", File.read!(Path.join(@fixtures_dir, entry.fixture_filename))),
+      pipe_img: data_uri(content_type, body),
+      heat_banded: nil,
+      heat_raw: nil
+    })
+  end
+
+  defp attach_images(card, body, content_type, pipe, entry) do
+    fixture = fixture_image(entry)
+    a = to_rgb(fixture)
+    b = to_rgb(pipe)
+    threshold = (card.tol || @default_tol).threshold
+
+    Map.merge(card, %{
+      imgproxy_img: data_uri("image/png", File.read!(Path.join(@fixtures_dir, entry.fixture_filename))),
+      pipe_img: data_uri(content_type, body),
+      heat_banded: data_uri("image/png", png(banded_heatmap(a, b, threshold))),
+      heat_raw: data_uri("image/png", png(raw_heatmap(a, b)))
+    })
+  end
+
+  defp data_uri(content_type, bytes), do: "data:#{content_type};base64,#{Base.encode64(bytes)}"
+
+  defp png(image), do: Image.write!(image, :memory, suffix: ".png")
+
+  # Align to a common 3-band RGB frame so the diff never raises on band-count
+  # mismatch (RGB vs RGBA, e.g. alpha_resize / background_alpha). Visualizes RGB
+  # deltas; the verdict metric (PixelCompare) still counts all bands incl. alpha.
+  defp to_rgb(image) do
+    case Image.bands(image) do
+      3 -> image
+      n when n > 3 -> ok!(Operation.extract_band(image, 0, n: 3))
+      _ -> image
+    end
+  end
+
+  # Banded: per-pixel max |Δ| across RGB → 256-entry LUT that dims pixels at/under
+  # the case's own threshold and ramps over-threshold pixels hot.
+  defp banded_heatmap(a, b, threshold) do
+    delta = abs_diff(a, b)
+    maxd = band_max(delta)
+    idx = ok!(Operation.cast(maxd, :VIPS_FORMAT_UCHAR))
+    ok!(Operation.maplut(idx, heat_lut(threshold)))
+  end
+
+  # Raw: |Δ| amplified for visibility, clamped to uchar (no threshold).
+  defp raw_heatmap(a, b) do
+    delta = abs_diff(a, b)
+    amped = ok!(Operation.linear(delta, [@raw_amp * 1.0], [0.0]))
+    ok!(Operation.cast(amped, :VIPS_FORMAT_UCHAR))
+  end
+
+  # subtract promotes uchar→signed short (no wrap); abs makes it non-negative.
+  defp abs_diff(a, b), do: ok!(Operation.abs(ok!(Operation.subtract(a, b))))
+
+  defp band_max(delta) do
+    b0 = ok!(Operation.extract_band(delta, 0))
+    b1 = ok!(Operation.extract_band(delta, 1))
+    b2 = ok!(Operation.extract_band(delta, 2))
+    ok!(Operation.maxpair(ok!(Operation.maxpair(b0, b1)), b2))
+  end
+
+  # 256×1 3-band uchar LUT: indices ≤ threshold → dim; above → cool→hot ramp.
+  defp heat_lut(threshold) do
+    bin =
+      for i <- 0..255, into: <<>> do
+        if i <= threshold do
+          <<24, 24, 28>>
+        else
+          t = (i - threshold) / max(255 - threshold, 1)
+          <<round(60 + t * 195), round(20 + t * 60), round(40 - t * 40)>>
+        end
+      end
+
+    {:ok, lut} = Vix.Vips.Image.new_from_binary(bin, 256, 1, 3, :VIPS_FORMAT_UCHAR)
+    lut
+  end
+
+  defp ok!({:ok, value}), do: value
+  defp ok!({:error, reason}), do: raise("vips operation failed: #{inspect(reason)}")
+```
+
+`fixture_image/1` stays as defined in Task 3 (reused by `attach_images/5`).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_gen_report_test.exs`
+Expected: PASS — report contains `data:image/png;base64,` and renders `alpha_resize`/`background_alpha` without raising.
+
+- [ ] **Step 5: Manually verify a heatmap is a valid PNG (sanity)**
+
+Run:
+```bash
+MIX_ENV=test mise exec -- mix run -e '
+  alias Mix.Tasks.Imgproxy.GenReport
+  GenReport.run(["--out", "/tmp/r.html"])
+' 2>&1 | tail -1
+```
+Expected: prints the "Wrote visual-diff report (… cards)" line with no crash. (The heatmap path ran for all transform/diverges cases including the band-mismatch ones.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add test/support/mix/tasks/imgproxy.gen_report.ex test/image_pipe/imgproxy_gen_report_test.exs
+git commit -m "feat(imgproxy): banded + raw diff heatmaps and base64 image inlining (#202)"
+```
+
+---
+
+## Task 5: ReportHtml — full self-contained template
+
+Replace the stub with a pure renderer: head (Geist fonts + slider CDN), provenance/skew header, counts summary, global heatmap toggle + filter controls, and per-card markup (badges, metric, side-by-side, slider, heatmap panel), all styled with the fiddle's CSS tokens.
+
+**Files:**
+- Create: `test/support/image_pipe/test/imgproxy_differential/report_html.ex`
+- Modify: `test/support/mix/tasks/imgproxy.gen_report.ex`
+- Test: `test/image_pipe/imgproxy_gen_report_test.exs`
+
+- [ ] **Step 1: Write ReportHtml unit tests**
+
+Append a new `describe` block to `test/image_pipe/imgproxy_gen_report_test.exs`:
+
+```elixir
+  describe "ReportHtml.render/1" do
+    alias ImagePipe.Test.ImgproxyDifferential.ReportHtml
+
+    defp sample_doc do
+      %{
+        provenance: %{
+          imgproxy_digest: "sha256:abc",
+          imgproxy_libvips: "42.20.2",
+          pipe_libvips_at_gen: "8.18.2",
+          runtime_libvips: "8.18.2",
+          skew?: false
+        },
+        cards: [
+          %{
+            id: "rs_fill_zone",
+            group: :transform,
+            verdict: :equal,
+            url: "/unsafe/rs:fill:240:180/f:png/plain/local:///high_freq.jpg",
+            summary: "resize fill 240×180",
+            status: :pass,
+            attention?: false,
+            hash_drift?: false,
+            triage: nil,
+            tol: nil,
+            metric_text: "0 band-bytes over Δ2 (budget 64)",
+            imgproxy_img: "data:image/png;base64,AAAA",
+            pipe_img: "data:image/png;base64,BBBB",
+            heat_banded: "data:image/png;base64,CCCC",
+            heat_raw: "data:image/png;base64,DDDD",
+            pipe_dims: {240, 180},
+            fixture_dims: {240, 180}
+          },
+          %{
+            id: "extend_offset_east_marker",
+            group: :transform,
+            verdict: :equal,
+            url: "/unsafe/rs:fit:400:150/ex:1:ea:20:0/f:png/plain/local:///marker.png",
+            summary: "resize fit 400×150; extend (east +20,+0)",
+            status: :over_budget,
+            attention?: true,
+            hash_drift?: false,
+            triage: %{reason: "extend east offset sign", issue: "#200"},
+            tol: nil,
+            metric_text: "9001 band-bytes over Δ2 (budget 64)",
+            imgproxy_img: "data:image/png;base64,EEEE",
+            pipe_img: "data:image/png;base64,FFFF",
+            heat_banded: "data:image/png;base64,GGGG",
+            heat_raw: "data:image/png;base64,HHHH",
+            pipe_dims: {400, 150},
+            fixture_dims: {400, 150}
+          },
+          %{
+            id: "lossy_avif",
+            group: :lossy,
+            verdict: :equal,
+            url: "/unsafe/rs:fill:240:180/f:avif/plain/local:///high_freq.jpg",
+            summary: "resize fill 240×180; format avif",
+            status: :contract_ok,
+            attention?: false,
+            hash_drift?: false,
+            triage: nil,
+            tol: nil,
+            metric_text: "dims 240×180 (expected 240×180); type \"image/avif\"",
+            imgproxy_img: nil,
+            pipe_img: "data:image/avif;base64,IIII",
+            heat_banded: nil,
+            heat_raw: nil,
+            pipe_dims: {240, 180},
+            fixture_dims: nil
+          }
+        ]
+      }
+    end
+
+    test "emits a self-contained document with fonts + slider CDN" do
+      html = ReportHtml.render(sample_doc())
+      assert html =~ "<!doctype html>"
+      assert html =~ "fonts.googleapis.com"
+      assert html =~ "img-comparison-slider"
+      assert html =~ "Geist"
+    end
+
+    test "renders a card anchor and metric per case" do
+      html = ReportHtml.render(sample_doc())
+      assert html =~ ~s(id="rs_fill_zone")
+      assert html =~ "0 band-bytes over Δ2 (budget 64)"
+      assert html =~ "resize fill 240×180"
+    end
+
+    test "triage issue is a clickable repo link" do
+      html = ReportHtml.render(sample_doc())
+      assert html =~ ~s(href="https://github.com/hlindset/image_pipe/issues/200")
+      assert html =~ "extend east offset sign"
+    end
+
+    test "counts summary reflects groups and attention" do
+      html = ReportHtml.render(sample_doc())
+      # 2 transform, 0 diverges, 1 lossy; 1 attention (over_budget)
+      assert html =~ "2 transform"
+      assert html =~ "1 lossy"
+      assert html =~ "1 attention"
+    end
+
+    test "lossy card omits imgproxy panel and heatmaps" do
+      html = ReportHtml.render(sample_doc())
+      # The lossy card has no second slider image / no heatmap data beyond its pipe img.
+      refute html =~ "data:image/png;base64,IIII"
+      assert html =~ "data:image/avif;base64,IIII"
+    end
+
+    test "global heatmap toggle + filter controls present" do
+      html = ReportHtml.render(sample_doc())
+      assert html =~ "data-heat"
+      assert html =~ "data-filter"
+    end
+  end
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_gen_report_test.exs`
+Expected: FAIL — `ReportHtml` undefined.
+
+- [ ] **Step 3: Implement ReportHtml**
+
+Create `test/support/image_pipe/test/imgproxy_differential/report_html.ex`:
+
+```elixir
+defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
+  @moduledoc """
+  Pure renderer: card data + provenance → a single self-contained HTML string for
+  the imgproxy differential visual-diff report. All images arrive pre-encoded as
+  `data:` URIs; the only view-time network deps are the img-comparison-slider CDN
+  and Google Fonts (both degrade: the side-by-side panels are the source of truth,
+  fonts fall back to system stacks). Card-data shape is documented in the plan and
+  produced by `Mix.Tasks.Imgproxy.GenReport`.
+  """
+
+  use Boundary, top_level?: true, deps: []
+
+  @slider_css "https://cdn.jsdelivr.net/npm/img-comparison-slider@8/dist/styles.css"
+  @slider_js "https://cdn.jsdelivr.net/npm/img-comparison-slider@8/dist/index.js"
+  @fonts "https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&family=Geist:wght@100..900&display=swap"
+  @issue_base "https://github.com/hlindset/image_pipe/issues/"
+
+  @spec render(%{provenance: map(), cards: [map()]}) :: String.t()
+  def render(%{provenance: prov, cards: cards}) do
+    ordered = Enum.sort_by(cards, fn c -> {if(c.attention?, do: 0, else: 1)} end)
+
+    """
+    <!doctype html>
+    <html lang="en">
+    <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>imgproxy differential — visual diff</title>
+    <link rel="stylesheet" href="#{@slider_css}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="stylesheet" href="#{@fonts}">
+    <script defer src="#{@slider_js}"></script>
+    <style>#{css()}</style>
+    </head>
+    <body data-heat="banded" data-filter="all">
+    #{header(prov, cards)}
+    <main class="cards">
+    #{Enum.map_join(ordered, "\n", &card/1)}
+    </main>
+    #{script()}
+    </body>
+    </html>
+    """
+  end
+
+  defp header(prov, cards) do
+    skew =
+      if prov.skew? do
+        ~s(<div class="banner skew">libvips skew: fixtures baked on #{esc(prov.imgproxy_libvips)}, running #{esc(prov.runtime_libvips)} — compare with care.</div>)
+      else
+        ""
+      end
+
+    """
+    <header class="report-header">
+      <h1>imgproxy differential — visual diff</h1>
+      <p class="provenance">imgproxy <code>#{esc(prov.imgproxy_digest)}</code> · imgproxy libvips <code>#{esc(prov.imgproxy_libvips)}</code> · ImagePipe libvips at gen <code>#{esc(prov.pipe_libvips_at_gen)}</code> · runtime <code>#{esc(prov.runtime_libvips)}</code></p>
+      #{skew}
+      <p class="counts">#{counts(cards)}</p>
+      <div class="controls">
+        <span class="control-group" role="group" aria-label="heatmap mode">
+          heatmap:
+          <button data-heat-set="banded">banded</button>
+          <button data-heat-set="raw">raw</button>
+        </span>
+        <span class="control-group" role="group" aria-label="filter">
+          show:
+          <button data-filter-set="all">all</button>
+          <button data-filter-set="attention">attention</button>
+          <button data-filter-set="transform">transform</button>
+          <button data-filter-set="diverges">diverges</button>
+          <button data-filter-set="lossy">lossy</button>
+        </span>
+      </div>
+    </header>
+    """
+  end
+
+  defp counts(cards) do
+    by_group = Enum.frequencies_by(cards, & &1.group)
+    attention = Enum.count(cards, & &1.attention?)
+    drift = Enum.count(cards, & &1.hash_drift?)
+
+    "#{Map.get(by_group, :transform, 0)} transform · " <>
+      "#{Map.get(by_group, :diverges, 0)} diverges · " <>
+      "#{Map.get(by_group, :lossy, 0)} lossy — " <>
+      "#{attention} attention · #{drift} hash-drift"
+  end
+
+  defp card(c) do
+    classes =
+      ["card", "group-#{c.group}", "status-#{c.status}"] ++
+        if(c.attention?, do: ["attention"], else: [])
+
+    """
+    <section id="#{esc(c.id)}" class="#{Enum.join(classes, " ")}" data-group="#{c.group}" data-attention="#{c.attention?}">
+      <div class="card-head">
+        <h2>#{esc(c.id)}</h2>
+        #{badges(c)}
+      </div>
+      <p class="summary">#{esc(c.summary)}</p>
+      <p class="url"><code>#{esc(c.url)}</code></p>
+      #{triage(c)}
+      #{drift_banner(c)}
+      <p class="metric #{metric_class(c)}">#{esc(c.metric_text)}</p>
+      #{visuals(c)}
+    </section>
+    """
+  end
+
+  defp badges(c) do
+    base = [
+      ~s(<span class="badge verdict">#{c.verdict}</span>),
+      ~s(<span class="badge group">#{c.group}</span>)
+    ]
+
+    tol = if c.tol, do: [~s(<span class="badge tol">tol Δ#{c.tol.threshold}/#{c.tol.budget}</span>)], else: []
+    triage = if c.triage, do: [~s(<span class="badge triage">quarantined</span>)], else: []
+
+    Enum.join(base ++ tol ++ triage, " ")
+  end
+
+  defp triage(%{triage: nil}), do: ""
+
+  defp triage(%{triage: %{reason: reason, issue: issue}}) do
+    n = String.trim_leading(issue, "#")
+
+    ~s(<p class="triage-note">⚠ quarantined: #{esc(reason)} — <a href="#{@issue_base}#{esc(n)}">#{esc(issue)}</a></p>)
+  end
+
+  defp drift_banner(%{hash_drift?: true}),
+    do: ~s(<p class="banner drift">authored fields changed since generation — run <code>mix imgproxy.reauthor</code> or regenerate.</p>)
+
+  defp drift_banner(_), do: ""
+
+  defp metric_class(c) do
+    if c.status in [:pass, :diverges_ok, :contract_ok], do: "ok", else: "bad"
+  end
+
+  # Lossy: pipe render alone + contract.
+  defp visuals(%{group: :lossy} = c) do
+    """
+    <div class="lossy-only">
+      <figure><img src="#{c.pipe_img}" alt="ImagePipe #{esc(c.id)}"><figcaption>ImagePipe (no imgproxy reference — contract only)</figcaption></figure>
+    </div>
+    """
+  end
+
+  # Dims mismatch: side-by-side only, no slider/heatmap.
+  defp visuals(%{status: :dims_mismatch} = c) do
+    side_by_side(c)
+  end
+
+  defp visuals(c) do
+    """
+    #{side_by_side(c)}
+    <div class="slider">
+      <img-comparison-slider>
+        <img slot="first" src="#{c.imgproxy_img}" alt="imgproxy">
+        <img slot="second" src="#{c.pipe_img}" alt="ImagePipe">
+      </img-comparison-slider>
+    </div>
+    <div class="heatmaps">
+      <figure class="heat-banded"><img src="#{c.heat_banded}" alt="banded diff"><figcaption>banded (Δ#{heat_threshold(c)})</figcaption></figure>
+      <figure class="heat-raw"><img src="#{c.heat_raw}" alt="raw diff"><figcaption>raw ×8</figcaption></figure>
+    </div>
+    """
+  end
+
+  defp heat_threshold(%{tol: %{threshold: t}}), do: t
+  defp heat_threshold(_), do: 2
+
+  defp side_by_side(c) do
+    """
+    <div class="pair">
+      <figure><img src="#{c.imgproxy_img}" alt="imgproxy"><figcaption>imgproxy #{fmt(c.fixture_dims)}</figcaption></figure>
+      <figure><img src="#{c.pipe_img}" alt="ImagePipe"><figcaption>ImagePipe #{fmt(c.pipe_dims)}</figcaption></figure>
+    </div>
+    """
+  end
+
+  defp fmt(nil), do: ""
+  defp fmt({w, h}), do: "#{w}×#{h}"
+
+  defp esc(value) do
+    value
+    |> to_string()
+    |> String.replace("&", "&amp;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
+    |> String.replace("\"", "&quot;")
+  end
+
+  defp script do
+    """
+    <script>
+    (function () {
+      var body = document.body;
+      function bind(attr, setAttr) {
+        document.querySelectorAll("[" + setAttr + "]").forEach(function (btn) {
+          btn.addEventListener("click", function () {
+            body.setAttribute(attr, btn.getAttribute(setAttr));
+          });
+        });
+      }
+      bind("data-heat", "data-heat-set");
+      bind("data-filter", "data-filter-set");
+    })();
+    </script>
+    """
+  end
+
+  defp css do
+    """
+    :root, :root[data-theme="dark"] {
+      color-scheme: dark;
+      --surface-app:#0b0d10; --surface-bar:#0d1015; --surface-control:#202733;
+      --border-subtle:#242b36; --text-primary:#f6f1e7; --text-muted:#8fa0b3;
+      --accent:#ffb84d; --danger:#ff6b6b; --checker-square:#1b222b;
+      --image-shadow:0 22px 80px rgb(0 0 0 / 38%);
+    }
+    @media (prefers-color-scheme: light) {
+      :root {
+        color-scheme: light;
+        --surface-app:#f4f6f8; --surface-bar:#fff; --surface-control:#eef2f7;
+        --border-subtle:#d9e0ea; --text-primary:#11151b; --text-muted:#687586;
+        --accent:#d48100; --danger:#c62828; --checker-square:#dfe5ee;
+        --image-shadow:0 22px 80px rgb(10 16 24 / 18%);
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin:0; background:var(--surface-app); color:var(--text-primary);
+      font-family:"Geist",ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;
+    }
+    code, .url, .metric { font-family:"Geist Mono",ui-monospace,"SFMono-Regular","Menlo",monospace; }
+    .report-header { position:sticky; top:0; z-index:2; padding:16px 24px;
+      background:var(--surface-bar); border-bottom:1px solid var(--border-subtle); }
+    .report-header h1 { margin:0 0 6px; font-size:18px; }
+    .provenance, .counts { margin:4px 0; color:var(--text-muted); font-size:12px; }
+    .counts { color:var(--text-primary); font-weight:600; }
+    .banner { margin:8px 0; padding:8px 10px; border-radius:6px; font-size:12px; }
+    .banner.skew { background:color-mix(in srgb, var(--accent) 18%, transparent); }
+    .banner.drift { background:color-mix(in srgb, var(--danger) 18%, transparent); }
+    .controls { display:flex; gap:18px; flex-wrap:wrap; margin-top:10px; }
+    .control-group { font-size:12px; color:var(--text-muted); }
+    .controls button { margin-left:4px; padding:3px 8px; border:1px solid var(--border-subtle);
+      background:var(--surface-control); color:var(--text-primary); border-radius:5px; cursor:pointer; }
+    .cards { padding:24px; display:flex; flex-direction:column; gap:24px; }
+    .card { background:var(--surface-bar); border:1px solid var(--border-subtle);
+      border-radius:10px; padding:16px; }
+    .card.attention { border-color:var(--danger); }
+    .card-head { display:flex; align-items:center; gap:10px; flex-wrap:wrap; }
+    .card-head h2 { margin:0; font-size:15px; }
+    .badge { font-size:11px; padding:2px 7px; border-radius:999px;
+      background:var(--surface-control); color:var(--text-muted); }
+    .badge.triage { background:color-mix(in srgb, var(--danger) 25%, transparent); color:var(--text-primary); }
+    .summary { margin:8px 0 2px; }
+    .url { margin:0 0 8px; color:var(--text-muted); font-size:12px; word-break:break-all; }
+    .triage-note { font-size:12px; color:var(--text-primary); margin:6px 0; }
+    .metric { font-weight:600; }
+    .metric.ok { color:var(--accent); }
+    .metric.bad { color:var(--danger); }
+    .pair, .heatmaps { display:grid; grid-template-columns:1fr 1fr; gap:12px; margin-top:12px; }
+    .lossy-only { margin-top:12px; max-width:420px; }
+    figure { margin:0; }
+    figure img, .slider img, .slider img-comparison-slider {
+      max-width:100%; display:block; border-radius:6px;
+      background:repeating-conic-gradient(var(--checker-square) 0 25%, transparent 0 50%) 50% / 20px 20px;
+    }
+    figcaption { font-size:11px; color:var(--text-muted); margin-top:4px; }
+    .slider { margin-top:12px; max-width:520px; box-shadow:var(--image-shadow); border-radius:6px; }
+    /* global heatmap toggle */
+    body[data-heat="banded"] .heat-raw { display:none; }
+    body[data-heat="raw"] .heat-banded { display:none; }
+    body[data-heat="banded"] .heatmaps, body[data-heat="raw"] .heatmaps { grid-template-columns:1fr; max-width:420px; }
+    /* filters */
+    body[data-filter="attention"] .card:not(.attention) { display:none; }
+    body[data-filter="transform"] .card:not(.group-transform) { display:none; }
+    body[data-filter="diverges"] .card:not(.group-diverges) { display:none; }
+    body[data-filter="lossy"] .card:not(.group-lossy) { display:none; }
+    """
+  end
+end
+```
+
+- [ ] **Step 4: Wire the task to ReportHtml; remove the stub**
+
+In `imgproxy.gen_report.ex`:
+
+1. Add to the alias: `ReportHtml` →
+   `alias ImagePipe.Test.ImgproxyDifferential.{Constellations, Manifest, OptsSummary, PixelCompare, ReportHtml, Skew}`
+2. Replace `File.write!(out, stub_html(cards))` with:
+
+```elixir
+    doc = %{provenance: provenance(manifest), cards: cards}
+    File.write!(out, ReportHtml.render(doc))
+```
+
+3. Delete `stub_html/1`.
+4. Add `provenance/1`:
+
+```elixir
+  defp provenance(manifest) do
+    runtime = Skew.runtime_libvips()
+
+    %{
+      imgproxy_digest: manifest.imgproxy_digest,
+      imgproxy_libvips: manifest.imgproxy_libvips,
+      pipe_libvips_at_gen: manifest.pipe_libvips_at_gen,
+      runtime_libvips: runtime,
+      skew?: not Skew.aligned?(manifest)
+    }
+  end
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_gen_report_test.exs`
+Expected: PASS — ReportHtml unit tests + the full-task smoke test (now asserting `id="..."` anchors against the real template) all green.
+
+- [ ] **Step 6: Generate and eyeball the real report**
+
+Run: `MIX_ENV=test mise exec -- mix imgproxy.gen_report`
+Expected: writes `test/support/image_pipe/test/imgproxy_differential/report.html` and prints the path. Open it in a browser: verify side-by-side, slider drags, heatmap toggle flips banded/raw across all cards, filter buttons work, triage cards show their over-budget metric + clickable issue link, lossy cards show a single image + contract pill.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add test/support/image_pipe/test/imgproxy_differential/report_html.ex test/support/mix/tasks/imgproxy.gen_report.ex test/image_pipe/imgproxy_gen_report_test.exs
+git commit -m "feat(imgproxy): self-contained visual-diff report HTML renderer (#202)"
+```
+
+---
+
+## Task 6: Docs + full gate
+
+**Files:**
+- Modify: `test/support/image_pipe/test/imgproxy_differential/README.md`
+
+- [ ] **Step 1: Document the task in the harness README**
+
+Add this section to `README.md` after the "Regenerate (requires Docker)" section (before "libvips skew"):
+
+```markdown
+## Visual-diff report (no Docker)
+
+Generate a self-contained `report.html` for eyeball triage — imgproxy vs ImagePipe
+side by side, a comparison slider, two diff heatmaps (banded over the case threshold,
+and raw amplified), and the live-recomputed metric/verdict/triage per constellation:
+
+```shell
+MIX_ENV=test mise exec -- mix imgproxy.gen_report          # writes report.html here
+MIX_ENV=test mise exec -- mix imgproxy.gen_report --out /tmp/r.html
+```
+
+It renders ImagePipe live and reads the committed fixtures — no Docker, no fixture or
+manifest changes. The default `report.html` is gitignored (it inlines ImagePipe PNGs as
+base64; regenerate on demand). Cases needing attention (over-budget, quarantined,
+dims-mismatch, a `:diverges` case that now matches, or authored-hash drift) sort to the
+top, and a top-of-page counts line summarizes them. The slider and Geist fonts load from
+a CDN; with no network the side-by-side panels remain the source of truth.
+```
+
+- [ ] **Step 2: Run the Elixir gate**
+
+Run: `mise run precommit`
+Expected: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, and `mix test` all pass. (No fiddle changes, so `precommit:demo` is not required.)
+
+If `mix format` rewrites the new files, re-stage them. If credo flags anything, fix to satisfy `--strict`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/support/image_pipe/test/imgproxy_differential/README.md
+git commit -m "docs(imgproxy): document gen_report visual-diff task (#202)"
+```
+
+---
+
+## Notes for the implementer
+
+- **`Vix.Vips.Operation.*` return `{:ok, _}`/`{:error, _}`** — always unwrap via `ok!/1`. The `Image.*` helpers (`open!`, `write!`, `width`, `height`, `bands`) are the bang-style `image`-library API and raise on their own.
+- **No uchar wrap to worry about:** `subtract` auto-promotes uchar→signed short, and `cast(_, :VIPS_FORMAT_UCHAR)` clamps (it does not wrap). Verified against this repo's Vix during spec review.
+- **Band-max is `extract_band` + `maxpair`-fold — not** `bandbool` (boolean only), `bandrank` (across a list of images), or `max` (global scalar). Those are the wrong primitives.
+- **Display images come from original bytes** (`File.read!` the fixture PNG; the response `body` for the pipe render). Decode only to feed the metric/heatmap. Never re-encode the decoded image for display.
+- **The smoke test runs the full task** (≈31 live renders + heatmaps). It runs on the default `mix test` lane like the conformance test. If it noticeably slows CI later, gate it behind a tag in `test_helper.exs` — but do not pre-optimize.
+- **Heatmap pixel-correctness is verified visually** (the tool's purpose), not by deep pixel assertions; the smoke test only guards that the path produces valid inlined PNGs without crashing, including the band-mismatch cases.
+
+---
+
+## Self-review checklist (completed during planning)
+
+- **Spec coverage:** task (T2/T5), no-Docker/always-compiled (T2), `--out`+gitignore (T2), full `plug_opts`/`RootHTTPAdapter` reuse (T2), per-group metric + dims-guard + triage-not-suppressed + hash-drift (T3), `:diverges`-below-floor + dims-mismatch attention triggers (T3), banded+raw heatmaps with RGB band-alignment (T4), original-bytes display (T4), counts summary + attention-first sort + filter + anchors (T5), clickable issue link (T5), global heatmap toggle (T5), offline degradation via independent side-by-side (T5), distinct lossy contract pill (T5), Geist fonts + slider CDN + fiddle palette/checkerboard (T5), README + no matrix change (T6). All mapped.
+- **Placeholder scan:** none — every code step is complete.
+- **Type consistency:** card-data keys are identical across T3 producer, T4 image-attachment, and T5 `ReportHtml` consumer + its sample fixtures; `status`/`group`/`verdict` atom sets match; `ok!/1`, `to_rgb/1`, `abs_diff/2`, `band_max/1`, `heat_lut/1` signatures are self-consistent.
+```

--- a/docs/superpowers/specs/2026-06-11-imgproxy-gen-report-design.md
+++ b/docs/superpowers/specs/2026-06-11-imgproxy-gen-report-design.md
@@ -1,0 +1,176 @@
+# imgproxy differential — visual-diff HTML report
+
+**Issue:** [#202](https://github.com/hlindset/image_pipe/issues/202)
+**Date:** 2026-06-11
+**Status:** Design approved, pending implementation plan
+
+## Problem
+
+The imgproxy differential conformance suite (`test/image_pipe/imgproxy_differential_conformance_test.exs`)
+compares ImagePipe's live render against committed imgproxy fixtures, but only
+**imgproxy's** output is persisted (the fixture PNG). ImagePipe's render is generated in
+the test, compared in memory, and discarded; `REPORT.md` is just a name list. A human
+can't visually inspect a divergence — or sanity-check a passing/tolerance/quarantined case
+— without running code and decoding bytes by hand. That makes triage, tolerance decisions,
+and quarantine review (e.g. #199, #200) slow and non-visual.
+
+## Goal
+
+A Mix task that renders ImagePipe's output for every constellation and writes a
+**single self-contained `report.html`** putting imgproxy vs ImagePipe side by side, with a
+comparison slider and per-pixel diff heatmaps, plus the verdict/tolerance/triage metadata
+and the live-recomputed conformance metric per case.
+
+## Non-goals / constraints
+
+- **DX / inspection only.** Must not change conformance behavior, fixtures, the manifest,
+  `REPORT.md`, or the default `mix test` lane. It only *reads* committed fixtures + the
+  manifest and renders ImagePipe live.
+- **No Docker.** imgproxy fixtures are already committed; ImagePipe renders are live. The
+  task is therefore **not** gated behind `IMGPROXY_DIFF`/Testcontainers (unlike
+  `gen_fixtures`) and is always compiled in `MIX_ENV=test`.
+- **No JS build.** The differential suite is pure Elixir/test-support; the `fiddle/` Svelte
+  app stays separate. The report is a single HTML file: images base64-inlined, the slider
+  loaded from a CDN, fonts from Google Fonts. No ImagePipe PNGs are committed; nothing
+  couples to the fiddle build.
+
+## The task
+
+`Mix.Tasks.Imgproxy.GenReport` at `test/support/mix/tasks/imgproxy.gen_report.ex`.
+
+```
+MIX_ENV=test mise exec -- mix imgproxy.gen_report [--out PATH]
+```
+
+- Default `--out`: `test/support/image_pipe/test/imgproxy_differential/report.html` (beside
+  `README.md`/`REPORT.md`). `report.html` is added to `.gitignore`. `--out PATH` overrides
+  (e.g. CI artifact upload or a scratch location).
+- Prints the absolute output path on completion.
+- Reuses the conformance test's render path exactly so it renders the **same** bytes the
+  test compares: an in-task `SourceOrigin` plug serving `sources/`, `ImagePipe.Parser.Imgproxy`,
+  `ImagePipe.Plug.call/2`, with `Image.open!(body, access: :random, fail_on: :error)`. (The
+  conformance test defines `SourceOrigin` inline; the task carries its own equivalent — these
+  are two test-support consumers of the same public render contract, not shared internals.)
+
+## Per-constellation computation (live, mirrors the test)
+
+For each constellation the task loads its manifest entry, renders ImagePipe, and recomputes
+the **same** metric the conformance test uses, so the report doubles as an eyeball-able
+re-run of the suite:
+
+- **transform group:** `PixelCompare.outliers/3` at the case's `tol.threshold` (default Δ2)
+  vs `tol.budget` → band-byte count + within-budget / over-budget status.
+- **`:diverges`:** `PixelCompare.fraction_over/3` vs the divergence floor → fraction +
+  above-floor status.
+- **lossy group:** ImagePipe's output dims + content-type vs the manifest's recorded
+  contract → match / mismatch.
+
+Manifest authored-hash drift (`Manifest.authored_sha256/1` vs the stored
+`authored_sha256`) is surfaced as a per-card warning banner — the same staleness the test
+asserts on — rather than aborting the whole report.
+
+### Ordering & filtering
+
+Cases that need attention (over-budget, `:triage`-quarantined, contract mismatch, or
+authored-hash drift) sort to the top; the rest follow in authored order. A small in-page
+filter (all / attention-only / by group) is included as client-side JS.
+
+## The two heatmaps (transform + `:diverges` only)
+
+Generated server-side per case via libvips (Vix, already in the dep tree), encoded to PNG,
+base64-inlined:
+
+- **Banded:** per-band `abs(imgproxy − pipe)` → per-pixel max delta → pixels at/under the
+  case's own threshold dimmed/transparent, pixels over mapped to a hot ramp. Ties the
+  picture to the verdict math (where the budget is being spent).
+- **Raw amplified:** `abs(diff)` multiplied for visibility, no thresholding — shows full
+  structure including sub-threshold AA skew. This is the "edge shifted vs same-x libvips AA"
+  question the constellation notes (`min_dims_dpr_marker`, `fill_down_marker`, …) keep making.
+
+A **global toggle** in the report header flips every card's heatmap panel between Banded and
+Raw at once (both PNGs are inlined; the toggle is pure client-side CSS/JS — no regeneration).
+
+Heatmaps are skipped for lossy cards (no imgproxy fixture to diff against) and when the
+ImagePipe/imgproxy dims differ (a dimension mismatch is itself the finding; the card shows
+the mismatch instead of a heatmap).
+
+## Card anatomy
+
+**Transform / `:diverges` card:**
+
+- **Header label:** `Constellations.imgproxy_path/1` URL **plus** a human-readable opts
+  summary. The summary is produced by a small, self-contained code→prose table living in the
+  task, covering the codes actually used in `constellations.ex`
+  (`rs`/`c`/`t`/`g`/`mw`/`mh`/`z`/`pd`/`ex`/`exar`/`dpr`/`bg`/`bl`/`sh`/`sm`/`scp`/`q`/`f`/`el`
+  + gravity codes), with unknown segments echoed verbatim as a fallback. Deliberately a tiny
+  dedicated formatter, not a reach into parser internals — keeps the boundary clean and the
+  report decoupled from plan/parser shape.
+- **Badges:** verdict (`:equal`/`:diverges`), group, and `tol` / `:triage` (reason + tracking
+  issue) when present.
+- **Metric line:** measured Δ-over-threshold band-byte count vs budget (or fraction vs floor),
+  with within/over status styled by `--accent`/`--danger`.
+- **Visuals:** imgproxy vs ImagePipe **side by side**; an **img-comparison-slider** overlay
+  of the two renders; the **heatmap panel** (Banded/Raw, driven by the global toggle).
+
+**Lossy card (reduced):** ImagePipe's live render alone (no slider/heatmap, no imgproxy
+fixture exists), plus expected-vs-actual dims & content-type from the manifest.
+
+## Header / provenance
+
+Top of the report shows manifest provenance (imgproxy digest, imgproxy libvips, ImagePipe
+libvips at generation, runtime libvips) and the **skew banner** when runtime libvips differs
+from the fixture-baked version — the same warn-and-attempt context the test prints, so a hot
+heatmap under skew is read correctly rather than mistaken for a regression. The global
+heatmap toggle and the case filter live here.
+
+## Styling
+
+A single inlined `<style>` block, borrowing the fiddle's design language so the report feels
+native:
+
+- **Palette via CSS custom properties**, dark-first with a light variant under
+  `prefers-color-scheme`, reusing the fiddle's tokens: `--surface-app`/`--surface-bar`/
+  `--surface-control`, `--border-subtle`, `--text-primary`/`--text-muted`, `--accent` (amber
+  `#ffb84d` dark / `#d48100` light), `--danger` (red) for over-budget/quarantine/mismatch.
+- **Checkerboard image backgrounds** via the same
+  `repeating-conic-gradient(var(--checker-square) …)` so alpha sources read correctly behind
+  the renders.
+- **Fonts:** Geist Sans + Geist Mono from **Google Fonts** (`<link>` in the head), matching
+  the fiddle exactly; the fiddle's declared system stacks remain the `font-family` fallback
+  if the font CDN is unreachable. `--font-mono` for opts/URL labels and metric numbers,
+  `--font-sans` for chrome.
+- Card chrome (`--surface-bar` panels, `--border-subtle`, subtle `--image-shadow`) mirrors
+  the fiddle's tool-section look.
+
+The only view-time network dependencies are the img-comparison-slider CDN `<script>` and the
+Google Fonts `<link>`; everything else (all images, all CSS) is inlined.
+
+## Docs
+
+Add a short "Visual-diff report" section to the harness `README.md` documenting the on-demand
+task (command, `--out`, that it needs no Docker, and that `report.html` is gitignored).
+
+No conformance-matrix (`docs/imgproxy_support_matrix.md`) change: the report is DX-only and
+observably touches no compatibility behavior. Per the project review-cycle rule, the
+implementation plan's parallel review will use non-compatibility lenses
+(correctness/boundaries, Elixir/Vix idiom, DX/output quality); the compatibility reviewer is
+optional here.
+
+## Module/file touch list
+
+- **New:** `test/support/mix/tasks/imgproxy.gen_report.ex` (the task: render, compute, build
+  HTML, opts-summary formatter, heatmap generation).
+- **Edit:** `.gitignore` (add the default `report.html` path).
+- **Edit:** `test/support/image_pipe/test/imgproxy_differential/README.md` (document the task).
+- **Unchanged:** `constellations.ex`, `pixel_compare.ex`, `manifest.ex`, fixtures, the
+  manifest, `REPORT.md`, the conformance test, the `mix test` lane.
+
+## Open risks
+
+- **Heatmap construction in libvips** is the least-trivial piece (per-band abs-diff → per-pixel
+  max → threshold/ramp colorization). The plan should prototype this against one real
+  constellation early and keep it isolated behind a small private function so it can be
+  verified independently.
+- **Self-contained size:** ~28 transform cases × (imgproxy + pipe + 2 heatmaps) base64-inlined
+  yields a multi-MB HTML file. Acceptable for a regenerate-on-demand DX artifact; noted so it
+  isn't mistaken for a problem.

--- a/docs/superpowers/specs/2026-06-11-imgproxy-gen-report-design.md
+++ b/docs/superpowers/specs/2026-06-11-imgproxy-gen-report-design.md
@@ -47,10 +47,17 @@ MIX_ENV=test mise exec -- mix imgproxy.gen_report [--out PATH]
   (e.g. CI artifact upload or a scratch location).
 - Prints the absolute output path on completion.
 - Reuses the conformance test's render path exactly so it renders the **same** bytes the
-  test compares: an in-task `SourceOrigin` plug serving `sources/`, `ImagePipe.Parser.Imgproxy`,
-  `ImagePipe.Plug.call/2`, with `Image.open!(body, access: :random, fail_on: :error)`. (The
-  conformance test defines `SourceOrigin` inline; the task carries its own equivalent — these
-  are two test-support consumers of the same public render contract, not shared internals.)
+  test compares. That means replicating the test's full `plug_opts/0`, not just the plug: the
+  source is wired as `sources: [path: {RootHTTPAdapter, root_url: "http://origin.test",
+  req_options: [plug: SourceOrigin]}]` (`conformance_test.exs:160-166`) — `SourceOrigin` is a
+  `req_options[:plug]` on `RootHTTPAdapter`, **not** a bare plug. The task carries its own
+  `SourceOrigin` + the same adapter wiring, then `ImagePipe.Plug.call/2` and
+  `Image.open!(body, access: :random, fail_on: :error)`. (The conformance test defines
+  `SourceOrigin` inline; the task carries its own equivalent — two test-support consumers of
+  the same public render contract, not shared internals.)
+- `use Boundary, top_level?: true, check: [out: false]` — the same shape as `gen_fixtures`/
+  `gen_sources`. `check: [out: false]` exempts the task from outgoing-dependency checks, so
+  naming `ImagePipe.Plug` / `ImagePipe.Parser.Imgproxy` / `RootHTTPAdapter` / `Vix` is clean.
 
 ## Per-constellation computation (live, mirrors the test)
 
@@ -61,38 +68,84 @@ re-run of the suite:
 - **transform group:** `PixelCompare.outliers/3` at the case's `tol.threshold` (default Δ2)
   vs `tol.budget` → band-byte count + within-budget / over-budget status.
 - **`:diverges`:** `PixelCompare.fraction_over/3` vs the divergence floor → fraction +
-  above-floor status.
+  above-floor status. A `:diverges` case whose live fraction has fallen **below** its floor
+  (ImagePipe now matches imgproxy where divergence was pinned) is an attention finding — it
+  means the manifest needs flipping to `:equal` — and is styled/sorted as such, not as a pass.
 - **lossy group:** ImagePipe's output dims + content-type vs the manifest's recorded
   contract → match / mismatch.
 
+**Dims-mismatch guard.** `PixelCompare.outliers/3` and `fraction_over/3` **raise** on a
+dimension mismatch (`pixel_compare.ex:24-26`). The report runs live and independently of the
+test, so a pipe-vs-imgproxy dimension mismatch is reachable even though the test's
+`assert_same_dims!` would hard-fail. The task must detect a dims mismatch up front and render
+a mismatch card (the mismatch is the finding) instead of calling the metric functions — one
+bad case must not crash the whole report.
+
+**Triage cards are not suppressed.** The two quarantined cases (`extend_offset_east_marker`,
+`extend_ar_dpr_marker`) are `group: :transform, verdict: :equal, tol: nil`, so they fall to
+the default Δ2/budget-64 metric and render as over-budget — which is exactly the divergence a
+human is adjudicating. The `:triage` badge (reason + clickable issue link) **annotates** the
+card; it never replaces the live metric line or the heatmaps. Surfacing that measured
+divergence is the whole point of the quarantine-review workflow (#199/#200).
+
 Manifest authored-hash drift (`Manifest.authored_sha256/1` vs the stored
 `authored_sha256`) is surfaced as a per-card warning banner — the same staleness the test
-asserts on — rather than aborting the whole report.
+asserts on — rather than aborting the whole report. (The task trusts the manifest term:
+`Manifest.load!/1` already validates shape at the serialization boundary, so the task does
+not re-validate.)
 
 ### Ordering & filtering
 
-Cases that need attention (over-budget, `:triage`-quarantined, contract mismatch, or
-authored-hash drift) sort to the top; the rest follow in authored order. A small in-page
-filter (all / attention-only / by group) is included as client-side JS.
+A **counts/summary line** at the top is the triage dashboard: total per group (transform /
+diverges / lossy) and the attention breakdown (over-budget · quarantined · diverges-below-floor ·
+dims-mismatch · contract-mismatch · hash-drift). It's derived from the same per-card statuses
+that drive the sort, so a regenerate's new attention items are visible in one glance before
+scrolling.
 
-## The two heatmaps (transform + `:diverges` only)
+Cases that need attention — over-budget, `:triage`-quarantined, **dims mismatch**,
+**`:diverges` below floor**, contract mismatch, or authored-hash drift — sort to the top; the
+rest follow in authored order. A small in-page filter (all / attention-only / by group) is
+client-side JS that toggles `display` (no DOM rebuild — keep first-paint and filtering snappy
+on a multi-MB page). Each card gets a stable `id` anchor (the constellation id) so a specific
+card can be linked into an issue comment.
+
+## The two heatmaps (transform + `:diverges`)
 
 Generated server-side per case via libvips (Vix, already in the dep tree), encoded to PNG,
-base64-inlined:
+base64-inlined. Both heatmaps are generated for **every** transform and `:diverges` case —
+including the `:diverges` `scp0_colorspace_124` case, whose diffuse P3 divergence is the most
+heatmap-worthy of all (the raw-amplified map is the ideal way to show "diffuse 2.6%, not
+localized"); the `:diverges` branch must not skip heatmap generation.
 
-- **Banded:** per-band `abs(imgproxy − pipe)` → per-pixel max delta → pixels at/under the
-  case's own threshold dimmed/transparent, pixels over mapped to a hot ramp. Ties the
-  picture to the verdict math (where the budget is being spent).
-- **Raw amplified:** `abs(diff)` multiplied for visibility, no thresholding — shows full
-  structure including sub-threshold AA skew. This is the "edge shifted vs same-x libvips AA"
-  question the constellation notes (`min_dims_dpr_marker`, `fill_down_marker`, …) keep making.
+**Band alignment first (MUST).** `Vix.Vips.Operation.subtract/2` raises on a band-count
+mismatch, and two cases can legitimately differ in band layout — `alpha_resize` (RGBA) and
+`background_alpha` (`bg:` → RGB) — which is itself a divergence worth seeing. Before diffing,
+align both images to a common 3-band RGB frame with `Operation.extract_band(img, 0, n: 3)`
+(not `Image.flatten!`, which keeps alpha on a bare RGBA buffer). Consequence: the banded
+heatmap visualizes **RGB-channel** deltas, while the printed verdict metric (`PixelCompare`)
+counts **all** bands including alpha — so the card must say the heatmap shows RGB deltas and
+must not claim the picture *is* the verdict math byte-for-byte.
+
+- **Banded:** `abs(subtract(imgproxy, pipe))` (subtract auto-promotes uchar→signed short, so
+  no wrap) → per-pixel max across the 3 bands via `extract_band` + a `maxpair`-fold (**not**
+  `bandbool`/`bandrank`/`max` — those are boolean / band-wise-across-images / global-scalar,
+  the wrong primitives) → `relational_const(:VIPS_OPERATION_RELATIONAL_MORE, [threshold])`
+  mask → `ifthenelse(mask, hot, dim)` (hot via a 256×3 `maplut` ramp on the delta for a
+  graded heat, dim elsewhere). Honors the case's own Δ threshold, so it shows where the
+  budget is spent.
+- **Raw amplified:** `linear(abs, [mult], [0.0])` then `cast(:VIPS_FORMAT_UCHAR)` (cast
+  clamps, no wrap) — no thresholding, shows full structure including sub-threshold AA skew.
+  This is the "edge shifted vs same-x libvips AA" question the constellation notes
+  (`min_dims_dpr_marker`, `fill_down_marker`, …) keep making.
 
 A **global toggle** in the report header flips every card's heatmap panel between Banded and
 Raw at once (both PNGs are inlined; the toggle is pure client-side CSS/JS — no regeneration).
+Global is the right default and sole control for v1: every stated workflow is a *scanning*
+workflow, and a global flip keeps the whole page speaking one mental model. No per-card toggle.
 
-Heatmaps are skipped for lossy cards (no imgproxy fixture to diff against) and when the
-ImagePipe/imgproxy dims differ (a dimension mismatch is itself the finding; the card shows
-the mismatch instead of a heatmap).
+Heatmaps are skipped only for lossy cards (no imgproxy fixture to diff against) and when the
+ImagePipe/imgproxy dims differ (a dimension mismatch is itself the finding; the card shows the
+mismatch instead of a heatmap — see the dims-mismatch guard above).
 
 ## Card anatomy
 
@@ -105,15 +158,30 @@ the mismatch instead of a heatmap).
   + gravity codes), with unknown segments echoed verbatim as a fallback. Deliberately a tiny
   dedicated formatter, not a reach into parser internals — keeps the boundary clean and the
   report decoupled from plan/parser shape.
-- **Badges:** verdict (`:equal`/`:diverges`), group, and `tol` / `:triage` (reason + tracking
-  issue) when present.
+- **Badges:** verdict (`:equal`/`:diverges`), group, and `tol` / `:triage` when present. The
+  `:triage` badge shows the reason **and a clickable issue link** — the bare `#200` string is
+  rendered as `<a href="https://github.com/hlindset/image_pipe/issues/200">#200</a>` (strip
+  the leading `#` for the URL). The issue is the literal next click in the triage loop, so it
+  must be a link, not text.
 - **Metric line:** measured Δ-over-threshold band-byte count vs budget (or fraction vs floor),
-  with within/over status styled by `--accent`/`--danger`.
-- **Visuals:** imgproxy vs ImagePipe **side by side**; an **img-comparison-slider** overlay
-  of the two renders; the **heatmap panel** (Banded/Raw, driven by the global toggle).
+  with within/over status styled by `--accent`/`--danger`. Always present on transform and
+  `:diverges` cards, **including quarantined ones** — the triage badge annotates this line, it
+  doesn't replace it.
+- **Visuals:** imgproxy vs ImagePipe **side by side** (the source of truth, independent of any
+  CDN); an **img-comparison-slider** overlay of the two renders; the **heatmap panel**
+  (Banded/Raw, driven by the global toggle).
+- **Images displayed from original bytes** (no re-encode): the imgproxy fixture is inlined
+  straight from its on-disk PNG bytes (`File.read!`), and the pipe transform render is inlined
+  from the response body (already PNG, `f:png` forced). The decoded `Vix` images are used only
+  to compute the metric + heatmaps; re-encoding the decoded image for display would add CPU
+  and risk re-compression drift, and would make the slider compare not-quite-the-committed
+  bytes.
 
-**Lossy card (reduced):** ImagePipe's live render alone (no slider/heatmap, no imgproxy
-fixture exists), plus expected-vs-actual dims & content-type from the manifest.
+**Lossy card (reduced):** ImagePipe's live render alone, inlined from the response body with
+its real content-type (no slider/heatmap, no imgproxy fixture exists), plus expected-vs-actual
+dims & content-type from the manifest. Its pass affordance is a **distinct contract pill**
+(e.g. "contract: dims+type ✓"), visibly different from the pixel cards' "within budget" pill,
+so a contract match is never visually conflated with a pixel pass.
 
 ## Header / provenance
 
@@ -145,6 +213,13 @@ native:
 The only view-time network dependencies are the img-comparison-slider CDN `<script>` and the
 Google Fonts `<link>`; everything else (all images, all CSS) is inlined.
 
+**Offline / CDN-unreachable degradation.** The report stays usable with both CDNs down: the
+side-by-side imgproxy/pipe panels are rendered independently of the slider and remain the
+source of truth, and the font `<link>` falls back to the fiddle's system stacks. The slider is
+an *enhancement*, not the only comparison — the plan should verify that an undefined
+`<img-comparison-slider>` custom element degrades cleanly (doesn't render as a broken overlap)
+rather than relying on slot fallback luck.
+
 ## Docs
 
 Add a short "Visual-diff report" section to the harness `README.md` documenting the on-demand
@@ -167,10 +242,14 @@ optional here.
 
 ## Open risks
 
-- **Heatmap construction in libvips** is the least-trivial piece (per-band abs-diff → per-pixel
-  max → threshold/ramp colorization). The plan should prototype this against one real
-  constellation early and keep it isolated behind a small private function so it can be
-  verified independently.
+- **Heatmap construction in libvips** is the least-trivial piece, but the operation chain is
+  now known (see the heatmaps section): `subtract`/`abs` (auto-promotes, no wrap) →
+  `extract_band` + `maxpair`-fold for per-pixel band-max (**not** `bandbool`/`bandrank`/`max`)
+  → `relational_const(:MORE)` → `ifthenelse`/`maplut`; raw = `linear` → `cast` (clamps). Keep
+  it behind a small private function and prototype it against one real constellation
+  (`rs_fill_zone`) plus one band-mismatch case (`alpha_resize`) early so it's verified
+  independently.
 - **Self-contained size:** ~28 transform cases × (imgproxy + pipe + 2 heatmaps) base64-inlined
   yields a multi-MB HTML file. Acceptable for a regenerate-on-demand DX artifact; noted so it
-  isn't mistaken for a problem.
+  isn't mistaken for a problem. Keep the in-page filter on `display` toggling (not DOM
+  rebuild) so the large page stays responsive.

--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,15 @@ defmodule ImagePipe.MixProject do
   end
 
   def cli do
-    [preferred_envs: [coveralls: :test, "coveralls.html": :test]]
+    [
+      preferred_envs: [
+        coveralls: :test,
+        "coveralls.html": :test,
+        "imgproxy.gen_report": :test,
+        "imgproxy.reauthor": :test,
+        "imgproxy.gen_sources": :test
+      ]
+    ]
   end
 
   # Specifies which paths to compile per environment.

--- a/test/image_pipe/imgproxy_gen_report_test.exs
+++ b/test/image_pipe/imgproxy_gen_report_test.exs
@@ -3,6 +3,7 @@ defmodule ImagePipe.ImgproxyGenReportTest do
 
   alias ImagePipe.Test.ImgproxyDifferential.Constellations
   alias ImagePipe.Test.ImgproxyDifferential.OptsSummary
+  alias ImagePipe.Test.ImgproxyDifferential.ReportHtml
 
   describe "OptsSummary.describe/1" do
     test "resize + gravity" do
@@ -64,6 +65,120 @@ defmodule ImagePipe.ImgproxyGenReportTest do
 
     test "unknown segments echo verbatim" do
       assert OptsSummary.describe("rs:fit:64:64/wat:9") == "resize fit 64×64; wat:9"
+    end
+  end
+
+  defp sample_doc do
+    %{
+      provenance: %{
+        imgproxy_digest: "sha256:abc",
+        imgproxy_libvips: "42.20.2",
+        pipe_libvips_at_gen: "8.18.2",
+        runtime_libvips: "8.18.2",
+        skew?: false
+      },
+      cards: [
+        %{
+          id: "rs_fill_zone",
+          group: :transform,
+          verdict: :equal,
+          url: "/unsafe/rs:fill:240:180/f:png/plain/local:///high_freq.jpg",
+          summary: "resize fill 240×180",
+          status: :pass,
+          attention?: false,
+          hash_drift?: false,
+          triage: nil,
+          tol: nil,
+          metric_text: "0 band-bytes over Δ2 (budget 64)",
+          imgproxy_img: "data:image/png;base64,AAAA",
+          pipe_img: "data:image/png;base64,BBBB",
+          heat_banded: "data:image/png;base64,CCCC",
+          heat_raw: "data:image/png;base64,DDDD",
+          pipe_dims: {240, 180},
+          fixture_dims: {240, 180}
+        },
+        %{
+          id: "extend_offset_east_marker",
+          group: :transform,
+          verdict: :equal,
+          url: "/unsafe/rs:fit:400:150/ex:1:ea:20:0/f:png/plain/local:///marker.png",
+          summary: "resize fit 400×150; extend (east +20,+0)",
+          status: :over_budget,
+          attention?: true,
+          hash_drift?: false,
+          triage: %{reason: "extend east offset sign", issue: "#200"},
+          tol: nil,
+          metric_text: "9001 band-bytes over Δ2 (budget 64)",
+          imgproxy_img: "data:image/png;base64,EEEE",
+          pipe_img: "data:image/png;base64,FFFF",
+          heat_banded: "data:image/png;base64,GGGG",
+          heat_raw: "data:image/png;base64,HHHH",
+          pipe_dims: {400, 150},
+          fixture_dims: {400, 150}
+        },
+        %{
+          id: "lossy_avif",
+          group: :lossy,
+          verdict: :equal,
+          url: "/unsafe/rs:fill:240:180/f:avif/plain/local:///high_freq.jpg",
+          summary: "resize fill 240×180; format avif",
+          status: :contract_ok,
+          attention?: false,
+          hash_drift?: false,
+          triage: nil,
+          tol: nil,
+          metric_text:
+            "dims 240×180 (expected 240×180); type \"image/avif\" (expected \"image/avif\")",
+          imgproxy_img: nil,
+          pipe_img: "data:image/avif;base64,IIII",
+          heat_banded: nil,
+          heat_raw: nil,
+          pipe_dims: {240, 180},
+          fixture_dims: nil
+        }
+      ]
+    }
+  end
+
+  describe "ReportHtml.render/1" do
+    test "emits a self-contained document with fonts + slider CDN" do
+      html = ReportHtml.render(sample_doc())
+      assert html =~ "<!doctype html>"
+      assert html =~ "fonts.googleapis.com"
+      assert html =~ "img-comparison-slider"
+      assert html =~ "Geist"
+    end
+
+    test "renders a card anchor and metric per case" do
+      html = ReportHtml.render(sample_doc())
+      assert html =~ ~s(id="rs_fill_zone")
+      assert html =~ "0 band-bytes over Δ2 (budget 64)"
+      assert html =~ "resize fill 240×180"
+    end
+
+    test "triage issue is a clickable repo link" do
+      html = ReportHtml.render(sample_doc())
+      assert html =~ ~s(href="https://github.com/hlindset/image_pipe/issues/200")
+      assert html =~ "extend east offset sign"
+    end
+
+    test "counts summary reflects groups and attention" do
+      html = ReportHtml.render(sample_doc())
+      assert html =~ "2 transform"
+      assert html =~ "1 lossy"
+      assert html =~ "1 attention"
+    end
+
+    test "lossy card omits imgproxy panel and heatmaps" do
+      html = ReportHtml.render(sample_doc())
+      refute html =~ "data:image/png;base64,IIII"
+      assert html =~ "data:image/avif;base64,IIII"
+    end
+
+    test "global heatmap toggle + filter controls present" do
+      html = ReportHtml.render(sample_doc())
+      assert html =~ "data-heat"
+      assert html =~ "data-filter"
     end
   end
 

--- a/test/image_pipe/imgproxy_gen_report_test.exs
+++ b/test/image_pipe/imgproxy_gen_report_test.exs
@@ -191,14 +191,15 @@ defmodule ImagePipe.ImgproxyGenReportTest do
       assert html =~ "extend east offset sign"
     end
 
-    test "counts summary reflects groups, attention, and failing" do
+    test "counts summary reflects groups and status breakdown" do
       html = ReportHtml.render(sample_doc())
       assert html =~ "3 transform"
       assert html =~ "1 lossy"
       # extend (quarantined over-budget) + dims-mismatch are both attention; only the
-      # non-quarantined dims-mismatch is a lane failure.
+      # non-quarantined dims-mismatch is a lane failure; only extend is quarantined.
       assert html =~ "2 attention"
       assert html =~ "1 failing"
+      assert html =~ "1 quarantined"
     end
 
     test "lossy card omits imgproxy panel and heatmaps" do
@@ -207,24 +208,37 @@ defmodule ImagePipe.ImgproxyGenReportTest do
       assert html =~ "data:image/avif;base64,IIII"
     end
 
-    test "heatmap modes (banded/raw/normalized) and filters incl. failing are present" do
+    test "heatmap modes (banded/raw/normalized) present" do
       html = ReportHtml.render(sample_doc())
       assert html =~ ~s(data-heat-set="banded")
       assert html =~ ~s(data-heat-set="raw")
       assert html =~ ~s(data-heat-set="normalized")
-      assert html =~ ~s(data-filter-set="all")
-      assert html =~ ~s(data-filter-set="failing")
       # the normalized heatmap image is inlined on a transform card
       assert html =~ "data:image/png;base64,NNNN"
       assert html =~ "heat-normalized"
     end
 
-    test "failing class marks lane failures but not quarantined cases" do
+    test "status and type filter axes are present and independent" do
       html = ReportHtml.render(sample_doc())
-      # dims-mismatch is a real lane failure → gets the `failing` class
+      assert html =~ ~s(data-status-set="all")
+      assert html =~ ~s(data-status-set="attention")
+      assert html =~ ~s(data-status-set="failing")
+      assert html =~ ~s(data-status-set="quarantined")
+      assert html =~ ~s(data-type-set="all")
+      assert html =~ ~s(data-type-set="transform")
+      assert html =~ ~s(data-type-set="diverges")
+      assert html =~ ~s(data-type-set="lossy")
+      # the body carries both independent axes, defaulting to all/all
+      assert html =~ ~s(data-status="all")
+      assert html =~ ~s(data-type="all")
+    end
+
+    test "status classes distinguish failing, attention, and quarantined" do
+      html = ReportHtml.render(sample_doc())
+      # dims-mismatch is a real lane failure → attention + failing, not quarantined
       assert html =~ "status-dims_mismatch attention failing"
-      # the quarantined over-budget case is attention but NOT failing
-      assert html =~ "status-over_budget attention"
+      # the quarantined over-budget case is attention + quarantined, but NOT failing
+      assert html =~ "status-over_budget attention quarantined"
       refute html =~ "status-over_budget attention failing"
     end
 

--- a/test/image_pipe/imgproxy_gen_report_test.exs
+++ b/test/image_pipe/imgproxy_gen_report_test.exs
@@ -4,6 +4,7 @@ defmodule ImagePipe.ImgproxyGenReportTest do
   alias ImagePipe.Test.ImgproxyDifferential.Constellations
   alias ImagePipe.Test.ImgproxyDifferential.OptsSummary
   alias ImagePipe.Test.ImgproxyDifferential.ReportHtml
+  alias Mix.Tasks.Imgproxy.GenReport
 
   describe "OptsSummary.describe/1" do
     test "resize + gravity" do
@@ -188,7 +189,7 @@ defmodule ImagePipe.ImgproxyGenReportTest do
 
     on_exit(fn -> File.rm_rf(out) end)
 
-    Mix.Tasks.Imgproxy.GenReport.run(["--out", out])
+    GenReport.run(["--out", out])
 
     assert File.exists?(out)
     html = File.read!(out)

--- a/test/image_pipe/imgproxy_gen_report_test.exs
+++ b/test/image_pipe/imgproxy_gen_report_test.exs
@@ -242,9 +242,15 @@ defmodule ImagePipe.ImgproxyGenReportTest do
       refute html =~ "status-over_budget flagged failing"
     end
 
-    test "slider wrapper is capped to the render width" do
+    test "slider panel is capped to the render width" do
       html = ReportHtml.render(sample_doc())
-      assert html =~ ~s(class="slider" style="width:240px;max-width:100%")
+      assert html =~ ~s(class="panel slider" style="width:240px")
+    end
+
+    test "filter buttons carry live-count slots and a theme toggle is present" do
+      html = ReportHtml.render(sample_doc())
+      assert html =~ ~s(class="btn-count")
+      assert html =~ ~s(id="theme-toggle")
     end
   end
 

--- a/test/image_pipe/imgproxy_gen_report_test.exs
+++ b/test/image_pipe/imgproxy_gen_report_test.exs
@@ -81,5 +81,10 @@ defmodule ImagePipe.ImgproxyGenReportTest do
     for c <- Constellations.all() do
       assert html =~ ~s(id="#{c.id}"), "report missing card anchor for #{c.id}"
     end
+
+    assert html =~ "band-bytes over Δ", "per-case metric text not rendered"
+    # The quarantined cases surface their live over-budget divergence (the triage
+    # state annotates, it does not suppress the metric).
+    assert html =~ "over_budget", "expected quarantined cases to show over-budget divergence"
   end
 end

--- a/test/image_pipe/imgproxy_gen_report_test.exs
+++ b/test/image_pipe/imgproxy_gen_report_test.exs
@@ -86,5 +86,11 @@ defmodule ImagePipe.ImgproxyGenReportTest do
     # The quarantined cases surface their live over-budget divergence (the triage
     # state annotates, it does not suppress the metric).
     assert html =~ "over_budget", "expected quarantined cases to show over-budget divergence"
+
+    assert html =~ "data:image/png;base64,", "no inlined PNG images in report"
+    # alpha_resize / background_alpha exercise RGB band-alignment in the heatmap
+    # path; the run must not crash on a band-count mismatch.
+    assert html =~ "alpha_resize"
+    assert html =~ "background_alpha"
   end
 end

--- a/test/image_pipe/imgproxy_gen_report_test.exs
+++ b/test/image_pipe/imgproxy_gen_report_test.exs
@@ -1,6 +1,7 @@
 defmodule ImagePipe.ImgproxyGenReportTest do
   use ExUnit.Case, async: true
 
+  alias ImagePipe.Test.ImgproxyDifferential.Constellations
   alias ImagePipe.Test.ImgproxyDifferential.OptsSummary
 
   describe "OptsSummary.describe/1" do
@@ -63,6 +64,22 @@ defmodule ImagePipe.ImgproxyGenReportTest do
 
     test "unknown segments echo verbatim" do
       assert OptsSummary.describe("rs:fit:64:64/wat:9") == "resize fit 64×64; wat:9"
+    end
+  end
+
+  test "gen_report renders every constellation to a self-contained file" do
+    out =
+      Path.join(System.tmp_dir!(), "imgproxy_report_#{System.unique_integer([:positive])}.html")
+
+    on_exit(fn -> File.rm_rf(out) end)
+
+    Mix.Tasks.Imgproxy.GenReport.run(["--out", out])
+
+    assert File.exists?(out)
+    html = File.read!(out)
+
+    for c <- Constellations.all() do
+      assert html =~ ~s(id="#{c.id}"), "report missing card anchor for #{c.id}"
     end
   end
 end

--- a/test/image_pipe/imgproxy_gen_report_test.exs
+++ b/test/image_pipe/imgproxy_gen_report_test.exs
@@ -86,7 +86,7 @@ defmodule ImagePipe.ImgproxyGenReportTest do
           url: "/unsafe/rs:fill:240:180/f:png/plain/local:///high_freq.jpg",
           summary: "resize fill 240×180",
           status: :pass,
-          attention?: false,
+          flagged?: false,
           failing?: false,
           hash_drift?: false,
           triage: nil,
@@ -107,8 +107,8 @@ defmodule ImagePipe.ImgproxyGenReportTest do
           url: "/unsafe/rs:fit:400:150/ex:1:ea:20:0/f:png/plain/local:///marker.png",
           summary: "resize fit 400×150; extend (east +20,+0)",
           status: :over_budget,
-          attention?: true,
-          # quarantined → noteworthy (attention) but NOT a lane failure
+          flagged?: true,
+          # quarantined → noteworthy (flagged) but NOT a lane failure
           failing?: false,
           hash_drift?: false,
           triage: %{reason: "extend east offset sign", issue: "#200"},
@@ -129,7 +129,7 @@ defmodule ImagePipe.ImgproxyGenReportTest do
           url: "/unsafe/rs:fit:100:100/f:png/plain/local:///marker.png",
           summary: "resize fit 100×100",
           status: :dims_mismatch,
-          attention?: true,
+          flagged?: true,
           failing?: true,
           hash_drift?: false,
           triage: nil,
@@ -150,7 +150,7 @@ defmodule ImagePipe.ImgproxyGenReportTest do
           url: "/unsafe/rs:fill:240:180/f:avif/plain/local:///high_freq.jpg",
           summary: "resize fill 240×180; format avif",
           status: :contract_ok,
-          attention?: false,
+          flagged?: false,
           failing?: false,
           hash_drift?: false,
           triage: nil,
@@ -195,9 +195,9 @@ defmodule ImagePipe.ImgproxyGenReportTest do
       html = ReportHtml.render(sample_doc())
       assert html =~ "3 transform"
       assert html =~ "1 lossy"
-      # extend (quarantined over-budget) + dims-mismatch are both attention; only the
+      # extend (quarantined over-budget) + dims-mismatch are both flagged; only the
       # non-quarantined dims-mismatch is a lane failure; only extend is quarantined.
-      assert html =~ "2 attention"
+      assert html =~ "2 flagged"
       assert html =~ "1 failing"
       assert html =~ "1 quarantined"
     end
@@ -221,25 +221,25 @@ defmodule ImagePipe.ImgproxyGenReportTest do
     test "status and type filter axes are present and independent" do
       html = ReportHtml.render(sample_doc())
       assert html =~ ~s(data-status-set="all")
-      assert html =~ ~s(data-status-set="attention")
+      assert html =~ ~s(data-status-set="flagged")
       assert html =~ ~s(data-status-set="failing")
       assert html =~ ~s(data-status-set="quarantined")
       assert html =~ ~s(data-type-set="all")
       assert html =~ ~s(data-type-set="transform")
-      assert html =~ ~s(data-type-set="diverges")
+      assert html =~ ~s(data-type-set="known_divergence")
       assert html =~ ~s(data-type-set="lossy")
       # the body carries both independent axes, defaulting to all/all
       assert html =~ ~s(data-status="all")
       assert html =~ ~s(data-type="all")
     end
 
-    test "status classes distinguish failing, attention, and quarantined" do
+    test "status classes distinguish failing, flagged, and quarantined" do
       html = ReportHtml.render(sample_doc())
-      # dims-mismatch is a real lane failure → attention + failing, not quarantined
-      assert html =~ "status-dims_mismatch attention failing"
-      # the quarantined over-budget case is attention + quarantined, but NOT failing
-      assert html =~ "status-over_budget attention quarantined"
-      refute html =~ "status-over_budget attention failing"
+      # dims-mismatch is a real lane failure → flagged + failing, not quarantined
+      assert html =~ "status-dims_mismatch flagged failing"
+      # the quarantined over-budget case is flagged + quarantined, but NOT failing
+      assert html =~ "status-over_budget flagged quarantined"
+      refute html =~ "status-over_budget flagged failing"
     end
 
     test "slider wrapper is capped to the render width" do

--- a/test/image_pipe/imgproxy_gen_report_test.exs
+++ b/test/image_pipe/imgproxy_gen_report_test.exs
@@ -87,6 +87,7 @@ defmodule ImagePipe.ImgproxyGenReportTest do
           summary: "resize fill 240×180",
           status: :pass,
           attention?: false,
+          failing?: false,
           hash_drift?: false,
           triage: nil,
           tol: nil,
@@ -95,6 +96,7 @@ defmodule ImagePipe.ImgproxyGenReportTest do
           pipe_img: "data:image/png;base64,BBBB",
           heat_banded: "data:image/png;base64,CCCC",
           heat_raw: "data:image/png;base64,DDDD",
+          heat_normalized: "data:image/png;base64,NNNN",
           pipe_dims: {240, 180},
           fixture_dims: {240, 180}
         },
@@ -106,6 +108,8 @@ defmodule ImagePipe.ImgproxyGenReportTest do
           summary: "resize fit 400×150; extend (east +20,+0)",
           status: :over_budget,
           attention?: true,
+          # quarantined → noteworthy (attention) but NOT a lane failure
+          failing?: false,
           hash_drift?: false,
           triage: %{reason: "extend east offset sign", issue: "#200"},
           tol: nil,
@@ -114,8 +118,30 @@ defmodule ImagePipe.ImgproxyGenReportTest do
           pipe_img: "data:image/png;base64,FFFF",
           heat_banded: "data:image/png;base64,GGGG",
           heat_raw: "data:image/png;base64,HHHH",
+          heat_normalized: "data:image/png;base64,OOOO",
           pipe_dims: {400, 150},
           fixture_dims: {400, 150}
+        },
+        %{
+          id: "dims_mismatch_marker",
+          group: :transform,
+          verdict: :equal,
+          url: "/unsafe/rs:fit:100:100/f:png/plain/local:///marker.png",
+          summary: "resize fit 100×100",
+          status: :dims_mismatch,
+          attention?: true,
+          failing?: true,
+          hash_drift?: false,
+          triage: nil,
+          tol: nil,
+          metric_text: "dims 101×100 ≠ imgproxy 100×100",
+          imgproxy_img: "data:image/png;base64,MMMM",
+          pipe_img: "data:image/png;base64,PPPP",
+          heat_banded: nil,
+          heat_raw: nil,
+          heat_normalized: nil,
+          pipe_dims: {101, 100},
+          fixture_dims: {100, 100}
         },
         %{
           id: "lossy_avif",
@@ -125,6 +151,7 @@ defmodule ImagePipe.ImgproxyGenReportTest do
           summary: "resize fill 240×180; format avif",
           status: :contract_ok,
           attention?: false,
+          failing?: false,
           hash_drift?: false,
           triage: nil,
           tol: nil,
@@ -134,6 +161,7 @@ defmodule ImagePipe.ImgproxyGenReportTest do
           pipe_img: "data:image/avif;base64,IIII",
           heat_banded: nil,
           heat_raw: nil,
+          heat_normalized: nil,
           pipe_dims: {240, 180},
           fixture_dims: nil
         }
@@ -163,11 +191,14 @@ defmodule ImagePipe.ImgproxyGenReportTest do
       assert html =~ "extend east offset sign"
     end
 
-    test "counts summary reflects groups and attention" do
+    test "counts summary reflects groups, attention, and failing" do
       html = ReportHtml.render(sample_doc())
-      assert html =~ "2 transform"
+      assert html =~ "3 transform"
       assert html =~ "1 lossy"
-      assert html =~ "1 attention"
+      # extend (quarantined over-budget) + dims-mismatch are both attention; only the
+      # non-quarantined dims-mismatch is a lane failure.
+      assert html =~ "2 attention"
+      assert html =~ "1 failing"
     end
 
     test "lossy card omits imgproxy panel and heatmaps" do
@@ -176,10 +207,30 @@ defmodule ImagePipe.ImgproxyGenReportTest do
       assert html =~ "data:image/avif;base64,IIII"
     end
 
-    test "global heatmap toggle + filter controls present" do
+    test "heatmap modes (banded/raw/normalized) and filters incl. failing are present" do
       html = ReportHtml.render(sample_doc())
-      assert html =~ "data-heat"
-      assert html =~ "data-filter"
+      assert html =~ ~s(data-heat-set="banded")
+      assert html =~ ~s(data-heat-set="raw")
+      assert html =~ ~s(data-heat-set="normalized")
+      assert html =~ ~s(data-filter-set="all")
+      assert html =~ ~s(data-filter-set="failing")
+      # the normalized heatmap image is inlined on a transform card
+      assert html =~ "data:image/png;base64,NNNN"
+      assert html =~ "heat-normalized"
+    end
+
+    test "failing class marks lane failures but not quarantined cases" do
+      html = ReportHtml.render(sample_doc())
+      # dims-mismatch is a real lane failure → gets the `failing` class
+      assert html =~ "status-dims_mismatch attention failing"
+      # the quarantined over-budget case is attention but NOT failing
+      assert html =~ "status-over_budget attention"
+      refute html =~ "status-over_budget attention failing"
+    end
+
+    test "slider wrapper is capped to the render width" do
+      html = ReportHtml.render(sample_doc())
+      assert html =~ ~s(class="slider" style="width:240px;max-width:100%")
     end
   end
 

--- a/test/image_pipe/imgproxy_gen_report_test.exs
+++ b/test/image_pipe/imgproxy_gen_report_test.exs
@@ -1,0 +1,68 @@
+defmodule ImagePipe.ImgproxyGenReportTest do
+  use ExUnit.Case, async: true
+
+  alias ImagePipe.Test.ImgproxyDifferential.OptsSummary
+
+  describe "OptsSummary.describe/1" do
+    test "resize + gravity" do
+      assert OptsSummary.describe("rs:fill:240:180/g:ce") ==
+               "resize fill 240×180; gravity center"
+    end
+
+    test "compound gravity codes and absolute offset" do
+      assert OptsSummary.describe("c:120:90/g:nowe") == "crop 120×90; gravity north-west"
+
+      assert OptsSummary.describe("rs:fill:120:120/g:no:10:20") ==
+               "resize fill 120×120; gravity north +10,+20"
+    end
+
+    test "trim, min-dims, zoom, dpr" do
+      assert OptsSummary.describe("t:10") == "trim (threshold 10)"
+
+      assert OptsSummary.describe("rs:fit:300:300/mw:280/mh:280") ==
+               "resize fit 300×300; min-width 280; min-height 280"
+
+      assert OptsSummary.describe("z:0.5") == "zoom 0.5"
+      assert OptsSummary.describe("rs:fit:80:80/dpr:2") == "resize fit 80×80; dpr 2"
+    end
+
+    test "extend variants" do
+      assert OptsSummary.describe("rs:fit:300:200/ex:1") == "resize fit 300×200; extend"
+
+      assert OptsSummary.describe("rs:fit:300:200/ex:1:so") ==
+               "resize fit 300×200; extend (south)"
+
+      assert OptsSummary.describe("rs:fit:400:150/ex:1:we:5:0") ==
+               "resize fit 400×150; extend (west +5,+0)"
+
+      assert OptsSummary.describe("rs:fit:300:200/exar:1") ==
+               "resize fit 300×200; extend-aspect-ratio"
+    end
+
+    test "background, blur, sharpen, strip, format, quality" do
+      assert OptsSummary.describe("rs:fit:64:64/bg:255:0:0") ==
+               "resize fit 64×64; background rgb(255,0,0)"
+
+      assert OptsSummary.describe("rs:fit:240:240/bl:3") == "resize fit 240×240; blur 3"
+      assert OptsSummary.describe("rs:fit:240:240/sh:2") == "resize fit 240×240; sharpen 2"
+
+      assert OptsSummary.describe("rs:fit:120:120/sm:1") ==
+               "resize fit 120×120; strip-metadata on"
+
+      assert OptsSummary.describe("rs:fit:200:200/scp:0") ==
+               "resize fit 200×200; strip-color-profile off"
+
+      assert OptsSummary.describe("rs:fill:240:180/q:40/f:jpg") ==
+               "resize fill 240×180; quality 40; format jpg"
+    end
+
+    test "padding" do
+      assert OptsSummary.describe("rs:fit:120:120/pd:10:20") ==
+               "resize fit 120×120; padding 10,20"
+    end
+
+    test "unknown segments echo verbatim" do
+      assert OptsSummary.describe("rs:fit:64:64/wat:9") == "resize fit 64×64; wat:9"
+    end
+  end
+end

--- a/test/support/image_pipe/test/imgproxy_differential/README.md
+++ b/test/support/image_pipe/test/imgproxy_differential/README.md
@@ -23,6 +23,24 @@ manifest's authored hashes without Docker: `MIX_ENV=test mise exec -- mix imgpro
 Rebuild the source images only deliberately (a libvips bump must not silently change
 inputs): `MIX_ENV=test mise exec -- mix imgproxy.gen_sources`.
 
+## Visual-diff report (no Docker)
+
+Generate a self-contained `report.html` for eyeball triage — imgproxy vs ImagePipe
+side by side, a comparison slider, two diff heatmaps (banded over the case threshold,
+and raw amplified), and the live-recomputed metric/verdict/triage per constellation:
+
+```shell
+MIX_ENV=test mise exec -- mix imgproxy.gen_report          # writes report.html here
+MIX_ENV=test mise exec -- mix imgproxy.gen_report --out /tmp/r.html
+```
+
+It renders ImagePipe live and reads the committed fixtures — no Docker, no fixture or
+manifest changes. The default `report.html` is gitignored (it inlines ImagePipe PNGs as
+base64; regenerate on demand). Cases needing attention (over-budget, quarantined,
+dims-mismatch, a `:diverges` case that now matches, or authored-hash drift) sort to the
+top, and a top-of-page counts line summarizes them. The slider and Geist fonts load from
+a CDN; with no network the side-by-side panels remain the source of truth.
+
 ## libvips skew — warn-and-attempt
 
 Fixtures are baked by the container's libvips (recorded as `imgproxy_libvips` in

--- a/test/support/image_pipe/test/imgproxy_differential/README.md
+++ b/test/support/image_pipe/test/imgproxy_differential/README.md
@@ -18,10 +18,15 @@ imgproxy's committed output and ImagePipe's live output and compares pixels.
    `REPORT.md` diff (not the binary PNGs) for what moved.
 
 For a `tol` tweak or a `:diverges`→`:equal` verdict flip (no pixels change), refresh the
-manifest's authored hashes without Docker: `MIX_ENV=test mise exec -- mix imgproxy.reauthor`.
+manifest's authored hashes without Docker: `mise exec -- mix imgproxy.reauthor`.
 
 Rebuild the source images only deliberately (a libvips bump must not silently change
-inputs): `MIX_ENV=test mise exec -- mix imgproxy.gen_sources`.
+inputs): `mise exec -- mix imgproxy.gen_sources`.
+
+(`imgproxy.reauthor`, `imgproxy.gen_sources`, and `imgproxy.gen_report` live in
+`test/support`, so they auto-select `MIX_ENV=test` via `mix.exs` `preferred_envs` — no
+prefix needed. `imgproxy.gen_fixtures` is the exception: it also needs `IMGPROXY_DIFF=1`,
+shown explicitly above.)
 
 ## Visual-diff report (no Docker)
 
@@ -30,8 +35,8 @@ side by side, a comparison slider, two diff heatmaps (banded over the case thres
 and raw amplified), and the live-recomputed metric/verdict/triage per constellation:
 
 ```shell
-MIX_ENV=test mise exec -- mix imgproxy.gen_report          # writes report.html here
-MIX_ENV=test mise exec -- mix imgproxy.gen_report --out /tmp/r.html
+mise exec -- mix imgproxy.gen_report          # writes report.html here
+mise exec -- mix imgproxy.gen_report --out /tmp/r.html
 ```
 
 It renders ImagePipe live and reads the committed fixtures — no Docker, no fixture or

--- a/test/support/image_pipe/test/imgproxy_differential/opts_summary.ex
+++ b/test/support/image_pipe/test/imgproxy_differential/opts_summary.ex
@@ -1,0 +1,70 @@
+defmodule ImagePipe.Test.ImgproxyDifferential.OptsSummary do
+  @moduledoc """
+  Renders an imgproxy `opts` string (as stored on a constellation) into a short
+  human-readable summary for the visual-diff report's card labels. Self-contained
+  on purpose — a tiny dedicated formatter, not a reach into the parser — covering
+  the option codes used in `constellations.ex`, with unknown segments echoed
+  verbatim so it never hides syntax it doesn't recognize.
+  """
+
+  use Boundary, top_level?: true, deps: []
+
+  @doc "Human-readable summary of a slash-separated imgproxy opts string."
+  @spec describe(String.t()) :: String.t()
+  def describe(opts) do
+    opts
+    |> String.split("/", trim: true)
+    |> Enum.map_join("; ", &segment/1)
+  end
+
+  defp segment(seg), do: seg |> String.split(":") |> segment_parts() |> with_fallback(seg)
+
+  defp with_fallback(nil, seg), do: seg
+  defp with_fallback(text, _seg), do: text
+
+  defp segment_parts(["rs", mode, w, h]), do: "resize #{mode} #{w}×#{h}"
+  defp segment_parts(["c", w, h]), do: "crop #{w}×#{h}"
+  defp segment_parts(["t", n]), do: "trim (threshold #{n})"
+  defp segment_parts(["g" | rest]), do: "gravity #{gravity(rest)}"
+  defp segment_parts(["mw", n]), do: "min-width #{n}"
+  defp segment_parts(["mh", n]), do: "min-height #{n}"
+  defp segment_parts(["z", f]), do: "zoom #{f}"
+  defp segment_parts(["pd" | vals]), do: "padding #{Enum.join(vals, ",")}"
+  defp segment_parts(["ex" | rest]), do: "extend#{extend_suffix(rest)}"
+  defp segment_parts(["exar" | _]), do: "extend-aspect-ratio"
+  defp segment_parts(["dpr", n]), do: "dpr #{n}"
+  defp segment_parts(["bg", r, g, b]), do: "background rgb(#{r},#{g},#{b})"
+  defp segment_parts(["bl", n]), do: "blur #{n}"
+  defp segment_parts(["sh", n]), do: "sharpen #{n}"
+  defp segment_parts(["sm", f]), do: "strip-metadata #{onoff(f)}"
+  defp segment_parts(["scp", f]), do: "strip-color-profile #{onoff(f)}"
+  defp segment_parts(["el", f]), do: "enlarge #{onoff(f)}"
+  defp segment_parts(["q", n]), do: "quality #{n}"
+  defp segment_parts(["f", fmt]), do: "format #{fmt}"
+  defp segment_parts(_), do: nil
+
+  defp gravity([code]), do: gravity_name(code)
+  defp gravity([code, x, y]), do: "#{gravity_name(code)} +#{x},+#{y}"
+  defp gravity(other), do: Enum.join(other, ":")
+
+  defp gravity_name("ce"), do: "center"
+  defp gravity_name("no"), do: "north"
+  defp gravity_name("so"), do: "south"
+  defp gravity_name("ea"), do: "east"
+  defp gravity_name("we"), do: "west"
+  defp gravity_name("noea"), do: "north-east"
+  defp gravity_name("nowe"), do: "north-west"
+  defp gravity_name("soea"), do: "south-east"
+  defp gravity_name("sowe"), do: "south-west"
+  defp gravity_name("sm"), do: "smart"
+  defp gravity_name(other), do: other
+
+  defp extend_suffix([_flag]), do: ""
+  defp extend_suffix([_flag, code]), do: " (#{gravity_name(code)})"
+  defp extend_suffix([_flag, code, x, y]), do: " (#{gravity_name(code)} +#{x},+#{y})"
+  defp extend_suffix(_), do: ""
+
+  defp onoff("0"), do: "off"
+  defp onoff("1"), do: "on"
+  defp onoff(x), do: x
+end

--- a/test/support/image_pipe/test/imgproxy_differential/report_html.ex
+++ b/test/support/image_pipe/test/imgproxy_differential/report_html.ex
@@ -66,17 +66,20 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
         </span>
         <span class="control-group" role="group" aria-label="status filter">
           status:
-          <button data-status-set="all">all</button>
-          <button data-status-set="flagged">flagged</button>
-          <button data-status-set="failing">failing</button>
-          <button data-status-set="quarantined">quarantined</button>
+          <button data-status-set="all">all <span class="btn-count"></span></button>
+          <button data-status-set="flagged">flagged <span class="btn-count"></span></button>
+          <button data-status-set="failing">failing <span class="btn-count"></span></button>
+          <button data-status-set="quarantined">quarantined <span class="btn-count"></span></button>
         </span>
         <span class="control-group" role="group" aria-label="type filter">
           type:
-          <button data-type-set="all">all</button>
-          <button data-type-set="transform">transform</button>
-          <button data-type-set="known_divergence">known divergence</button>
-          <button data-type-set="lossy">lossy</button>
+          <button data-type-set="all">all <span class="btn-count"></span></button>
+          <button data-type-set="transform">transform <span class="btn-count"></span></button>
+          <button data-type-set="known_divergence">known divergence <span class="btn-count"></span></button>
+          <button data-type-set="lossy">lossy <span class="btn-count"></span></button>
+        </span>
+        <span class="control-group" role="group" aria-label="theme">
+          <button id="theme-toggle">theme: auto</button>
         </span>
       </div>
     </header>
@@ -154,46 +157,53 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
     if c.status in [:pass, :diverges_ok, :contract_ok], do: "ok", else: "bad"
   end
 
+  # Lossy: ImagePipe render alone (no imgproxy fixture to compare).
   defp visuals(%{group: :lossy} = c) do
     """
-    <div class="lossy-only">
-      <figure><img src="#{c.pipe_img}" alt="ImagePipe #{esc(c.id)}"><figcaption>ImagePipe (no imgproxy reference — contract only)</figcaption></figure>
+    <div class="visuals">
+      #{panel(c.pipe_img, "ImagePipe (contract only — no imgproxy reference)")}
     </div>
     """
   end
 
+  # Dims mismatch: the two renders side by side; no slider/heatmap (the mismatch is
+  # the finding).
   defp visuals(%{status: :dims_mismatch} = c) do
-    side_by_side(c)
+    """
+    <div class="visuals">
+      #{panel(c.imgproxy_img, "imgproxy #{fmt(c.fixture_dims)}")}
+      #{panel(c.pipe_img, "ImagePipe #{fmt(c.pipe_dims)}")}
+    </div>
+    """
   end
 
+  # All panels flow in one wrapping row: imgproxy, ImagePipe, slider, and the
+  # active heatmap (the toggle hides the other two).
   defp visuals(c) do
     """
-    #{side_by_side(c)}
-    <div class="slider" style="width:#{elem(c.pipe_dims, 0)}px;max-width:100%">
-      <img-comparison-slider>
-        <img slot="first" src="#{c.imgproxy_img}" alt="imgproxy">
-        <img slot="second" src="#{c.pipe_img}" alt="ImagePipe">
-      </img-comparison-slider>
-    </div>
-    <div class="heatmaps">
-      <figure class="heat-banded"><img src="#{c.heat_banded}" alt="banded diff"><figcaption>banded (Δ#{heat_threshold(c)})</figcaption></figure>
-      <figure class="heat-raw"><img src="#{c.heat_raw}" alt="raw diff"><figcaption>raw ×8</figcaption></figure>
-      <figure class="heat-normalized"><img src="#{c.heat_normalized}" alt="normalized diff"><figcaption>normalized (per-case)</figcaption></figure>
+    <div class="visuals">
+      #{panel(c.imgproxy_img, "imgproxy #{fmt(c.fixture_dims)}")}
+      #{panel(c.pipe_img, "ImagePipe #{fmt(c.pipe_dims)}")}
+      <figure class="panel slider" style="width:#{min(elem(c.pipe_dims, 0), 280)}px">
+        <img-comparison-slider>
+          <img slot="first" src="#{c.imgproxy_img}" alt="imgproxy">
+          <img slot="second" src="#{c.pipe_img}" alt="ImagePipe">
+        </img-comparison-slider>
+        <figcaption>slider</figcaption>
+      </figure>
+      <figure class="panel heat-banded"><img src="#{c.heat_banded}" alt="banded diff"><figcaption>banded (Δ#{heat_threshold(c)})</figcaption></figure>
+      <figure class="panel heat-raw"><img src="#{c.heat_raw}" alt="raw diff"><figcaption>raw ×8</figcaption></figure>
+      <figure class="panel heat-normalized"><img src="#{c.heat_normalized}" alt="normalized diff"><figcaption>normalized (per-case)</figcaption></figure>
     </div>
     """
+  end
+
+  defp panel(img, caption) do
+    ~s(<figure class="panel"><img src="#{img}" alt="#{esc(caption)}"><figcaption>#{esc(caption)}</figcaption></figure>)
   end
 
   defp heat_threshold(%{tol: %{threshold: t}}), do: t
   defp heat_threshold(_), do: 2
-
-  defp side_by_side(c) do
-    """
-    <div class="pair">
-      <figure><img src="#{c.imgproxy_img}" alt="imgproxy"><figcaption>imgproxy #{fmt(c.fixture_dims)}</figcaption></figure>
-      <figure><img src="#{c.pipe_img}" alt="ImagePipe"><figcaption>ImagePipe #{fmt(c.pipe_dims)}</figcaption></figure>
-    </div>
-    """
-  end
 
   defp fmt(nil), do: ""
   defp fmt({w, h}), do: "#{w}×#{h}"
@@ -211,17 +221,70 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
     """
     <script>
     (function () {
-      var body = document.body;
+      var root = document.documentElement, body = document.body;
+      var cards = Array.prototype.slice.call(document.querySelectorAll(".card"));
+
+      function statusMatch(c, s) { return s === "all" || c.classList.contains(s); }
+      function typeMatch(c, t) { return t === "all" || c.classList.contains("group-" + t); }
+      function countWhere(pred) { return cards.filter(pred).length; }
+
+      // Live counts: each button shows how many cards it would leave visible, given
+      // the OTHER axis's current selection. Also marks the active button per axis.
+      function refresh() {
+        var st = body.getAttribute("data-status");
+        var ty = body.getAttribute("data-type");
+        var ht = body.getAttribute("data-heat");
+        document.querySelectorAll("[data-status-set]").forEach(function (b) {
+          var s = b.getAttribute("data-status-set");
+          setCount(b, countWhere(function (c) { return statusMatch(c, s) && typeMatch(c, ty); }));
+          b.classList.toggle("active", s === st);
+        });
+        document.querySelectorAll("[data-type-set]").forEach(function (b) {
+          var t = b.getAttribute("data-type-set");
+          setCount(b, countWhere(function (c) { return statusMatch(c, st) && typeMatch(c, t); }));
+          b.classList.toggle("active", t === ty);
+        });
+        document.querySelectorAll("[data-heat-set]").forEach(function (b) {
+          b.classList.toggle("active", b.getAttribute("data-heat-set") === ht);
+        });
+      }
+
+      function setCount(b, n) {
+        var s = b.querySelector(".btn-count");
+        if (s) s.textContent = "(" + n + ")";
+      }
+
       function bind(attr, setAttr) {
-        document.querySelectorAll("[" + setAttr + "]").forEach(function (btn) {
-          btn.addEventListener("click", function () {
-            body.setAttribute(attr, btn.getAttribute(setAttr));
+        document.querySelectorAll("[" + setAttr + "]").forEach(function (b) {
+          b.addEventListener("click", function () {
+            body.setAttribute(attr, b.getAttribute(setAttr));
+            refresh();
           });
         });
       }
       bind("data-heat", "data-heat-set");
       bind("data-status", "data-status-set");
       bind("data-type", "data-type-set");
+
+      // theme: auto → light → dark, persisted across regenerations
+      var THEMES = ["auto", "light", "dark"], KEY = "imgproxy-report-theme";
+      var themeBtn = document.getElementById("theme-toggle");
+      function applyTheme(mode) {
+        if (mode === "auto") root.removeAttribute("data-theme");
+        else root.setAttribute("data-theme", mode);
+        themeBtn.textContent = "theme: " + mode;
+      }
+      var saved = null;
+      try { saved = localStorage.getItem(KEY); } catch (e) {}
+      applyTheme(THEMES.indexOf(saved) >= 0 ? saved : "auto");
+      themeBtn.addEventListener("click", function () {
+        var cur = root.getAttribute("data-theme") || "auto";
+        var next = THEMES[(THEMES.indexOf(cur) + 1) % THEMES.length];
+        applyTheme(next);
+        try { localStorage.setItem(KEY, next); } catch (e) {}
+      });
+
+      refresh();
     })();
     </script>
     """
@@ -229,19 +292,28 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
 
   defp css do
     """
+    /* dark is the base; `data-theme` (set by the toggle) overrides, and with no
+       explicit choice the auto media-query below follows the OS preference */
     :root {
       color-scheme: dark;
       --surface-app:#0b0d10; --surface-bar:#0d1015; --surface-control:#202733;
       --border-subtle:#242b36; --text-primary:#f6f1e7; --text-muted:#8fa0b3;
-      --accent:#ffb84d; --danger:#ff6b6b; --checker-square:#1b222b;
+      --accent:#ffb84d; --accent-text:#0b0d10; --danger:#ff6b6b; --checker-square:#1b222b;
       --image-shadow:0 22px 80px rgb(0 0 0 / 38%);
     }
+    :root[data-theme="light"] {
+      color-scheme: light;
+      --surface-app:#f4f6f8; --surface-bar:#fff; --surface-control:#eef2f7;
+      --border-subtle:#d9e0ea; --text-primary:#11151b; --text-muted:#687586;
+      --accent:#d48100; --accent-text:#fff; --danger:#c62828; --checker-square:#dfe5ee;
+      --image-shadow:0 22px 80px rgb(10 16 24 / 18%);
+    }
     @media (prefers-color-scheme: light) {
-      :root {
+      :root:not([data-theme="dark"]) {
         color-scheme: light;
         --surface-app:#f4f6f8; --surface-bar:#fff; --surface-control:#eef2f7;
         --border-subtle:#d9e0ea; --text-primary:#11151b; --text-muted:#687586;
-        --accent:#d48100; --danger:#c62828; --checker-square:#dfe5ee;
+        --accent:#d48100; --accent-text:#fff; --danger:#c62828; --checker-square:#dfe5ee;
         --image-shadow:0 22px 80px rgb(10 16 24 / 18%);
       }
     }
@@ -259,10 +331,12 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
     .banner { margin:8px 0; padding:8px 10px; border-radius:6px; font-size:12px; }
     .banner.skew { background:color-mix(in srgb, var(--accent) 18%, transparent); }
     .banner.drift { background:color-mix(in srgb, var(--danger) 18%, transparent); }
-    .controls { display:flex; gap:18px; flex-wrap:wrap; margin-top:10px; }
+    .controls { display:flex; gap:18px; flex-wrap:wrap; align-items:baseline; margin-top:10px; }
     .control-group { font-size:12px; color:var(--text-muted); }
     .controls button { margin-left:4px; padding:3px 8px; border:1px solid var(--border-subtle);
       background:var(--surface-control); color:var(--text-primary); border-radius:5px; cursor:pointer; }
+    .controls button.active { background:var(--accent); border-color:var(--accent); color:var(--accent-text); font-weight:600; }
+    .btn-count { opacity:0.7; font-variant-numeric:tabular-nums; }
     .cards { padding:24px; display:flex; flex-direction:column; gap:24px; }
     .card { background:var(--surface-bar); border:1px solid var(--border-subtle);
       border-radius:10px; padding:16px; }
@@ -278,20 +352,23 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
     .metric { font-weight:600; }
     .metric.ok { color:var(--accent); }
     .metric.bad { color:var(--danger); }
-    .pair { display:grid; grid-template-columns:1fr 1fr; gap:12px; margin-top:12px; }
-    /* one heatmap shows at a time (global toggle), so the panel is single-column */
-    .heatmaps { display:grid; grid-template-columns:1fr; gap:12px; margin-top:12px; max-width:420px; }
-    .lossy-only { margin-top:12px; max-width:420px; }
-    figure { margin:0; }
-    figure img, .slider img, .slider img-comparison-slider {
-      max-width:100%; display:block; border-radius:6px;
+    /* all panels (imgproxy, ImagePipe, slider, the active heatmap) flow in one
+       wrapping row at a consistent width so nothing is stranded or stacked */
+    .visuals { display:flex; flex-wrap:wrap; gap:14px; align-items:flex-start; margin-top:14px; }
+    .panel { margin:0; }
+    .panel img, .panel img-comparison-slider {
+      display:block; max-width:280px; border-radius:6px;
       background:repeating-conic-gradient(var(--checker-square) 0 25%, transparent 0 50%) 50% / 20px 20px;
     }
     figcaption { font-size:11px; color:var(--text-muted); margin-top:4px; }
-    /* slider wrapper is capped to the render's own width (inline style) so the drag
-       divider never extends past the images; it still shrinks on narrow screens */
-    .slider { margin-top:12px; box-shadow:var(--image-shadow); border-radius:6px; }
-    .slider img, .slider img-comparison-slider { width:100%; }
+    /* slider wrapper is capped to the render width (inline style); the divider/handle
+       use the accent colour so they stay visible over a light, checkered image */
+    .panel.slider { max-width:100%; box-shadow:var(--image-shadow); border-radius:6px; }
+    .panel.slider img, .panel.slider img-comparison-slider { width:100%; max-width:100%; }
+    .panel.slider img-comparison-slider {
+      --divider-width:3px; --divider-color:var(--accent);
+      --default-handle-color:var(--accent); --default-handle-opacity:1;
+    }
     body[data-heat="banded"] .heat-raw, body[data-heat="banded"] .heat-normalized { display:none; }
     body[data-heat="raw"] .heat-banded, body[data-heat="raw"] .heat-normalized { display:none; }
     body[data-heat="normalized"] .heat-banded, body[data-heat="normalized"] .heat-raw { display:none; }

--- a/test/support/image_pipe/test/imgproxy_differential/report_html.ex
+++ b/test/support/image_pipe/test/imgproxy_differential/report_html.ex
@@ -32,7 +32,7 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
     <script defer src="#{@slider_js}"></script>
     <style>#{css()}</style>
     </head>
-    <body data-heat="banded" data-filter="all">
+    <body data-heat="banded" data-status="all" data-type="all">
     #{header(prov, cards)}
     <main class="cards">
     #{Enum.map_join(ordered, "\n", &card/1)}
@@ -64,14 +64,19 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
           <button data-heat-set="raw">raw</button>
           <button data-heat-set="normalized">normalized</button>
         </span>
-        <span class="control-group" role="group" aria-label="filter">
-          show:
-          <button data-filter-set="all">all</button>
-          <button data-filter-set="failing">failing</button>
-          <button data-filter-set="attention">attention</button>
-          <button data-filter-set="transform">transform</button>
-          <button data-filter-set="diverges">diverges</button>
-          <button data-filter-set="lossy">lossy</button>
+        <span class="control-group" role="group" aria-label="status filter">
+          status:
+          <button data-status-set="all">all</button>
+          <button data-status-set="attention">attention</button>
+          <button data-status-set="failing">failing</button>
+          <button data-status-set="quarantined">quarantined</button>
+        </span>
+        <span class="control-group" role="group" aria-label="type filter">
+          type:
+          <button data-type-set="all">all</button>
+          <button data-type-set="transform">transform</button>
+          <button data-type-set="diverges">diverges</button>
+          <button data-type-set="lossy">lossy</button>
         </span>
       </div>
     </header>
@@ -82,19 +87,22 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
     by_group = Enum.frequencies_by(cards, & &1.group)
     attention = Enum.count(cards, & &1.attention?)
     failing = Enum.count(cards, & &1.failing?)
+    quarantined = Enum.count(cards, &(&1.triage != nil))
     drift = Enum.count(cards, & &1.hash_drift?)
 
     "#{Map.get(by_group, :transform, 0)} transform · " <>
       "#{Map.get(by_group, :diverges, 0)} diverges · " <>
       "#{Map.get(by_group, :lossy, 0)} lossy — " <>
-      "#{attention} attention · #{failing} failing · #{drift} hash-drift"
+      "#{attention} attention · #{failing} failing · " <>
+      "#{quarantined} quarantined · #{drift} hash-drift"
   end
 
   defp card(c) do
     classes =
       ["card", "group-#{c.group}", "status-#{c.status}"] ++
         if(c.attention?, do: ["attention"], else: []) ++
-        if(c.failing?, do: ["failing"], else: [])
+        if(c.failing?, do: ["failing"], else: []) ++
+        if(c.triage, do: ["quarantined"], else: [])
 
     """
     <section id="#{esc(c.id)}" class="#{Enum.join(classes, " ")}" data-group="#{c.group}" data-attention="#{c.attention?}">
@@ -212,7 +220,8 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
         });
       }
       bind("data-heat", "data-heat-set");
-      bind("data-filter", "data-filter-set");
+      bind("data-status", "data-status-set");
+      bind("data-type", "data-type-set");
     })();
     </script>
     """
@@ -286,11 +295,14 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
     body[data-heat="banded"] .heat-raw, body[data-heat="banded"] .heat-normalized { display:none; }
     body[data-heat="raw"] .heat-banded, body[data-heat="raw"] .heat-normalized { display:none; }
     body[data-heat="normalized"] .heat-banded, body[data-heat="normalized"] .heat-raw { display:none; }
-    body[data-filter="failing"] .card:not(.failing) { display:none; }
-    body[data-filter="attention"] .card:not(.attention) { display:none; }
-    body[data-filter="transform"] .card:not(.group-transform) { display:none; }
-    body[data-filter="diverges"] .card:not(.group-diverges) { display:none; }
-    body[data-filter="lossy"] .card:not(.group-lossy) { display:none; }
+    /* status and type are independent axes — a card hidden by either stays hidden,
+       so the two filters intersect (e.g. status=failing + type=transform) */
+    body[data-status="attention"] .card:not(.attention) { display:none; }
+    body[data-status="failing"] .card:not(.failing) { display:none; }
+    body[data-status="quarantined"] .card:not(.quarantined) { display:none; }
+    body[data-type="transform"] .card:not(.group-transform) { display:none; }
+    body[data-type="diverges"] .card:not(.group-diverges) { display:none; }
+    body[data-type="lossy"] .card:not(.group-lossy) { display:none; }
     """
   end
 end

--- a/test/support/image_pipe/test/imgproxy_differential/report_html.ex
+++ b/test/support/image_pipe/test/imgproxy_differential/report_html.ex
@@ -54,7 +54,7 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
     """
     <header class="report-header">
       <h1>imgproxy differential — visual diff</h1>
-      <p class="provenance">imgproxy <code>#{esc(prov.imgproxy_digest)}</code> · imgproxy libvips <code>#{esc(prov.imgproxy_libvips)}</code> · ImagePipe libvips at gen <code>#{esc(prov.pipe_libvips_at_gen)}</code> · runtime <code>#{esc(prov.runtime_libvips)}</code></p>
+      <p class="provenance">imgproxy <code>#{esc(prov.imgproxy_digest)}</code> · imgproxy libvips <code>#{esc(prov.imgproxy_libvips)}</code> (.so ABI soname) · ImagePipe libvips <code>#{esc(prov.pipe_libvips_at_gen)}</code> (release, at gen) · runtime <code>#{esc(prov.runtime_libvips)}</code> (release)</p>
       #{skew}
       <p class="counts">#{counts(cards)}</p>
       <div class="controls">
@@ -358,7 +358,10 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
        wrapping row at a consistent width so nothing is stranded or stacked */
     .visuals { display:flex; flex-wrap:wrap; gap:14px; align-items:flex-start; margin-top:14px; }
     .panel { margin:0; }
-    .panel img, .panel img-comparison-slider {
+    /* checker lives on ONE layer per panel: the static panels' own img, and the
+       slider HOST (behind both slotted images) — never on the stacked slider images,
+       or a transparent top image would reveal the opaque one beneath as a checker */
+    .panel > img, .panel img-comparison-slider {
       display:block; max-width:280px; border-radius:6px;
       background:repeating-conic-gradient(var(--checker-square) 0 25%, transparent 0 50%) 50% / 20px 20px;
     }
@@ -368,6 +371,7 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
        visible over a light, checkered image */
     .panel.slider { max-width:100%; }
     .panel.slider img, .panel.slider img-comparison-slider { width:100%; max-width:100%; }
+    .panel.slider img { display:block; border-radius:6px; background:none; }
     .panel.slider img-comparison-slider {
       --divider-width:3px; --divider-color:var(--accent);
       --default-handle-color:var(--accent); --default-handle-opacity:1;

--- a/test/support/image_pipe/test/imgproxy_differential/report_html.ex
+++ b/test/support/image_pipe/test/imgproxy_differential/report_html.ex
@@ -363,9 +363,10 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
       background:repeating-conic-gradient(var(--checker-square) 0 25%, transparent 0 50%) 50% / 20px 20px;
     }
     figcaption { font-size:11px; color:var(--text-muted); margin-top:4px; }
-    /* slider wrapper is capped to the render width (inline style); the divider/handle
-       use the accent colour so they stay visible over a light, checkered image */
-    .panel.slider { max-width:100%; box-shadow:var(--image-shadow); border-radius:6px; }
+    /* slider wrapper is capped to the render width (inline style); kept flush with the
+       other panels (no shadow). The divider/handle use the accent colour so they stay
+       visible over a light, checkered image */
+    .panel.slider { max-width:100%; }
     .panel.slider img, .panel.slider img-comparison-slider { width:100%; max-width:100%; }
     .panel.slider img-comparison-slider {
       --divider-width:3px; --divider-color:var(--accent);

--- a/test/support/image_pipe/test/imgproxy_differential/report_html.ex
+++ b/test/support/image_pipe/test/imgproxy_differential/report_html.ex
@@ -53,7 +53,10 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
 
     """
     <header class="report-header">
-      <h1>imgproxy differential — visual diff</h1>
+      <div class="title-row">
+        <h1>imgproxy differential — visual diff</h1>
+        <button id="theme-toggle">theme: auto</button>
+      </div>
       <p class="provenance">imgproxy <code>#{esc(prov.imgproxy_digest)}</code> · imgproxy libvips <code>#{esc(prov.imgproxy_libvips)}</code> (.so ABI soname) · ImagePipe libvips <code>#{esc(prov.pipe_libvips_at_gen)}</code> (release, at gen) · runtime <code>#{esc(prov.runtime_libvips)}</code> (release)</p>
       #{skew}
       <p class="counts">#{counts(cards)}</p>
@@ -72,14 +75,11 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
           <button data-status-set="failing">failing <span class="btn-count"></span></button>
           <button data-status-set="quarantined">quarantined <span class="btn-count"></span></button>
         </span>
-        <span class="control-group control-group--right" role="group" aria-label="heatmap mode">
+        <span class="control-group" role="group" aria-label="heatmap mode">
           heatmap:
           <button data-heat-set="banded">banded</button>
           <button data-heat-set="raw">raw</button>
           <button data-heat-set="normalized">normalized</button>
-        </span>
-        <span class="control-group" role="group" aria-label="theme">
-          <button id="theme-toggle">theme: auto</button>
         </span>
       </div>
     </header>
@@ -325,7 +325,10 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
     code, .url, .metric { font-family:"Geist Mono",ui-monospace,"SFMono-Regular","Menlo",monospace; }
     .report-header { position:sticky; top:0; z-index:2; padding:16px 24px;
       background:var(--surface-bar); border-bottom:1px solid var(--border-subtle); }
+    .title-row { display:flex; align-items:center; justify-content:space-between; gap:12px; }
     .report-header h1 { margin:0 0 6px; font-size:18px; }
+    #theme-toggle { font-size:12px; padding:3px 8px; border:1px solid var(--border-subtle);
+      background:var(--surface-control); color:var(--text-primary); border-radius:5px; cursor:pointer; }
     .provenance, .counts { margin:4px 0; color:var(--text-muted); font-size:12px; }
     .counts { color:var(--text-primary); font-weight:600; }
     .banner { margin:8px 0; padding:8px 10px; border-radius:6px; font-size:12px; }
@@ -333,8 +336,6 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
     .banner.drift { background:color-mix(in srgb, var(--danger) 18%, transparent); }
     .controls { display:flex; gap:18px; flex-wrap:wrap; align-items:baseline; margin-top:10px; }
     .control-group { font-size:12px; color:var(--text-muted); }
-    /* filters cluster left, display controls (heatmap, theme) get pushed right */
-    .control-group--right { margin-left:auto; }
     .controls button { margin-left:4px; padding:3px 8px; border:1px solid var(--border-subtle);
       background:var(--surface-control); color:var(--text-primary); border-radius:5px; cursor:pointer; }
     .controls button.active { background:var(--accent); border-color:var(--accent); color:var(--accent-text); font-weight:600; }

--- a/test/support/image_pipe/test/imgproxy_differential/report_html.ex
+++ b/test/support/image_pipe/test/imgproxy_differential/report_html.ex
@@ -62,10 +62,12 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
           heatmap:
           <button data-heat-set="banded">banded</button>
           <button data-heat-set="raw">raw</button>
+          <button data-heat-set="normalized">normalized</button>
         </span>
         <span class="control-group" role="group" aria-label="filter">
           show:
           <button data-filter-set="all">all</button>
+          <button data-filter-set="failing">failing</button>
           <button data-filter-set="attention">attention</button>
           <button data-filter-set="transform">transform</button>
           <button data-filter-set="diverges">diverges</button>
@@ -79,18 +81,20 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
   defp counts(cards) do
     by_group = Enum.frequencies_by(cards, & &1.group)
     attention = Enum.count(cards, & &1.attention?)
+    failing = Enum.count(cards, & &1.failing?)
     drift = Enum.count(cards, & &1.hash_drift?)
 
     "#{Map.get(by_group, :transform, 0)} transform · " <>
       "#{Map.get(by_group, :diverges, 0)} diverges · " <>
       "#{Map.get(by_group, :lossy, 0)} lossy — " <>
-      "#{attention} attention · #{drift} hash-drift"
+      "#{attention} attention · #{failing} failing · #{drift} hash-drift"
   end
 
   defp card(c) do
     classes =
       ["card", "group-#{c.group}", "status-#{c.status}"] ++
-        if(c.attention?, do: ["attention"], else: [])
+        if(c.attention?, do: ["attention"], else: []) ++
+        if(c.failing?, do: ["failing"], else: [])
 
     """
     <section id="#{esc(c.id)}" class="#{Enum.join(classes, " ")}" data-group="#{c.group}" data-attention="#{c.attention?}">
@@ -157,7 +161,7 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
   defp visuals(c) do
     """
     #{side_by_side(c)}
-    <div class="slider">
+    <div class="slider" style="width:#{elem(c.pipe_dims, 0)}px;max-width:100%">
       <img-comparison-slider>
         <img slot="first" src="#{c.imgproxy_img}" alt="imgproxy">
         <img slot="second" src="#{c.pipe_img}" alt="ImagePipe">
@@ -166,6 +170,7 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
     <div class="heatmaps">
       <figure class="heat-banded"><img src="#{c.heat_banded}" alt="banded diff"><figcaption>banded (Δ#{heat_threshold(c)})</figcaption></figure>
       <figure class="heat-raw"><img src="#{c.heat_raw}" alt="raw diff"><figcaption>raw ×8</figcaption></figure>
+      <figure class="heat-normalized"><img src="#{c.heat_normalized}" alt="normalized diff"><figcaption>normalized (per-case)</figcaption></figure>
     </div>
     """
   end
@@ -264,7 +269,9 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
     .metric { font-weight:600; }
     .metric.ok { color:var(--accent); }
     .metric.bad { color:var(--danger); }
-    .pair, .heatmaps { display:grid; grid-template-columns:1fr 1fr; gap:12px; margin-top:12px; }
+    .pair { display:grid; grid-template-columns:1fr 1fr; gap:12px; margin-top:12px; }
+    /* one heatmap shows at a time (global toggle), so the panel is single-column */
+    .heatmaps { display:grid; grid-template-columns:1fr; gap:12px; margin-top:12px; max-width:420px; }
     .lossy-only { margin-top:12px; max-width:420px; }
     figure { margin:0; }
     figure img, .slider img, .slider img-comparison-slider {
@@ -272,10 +279,14 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
       background:repeating-conic-gradient(var(--checker-square) 0 25%, transparent 0 50%) 50% / 20px 20px;
     }
     figcaption { font-size:11px; color:var(--text-muted); margin-top:4px; }
-    .slider { margin-top:12px; max-width:520px; box-shadow:var(--image-shadow); border-radius:6px; }
-    body[data-heat="banded"] .heat-raw { display:none; }
-    body[data-heat="raw"] .heat-banded { display:none; }
-    body[data-heat="banded"] .heatmaps, body[data-heat="raw"] .heatmaps { grid-template-columns:1fr; max-width:420px; }
+    /* slider wrapper is capped to the render's own width (inline style) so the drag
+       divider never extends past the images; it still shrinks on narrow screens */
+    .slider { margin-top:12px; box-shadow:var(--image-shadow); border-radius:6px; }
+    .slider img, .slider img-comparison-slider { width:100%; }
+    body[data-heat="banded"] .heat-raw, body[data-heat="banded"] .heat-normalized { display:none; }
+    body[data-heat="raw"] .heat-banded, body[data-heat="raw"] .heat-normalized { display:none; }
+    body[data-heat="normalized"] .heat-banded, body[data-heat="normalized"] .heat-raw { display:none; }
+    body[data-filter="failing"] .card:not(.failing) { display:none; }
     body[data-filter="attention"] .card:not(.attention) { display:none; }
     body[data-filter="transform"] .card:not(.group-transform) { display:none; }
     body[data-filter="diverges"] .card:not(.group-diverges) { display:none; }

--- a/test/support/image_pipe/test/imgproxy_differential/report_html.ex
+++ b/test/support/image_pipe/test/imgproxy_differential/report_html.ex
@@ -58,11 +58,12 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
       #{skew}
       <p class="counts">#{counts(cards)}</p>
       <div class="controls">
-        <span class="control-group" role="group" aria-label="heatmap mode">
-          heatmap:
-          <button data-heat-set="banded">banded</button>
-          <button data-heat-set="raw">raw</button>
-          <button data-heat-set="normalized">normalized</button>
+        <span class="control-group" role="group" aria-label="type filter">
+          type:
+          <button data-type-set="all">all <span class="btn-count"></span></button>
+          <button data-type-set="transform">transform <span class="btn-count"></span></button>
+          <button data-type-set="known_divergence">known divergence <span class="btn-count"></span></button>
+          <button data-type-set="lossy">lossy <span class="btn-count"></span></button>
         </span>
         <span class="control-group" role="group" aria-label="status filter">
           status:
@@ -71,12 +72,11 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
           <button data-status-set="failing">failing <span class="btn-count"></span></button>
           <button data-status-set="quarantined">quarantined <span class="btn-count"></span></button>
         </span>
-        <span class="control-group" role="group" aria-label="type filter">
-          type:
-          <button data-type-set="all">all <span class="btn-count"></span></button>
-          <button data-type-set="transform">transform <span class="btn-count"></span></button>
-          <button data-type-set="known_divergence">known divergence <span class="btn-count"></span></button>
-          <button data-type-set="lossy">lossy <span class="btn-count"></span></button>
+        <span class="control-group control-group--right" role="group" aria-label="heatmap mode">
+          heatmap:
+          <button data-heat-set="banded">banded</button>
+          <button data-heat-set="raw">raw</button>
+          <button data-heat-set="normalized">normalized</button>
         </span>
         <span class="control-group" role="group" aria-label="theme">
           <button id="theme-toggle">theme: auto</button>
@@ -333,6 +333,8 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
     .banner.drift { background:color-mix(in srgb, var(--danger) 18%, transparent); }
     .controls { display:flex; gap:18px; flex-wrap:wrap; align-items:baseline; margin-top:10px; }
     .control-group { font-size:12px; color:var(--text-muted); }
+    /* filters cluster left, display controls (heatmap, theme) get pushed right */
+    .control-group--right { margin-left:auto; }
     .controls button { margin-left:4px; padding:3px 8px; border:1px solid var(--border-subtle);
       background:var(--surface-control); color:var(--text-primary); border-radius:5px; cursor:pointer; }
     .controls button.active { background:var(--accent); border-color:var(--accent); color:var(--accent-text); font-weight:600; }

--- a/test/support/image_pipe/test/imgproxy_differential/report_html.ex
+++ b/test/support/image_pipe/test/imgproxy_differential/report_html.ex
@@ -1,0 +1,285 @@
+defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
+  @moduledoc """
+  Pure renderer: card data + provenance → a single self-contained HTML string for
+  the imgproxy differential visual-diff report. All images arrive pre-encoded as
+  `data:` URIs; the only view-time network deps are the img-comparison-slider CDN
+  and Google Fonts (both degrade: the side-by-side panels are the source of truth,
+  fonts fall back to system stacks). Card-data shape is documented in the plan and
+  produced by `Mix.Tasks.Imgproxy.GenReport`.
+  """
+
+  use Boundary, top_level?: true, deps: []
+
+  @slider_css "https://cdn.jsdelivr.net/npm/img-comparison-slider@8/dist/styles.css"
+  @slider_js "https://cdn.jsdelivr.net/npm/img-comparison-slider@8/dist/index.js"
+  @fonts "https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&family=Geist:wght@100..900&display=swap"
+  @issue_base "https://github.com/hlindset/image_pipe/issues/"
+
+  @spec render(%{provenance: map(), cards: [map()]}) :: String.t()
+  def render(%{provenance: prov, cards: cards}) do
+    ordered = Enum.sort_by(cards, fn c -> if(c.attention?, do: 0, else: 1) end)
+
+    """
+    <!doctype html>
+    <html lang="en">
+    <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>imgproxy differential — visual diff</title>
+    <link rel="stylesheet" href="#{@slider_css}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="stylesheet" href="#{@fonts}">
+    <script defer src="#{@slider_js}"></script>
+    <style>#{css()}</style>
+    </head>
+    <body data-heat="banded" data-filter="all">
+    #{header(prov, cards)}
+    <main class="cards">
+    #{Enum.map_join(ordered, "\n", &card/1)}
+    </main>
+    #{script()}
+    </body>
+    </html>
+    """
+  end
+
+  defp header(prov, cards) do
+    skew =
+      if prov.skew? do
+        ~s(<div class="banner skew">libvips skew: fixtures baked on #{esc(prov.imgproxy_libvips)}, running #{esc(prov.runtime_libvips)} — compare with care.</div>)
+      else
+        ""
+      end
+
+    """
+    <header class="report-header">
+      <h1>imgproxy differential — visual diff</h1>
+      <p class="provenance">imgproxy <code>#{esc(prov.imgproxy_digest)}</code> · imgproxy libvips <code>#{esc(prov.imgproxy_libvips)}</code> · ImagePipe libvips at gen <code>#{esc(prov.pipe_libvips_at_gen)}</code> · runtime <code>#{esc(prov.runtime_libvips)}</code></p>
+      #{skew}
+      <p class="counts">#{counts(cards)}</p>
+      <div class="controls">
+        <span class="control-group" role="group" aria-label="heatmap mode">
+          heatmap:
+          <button data-heat-set="banded">banded</button>
+          <button data-heat-set="raw">raw</button>
+        </span>
+        <span class="control-group" role="group" aria-label="filter">
+          show:
+          <button data-filter-set="all">all</button>
+          <button data-filter-set="attention">attention</button>
+          <button data-filter-set="transform">transform</button>
+          <button data-filter-set="diverges">diverges</button>
+          <button data-filter-set="lossy">lossy</button>
+        </span>
+      </div>
+    </header>
+    """
+  end
+
+  defp counts(cards) do
+    by_group = Enum.frequencies_by(cards, & &1.group)
+    attention = Enum.count(cards, & &1.attention?)
+    drift = Enum.count(cards, & &1.hash_drift?)
+
+    "#{Map.get(by_group, :transform, 0)} transform · " <>
+      "#{Map.get(by_group, :diverges, 0)} diverges · " <>
+      "#{Map.get(by_group, :lossy, 0)} lossy — " <>
+      "#{attention} attention · #{drift} hash-drift"
+  end
+
+  defp card(c) do
+    classes =
+      ["card", "group-#{c.group}", "status-#{c.status}"] ++
+        if(c.attention?, do: ["attention"], else: [])
+
+    """
+    <section id="#{esc(c.id)}" class="#{Enum.join(classes, " ")}" data-group="#{c.group}" data-attention="#{c.attention?}">
+      <div class="card-head">
+        <h2>#{esc(c.id)}</h2>
+        #{badges(c)}
+      </div>
+      <p class="summary">#{esc(c.summary)}</p>
+      <p class="url"><code>#{esc(c.url)}</code></p>
+      #{triage(c)}
+      #{drift_banner(c)}
+      <p class="metric #{metric_class(c)}">#{esc(c.metric_text)}</p>
+      #{visuals(c)}
+    </section>
+    """
+  end
+
+  defp badges(c) do
+    base = [
+      ~s(<span class="badge verdict">#{c.verdict}</span>),
+      ~s(<span class="badge group">#{c.group}</span>)
+    ]
+
+    tol =
+      if c.tol,
+        do: [~s(<span class="badge tol">tol Δ#{c.tol.threshold}/#{c.tol.budget}</span>)],
+        else: []
+
+    triage = if c.triage, do: [~s(<span class="badge triage">quarantined</span>)], else: []
+
+    Enum.join(base ++ tol ++ triage, " ")
+  end
+
+  defp triage(%{triage: nil}), do: ""
+
+  defp triage(%{triage: %{reason: reason, issue: issue}}) do
+    n = String.trim_leading(issue, "#")
+
+    ~s(<p class="triage-note">⚠ quarantined: #{esc(reason)} — <a href="#{@issue_base}#{esc(n)}">#{esc(issue)}</a></p>)
+  end
+
+  defp drift_banner(%{hash_drift?: true}),
+    do:
+      ~s(<p class="banner drift">authored fields changed since generation — run <code>mix imgproxy.reauthor</code> or regenerate.</p>)
+
+  defp drift_banner(_), do: ""
+
+  defp metric_class(c) do
+    if c.status in [:pass, :diverges_ok, :contract_ok], do: "ok", else: "bad"
+  end
+
+  defp visuals(%{group: :lossy} = c) do
+    """
+    <div class="lossy-only">
+      <figure><img src="#{c.pipe_img}" alt="ImagePipe #{esc(c.id)}"><figcaption>ImagePipe (no imgproxy reference — contract only)</figcaption></figure>
+    </div>
+    """
+  end
+
+  defp visuals(%{status: :dims_mismatch} = c) do
+    side_by_side(c)
+  end
+
+  defp visuals(c) do
+    """
+    #{side_by_side(c)}
+    <div class="slider">
+      <img-comparison-slider>
+        <img slot="first" src="#{c.imgproxy_img}" alt="imgproxy">
+        <img slot="second" src="#{c.pipe_img}" alt="ImagePipe">
+      </img-comparison-slider>
+    </div>
+    <div class="heatmaps">
+      <figure class="heat-banded"><img src="#{c.heat_banded}" alt="banded diff"><figcaption>banded (Δ#{heat_threshold(c)})</figcaption></figure>
+      <figure class="heat-raw"><img src="#{c.heat_raw}" alt="raw diff"><figcaption>raw ×8</figcaption></figure>
+    </div>
+    """
+  end
+
+  defp heat_threshold(%{tol: %{threshold: t}}), do: t
+  defp heat_threshold(_), do: 2
+
+  defp side_by_side(c) do
+    """
+    <div class="pair">
+      <figure><img src="#{c.imgproxy_img}" alt="imgproxy"><figcaption>imgproxy #{fmt(c.fixture_dims)}</figcaption></figure>
+      <figure><img src="#{c.pipe_img}" alt="ImagePipe"><figcaption>ImagePipe #{fmt(c.pipe_dims)}</figcaption></figure>
+    </div>
+    """
+  end
+
+  defp fmt(nil), do: ""
+  defp fmt({w, h}), do: "#{w}×#{h}"
+
+  defp esc(value) do
+    value
+    |> to_string()
+    |> String.replace("&", "&amp;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
+    |> String.replace("\"", "&quot;")
+  end
+
+  defp script do
+    """
+    <script>
+    (function () {
+      var body = document.body;
+      function bind(attr, setAttr) {
+        document.querySelectorAll("[" + setAttr + "]").forEach(function (btn) {
+          btn.addEventListener("click", function () {
+            body.setAttribute(attr, btn.getAttribute(setAttr));
+          });
+        });
+      }
+      bind("data-heat", "data-heat-set");
+      bind("data-filter", "data-filter-set");
+    })();
+    </script>
+    """
+  end
+
+  defp css do
+    """
+    :root {
+      color-scheme: dark;
+      --surface-app:#0b0d10; --surface-bar:#0d1015; --surface-control:#202733;
+      --border-subtle:#242b36; --text-primary:#f6f1e7; --text-muted:#8fa0b3;
+      --accent:#ffb84d; --danger:#ff6b6b; --checker-square:#1b222b;
+      --image-shadow:0 22px 80px rgb(0 0 0 / 38%);
+    }
+    @media (prefers-color-scheme: light) {
+      :root {
+        color-scheme: light;
+        --surface-app:#f4f6f8; --surface-bar:#fff; --surface-control:#eef2f7;
+        --border-subtle:#d9e0ea; --text-primary:#11151b; --text-muted:#687586;
+        --accent:#d48100; --danger:#c62828; --checker-square:#dfe5ee;
+        --image-shadow:0 22px 80px rgb(10 16 24 / 18%);
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin:0; background:var(--surface-app); color:var(--text-primary);
+      font-family:"Geist",ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;
+    }
+    code, .url, .metric { font-family:"Geist Mono",ui-monospace,"SFMono-Regular","Menlo",monospace; }
+    .report-header { position:sticky; top:0; z-index:2; padding:16px 24px;
+      background:var(--surface-bar); border-bottom:1px solid var(--border-subtle); }
+    .report-header h1 { margin:0 0 6px; font-size:18px; }
+    .provenance, .counts { margin:4px 0; color:var(--text-muted); font-size:12px; }
+    .counts { color:var(--text-primary); font-weight:600; }
+    .banner { margin:8px 0; padding:8px 10px; border-radius:6px; font-size:12px; }
+    .banner.skew { background:color-mix(in srgb, var(--accent) 18%, transparent); }
+    .banner.drift { background:color-mix(in srgb, var(--danger) 18%, transparent); }
+    .controls { display:flex; gap:18px; flex-wrap:wrap; margin-top:10px; }
+    .control-group { font-size:12px; color:var(--text-muted); }
+    .controls button { margin-left:4px; padding:3px 8px; border:1px solid var(--border-subtle);
+      background:var(--surface-control); color:var(--text-primary); border-radius:5px; cursor:pointer; }
+    .cards { padding:24px; display:flex; flex-direction:column; gap:24px; }
+    .card { background:var(--surface-bar); border:1px solid var(--border-subtle);
+      border-radius:10px; padding:16px; }
+    .card.attention { border-color:var(--danger); }
+    .card-head { display:flex; align-items:center; gap:10px; flex-wrap:wrap; }
+    .card-head h2 { margin:0; font-size:15px; }
+    .badge { font-size:11px; padding:2px 7px; border-radius:999px;
+      background:var(--surface-control); color:var(--text-muted); }
+    .badge.triage { background:color-mix(in srgb, var(--danger) 25%, transparent); color:var(--text-primary); }
+    .summary { margin:8px 0 2px; }
+    .url { margin:0 0 8px; color:var(--text-muted); font-size:12px; word-break:break-all; }
+    .triage-note { font-size:12px; color:var(--text-primary); margin:6px 0; }
+    .metric { font-weight:600; }
+    .metric.ok { color:var(--accent); }
+    .metric.bad { color:var(--danger); }
+    .pair, .heatmaps { display:grid; grid-template-columns:1fr 1fr; gap:12px; margin-top:12px; }
+    .lossy-only { margin-top:12px; max-width:420px; }
+    figure { margin:0; }
+    figure img, .slider img, .slider img-comparison-slider {
+      max-width:100%; display:block; border-radius:6px;
+      background:repeating-conic-gradient(var(--checker-square) 0 25%, transparent 0 50%) 50% / 20px 20px;
+    }
+    figcaption { font-size:11px; color:var(--text-muted); margin-top:4px; }
+    .slider { margin-top:12px; max-width:520px; box-shadow:var(--image-shadow); border-radius:6px; }
+    body[data-heat="banded"] .heat-raw { display:none; }
+    body[data-heat="raw"] .heat-banded { display:none; }
+    body[data-heat="banded"] .heatmaps, body[data-heat="raw"] .heatmaps { grid-template-columns:1fr; max-width:420px; }
+    body[data-filter="attention"] .card:not(.attention) { display:none; }
+    body[data-filter="transform"] .card:not(.group-transform) { display:none; }
+    body[data-filter="diverges"] .card:not(.group-diverges) { display:none; }
+    body[data-filter="lossy"] .card:not(.group-lossy) { display:none; }
+    """
+  end
+end

--- a/test/support/image_pipe/test/imgproxy_differential/report_html.ex
+++ b/test/support/image_pipe/test/imgproxy_differential/report_html.ex
@@ -17,7 +17,7 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
 
   @spec render(%{provenance: map(), cards: [map()]}) :: String.t()
   def render(%{provenance: prov, cards: cards}) do
-    ordered = Enum.sort_by(cards, fn c -> if(c.attention?, do: 0, else: 1) end)
+    ordered = Enum.sort_by(cards, fn c -> if(c.flagged?, do: 0, else: 1) end)
 
     """
     <!doctype html>
@@ -67,7 +67,7 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
         <span class="control-group" role="group" aria-label="status filter">
           status:
           <button data-status-set="all">all</button>
-          <button data-status-set="attention">attention</button>
+          <button data-status-set="flagged">flagged</button>
           <button data-status-set="failing">failing</button>
           <button data-status-set="quarantined">quarantined</button>
         </span>
@@ -75,7 +75,7 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
           type:
           <button data-type-set="all">all</button>
           <button data-type-set="transform">transform</button>
-          <button data-type-set="diverges">diverges</button>
+          <button data-type-set="known_divergence">known divergence</button>
           <button data-type-set="lossy">lossy</button>
         </span>
       </div>
@@ -85,27 +85,27 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
 
   defp counts(cards) do
     by_group = Enum.frequencies_by(cards, & &1.group)
-    attention = Enum.count(cards, & &1.attention?)
+    flagged = Enum.count(cards, & &1.flagged?)
     failing = Enum.count(cards, & &1.failing?)
     quarantined = Enum.count(cards, &(&1.triage != nil))
     drift = Enum.count(cards, & &1.hash_drift?)
 
     "#{Map.get(by_group, :transform, 0)} transform · " <>
-      "#{Map.get(by_group, :diverges, 0)} diverges · " <>
+      "#{Map.get(by_group, :known_divergence, 0)} known divergence · " <>
       "#{Map.get(by_group, :lossy, 0)} lossy — " <>
-      "#{attention} attention · #{failing} failing · " <>
+      "#{flagged} flagged · #{failing} failing · " <>
       "#{quarantined} quarantined · #{drift} hash-drift"
   end
 
   defp card(c) do
     classes =
       ["card", "group-#{c.group}", "status-#{c.status}"] ++
-        if(c.attention?, do: ["attention"], else: []) ++
+        if(c.flagged?, do: ["flagged"], else: []) ++
         if(c.failing?, do: ["failing"], else: []) ++
         if(c.triage, do: ["quarantined"], else: [])
 
     """
-    <section id="#{esc(c.id)}" class="#{Enum.join(classes, " ")}" data-group="#{c.group}" data-attention="#{c.attention?}">
+    <section id="#{esc(c.id)}" class="#{Enum.join(classes, " ")}" data-group="#{c.group}">
       <div class="card-head">
         <h2>#{esc(c.id)}</h2>
         #{badges(c)}
@@ -266,7 +266,7 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
     .cards { padding:24px; display:flex; flex-direction:column; gap:24px; }
     .card { background:var(--surface-bar); border:1px solid var(--border-subtle);
       border-radius:10px; padding:16px; }
-    .card.attention { border-color:var(--danger); }
+    .card.flagged { border-color:var(--danger); }
     .card-head { display:flex; align-items:center; gap:10px; flex-wrap:wrap; }
     .card-head h2 { margin:0; font-size:15px; }
     .badge { font-size:11px; padding:2px 7px; border-radius:999px;
@@ -297,11 +297,11 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ReportHtml do
     body[data-heat="normalized"] .heat-banded, body[data-heat="normalized"] .heat-raw { display:none; }
     /* status and type are independent axes — a card hidden by either stays hidden,
        so the two filters intersect (e.g. status=failing + type=transform) */
-    body[data-status="attention"] .card:not(.attention) { display:none; }
+    body[data-status="flagged"] .card:not(.flagged) { display:none; }
     body[data-status="failing"] .card:not(.failing) { display:none; }
     body[data-status="quarantined"] .card:not(.quarantined) { display:none; }
     body[data-type="transform"] .card:not(.group-transform) { display:none; }
-    body[data-type="diverges"] .card:not(.group-diverges) { display:none; }
+    body[data-type="known_divergence"] .card:not(.group-known_divergence) { display:none; }
     body[data-type="lossy"] .card:not(.group-lossy) { display:none; }
     """
   end

--- a/test/support/mix/tasks/imgproxy.gen_report.ex
+++ b/test/support/mix/tasks/imgproxy.gen_report.ex
@@ -17,20 +17,21 @@ defmodule Mix.Tasks.Imgproxy.GenReport do
   import Plug.Test, only: [conn: 2]
 
   alias ImagePipe.SourceTest.RootHTTPAdapter
-  alias ImagePipe.Test.ImgproxyDifferential.{Constellations, Manifest}
+  alias ImagePipe.Test.ImgproxyDifferential.{Constellations, Manifest, OptsSummary, PixelCompare}
 
   @base "test/support/image_pipe/test/imgproxy_differential"
   @sources_dir "#{@base}/sources"
+  @fixtures_dir "#{@base}/fixtures"
   @manifest_path "#{@base}/manifest.exs"
   @default_out "#{@base}/report.html"
+  @default_tol %{threshold: 2, budget: 64}
 
   @impl Mix.Task
   def run(args) do
     {opts, _, _} = OptionParser.parse(args, strict: [out: :string])
     out = Keyword.get(opts, :out, @default_out)
 
-    {:ok, _} = Application.ensure_all_started(:image)
-    {:ok, _} = Application.ensure_all_started(:req)
+    {:ok, _} = Application.ensure_all_started(:image_pipe)
 
     manifest = Manifest.load!(@manifest_path)
     plug_opts = plug_opts()
@@ -43,16 +44,106 @@ defmodule Mix.Tasks.Imgproxy.GenReport do
 
   # Throwaway placeholder body — replaced by the real HTML renderer in a later task.
   defp stub_html(cards) do
-    body = Enum.map_join(cards, "\n", fn c -> ~s(<div id="#{c.id}">#{c.id}</div>) end)
+    body =
+      Enum.map_join(cards, "\n", fn c ->
+        ~s(<div id="#{c.id}">#{c.id} — #{c.status} — #{c.metric_text}</div>)
+      end)
+
     "<!doctype html><meta charset=\"utf-8\"><body>#{body}</body>"
   end
 
-  # Card assembly stub — fleshed out in later tasks. For now just render the pipe
-  # output so the end-to-end render path is exercised.
-  defp build_card(c, _manifest, plug_opts) do
-    {_body, _ct} = render(c, plug_opts)
-    %{id: c.id}
+  defp build_card(c, manifest, plug_opts) do
+    entry = Map.fetch!(manifest.entries, c.id)
+    {body, content_type} = render(c, plug_opts)
+    pipe = Image.open!(body, access: :random, fail_on: :error)
+
+    %{
+      id: c.id,
+      group: display_group(c),
+      verdict: c.verdict,
+      url: Constellations.imgproxy_path(c),
+      summary: OptsSummary.describe(c.opts),
+      triage: c.triage,
+      tol: c.tol,
+      hash_drift?: Manifest.authored_sha256(c) != entry.authored_sha256,
+      pipe_dims: dims(pipe)
+    }
+    |> Map.merge(group_fields(c, entry, pipe, content_type))
+    |> finalize_attention()
   end
+
+  # The `:diverges` constellation is stored as `group: :transform, verdict:
+  # :diverges` (it IS a fixture pixel comparison). For the report's display
+  # category/filter/counts it's its own bucket; the metric dispatch below still
+  # uses the constellation's real `group`/`verdict`, so this is display-only.
+  defp display_group(%{verdict: :diverges}), do: :diverges
+  defp display_group(%{group: group}), do: group
+
+  # transform / :diverges: compare against the committed fixture image.
+  defp group_fields(%{group: :transform} = c, entry, pipe, _content_type) do
+    fixture = fixture_image(entry)
+    fixture_dims = dims(fixture)
+
+    if fixture_dims != dims(pipe) do
+      %{
+        fixture_dims: fixture_dims,
+        status: :dims_mismatch,
+        metric_text: "dims #{fmt_dims(dims(pipe))} ≠ imgproxy #{fmt_dims(fixture_dims)}"
+      }
+    else
+      Map.put(metric_fields(c, pipe, fixture), :fixture_dims, fixture_dims)
+    end
+  end
+
+  defp group_fields(%{group: :lossy}, entry, pipe, content_type) do
+    ok? = dims(pipe) == {entry.width, entry.height} and content_type == entry.content_type
+
+    %{
+      fixture_dims: nil,
+      status: if(ok?, do: :contract_ok, else: :contract_mismatch),
+      metric_text:
+        "dims #{fmt_dims(dims(pipe))} (expected #{fmt_dims({entry.width, entry.height})}); " <>
+          "type #{inspect(content_type)} (expected #{inspect(entry.content_type)})"
+    }
+  end
+
+  defp metric_fields(%{verdict: :diverges} = c, pipe, fixture) do
+    %{metric: :fraction_over, threshold: threshold, floor: floor} = c.divergence
+    frac = PixelCompare.fraction_over(pipe, fixture, threshold)
+
+    %{
+      status: if(frac >= floor, do: :diverges_ok, else: :diverges_below_floor),
+      metric_text: "#{Float.round(frac, 4)} fraction over Δ#{threshold} (floor #{floor})"
+    }
+  end
+
+  defp metric_fields(%{verdict: :equal} = c, pipe, fixture) do
+    tol = c.tol || @default_tol
+    outliers = PixelCompare.outliers(pipe, fixture, tol.threshold)
+
+    %{
+      status: if(outliers <= tol.budget, do: :pass, else: :over_budget),
+      metric_text: "#{outliers} band-bytes over Δ#{tol.threshold} (budget #{tol.budget})"
+    }
+  end
+
+  defp finalize_attention(card) do
+    attention? =
+      card.hash_drift? or
+        card.status in [:over_budget, :diverges_below_floor, :dims_mismatch, :contract_mismatch]
+
+    Map.put(card, :attention?, attention?)
+  end
+
+  defp fixture_image(entry) do
+    Image.open!(File.read!(Path.join(@fixtures_dir, entry.fixture_filename)),
+      access: :random,
+      fail_on: :error
+    )
+  end
+
+  defp dims(image), do: {Image.width(image), Image.height(image)}
+  defp fmt_dims({w, h}), do: "#{w}×#{h}"
 
   defp render(c, plug_opts) do
     conn =

--- a/test/support/mix/tasks/imgproxy.gen_report.ex
+++ b/test/support/mix/tasks/imgproxy.gen_report.ex
@@ -147,11 +147,16 @@ defmodule Mix.Tasks.Imgproxy.GenReport do
   end
 
   defp finalize_attention(card) do
-    attention? =
+    failure? =
       card.hash_drift? or
         card.status in [:over_budget, :diverges_below_floor, :dims_mismatch, :contract_mismatch]
 
-    Map.put(card, :attention?, attention?)
+    # `failing?` is the stricter "would the default `mix test` lane go red" subset:
+    # a quarantined (`:triage`) case is excluded from the lane, so it counts as
+    # attention (noteworthy) but not failing.
+    card
+    |> Map.put(:attention?, failure?)
+    |> Map.put(:failing?, failure? and is_nil(card.triage))
   end
 
   # Attach base64 data URIs. Images are displayed from ORIGINAL bytes (no
@@ -162,7 +167,8 @@ defmodule Mix.Tasks.Imgproxy.GenReport do
       imgproxy_img: nil,
       pipe_img: data_uri(content_type, body),
       heat_banded: nil,
-      heat_raw: nil
+      heat_raw: nil,
+      heat_normalized: nil
     })
   end
 
@@ -172,7 +178,8 @@ defmodule Mix.Tasks.Imgproxy.GenReport do
         data_uri("image/png", File.read!(Path.join(@fixtures_dir, entry.fixture_filename))),
       pipe_img: data_uri(content_type, body),
       heat_banded: nil,
-      heat_raw: nil
+      heat_raw: nil,
+      heat_normalized: nil
     })
   end
 
@@ -187,7 +194,8 @@ defmodule Mix.Tasks.Imgproxy.GenReport do
         data_uri("image/png", File.read!(Path.join(@fixtures_dir, entry.fixture_filename))),
       pipe_img: data_uri(content_type, body),
       heat_banded: data_uri("image/png", png(banded_heatmap(a, b, threshold))),
-      heat_raw: data_uri("image/png", png(raw_heatmap(a, b)))
+      heat_raw: data_uri("image/png", png(raw_heatmap(a, b))),
+      heat_normalized: data_uri("image/png", png(normalized_heatmap(a, b)))
     })
   end
 
@@ -220,6 +228,18 @@ defmodule Mix.Tasks.Imgproxy.GenReport do
     delta = abs_diff(a, b)
     amped = ok!(Operation.linear(delta, [@raw_amp * 1.0], [0.0]))
     ok!(Operation.cast(amped, :VIPS_FORMAT_UCHAR))
+  end
+
+  # Normalized: per-pixel max |Δ| contrast-stretched to THIS frame's own peak
+  # (`Operation.scale` maps min→0, max→255), so a diffuse, low-magnitude divergence
+  # (e.g. the scp0 colorspace case) fills the dynamic range and is visible where the
+  # banded/raw maps render near-black. Magnitudes are NOT comparable across cards —
+  # each is self-scaled. `scale` is safe on an all-equal frame (no divide-by-zero).
+  defp normalized_heatmap(a, b) do
+    delta = abs_diff(a, b)
+    maxd = band_max(delta)
+    idx = ok!(Operation.cast(ok!(Operation.scale(maxd)), :VIPS_FORMAT_UCHAR))
+    ok!(Operation.maplut(idx, heat_lut(0)))
   end
 
   # subtract promotes uchar→signed short (no wrap); abs makes it non-negative.

--- a/test/support/mix/tasks/imgproxy.gen_report.ex
+++ b/test/support/mix/tasks/imgproxy.gen_report.ex
@@ -7,9 +7,10 @@ defmodule Mix.Tasks.Imgproxy.GenReport do
   imgproxy fixtures are already committed and ImagePipe renders are live. A DX /
   inspection tool only: it touches no fixtures, manifest, or the `mix test` lane.
 
-      MIX_ENV=test mise exec -- mix imgproxy.gen_report [--out PATH]
+      mise exec -- mix imgproxy.gen_report [--out PATH]
 
-  `--out` defaults to `report.html` beside the harness (gitignored).
+  Auto-selects `MIX_ENV=test` via `mix.exs` `preferred_envs` (the task lives in
+  `test/support`). `--out` defaults to `report.html` beside the harness (gitignored).
   """
   use Mix.Task
   use Boundary, top_level?: true, check: [out: false]

--- a/test/support/mix/tasks/imgproxy.gen_report.ex
+++ b/test/support/mix/tasks/imgproxy.gen_report.ex
@@ -86,16 +86,17 @@ defmodule Mix.Tasks.Imgproxy.GenReport do
         pipe_dims: dims(pipe)
       }
       |> Map.merge(group_fields(c, entry, pipe, content_type))
-      |> finalize_attention()
+      |> finalize_flags()
 
     attach_images(card, body, content_type, pipe, entry)
   end
 
   # The `:diverges` constellation is stored as `group: :transform, verdict:
   # :diverges` (it IS a fixture pixel comparison). For the report's display
-  # category/filter/counts it's its own bucket; the metric dispatch below still
-  # uses the constellation's real `group`/`verdict`, so this is display-only.
-  defp display_group(%{verdict: :diverges}), do: :diverges
+  # category/filter/counts it's its own `:known_divergence` bucket; the metric
+  # dispatch below still uses the constellation's real `group`/`verdict`, so this
+  # is display-only.
+  defp display_group(%{verdict: :diverges}), do: :known_divergence
   defp display_group(%{group: group}), do: group
 
   # transform / :diverges: compare against the committed fixture image.
@@ -146,16 +147,16 @@ defmodule Mix.Tasks.Imgproxy.GenReport do
     }
   end
 
-  defp finalize_attention(card) do
+  defp finalize_flags(card) do
     failure? =
       card.hash_drift? or
         card.status in [:over_budget, :diverges_below_floor, :dims_mismatch, :contract_mismatch]
 
-    # `failing?` is the stricter "would the default `mix test` lane go red" subset:
-    # a quarantined (`:triage`) case is excluded from the lane, so it counts as
-    # attention (noteworthy) but not failing.
+    # `flagged?` is anything noteworthy (a divergence, quarantined or not). `failing?`
+    # is the stricter "would the default `mix test` lane go red" subset: a quarantined
+    # (`:triage`) case is excluded from the lane, so it is flagged but not failing.
     card
-    |> Map.put(:attention?, failure?)
+    |> Map.put(:flagged?, failure?)
     |> Map.put(:failing?, failure? and is_nil(card.triage))
   end
 

--- a/test/support/mix/tasks/imgproxy.gen_report.ex
+++ b/test/support/mix/tasks/imgproxy.gen_report.ex
@@ -18,6 +18,8 @@ defmodule Mix.Tasks.Imgproxy.GenReport do
 
   alias ImagePipe.SourceTest.RootHTTPAdapter
   alias ImagePipe.Test.ImgproxyDifferential.{Constellations, Manifest, OptsSummary, PixelCompare}
+  alias Vix.Vips.Image, as: VixImage
+  alias Vix.Vips.Operation
 
   @base "test/support/image_pipe/test/imgproxy_differential"
   @sources_dir "#{@base}/sources"
@@ -25,6 +27,7 @@ defmodule Mix.Tasks.Imgproxy.GenReport do
   @manifest_path "#{@base}/manifest.exs"
   @default_out "#{@base}/report.html"
   @default_tol %{threshold: 2, budget: 64}
+  @raw_amp 8
 
   @impl Mix.Task
   def run(args) do
@@ -46,7 +49,12 @@ defmodule Mix.Tasks.Imgproxy.GenReport do
   defp stub_html(cards) do
     body =
       Enum.map_join(cards, "\n", fn c ->
-        ~s(<div id="#{c.id}">#{c.id} — #{c.status} — #{c.metric_text}</div>)
+        imgs =
+          [c.imgproxy_img, c.pipe_img, c.heat_banded, c.heat_raw]
+          |> Enum.reject(&is_nil/1)
+          |> Enum.map_join("", fn uri -> ~s(<img src="#{uri}">) end)
+
+        ~s(<div id="#{c.id}">#{c.id} — #{c.status} — #{c.metric_text}#{imgs}</div>)
       end)
 
     "<!doctype html><meta charset=\"utf-8\"><body>#{body}</body>"
@@ -57,19 +65,22 @@ defmodule Mix.Tasks.Imgproxy.GenReport do
     {body, content_type} = render(c, plug_opts)
     pipe = Image.open!(body, access: :random, fail_on: :error)
 
-    %{
-      id: c.id,
-      group: display_group(c),
-      verdict: c.verdict,
-      url: Constellations.imgproxy_path(c),
-      summary: OptsSummary.describe(c.opts),
-      triage: c.triage,
-      tol: c.tol,
-      hash_drift?: Manifest.authored_sha256(c) != entry.authored_sha256,
-      pipe_dims: dims(pipe)
-    }
-    |> Map.merge(group_fields(c, entry, pipe, content_type))
-    |> finalize_attention()
+    card =
+      %{
+        id: c.id,
+        group: display_group(c),
+        verdict: c.verdict,
+        url: Constellations.imgproxy_path(c),
+        summary: OptsSummary.describe(c.opts),
+        triage: c.triage,
+        tol: c.tol,
+        hash_drift?: Manifest.authored_sha256(c) != entry.authored_sha256,
+        pipe_dims: dims(pipe)
+      }
+      |> Map.merge(group_fields(c, entry, pipe, content_type))
+      |> finalize_attention()
+
+    attach_images(card, body, content_type, pipe, entry)
   end
 
   # The `:diverges` constellation is stored as `group: :transform, verdict:
@@ -134,6 +145,102 @@ defmodule Mix.Tasks.Imgproxy.GenReport do
 
     Map.put(card, :attention?, attention?)
   end
+
+  # Attach base64 data URIs. Images are displayed from ORIGINAL bytes (no
+  # re-encode): the imgproxy fixture from its on-disk PNG, the pipe render from
+  # the response body. Decoded images feed the diff/heatmaps only.
+  defp attach_images(%{group: :lossy} = card, body, content_type, _pipe, _entry) do
+    Map.merge(card, %{
+      imgproxy_img: nil,
+      pipe_img: data_uri(content_type, body),
+      heat_banded: nil,
+      heat_raw: nil
+    })
+  end
+
+  defp attach_images(%{status: :dims_mismatch} = card, body, content_type, _pipe, entry) do
+    Map.merge(card, %{
+      imgproxy_img:
+        data_uri("image/png", File.read!(Path.join(@fixtures_dir, entry.fixture_filename))),
+      pipe_img: data_uri(content_type, body),
+      heat_banded: nil,
+      heat_raw: nil
+    })
+  end
+
+  defp attach_images(card, body, content_type, pipe, entry) do
+    fixture = fixture_image(entry)
+    a = to_rgb(fixture)
+    b = to_rgb(pipe)
+    threshold = (card.tol || @default_tol).threshold
+
+    Map.merge(card, %{
+      imgproxy_img:
+        data_uri("image/png", File.read!(Path.join(@fixtures_dir, entry.fixture_filename))),
+      pipe_img: data_uri(content_type, body),
+      heat_banded: data_uri("image/png", png(banded_heatmap(a, b, threshold))),
+      heat_raw: data_uri("image/png", png(raw_heatmap(a, b)))
+    })
+  end
+
+  defp data_uri(content_type, bytes), do: "data:#{content_type};base64,#{Base.encode64(bytes)}"
+
+  defp png(image), do: Image.write!(image, :memory, suffix: ".png")
+
+  # Align to a common 3-band RGB frame so the diff never raises on band-count
+  # mismatch (RGB vs RGBA, e.g. alpha_resize / background_alpha). Visualizes RGB
+  # deltas; the verdict metric (PixelCompare) still counts all bands incl. alpha.
+  defp to_rgb(image) do
+    case Image.bands(image) do
+      3 -> image
+      n when n > 3 -> ok!(Operation.extract_band(image, 0, n: 3))
+      _ -> image
+    end
+  end
+
+  # Banded: per-pixel max |Δ| across RGB → 256-entry LUT that dims pixels at/under
+  # the case's own threshold and ramps over-threshold pixels hot.
+  defp banded_heatmap(a, b, threshold) do
+    delta = abs_diff(a, b)
+    maxd = band_max(delta)
+    idx = ok!(Operation.cast(maxd, :VIPS_FORMAT_UCHAR))
+    ok!(Operation.maplut(idx, heat_lut(threshold)))
+  end
+
+  # Raw: |Δ| amplified for visibility, clamped to uchar (no threshold).
+  defp raw_heatmap(a, b) do
+    delta = abs_diff(a, b)
+    amped = ok!(Operation.linear(delta, [@raw_amp * 1.0], [0.0]))
+    ok!(Operation.cast(amped, :VIPS_FORMAT_UCHAR))
+  end
+
+  # subtract promotes uchar→signed short (no wrap); abs makes it non-negative.
+  defp abs_diff(a, b), do: ok!(Operation.abs(ok!(Operation.subtract(a, b))))
+
+  defp band_max(delta) do
+    b0 = ok!(Operation.extract_band(delta, 0))
+    b1 = ok!(Operation.extract_band(delta, 1))
+    b2 = ok!(Operation.extract_band(delta, 2))
+    ok!(Operation.maxpair(ok!(Operation.maxpair(b0, b1)), b2))
+  end
+
+  # 256×1 3-band uchar LUT: indices ≤ threshold → dim; above → cool→hot ramp.
+  defp heat_lut(threshold) do
+    bin =
+      for i <- 0..255, into: <<>> do
+        if i <= threshold do
+          <<24, 24, 28>>
+        else
+          t = (i - threshold) / max(255 - threshold, 1)
+          <<round(60 + t * 195), round(20 + t * 60), round(40 - t * 40)>>
+        end
+      end
+
+    ok!(VixImage.new_from_binary(bin, 256, 1, 3, :VIPS_FORMAT_UCHAR))
+  end
+
+  defp ok!({:ok, value}), do: value
+  defp ok!({:error, reason}), do: raise("vips operation failed: #{inspect(reason)}")
 
   defp fixture_image(entry) do
     Image.open!(File.read!(Path.join(@fixtures_dir, entry.fixture_filename)),

--- a/test/support/mix/tasks/imgproxy.gen_report.ex
+++ b/test/support/mix/tasks/imgproxy.gen_report.ex
@@ -17,7 +17,16 @@ defmodule Mix.Tasks.Imgproxy.GenReport do
   import Plug.Test, only: [conn: 2]
 
   alias ImagePipe.SourceTest.RootHTTPAdapter
-  alias ImagePipe.Test.ImgproxyDifferential.{Constellations, Manifest, OptsSummary, PixelCompare}
+
+  alias ImagePipe.Test.ImgproxyDifferential.{
+    Constellations,
+    Manifest,
+    OptsSummary,
+    PixelCompare,
+    ReportHtml,
+    Skew
+  }
+
   alias Vix.Vips.Image, as: VixImage
   alias Vix.Vips.Operation
 
@@ -41,23 +50,21 @@ defmodule Mix.Tasks.Imgproxy.GenReport do
 
     cards = Enum.map(Constellations.all(), fn c -> build_card(c, manifest, plug_opts) end)
 
-    File.write!(out, stub_html(cards))
+    doc = %{provenance: provenance(manifest), cards: cards}
+    File.write!(out, ReportHtml.render(doc))
     Mix.shell().info("Wrote visual-diff report (#{length(cards)} cards) to #{Path.expand(out)}")
   end
 
-  # Throwaway placeholder body — replaced by the real HTML renderer in a later task.
-  defp stub_html(cards) do
-    body =
-      Enum.map_join(cards, "\n", fn c ->
-        imgs =
-          [c.imgproxy_img, c.pipe_img, c.heat_banded, c.heat_raw]
-          |> Enum.reject(&is_nil/1)
-          |> Enum.map_join("", fn uri -> ~s(<img src="#{uri}">) end)
+  defp provenance(manifest) do
+    runtime = Skew.runtime_libvips()
 
-        ~s(<div id="#{c.id}">#{c.id} — #{c.status} — #{c.metric_text}#{imgs}</div>)
-      end)
-
-    "<!doctype html><meta charset=\"utf-8\"><body>#{body}</body>"
+    %{
+      imgproxy_digest: manifest.imgproxy_digest,
+      imgproxy_libvips: manifest.imgproxy_libvips,
+      pipe_libvips_at_gen: manifest.pipe_libvips_at_gen,
+      runtime_libvips: runtime,
+      skew?: not Skew.aligned?(manifest)
+    }
   end
 
   defp build_card(c, manifest, plug_opts) do

--- a/test/support/mix/tasks/imgproxy.gen_report.ex
+++ b/test/support/mix/tasks/imgproxy.gen_report.ex
@@ -1,0 +1,101 @@
+defmodule Mix.Tasks.Imgproxy.GenReport do
+  @shortdoc "Generate a self-contained visual-diff HTML report for the imgproxy differential suite"
+  @moduledoc """
+  Renders ImagePipe live for every constellation in `constellations.ex`, compares
+  against the committed imgproxy fixtures, and writes a single self-contained
+  `report.html` (images base64-inlined, slider + fonts from CDN). No Docker — the
+  imgproxy fixtures are already committed and ImagePipe renders are live. A DX /
+  inspection tool only: it touches no fixtures, manifest, or the `mix test` lane.
+
+      MIX_ENV=test mise exec -- mix imgproxy.gen_report [--out PATH]
+
+  `--out` defaults to `report.html` beside the harness (gitignored).
+  """
+  use Mix.Task
+  use Boundary, top_level?: true, check: [out: false]
+
+  import Plug.Test, only: [conn: 2]
+
+  alias ImagePipe.SourceTest.RootHTTPAdapter
+  alias ImagePipe.Test.ImgproxyDifferential.{Constellations, Manifest}
+
+  @base "test/support/image_pipe/test/imgproxy_differential"
+  @sources_dir "#{@base}/sources"
+  @manifest_path "#{@base}/manifest.exs"
+  @default_out "#{@base}/report.html"
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _, _} = OptionParser.parse(args, strict: [out: :string])
+    out = Keyword.get(opts, :out, @default_out)
+
+    {:ok, _} = Application.ensure_all_started(:image)
+    {:ok, _} = Application.ensure_all_started(:req)
+
+    manifest = Manifest.load!(@manifest_path)
+    plug_opts = plug_opts()
+
+    cards = Enum.map(Constellations.all(), fn c -> build_card(c, manifest, plug_opts) end)
+
+    File.write!(out, stub_html(cards))
+    Mix.shell().info("Wrote visual-diff report (#{length(cards)} cards) to #{Path.expand(out)}")
+  end
+
+  # Throwaway placeholder body — replaced by the real HTML renderer in a later task.
+  defp stub_html(cards) do
+    body = Enum.map_join(cards, "\n", fn c -> ~s(<div id="#{c.id}">#{c.id}</div>) end)
+    "<!doctype html><meta charset=\"utf-8\"><body>#{body}</body>"
+  end
+
+  # Card assembly stub — fleshed out in later tasks. For now just render the pipe
+  # output so the end-to-end render path is exercised.
+  defp build_card(c, _manifest, plug_opts) do
+    {_body, _ct} = render(c, plug_opts)
+    %{id: c.id}
+  end
+
+  defp render(c, plug_opts) do
+    conn =
+      :get
+      |> conn(Constellations.imgproxy_path(c))
+      |> ImagePipe.Plug.call(plug_opts)
+
+    content_type =
+      conn
+      |> Plug.Conn.get_resp_header("content-type")
+      |> List.first()
+      |> then(fn ct -> ct && ct |> String.split(";") |> List.first() end)
+
+    {conn.resp_body, content_type}
+  end
+
+  defp plug_opts do
+    ImagePipe.Plug.init(
+      parser: ImagePipe.Parser.Imgproxy,
+      sources: [
+        path:
+          {RootHTTPAdapter, root_url: "http://origin.test", req_options: [plug: &source_plug/1]}
+      ]
+    )
+  end
+
+  # Function plug mirroring the conformance test's inline SourceOrigin: serve the
+  # committed source bytes for the requested basename. RootHTTPAdapter forwards
+  # `req_options` straight into Req.get, so a function plug wires identically to
+  # the test's module plug.
+  defp source_plug(conn) do
+    file = Path.basename(conn.request_path)
+
+    conn
+    |> Plug.Conn.put_resp_content_type(content_type(file))
+    |> Plug.Conn.send_resp(200, File.read!(Path.join(@sources_dir, file)))
+  end
+
+  defp content_type(file) do
+    case Path.extname(file) do
+      ".jpg" -> "image/jpeg"
+      ".webp" -> "image/webp"
+      _ -> "image/png"
+    end
+  end
+end

--- a/test/support/mix/tasks/imgproxy.gen_sources.ex
+++ b/test/support/mix/tasks/imgproxy.gen_sources.ex
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.Imgproxy.GenSources do
   the outputs. Regenerating sources is a deliberate act (a libvips bump must not
   silently change inputs).
 
-      MIX_ENV=test mise exec -- mix imgproxy.gen_sources
+      mise exec -- mix imgproxy.gen_sources
   """
   use Mix.Task
   use Boundary, top_level?: true, check: [out: false]

--- a/test/support/mix/tasks/imgproxy.reauthor.ex
+++ b/test/support/mix/tasks/imgproxy.reauthor.ex
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.Imgproxy.Reauthor do
   and rewrites the manifest, leaving fixtures and REPORT untouched. Use after a
   `tol` tweak or a `:diverges`→`:equal` verdict flip (no pixels change).
 
-      MIX_ENV=test mise exec -- mix imgproxy.reauthor
+      mise exec -- mix imgproxy.reauthor
   """
   use Mix.Task
   use Boundary, top_level?: true, check: [out: false]


### PR DESCRIPTION
## Summary

Adds `mix imgproxy.gen_report` — a no-Docker DX tool that renders ImagePipe live for every constellation in the imgproxy differential conformance suite and writes a **single self-contained `report.html`** for eyeball triage. Closes #202.

Per case the report shows:
- imgproxy fixture vs live ImagePipe render **side by side**, plus an `img-comparison-slider` overlay.
- Two diff heatmaps with a global banded/raw toggle: **banded** (per-pixel max Δ over the case's own threshold) and **raw amplified** (full structure incl. sub-threshold AA skew).
- The **live-recomputed** conformance metric/verdict, with `tol`/`:triage` (reason + clickable issue link) annotations and a human-readable opts summary.
- Attention-first ordering (over-budget, quarantined, dims-mismatch, a `:diverges` case that now matches, or authored-hash drift) with a top-of-page counts line and a client-side group/attention filter.

Self-contained: images base64-inlined, slider + Geist fonts from CDN (side-by-side panels remain the source of truth offline). Styling borrows the fiddle's palette/checkerboard. The default `report.html` is gitignored; lossy cases render as contract-only cards (no committed imgproxy bytes to diff).

## Design / approach

- Pure, isolated, `deps: []` support modules for the two testable pure pieces: `OptsSummary` (opts→prose) and `ReportHtml` (card-data→HTML). The Mix task (`check: [out: false]`) owns render/metric/heatmap orchestration and reuses the conformance test's exact `plug_opts` wiring so the report shows the same bytes the test compares.
- Heatmaps align both operands to 3-band RGB before diffing (so RGBA/RGB band mismatches like `alpha_resize`/`background_alpha` don't raise); banded uses a 256-entry LUT keyed on the case threshold.
- **DX/inspection only** — no change to conformance behavior, fixtures, the manifest, `REPORT.md`, or the default `mix test` lane.

Spec: `docs/superpowers/specs/2026-06-11-imgproxy-gen-report-design.md` · Plan: `docs/superpowers/plans/2026-06-11-imgproxy-gen-report.md` (both went through a parallel multi-lens review cycle before implementation).

## Test Plan

- [x] `mise run precommit` green — `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, full `mix test` (**1708 tests, 0 failures, 7 excluded**).
- [x] New focused tests: `OptsSummary.describe/1` (7), `ReportHtml.render/1` structure (6), and a full-task smoke test rendering every constellation to a tmp file.
- [x] Live run: `MIX_ENV=test mix imgproxy.gen_report` writes a 34-card report with no crash; spot-checked triage cards (metric + issue link), the `:diverges` card (heatmaps + diverges bucket), and lossy contract-only cards.
- [ ] Eyeball `report.html` in a browser: drag the slider, flip the banded/raw heatmap toggle, exercise the filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual-diff report generation for comparing imgproxy fixtures against live renders in a self-contained HTML file with side-by-side panels, image sliders, heatmaps, and per-case metrics.

* **Documentation**
  * Added implementation plan and design specification for report generation workflow.
  * Updated README with instructions for generating visual-diff reports without Docker.

* **Tests**
  * Added comprehensive test coverage for report HTML rendering, options formatting, and end-to-end report generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->