### PR TITLE
test(imgproxy-differential): #203 Tier 3 non-pixel conformance (T3.1–T3.8)

### DIFF
--- a/docs/imgproxy_support_matrix.md
+++ b/docs/imgproxy_support_matrix.md
@@ -754,8 +754,8 @@ transforms or output encoding.
 | `zoom` | `z` | Supported | Single value or separate x/y factors. |
 | `dpr` | | Supported | Affects resize sizing and cache key data. |
 | `enlarge` | `el` | Supported | boolean. |
-| `extend` | `ex` | Supported | Canvas extension with anchor gravity and offsets, with effective DPR scaling of the target box and absolute offsets (see stage 10 for the east/south sign divergence #200). |
-| `extend_aspect_ratio` | `extend_ar`, `exar` | Supported | boolean extend plus gravity. Extends the canvas to the requested resize aspect ratio. `fp` extend-gravity isn't supported (matches `extend`). No-op when a resize dimension is auto or zero. |
+| `extend` | `ex` | Supported | Canvas extension with anchor gravity and offsets, with effective DPR scaling of the target box and absolute offsets (see stage 10 for the east/south sign divergence #200). **Diverges (surface):** extend gravity admits only the nine cardinal/corner anchors; imgproxy's `ExtendGravityTypes` also accepts focal-point (`fp`), so `ex:1:fp:x:y` parses upstream but is rejected here (#203 T3.2). |
+| `extend_aspect_ratio` | `extend_ar`, `exar` | Supported | boolean extend plus gravity. Extends the canvas to the requested resize aspect ratio. `fp` extend-gravity isn't supported (matches `extend` — see its divergence note). No-op when a resize dimension is auto or zero. |
 | `gravity` anchors | `g` | Supported | `ce`, `no`, `so`, `ea`, `we`, `noea`, `nowe`, `soea`, `sowe`. |
 | `gravity:fp` | `g:fp` | Supported | Focal point coordinates from `0.0` to `1.0`. |
 | `gravity:sm` | `g:sm` | Supported | Smart gravity via libvips attention smart crop (`VIPS_INTERESTING_ATTENTION`). |

--- a/test/parser/imgproxy/option_grammar_test.exs
+++ b/test/parser/imgproxy/option_grammar_test.exs
@@ -165,6 +165,17 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammarTest do
     assert {:error, _} = OptionGrammar.parse("ex:1:obj")
   end
 
+  test "extend gravity rejects focal-point gravity (diverges from imgproxy)" do
+    # imgproxy's `ExtendGravityTypes` (processing/gravity_type.go) includes
+    # `GravityFocusPoint`, so `ex:1:fp:x:y` is accepted upstream. ImagePipe's extend
+    # gravity admits only the nine cardinal/corner anchors — `fp`/`sm`/`obj` are
+    # crop/cover-only — so it rejects fp on extend. This pins the documented divergence
+    # (`docs/imgproxy_support_matrix.md` stage 10/11; #203 T3.2). `fp` is still accepted
+    # for `g:`/`c:`, asserted elsewhere.
+    assert {:error, _} = OptionGrammar.parse("ex:1:fp:0.3:0.7")
+    assert {:error, _} = OptionGrammar.parse("extend:1:fp:0.5:0.5")
+  end
+
   test "malformed padding and background options keep current error shapes" do
     assert OptionGrammar.parse("padding:1:2:3:4:5") ==
              {:error, {:invalid_option_segment, "padding:1:2:3:4:5"}}
@@ -217,10 +228,15 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammarTest do
   end
 
   test "dpr parses positive floats and rejects non-positive values" do
+    # imgproxy `parsePositiveNonZeroFloat` (options/parser/parse.go): any float > 0
+    # is accepted — including fractional sub-1 DPRs — and <= 0 is rejected. ImagePipe's
+    # `:positive_float` matches: 0.5 parses, 0/-1/non-numeric reject (#203 T3.1).
     assert OptionGrammar.parse("dpr:1.5") == {:ok, {:pipeline, [dpr: 1.5]}}
     assert OptionGrammar.parse("dpr:2") == {:ok, {:pipeline, [dpr: 2.0]}}
+    assert OptionGrammar.parse("dpr:0.5") == {:ok, {:pipeline, [dpr: 0.5]}}
     assert OptionGrammar.parse("dpr:0") == {:error, {:invalid_positive_float, "0"}}
     assert OptionGrammar.parse("dpr:-1") == {:error, {:invalid_positive_float, "-1"}}
+    assert OptionGrammar.parse("dpr:abc") == {:error, {:invalid_positive_float, "abc"}}
   end
 
   test "blur, sharpen, and pixelate reject invalid values with type-specific tags" do

--- a/test/parser/imgproxy/plan_builder_test.exs
+++ b/test/parser/imgproxy/plan_builder_test.exs
@@ -671,6 +671,62 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilderTest do
     assert resize.dpr == ratio(2, 1)
   end
 
+  # #203 Tier 3 — zero/auto-dim and DPR dimension rules settled at the planner layer
+  # against imgproxy's `prepare.go` geometry. T3.6 in particular can't be a pixel
+  # fixture: its dpr-scaled output dims diverge from any committable baseline and
+  # `pixel_compare` raises on a dims mismatch.
+
+  test "exar gates off on a single zero/auto dimension while min-dims stay live (T3.3)" do
+    # imgproxy applies extend-aspect-ratio only when both target dims are > 0
+    # (`prepare.go`: `c.TargetWidth > 0 && c.TargetHeight > 0`); ImagePipe's
+    # `resize_target_ratio` carries the same `w > 0 and h > 0` guard, so a single
+    # zero/auto dim emits no canvas. `rs:fit:300:0/exar:1` → resize only.
+    assert {:ok, %Plan{pipelines: [%Pipeline{operations: ops}]}} =
+             plan_pipeline(
+               width: {:pixels, 300},
+               height: {:pixels, 0},
+               extend_aspect_ratio: true
+             )
+
+    assert [%Operation.Resize{mode: :fit} = resize] = ops
+    assert resize.width == pixels(300)
+    assert resize.height == auto()
+    refute Enum.any?(ops, &match?(%Operation.Canvas{}, &1))
+
+    # Min-dims are NOT gated by a zero dim — imgproxy applies minWidth/minHeight
+    # unconditionally in `calcScale` (`prepare.go`). `rs:fit:0:200/mw:280` keeps mw.
+    assert {:ok, %Plan{pipelines: [%Pipeline{operations: [%Operation.Resize{} = min_resize]}]}} =
+             plan_pipeline(
+               width: {:pixels, 0},
+               height: {:pixels, 200},
+               min_width: {:pixels, 280}
+             )
+
+    assert min_resize.width == auto()
+    assert min_resize.height == pixels(200)
+    assert min_resize.min_width == pixels(280)
+  end
+
+  test "raw fit + dpr folds into the resize with no canvas wrapper (T3.6)" do
+    # `rs:fit:300:200/dpr:2` carries the DPR on the resize itself (final 600x400);
+    # no extend/padding wrapper means the output dims diverge from a 300x200 baseline,
+    # so it can only be settled here, not as a pixel fixture.
+    assert {:ok, %Plan{pipelines: [%Pipeline{operations: ops}]}} =
+             plan_pipeline(
+               resizing_type: :fit,
+               width: {:pixels, 300},
+               height: {:pixels, 200},
+               dpr: 2.0
+             )
+
+    assert [%Operation.Resize{mode: :fit} = resize] = ops
+    assert resize.width == pixels(300)
+    assert resize.height == pixels(200)
+    assert resize.dpr == ratio(2, 1)
+    refute Enum.any?(ops, &match?(%Operation.Canvas{}, &1))
+    refute Enum.any?(ops, &match?(%Operation.Padding{}, &1))
+  end
+
   test "plans parsed crop and orientation semantics before no-op operations" do
     assert {:ok, %Plan{pipelines: [%Pipeline{operations: [%Operation.CropGuided{}]}]}} =
              plan_pipeline(crop: struct(ImagePipe.Parser.Imgproxy.CropRequest))


### PR DESCRIPTION
Closes out **Tier 3** of #203 — the backlog items that route to cheaper parser/planner/unit/header layers instead of Docker pixel fixtures.

Auditing existing coverage showed **half the items were already pinned** by pre-existing wire/differential tests, so this adds focused tests only for the genuine gaps and leaves the rest untouched (no redundant tests, per the repo's test guidelines).

## New tests (genuine gaps)

| Item | What | Where |
|---|---|---|
| **T3.1** `dpr:0.5` | fractional sub-1 DPR accepted (existing test only had `0`/`-1`/`2`/`1.5`); `dpr:abc` rejected. Matches imgproxy `parsePositiveNonZeroFloat`. | `option_grammar_test.exs` |
| **T3.2** `ex:1:fp:x:y` | extend focal-point gravity rejected — **diverges** from imgproxy, whose `ExtendGravityTypes` includes `GravityFocusPoint`. Existing test only rejected `obj`. | `option_grammar_test.exs` |
| **T3.3** zero/auto-dim gating | `rs:fit:300:0/exar:1` gates exar off while `rs:fit:0:200/mw:280` keeps min-dims live (contrast wasn't pinned together), matching `prepare.go`. | `plan_builder_test.exs` |
| **T3.6** raw fit+dpr | `rs:fit:300:200/dpr:2` folds dpr onto the resize with no Canvas/Padding wrapper; dpr-scaled dims diverge from any baseline so `pixel_compare` can't compare it — hence a planner pin. | `plan_builder_test.exs` |

Plus a one-line **support-matrix** clarification framing fp-on-extend as a real divergence (previously read "not supported" without noting imgproxy accepts it).

## Already covered — verified, no new test

- **T3.4** fixSize clamp → wire `#150` describe (`rs:force:18000:200/f:webp` clamps to 16383 w/ telemetry) + `clamp_test.exs` `encoder_limit`/clamp math.
- **T3.5** `sm`/`kcr` metadata → wire `sm/kcr metadata stripping` with a real XMP-carrying `meta.jpg` fixture (stronger than an encoder-unit test; asserts XMP/IPTC stripping — the actual divergence).
- **T3.7** min-dims+dpr → planner rule-inputs test + `min_dims_dpr_marker` / `min_dims_dpr_enlarge_off_small` differential fixtures.
- **T3.8** `g:sm` smart crop → wire `g:sm` requested-size + differs-from-center plausibility check.

## Verification

Full `mise run precommit` gate green: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, and 1802 tests / 53 properties / 1 doctest, 0 failures.

Refs #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)