### PR TITLE
fix(detector): backoff between warmup retries, skip when unavailable (#243)

### DIFF
--- a/lib/image_pipe/transform/detector/warmup.ex
+++ b/lib/image_pipe/transform/detector/warmup.ex
@@ -14,8 +14,12 @@ defmodule ImagePipe.Transform.Detector.Warmup do
   `restart: :transient` — it warms once and terminates `:normal`, so the
   supervisor does not restart it. It does NOT trap exits: a shutdown mid-download
   is acceptable (nothing is staged to clean up). A failed warmup logs and retries
-  in-process a bounded number of times, then terminates `:normal` — it never
-  raises (a raised exit under `:transient` would restart-storm).
+  in-process a bounded number of times with exponential backoff (so a transient
+  blip — e.g. a model download hiccup — gets a real chance to recover and the
+  retry warnings aren't a same-instant burst), then terminates `:normal` — it
+  never raises (a raised exit under `:transient` would restart-storm). A detector
+  whose `available?/1` is `false` is structurally unavailable, so warmup is
+  skipped entirely (no point retrying a failure that cannot recover).
 
   The worker runs the blocking model load inside `handle_continue/2`, so
   `start_link/1` returns immediately and the host's boot is never blocked.
@@ -26,6 +30,12 @@ defmodule ImagePipe.Transform.Detector.Warmup do
 
   alias ImagePipe.Transform
   alias ImagePipe.Transform.Detector
+
+  # Exponential backoff between failed-warmup retries: 100ms, 200ms, 400ms, …
+  # capped at 1s. Bounded and non-blocking relative to host boot (the work runs
+  # in handle_continue/2).
+  @backoff_base_ms 100
+  @backoff_cap_ms 1_000
 
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
@@ -52,10 +62,21 @@ defmodule ImagePipe.Transform.Detector.Warmup do
     {:stop, :normal, state}
   end
 
-  defp warm(_state, _module, retries) when retries < 0, do: :ok
-
   defp warm(state, module, retries) do
-    case Detector.warmup(module, Keyword.put(state.opts, :classes, state.classes)) do
+    opts = Keyword.put(state.opts, :classes, state.classes)
+
+    if module.available?(opts) do
+      attempt(state, module, opts, retries)
+    else
+      Logger.warning("ImagePipe detector warmup skipped: #{inspect(module)} is unavailable")
+      :ok
+    end
+  end
+
+  defp attempt(_state, _module, _opts, retries) when retries < 0, do: :ok
+
+  defp attempt(state, module, opts, retries) do
+    case Detector.warmup(module, opts) do
       :ok ->
         :ok
 
@@ -64,7 +85,12 @@ defmodule ImagePipe.Transform.Detector.Warmup do
           "ImagePipe detector warmup failed (#{inspect(reason)}); #{retries} retries left"
         )
 
-        warm(state, module, retries - 1)
+        if retries > 0, do: Process.sleep(backoff_ms(state.retries - retries))
+        attempt(state, module, opts, retries - 1)
     end
+  end
+
+  defp backoff_ms(prior_failures) do
+    min(@backoff_cap_ms, @backoff_base_ms * Integer.pow(2, prior_failures))
   end
 end

--- a/test/image_pipe/transform/detector/warmup_test.exs
+++ b/test/image_pipe/transform/detector/warmup_test.exs
@@ -36,7 +36,27 @@ defmodule ImagePipe.Transform.Detector.WarmupTest do
     @impl true
     def identity(_o), do: {__MODULE__, :unavailable}
     @impl true
-    def warmup(_opts), do: {:error, {:detector, :unavailable}}
+    def warmup(opts) do
+      if pid = Keyword.get(opts, :test_pid), do: send(pid, :warmup_called)
+      {:error, {:detector, :unavailable}}
+    end
+  end
+
+  defmodule FailingDetector do
+    @behaviour ImagePipe.Transform.Detector
+    @impl true
+    def supported_classes(_o), do: ["face"]
+    @impl true
+    def detect(_i, _o), do: {:error, :boom}
+    @impl true
+    def available?(_o), do: true
+    @impl true
+    def identity(_o), do: {__MODULE__, :failing}
+    @impl true
+    def warmup(opts) do
+      send(Keyword.fetch!(opts, :test_pid), :warmup_attempt)
+      {:error, :boom}
+    end
   end
 
   test "async warmup does not block start and terminates :normal" do
@@ -52,16 +72,32 @@ defmodule ImagePipe.Transform.Detector.WarmupTest do
     assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
   end
 
-  test "unavailable detector is a clean no-op that still terminates :normal" do
+  test "unavailable detector skips warmup entirely and terminates :normal" do
     pid =
-      start_supervised!({Warmup, detector: UnavailableDetector, classes: ["face"], opts: []})
+      start_supervised!(
+        {Warmup, detector: UnavailableDetector, classes: ["face"], opts: [test_pid: self()]}
+      )
 
     ref = Process.monitor(pid)
-    # The failed-warmup retries have no backoff, so the worker can terminate
-    # before we monitor it; the monitor then reports :noproc. Either way it ended
-    # cleanly — a never-raising worker under :transient would have been restarted
-    # otherwise.
     assert_receive {:DOWN, ^ref, :process, ^pid, reason} when reason in [:normal, :noproc]
+    # available?/1 is false, so warmup is never attempted — no retry storm. The
+    # worker is dead by the DOWN, so any warmup signal would already be queued.
+    refute_received :warmup_called
+  end
+
+  test "available detector that keeps failing retries a bounded number of times" do
+    pid =
+      start_supervised!(
+        {Warmup,
+         detector: FailingDetector, classes: ["face"], opts: [test_pid: self()], retries: 1}
+      )
+
+    ref = Process.monitor(pid)
+    # retries: 1 → the initial attempt plus one backed-off retry, then it stops.
+    assert_receive :warmup_attempt
+    assert_receive :warmup_attempt
+    assert_receive {:DOWN, ^ref, :process, ^pid, reason} when reason in [:normal, :noproc]
+    refute_received :warmup_attempt
   end
 
   test "nil detector disables warmup as a clean no-op" do


### PR DESCRIPTION
## What

`ImagePipe.Transform.Detector.Warmup.warm/3` retried a failed warmup **back-to-back with no delay**. Two consequences, per #243:

1. **Restart-storm of logs** — a consistently-failing warmup emitted all its retry warnings in a single instant (the CI flake in #242 showed three "retries left" warnings sharing one timestamp).
2. **Wasted retries on structural failures** — an `available?/1 == false` detector burned every retry repeating a failure with no transient condition to recover.

## Change

- **Skip warmup entirely when `available?/1` is `false`** — log once and stop. A structurally-unavailable detector cannot recover, so there is nothing to retry.
- **Exponential backoff between retries** for an available-but-failing detector: 100ms, 200ms, 400ms… capped at 1s. A real blip (e.g. a model-download hiccup) gets a chance to recover, and the retry warnings are no longer a same-instant burst. The sleep runs inside `handle_continue/2`, so `start_link/1` still returns immediately and host boot is never blocked.

## Tests

- Unavailable detector: asserts `warmup/1` is **never attempted** (no retry storm) and the worker still terminates `:normal`.
- Available-but-failing detector: asserts the bounded retry count (initial attempt + `retries`) and clean termination.

`mix format`, `mix compile --warnings-as-errors`, and `mix credo --strict` all clean; focused warmup tests green.

Fixes #243