### PR TITLE
docs(imgproxy-differential): note the :imgproxy_report test exclusion

### DIFF
--- a/test/support/image_pipe/test/imgproxy_differential/README.md
+++ b/test/support/image_pipe/test/imgproxy_differential/README.md
@@ -52,6 +52,12 @@ dims-mismatch, a `:diverges` case that now matches, or authored-hash drift) sort
 top, and a top-of-page counts line summarizes them. The slider and Geist fonts load from
 a CDN; with no network the side-by-side panels remain the source of truth.
 
+The end-to-end smoke test that renders the report across every constellation
+(`ImagePipeGenReportTest`'s full-render case) is tagged `:imgproxy_report` and excluded by
+default in `test/test_helper.exs` (it bakes every constellation + inlines PNGs — slow, and
+not unit coverage). The `mix imgproxy.gen_report` task above is unaffected; to run the test
+itself: `mise exec -- mix test test/image_pipe/imgproxy_gen_report_test.exs --include imgproxy_report`.
+
 ## Triage a bake (no Docker)
 
 When a freshly baked case fails the conformance lane, `mix imgproxy.diagnose` prints a


### PR DESCRIPTION
Follow-up to #245. The full-constellation report-render smoke test is now excluded by default via the `:imgproxy_report` tag. That's noted in `test/test_helper.exs`, but not in the differential README — unlike the parallel `:imgproxy_triage` exclusion, which is.

Adds a one-line note to the README's "Visual-diff report" section, where someone reading about the report would look, clarifying that:
- `mix imgproxy.gen_report` (the actual render path) is **unaffected**;
- the *test* is opt-in via `--include imgproxy_report`.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)