### PR TITLE
test(detector): fix warmup monitor race in unavailable-detector test

### DIFF
--- a/test/image_pipe/transform/detector/warmup_test.exs
+++ b/test/image_pipe/transform/detector/warmup_test.exs
@@ -57,7 +57,11 @@ defmodule ImagePipe.Transform.Detector.WarmupTest do
       start_supervised!({Warmup, detector: UnavailableDetector, classes: ["face"], opts: []})
 
     ref = Process.monitor(pid)
-    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
+    # The failed-warmup retries have no backoff, so the worker can terminate
+    # before we monitor it; the monitor then reports :noproc. Either way it ended
+    # cleanly — a never-raising worker under :transient would have been restarted
+    # otherwise.
+    assert_receive {:DOWN, ^ref, :process, ^pid, reason} when reason in [:normal, :noproc]
   end
 
   test "nil detector disables warmup as a clean no-op" do


### PR DESCRIPTION
## Problem

CI flake in `ImagePipe.Transform.Detector.Warmup` ([failing run](https://github.com/hlindset/image_pipe/actions/runs/27399858662/job/80975178093)):

```
1) test unavailable detector is a clean no-op that still terminates :normal
   Assertion failed, no matching message after 2000ms
   code: assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
```

## Root cause — a monitor race, not a real bug

`start_supervised!` returns the moment `init/1` returns `{:ok, state, {:continue, :warm_then_stop}}`; the warmup runs concurrently in `handle_continue`. For `UnavailableDetector`, `warmup/1` returns `{:error, ...}` immediately and the retries loop **with no backoff** (the three "retries left" warnings in the CI log share one timestamp). So the worker often reaches `{:stop, :normal, state}` and dies **before** the test's next line, `Process.monitor(pid)`, runs.

Monitoring an already-dead process delivers `{:DOWN, ref, :process, pid, :noproc}` — not `:normal`. The assertion matched only `:normal`, so on the losing side of the race it never matched and timed out.

## Fix

Accept `reason in [:normal, :noproc]`, matching the two sibling tests in the same file that already handle this identical fast-no-op race. Under `:transient`, a non-clean exit would have restarted the worker, so `:noproc` still proves clean termination.

Test-only change — no production code touched.

## Verification

- 30 consecutive seeded runs of `warmup_test.exs` pass.
- `mix format --check-formatted` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)