### PR TITLE
ci: run Elixir CI only on Elixir-relevant path changes

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -3,8 +3,17 @@ name: Elixir CI
 on:
   push:
     branches: ["main"]
+    paths: &elixir_paths
+      - "lib/**"
+      - "test/**"
+      - "priv/**"
+      - "config/**"
+      - "mix.exs"
+      - "mix.lock"
+      - ".github/workflows/elixir.yml"
   pull_request:
     branches: ["main"]
+    paths: *elixir_paths
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,18 @@ name: Lint
 on:
   push:
     branches: ["main"]
+    paths: &lint_paths
+      - "lib/**"
+      - "test/**"
+      - "config/**"
+      - "fiddle/**"
+      - ".formatter.exs"
+      - "mix.exs"
+      - "mix.lock"
+      - ".github/workflows/lint.yml"
   pull_request:
     branches: ["main"]
+    paths: *lint_paths
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

Both CI workflows triggered on **every** push/PR to `main` with no path filtering, so doc-only edits (e.g. `AGENTS.md`) — and any other non-Elixir change — ran the full Elixir compile/test/credo gate.

## Change

Switch each workflow to a `paths` **allowlist**, shared across the `push` and `pull_request` triggers via a YAML anchor so the two stay in sync:

- **elixir.yml** (library compile + test): `lib`, `test`, `priv`, `config`, `mix.exs`, `mix.lock`, and its own workflow file.
  - `priv/**` is included because the ICC profiles and image fixtures it holds are runtime/test inputs.
  - Deliberately excludes `fiddle/**` — elixir.yml does not test the demo app.
- **lint.yml** (library format/credo + fiddle format/JS lint): `lib`, `test`, `config`, `fiddle`, `.formatter.exs`, `mix.exs`, `mix.lock`, and its own workflow file.

Each workflow lists its own file, so edits to the allowlist still trigger a run.

## Behavior

| Change | elixir.yml | lint.yml |
|---|---|---|
| `lib/`, `test/`, `mix.exs`, `mix.lock`, `config/` | ✅ | ✅ |
| `priv/` | ✅ | ⏭️ |
| `.formatter.exs` | ⏭️ | ✅ |
| `fiddle/**` | ⏭️ | ✅ |
| docs/`*.md`, `vale/`, `bench/`, `mise.toml`, tooling dotfiles | ⏭️ | ⏭️ |

A PR mixing Elixir + anything else still runs in full (any single path match is enough).

## Notes

- `main` is currently unprotected, so there is no required-check-stuck-pending concern. If branch protection with these as required checks is added later, a skipped workflow would leave the required check pending — at which point the dummy-job-with-matching-name pattern would be needed.
- Trade-off: an allowlist's failure mode is silent *under*-testing if a brand-new top-level Elixir directory (sibling of `lib/`) is added without updating the list. `priv/` and `config/` are included to cover the non-obvious runtime inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)