### PR TITLE
test: speed up suite (exclude report render, trim props, shrink #146 orientation guard)

### DIFF
--- a/test/image_pipe/imgproxy_gen_report_test.exs
+++ b/test/image_pipe/imgproxy_gen_report_test.exs
@@ -263,6 +263,7 @@ defmodule ImagePipe.ImgproxyGenReportTest do
     end
   end
 
+  @tag :imgproxy_report
   test "gen_report renders every constellation to a self-contained file" do
     out =
       Path.join(System.tmp_dir!(), "imgproxy_report_#{System.unique_integer([:positive])}.html")

--- a/test/image_pipe/shrink_through_crop_test.exs
+++ b/test/image_pipe/shrink_through_crop_test.exs
@@ -293,115 +293,74 @@ defmodule ImagePipe.ShrinkThroughCropTest do
     end
   end
 
-  # Per-stage random-access gate (#146 follow-up). OrientationFlush applies the EXIF
-  # autorotate and the user rotate as SEPARATE libvips ops; EACH that rotates or
-  # vertically flips needs a random-access source. The earlier net-angle predicate
-  # only pre-copied on the COMBINED angle, so when an EXIF quarter/half-turn and a
+  # Per-stage random-access gate (#146). OrientationFlush applies the EXIF autorotate
+  # and the user rotate as SEPARATE libvips ops; EACH stage that rotates 90/180/270 —
+  # or vertically flips — reads out of row order and independently needs a
+  # random-access source. The fixed predicate
+  # (`exif_angle != 0 or user_angle != 0 or user_flip_y`, in
+  # `ImagePipe.Transform.OrientationFlush`) fires on ANY such stage; the earlier
+  # net-angle predicate (`rem(exif_angle + user_angle, 360) != 0 or user_flip_y`)
+  # pre-copied only on the COMBINED angle, so when an EXIF quarter/half-turn and a
   # user rotate cancel (net 0 mod 360) the per-stage rotations still ran on the
   # un-materialized `access: :sequential` decode and copy_memory raised
   # `{:decode, "Failed to memory copy image"}` at large sizes — a user-reachable
   # HTTP 415 on a valid request (e.g. `/_/rot:270/.../EXIF-5 source`).
   #
-  # This drives the full pending-orientation matrix that reaches `flush` at
-  # @big_src (5000) through the NO-GEOMETRY delivery-flush path (a bare rotate/flip
-  # carries the whole orientation to delivery and flushes at full resolution —
-  # there is no crop or resize to reshape libvips' pipeline). That path is what
-  # makes the test non-tautological: a trailing region crop reorganizes the lazy
-  # pipeline and lets libvips SILENTLY BUFFER the random read, masking the wall, so
-  # a crop-driven flush would pass even with the buggy predicate. The bare-rotate
-  # path trips the wall for real (the EXIF-5/7 net-cancel holes raise here under the
-  # old predicate; libvips silently buffers the 6/8/3/4 holes, so those holes do
-  # not crash empirically but the fix pre-copies them anyway since each stage
-  # genuinely rotates). The source is decoded `access: :sequential, fail_on: :error`
-  # by the real processor decode path — a genuinely streamed open, NOT a buffered
-  # `from_binary`. Every case must (a) succeed (no sequential-wall crash) and
-  # (b) match the eager autorotate-first reference (dims ±1px, coarse MAE < 4).
+  # The two predicates DIVERGE on exactly six (orientation, user_rotate) pairs: the
+  # net-cancel holes where `exif_angle != 0` but the angles sum to 0 mod 360 —
+  # EXIF{3,4}+rot:180, EXIF{5,6}+rot:270, EXIF{7,8}+rot:90. Those six are the entire
+  # falsifiable surface of the fix; every other orientation/rotation/flip passes
+  # under both predicates. Composition correctness of the flush across the full
+  # EXIF × rotate × flip space is covered pixel-exact at small size by
+  # `ImagePipe.Transform.DeferredOrientationTest`, so it is not re-tested here — this
+  # guard exists solely to keep the large-size materialization fix non-tautological.
   #
-  # The matrix is an adversarial subset that includes ALL net-cancel holes
-  # (EXIF {5,6,7,8}+quarter, EXIF {3,4}+180) plus streaming-safe cases (EXIF 1/2,
-  # rot 0, hflip-only) and vertical flips, spanning EXIF 1..8 × rot {0,90,180,270}
-  # × flip {none, h, v}.
+  # Each hole drives the NO-GEOMETRY delivery-flush path: a bare rotate carries the
+  # whole orientation to delivery and flushes at full resolution, with no crop/resize
+  # to reshape libvips' lazy pipeline. That matters — a trailing region crop
+  # reorganizes the pipeline and lets libvips SILENTLY BUFFER the random read,
+  # masking the wall, so a crop-driven flush would pass even with the buggy
+  # predicate. The source is decoded `access: :sequential, fail_on: :error` by the
+  # real processor path (a genuinely streamed open, NOT a buffered `from_binary`).
+  # Each hole must (a) succeed (no sequential-wall crash) and (b) match the eager
+  # autorotate-first reference (dims ±1px, coarse MAE < 4).
   #
-  # Non-tautological self-check: with the predicate reverted to the net-angle form
-  # (`rem(exif_angle + user_angle, 360) != 0 or user_flip_y`), the EXIF-5+rot:270
-  # and EXIF-7+rot:90 cases FAIL with `{:decode, "Failed to memory copy image"}`
-  # (verified manually). The fix (`exif_angle != 0 or user_angle != 0 or
-  # user_flip_y`) is what makes them pass.
-  @orient_matrix (for orientation <- 1..8,
-                      {angle, flip} <-
-                        [
-                          {0, :none},
-                          {90, :none},
-                          {180, :none},
-                          {270, :none},
-                          {0, :horizontal},
-                          {0, :vertical}
-                        ] do
-                    {orientation, angle, flip}
-                  end)
+  # Runs at @src (3200), in the previously-failing range. Under the broken predicate
+  # the EXIF-5+rot:270 and EXIF-7+rot:90 holes crash here while libvips silently
+  # buffers 3/4/6/8 (masked, not absent) — keeping all six holds the guard to the
+  # complete divergence surface rather than today's-crashing subset, since a libvips
+  # buffering shift could expose any of them.
+  @net_cancel_holes [{3, 180}, {4, 180}, {5, 270}, {6, 270}, {7, 90}, {8, 90}]
 
-  defp orient_ops(angle, flip) do
-    rotate_ops =
-      case angle do
-        0 -> []
-        a -> [elem(Operation.rotate(a), 1)]
-      end
-
-    flip_ops =
-      case flip do
-        :none -> []
-        axis -> [elem(Operation.flip(axis), 1)]
-      end
-
-    # No crop/resize: a bare rotate/flip (or empty list for the identity case)
-    # defers the whole orientation to the delivery flush at full resolution.
-    rotate_ops ++ flip_ops
-  end
-
-  # 5000px so the sequential wall is reliably tripped by any rotating stage that
-  # runs on the un-materialized decode (the EXIF-5/7 holes crash at 3200 and 5000;
-  # libvips silently buffers the rest, so those do not crash empirically — the bug
-  # is masked, not absent — but the fix pre-copies them defensively).
-  @big_src 5000
-
-  describe "per-stage orientation flush gate over full matrix at large size (#146)" do
-    # Self-check: prove the streamed open at @big_src genuinely LACKS random access,
-    # so the matrix successes below are not tautological. A raw quarter-turn rotate
-    # (transpose) on a source opened `access: :sequential, fail_on: :error` followed
-    # by copy_memory must FAIL the sequential-access wall at this size. If this ever
-    # starts passing, libvips has grown a silent buffer and the matrix proves nothing.
-    test "known-random transpose on the streamed #{@big_src}px decode trips the sequential wall" do
-      # Use the EXACT processor decode path (access: :sequential, fail_on: :error,
-      # over the source-response seekable input — NOT a buffered from_binary), grab
-      # the streamed image, then apply a raw quarter-turn transpose and copy_memory.
-      # It must FAIL the sequential wall at this size; otherwise libvips silently
-      # buffered and the matrix below would prove nothing.
-      body = oriented(@big_src, @big_src, 1, ".png")
+  describe "per-stage orientation flush materialization holes (#146)" do
+    # Non-tautology self-check: prove the streamed open at @src genuinely LACKS random
+    # access, so the hole successes below are not tautological. A raw quarter-turn
+    # rotate (transpose) on a source opened `access: :sequential, fail_on: :error`
+    # followed by copy_memory must FAIL the sequential-access wall at this size. If it
+    # ever starts passing, libvips has grown a silent buffer and the holes prove
+    # nothing — this size must match the holes below.
+    test "known-random transpose on the streamed #{@src}px decode trips the sequential wall" do
+      body = oriented(@src, @src, 1, ".png")
       streamed = decode_streamed(body)
       {:ok, transposed} = Image.rotate(streamed, 90)
 
       assert {:error, _} = VipsImage.copy_memory(transposed),
-             "expected the streamed transpose to trip the sequential wall at #{@big_src}px; " <>
-               "if it succeeded, libvips silently buffered and the matrix is tautological"
+             "expected the streamed transpose to trip the sequential wall at #{@src}px; " <>
+               "if it succeeded, libvips silently buffered and the holes are tautological"
     end
 
-    for {orientation, angle, flip} <- @orient_matrix do
-      test "EXIF #{orientation} rot:#{angle} flip:#{flip} streams+matches eager at #{@big_src}px" do
+    for {orientation, angle} <- @net_cancel_holes do
+      test "EXIF #{orientation} + rot:#{angle} (net-cancel) materializes and matches eager at #{@src}px" do
         orientation = unquote(orientation)
         angle = unquote(angle)
-        flip = unquote(flip)
-        ops = orient_ops(angle, flip)
+        {:ok, rotate} = Operation.rotate(angle)
 
-        body = oriented(@big_src, @big_src, orientation, ".png")
-        assert {final, _shrink} = run_auto_rotate(body, ops)
+        body = oriented(@src, @src, orientation, ".png")
+        assert {final, _shrink} = run_auto_rotate(body, [rotate])
 
-        eager = run_eager_reference(body, ops)
+        eager = run_eager_reference(body, [rotate])
 
-        assert_orientation_equivalent(
-          final,
-          eager,
-          "EXIF #{orientation} rot:#{angle} flip:#{flip}"
-        )
+        assert_orientation_equivalent(final, eager, "EXIF #{orientation} + rot:#{angle}")
       end
     end
   end

--- a/test/image_pipe/transform/sequential_access_test.exs
+++ b/test/image_pipe/transform/sequential_access_test.exs
@@ -161,7 +161,7 @@ defmodule ImagePipe.Transform.SequentialAccessTest do
             h <- integer(8..150),
             anchor <-
               member_of([:center, :left, :right, :top, :bottom, :top_left, :bottom_right]),
-            max_runs: 25
+            max_runs: 18
           ) do
       {ax, ay} = anchor_to_xy(anchor)
 
