### PR TITLE
test(plug): fix flaky slow-origin first-chunk timeout (align with 10s CI-load budget)

### DIFF
--- a/test/image_pipe/plug_test.exs
+++ b/test/image_pipe/plug_test.exs
@@ -7,7 +7,7 @@ defmodule ImagePipe.PlugTest do
 
   doctest ImagePipe.Plug
 
-  @slow_origin_first_chunk_timeout 5_000
+  @slow_origin_ci_load_timeout 10_000
 
   alias ImagePipe.Parser.Imgproxy.Presets
   alias ImagePipe.Parser.Imgproxy.Signature
@@ -532,12 +532,16 @@ defmodule ImagePipe.PlugTest do
   defp call_after_slow_origin_first_chunk(conn, opts, ref, server) do
     task = Task.async(fn -> call_image_pipe(conn, opts) end)
 
-    assert_receive {^ref, :first_chunk_sent, ^server}, @slow_origin_first_chunk_timeout
-
-    # The behavior under test is the request's own `origin_receive_timeout` (~1s);
-    # this is just the harness waiting for that to surface. Keep the upper bound
-    # generous so CI scheduler load can't trip it before the request completes.
-    Task.await(task, 10_000)
+    # This real-socket handshake has two sequential waits: first for the fake
+    # origin's first chunk (the client must be scheduled to connect + send the
+    # request), then for the request's own `origin_receive_timeout` (~1s) to
+    # surface. Neither leg is the behavior under test — both are dominated by
+    # BEAM scheduling latency, which has a heavy tail on a loaded/throttled CI
+    # runner even though the work itself is trivial. So both share one generous
+    # CI-load budget; capping the first leg lower than the second is what made
+    # this test flaky.
+    assert_receive {^ref, :first_chunk_sent, ^server}, @slow_origin_ci_load_timeout
+    Task.await(task, @slow_origin_ci_load_timeout)
   end
 
   defp chunked_body_chunk(body) do


### PR DESCRIPTION
## What

Fixes a flaky real-socket integration test in `ImagePipe.PlugTest` — *"source timeout while decoding partial valid image bytes surfaces as a source error"* (and its sibling sequential-timeout test). On a loaded CI runner it failed with:

```
Assertion failed, no matching message after 5000ms
code: assert_receive {^ref, :first_chunk_sent, ^server}
```

## Diagnosis: CI-load timing flake, not a bug

`call_after_slow_origin_first_chunk/4` is one logical handshake with **two sequential, scheduling-bound waits**:

1. wait for the fake origin's first chunk — the client must be *scheduled* to connect + send the request;
2. wait for the request's own `origin_receive_timeout` (~1s) to surface → `422`.

Neither leg is the behavior under test — both are dominated by **BEAM scheduling latency**. The fake origin blocks on `accept`/`recv` forever (no timeout), so the first leg's budget gates only *how soon the client gets scheduled to connect*, not the request itself.

Evidence from local characterization (temporary instrumentation, since removed):

- Unconstrained, first-chunk latency is **0–26 ms**.
- Under a CI-like squeeze (`+S 2:2` + 24 CPU hogs): `p50 = 9 ms` but the tail spiked to **560 ms — >40× the median**, a clean bimodal distribution. **0 failures across 6 full-file stress runs (480 tests)** — the path always connects and returns the correct `422`; only *when* the client gets scheduled varies.

A real GitHub runner is more hostile than a throttled 12-core box (genuinely 2 cores, hypervisor CPU throttling, libvips dirty-NIF work from concurrent async tests, GC pauses), so that tail can rarely cross 5s.

## Fix

The author already gave the **second** leg 10s ("so CI scheduler load can't trip it") but left the **first** leg — which runs earlier and is the same kind of wait — at 5s. That asymmetry was the flake.

This unifies both legs under one named budget (`@slow_origin_ci_load_timeout 10_000`) so the asymmetry can't be silently reintroduced, and documents *why* the bound is generous.

Scope notes:
- The synchronous slow-origin test (`source-format automatic negotiation cancels streaming source when decode fails`) is **race-free** — `:first_chunk_sent` is already enqueued before its `assert_receive` — and is left untouched.
- This is a timeout-*bound* change, not a sleep→condition change: the test already waits on a real message condition; a finite-but-generous bound is correct (an unbounded wait would hang CI on a genuine regression instead of failing clearly).

## Verification

- `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`: clean
- 3 slow-origin tests + full `plug_test.exs` (80 tests): 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)