@@ -182,7 +182,7 @@ defmodule ImagePipe.Transform.SequentialAccessTest do
   property "fit resize streams across varied targets" do
     body = File.read!(@dog)
 
-    check all(w <- integer(16..400), max_runs: 25) do
+    check all(w <- integer(16..400), max_runs: 12) do
       assert_sequential_matches_random(
         [%Resize{mode: :fit, width: {:pixels, w}, height: :auto}],
         body
@@ -193,7 +193,7 @@ defmodule ImagePipe.Transform.SequentialAccessTest do
   property "blur streams across varied sigma" do
     body = File.read!(@beach)
 
-    check all(sigma_tenths <- integer(5..40), max_runs: 20) do
+    check all(sigma_tenths <- integer(5..40), max_runs: 12) do
       assert_sequential_matches_random([%Blur{sigma: sigma_tenths / 10}], body)
     end
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,10 +6,14 @@
 # `:imgproxy_triage` quarantines recorded-but-unresolved imgproxy differential
 # discrepancies (see the lane README + issues #194-#197); run them with
 # `--include imgproxy_triage`.
+# `:imgproxy_report` is the full-constellation HTML report render (bakes every
+# constellation + inlines PNGs); it is an integration/report job, not unit
+# coverage, so it is opt-in via `--include imgproxy_report` (or `mix
+# imgproxy.gen_report`). Its rendering logic is unit-tested separately.
 ExUnit.start(
   capture_log: true,
   assert_receive_timeout: 2_000,
-  exclude: [:image_vision, :imgproxy_triage]
+  exclude: [:image_vision, :imgproxy_triage, :imgproxy_report]
 )
 
 {:ok, _} = Application.ensure_all_started(:req)


### PR DESCRIPTION
Test-suite speedups via **work reduction** (not sync/async reshuffling — that just relocates CPU-bound work and raises peak memory on small CI). Three independent changes, each commit standalone.

## Changes

**1. Exclude the full-constellation report render** (`38f0b149`)
`gen_report renders every constellation` baked every constellation + inlined PNGs on every `mix test`. Its rendering logic is unit-tested separately, so it's now tagged `:imgproxy_report` and excluded by default. Run on demand with `--include imgproxy_report` (or `mix imgproxy.gen_report`).

**2. Trim oversampled sequential-access properties** (`38f0b149`)
`max_runs` lowered on the three slow, well-sampled 1-D continuous properties — fit-resize 25→12, blur 20→12, anchor-crop 25→18. The 8-way categorical orientation-flush property is left untouched to avoid under-sampling orientations.

**3. Replace the 48-case 5000px orientation matrix with a focused #146 guard** (`6502f5a2`)
The "per-stage orientation flush gate over full matrix" baked a 48-case EXIF×rotate×flip matrix at 5000px ×2 (deferred + eager). **Mutation testing** (reintroducing the broken net-angle predicate) showed only **2 of 48** cases actually trip the materialization wall — EXIF-5+rot:270 and EXIF-7+rot:90. The other 46 pass under *both* predicates: tautological for #146, providing only composition coverage that `DeferredOrientationTest` already covers pixel-exact across 96 cases.

Replaced with the non-tautology self-check transpose + the **6 net-cancel holes** (EXIF{3,4}+180, {5,6}+270, {7,8}+90) — the complete set where the fixed and broken predicates diverge, so the guard tracks the whole falsifiable surface rather than today's-crashing subset. Runs at `@src` (3200, this file's established large size; threshold verified ≤3200), lowering peak per-render memory **25MP → 10.2MP**.

## Verification

- **Mutation-based TDD on change 3:** GREEN under the fixed predicate; under the broken net-angle predicate the EXIF-5+270 and EXIF-7+90 holes fail with the exact `{:decode, "Failed to memory copy image"}` (#146) error — proving the guard is non-tautological.
- **Full project gate green:** `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict` (no issues), `mix test` (0 failures).
- Drops 42 redundant tests (1843 → 1801). No production behavior change; predicate untouched.

> Note: absolute wall-clock numbers were unreliable during development (concurrent CI/test runs from other work skewed timings). The win is work-reduction, which is machine-independent; a clean re-measure on a quiet machine would give trustworthy before/after figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)