### PR TITLE
fix(parser): adapters own their option contract; drop imgproxy from the core

### DIFF
--- a/docs/imgproxy_support_matrix.md
+++ b/docs/imgproxy_support_matrix.md
@@ -404,7 +404,10 @@ application-owned source adapters.
 ImagePipe supports Base64 encoded source URLs. It also supports encrypted source
 URLs when callers configure `source_url_encryption_key` through
 `ImagePipe.Plug.init/1`. Direct `ImagePipe.Parser.Imgproxy.parse/2` callers should
-pass `imgproxy: ImagePipe.Parser.Imgproxy.validate_options!(...)`.
+validate the host options first with
+`ImagePipe.Parser.Imgproxy.validate_options!(imgproxy: [...])` (which normalizes
+the `:imgproxy` namespace in place and returns the full option list) and pass the
+result as `parse/2`'s options.
 
 - ✅ Base64 encoded source URLs
 - ✅ Encrypted source URLs

--- a/lib/image_pipe/parser.ex
+++ b/lib/image_pipe/parser.ex
@@ -50,9 +50,22 @@ defmodule ImagePipe.Parser do
   @spec validate_options!(module(), keyword()) :: keyword()
   def validate_options!(parser, opts) when is_atom(parser) and is_list(opts) do
     if Code.ensure_loaded?(parser) and function_exported?(parser, :validate_options!, 1) do
-      parser.validate_options!(opts)
+      validate_returned_options!(parser, parser.validate_options!(opts))
     else
       opts
     end
+  end
+
+  defp validate_returned_options!(parser, opts) when is_list(opts) do
+    if Keyword.keyword?(opts),
+      do: opts,
+      else: raise(ArgumentError, keyword_return_error(parser, opts))
+  end
+
+  defp validate_returned_options!(parser, opts),
+    do: raise(ArgumentError, keyword_return_error(parser, opts))
+
+  defp keyword_return_error(parser, returned) do
+    "#{inspect(parser)}.validate_options!/1 must return a keyword list, got: #{inspect(returned)}"
   end
 end

--- a/lib/image_pipe/parser.ex
+++ b/lib/image_pipe/parser.ex
@@ -9,7 +9,7 @@ defmodule ImagePipe.Parser do
       ImagePipe.Format,
       ImagePipe.Plan
     ],
-    exports: [Imgproxy]
+    exports: []
 
   alias ImagePipe.Plan
 
@@ -24,4 +24,35 @@ defmodule ImagePipe.Parser do
   Render request parsing or request validation errors to the client.
   """
   @callback handle_error(Plug.Conn.t(), {:error, any()}) :: Plug.Conn.t()
+
+  @doc """
+  Validate and normalize the host options the parser owns.
+
+  Called once at `ImagePipe.Plug.init/1` time with the full host option list. A
+  parser inspects only its own option namespace, validates/normalizes it, and
+  returns the (possibly updated) full option list. Raises on invalid
+  configuration — this runs at init, not per-request.
+
+  Optional: a parser that takes no host options omits it, and
+  `validate_options!/2` is an identity.
+  """
+  @callback validate_options!(opts :: keyword()) :: keyword()
+
+  @optional_callbacks validate_options!: 1
+
+  @doc """
+  Dispatch parser option validation generically.
+
+  Invokes `parser.validate_options!/1` when the parser implements it, otherwise
+  returns `opts` unchanged. This keeps the core unaware of any concrete parser:
+  the parser owns its own option contract.
+  """
+  @spec validate_options!(module(), keyword()) :: keyword()
+  def validate_options!(parser, opts) when is_atom(parser) and is_list(opts) do
+    if Code.ensure_loaded?(parser) and function_exported?(parser, :validate_options!, 1) do
+      parser.validate_options!(opts)
+    else
+      opts
+    end
+  end
 end

--- a/lib/image_pipe/parser/imgproxy.ex
+++ b/lib/image_pipe/parser/imgproxy.ex
@@ -76,8 +76,17 @@ defmodule ImagePipe.Parser.Imgproxy do
     SourceEncryption.encrypt_source_url(source_url, hex_key, opts)
   end
 
-  @doc false
-  def validate_options!(imgproxy_opts) when is_list(imgproxy_opts) do
+  @impl ImagePipe.Parser
+  def validate_options!(opts) when is_list(opts) do
+    imgproxy_opts =
+      opts
+      |> Keyword.get(:imgproxy, [])
+      |> validate_imgproxy_options!()
+
+    Keyword.put(opts, :imgproxy, imgproxy_opts)
+  end
+
+  defp validate_imgproxy_options!(imgproxy_opts) when is_list(imgproxy_opts) do
     case NimbleOptions.validate(imgproxy_opts, @imgproxy_schema) do
       {:ok, validated} ->
         validated
@@ -89,7 +98,7 @@ defmodule ImagePipe.Parser.Imgproxy do
     end
   end
 
-  def validate_options!(_imgproxy_opts),
+  defp validate_imgproxy_options!(_imgproxy_opts),
     do: raise(ArgumentError, "invalid imgproxy options: expected a keyword list")
 
   @doc false

--- a/lib/image_pipe/plan/key_data.ex
+++ b/lib/image_pipe/plan/key_data.ex
@@ -212,7 +212,7 @@ defmodule ImagePipe.Plan.KeyData do
     do: [type: :detect, classes: Enum.sort(classes), weights: weights]
 
   defp resize_rule_data(data, %Resize{mode: :auto}),
-    do: data ++ [rule: :imgproxy_orientation_match_v1]
+    do: data ++ [rule: :auto_orientation_match_v1]
 
   defp resize_rule_data(data, %Resize{}), do: data
 

--- a/lib/image_pipe/plug.ex
+++ b/lib/image_pipe/plug.ex
@@ -19,7 +19,7 @@ defmodule ImagePipe.Plug do
   @behaviour Plug
 
   alias ImagePipe.Error
-  alias ImagePipe.Parser.Imgproxy
+  alias ImagePipe.Parser
   alias ImagePipe.Plan
   alias ImagePipe.Request.HTTPCache
   alias ImagePipe.Request.Options
@@ -217,17 +217,6 @@ defmodule ImagePipe.Plug do
   defp validate_parser_options(opts) do
     opts
     |> Keyword.fetch!(:parser)
-    |> validate_parser_options(opts)
+    |> Parser.validate_options!(opts)
   end
-
-  defp validate_parser_options(Imgproxy, opts) do
-    imgproxy_opts =
-      opts
-      |> Keyword.get(:imgproxy, [])
-      |> Imgproxy.validate_options!()
-
-    Keyword.put(opts, :imgproxy, imgproxy_opts)
-  end
-
-  defp validate_parser_options(_parser, opts), do: opts
 end

--- a/test/image_pipe/architecture_boundary_test.exs
+++ b/test/image_pipe/architecture_boundary_test.exs
@@ -24,6 +24,7 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
     "lib/image_pipe/plan/**/*.ex"
   ]
   @parser_forbidden_globs [
+    "lib/image_pipe/plug.ex",
     "lib/image_pipe/request.ex",
     "lib/image_pipe/request/**/*.ex",
     "lib/image_pipe/source.ex",
@@ -33,7 +34,9 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
     "lib/image_pipe/cache.ex",
     "lib/image_pipe/cache/**/*.ex",
     "lib/image_pipe/output.ex",
-    "lib/image_pipe/output/**/*.ex"
+    "lib/image_pipe/output/**/*.ex",
+    "lib/image_pipe/plan.ex",
+    "lib/image_pipe/plan/**/*.ex"
   ]
   @parser_globs [
     "lib/image_pipe/parser.ex",
@@ -95,7 +98,10 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
     imgproxy = boundary_declaration(ImagePipe.Parser.Imgproxy)
 
     assert_boundary_deps(parser, [ImagePipe.Format, ImagePipe.Plan])
-    assert_boundary_exports(parser, [ImagePipe.Parser.Imgproxy])
+    # The Parser behaviour boundary must not export any concrete adapter: the core
+    # never names a specific parser, so an adapter (imgproxy/…) can be ripped out
+    # without editing the behaviour boundary.
+    assert_boundary_exports(parser, [])
 
     assert_boundary_deps(imgproxy, [
       ImagePipe.Format,
@@ -389,11 +395,11 @@ defmodule ImagePipe.ArchitectureBoundaryTest do
     assert violations == []
   end
 
-  test "request, source, response, cache, and output code does not depend on imgproxy parser structs" do
+  test "core code (plug, request, source, response, cache, output, plan) does not name the imgproxy parser" do
     violations =
       for file <- parser_forbidden_files(),
           violation <- imgproxy_parser_references(file) do
-        "#{file}:#{violation.line} must not name #{violation.module}; keep Imgproxy parser dependencies out of request, source, response, cache, and output code"
+        "#{file}:#{violation.line} must not name #{violation.module}; an adapter must be removable without changing the core — keep Imgproxy out of plug, request, source, response, cache, output, and plan code"
       end
 
     assert violations == []

--- a/test/image_pipe/cache/key_test.exs
+++ b/test/image_pipe/cache/key_test.exs
@@ -344,13 +344,13 @@ defmodule ImagePipe.Cache.KeyTest do
     encrypted_conn = conn(:get, "/_/enc/#{encrypted}/puppy.jpg")
     alternate_encrypted_conn = conn(:get, "/_/enc/#{alternate_encrypted}/kitten.jpg")
 
-    opts = [
-      imgproxy:
-        Imgproxy.validate_options!(
+    opts =
+      Imgproxy.validate_options!(
+        imgproxy: [
           source_url_encryption_key: source_url_encryption_key(),
           base64_url_includes_filename: true
-        )
-    ]
+        ]
+      )
 
     assert {:ok, plain_plan} = Imgproxy.parse(plain_conn, opts)
     assert {:ok, encoded_plan} = Imgproxy.parse(encoded_conn, opts)
@@ -487,7 +487,7 @@ defmodule ImagePipe.Cache.KeyTest do
                  min_height: nil,
                  zoom_x: 1.0,
                  zoom_y: 1.0,
-                 rule: :imgproxy_orientation_match_v1
+                 rule: :auto_orientation_match_v1
                ]
              ]
            ]
@@ -576,7 +576,7 @@ defmodule ImagePipe.Cache.KeyTest do
              min_height: nil,
              zoom_x: 1.0,
              zoom_y: 1.0,
-             rule: :imgproxy_orientation_match_v1
+             rule: :auto_orientation_match_v1
            ]
 
     serialized = Key.serialize_key_data(key_a.data)
@@ -1156,9 +1156,8 @@ defmodule ImagePipe.Cache.KeyTest do
     conn = conn(:get, "/_/pr:thumb/plain/images/cat.jpg")
     expanded_conn = conn(:get, "/_/rt:fill/w:120/h:90/q:82/plain/images/cat.jpg")
 
-    opts = [
-      imgproxy: Imgproxy.validate_options!(presets: %{"thumb" => "rt:fill/w:120/h:90/q:82"})
-    ]
+    opts =
+      Imgproxy.validate_options!(imgproxy: [presets: %{"thumb" => "rt:fill/w:120/h:90/q:82"}])
 
     assert {:ok, preset_plan} = Imgproxy.parse(conn, opts)
     assert {:ok, expanded_plan} = Imgproxy.parse(expanded_conn, [])

--- a/test/image_pipe/parser_test.exs
+++ b/test/image_pipe/parser_test.exs
@@ -26,6 +26,19 @@ defmodule ImagePipe.ParserTest do
     def validate_options!(opts), do: Keyword.put(opts, :validated_namespace, normalized: true)
   end
 
+  defmodule MisbehavingParser do
+    @behaviour ImagePipe.Parser
+
+    @impl ImagePipe.Parser
+    def parse(_conn, _opts), do: {:error, :unused}
+
+    @impl ImagePipe.Parser
+    def handle_error(conn, _error), do: conn
+
+    @impl ImagePipe.Parser
+    def validate_options!(_opts), do: %{not: :a_keyword_list}
+  end
+
   describe "validate_options!/2" do
     test "dispatches to a parser that owns option validation" do
       result = Parser.validate_options!(OptionParser, parser: OptionParser)
@@ -38,6 +51,12 @@ defmodule ImagePipe.ParserTest do
       opts = [parser: NoOptionParser, max_body_bytes: 1_000]
 
       assert Parser.validate_options!(NoOptionParser, opts) == opts
+    end
+
+    test "rejects a parser whose validate_options!/1 returns a non-keyword" do
+      assert_raise ArgumentError, ~r/must return a keyword list/, fn ->
+        Parser.validate_options!(MisbehavingParser, parser: MisbehavingParser)
+      end
     end
   end
 end

--- a/test/image_pipe/parser_test.exs
+++ b/test/image_pipe/parser_test.exs
@@ -1,0 +1,43 @@
+defmodule ImagePipe.ParserTest do
+  use ExUnit.Case, async: true
+
+  alias ImagePipe.Parser
+
+  defmodule NoOptionParser do
+    @behaviour ImagePipe.Parser
+
+    @impl ImagePipe.Parser
+    def parse(_conn, _opts), do: {:error, :unused}
+
+    @impl ImagePipe.Parser
+    def handle_error(conn, _error), do: conn
+  end
+
+  defmodule OptionParser do
+    @behaviour ImagePipe.Parser
+
+    @impl ImagePipe.Parser
+    def parse(_conn, _opts), do: {:error, :unused}
+
+    @impl ImagePipe.Parser
+    def handle_error(conn, _error), do: conn
+
+    @impl ImagePipe.Parser
+    def validate_options!(opts), do: Keyword.put(opts, :validated_namespace, normalized: true)
+  end
+
+  describe "validate_options!/2" do
+    test "dispatches to a parser that owns option validation" do
+      result = Parser.validate_options!(OptionParser, parser: OptionParser)
+
+      assert result[:parser] == OptionParser
+      assert result[:validated_namespace] == [normalized: true]
+    end
+
+    test "is an identity for a parser that takes no host options" do
+      opts = [parser: NoOptionParser, max_body_bytes: 1_000]
+
+      assert Parser.validate_options!(NoOptionParser, opts) == opts
+    end
+  end
+end

--- a/test/image_pipe/plan/operation_key_data_test.exs
+++ b/test/image_pipe/plan/operation_key_data_test.exs
@@ -98,7 +98,7 @@ defmodule ImagePipe.Plan.OperationKeyDataTest do
                min_height: nil,
                zoom_x: 1.0,
                zoom_y: 1.0,
-               rule: :imgproxy_orientation_match_v1
+               rule: :auto_orientation_match_v1
              ]
 
       refute Keyword.has_key?(data, :selected_branch)

--- a/test/parser/imgproxy/signature_test.exs
+++ b/test/parser/imgproxy/signature_test.exs
@@ -5,7 +5,10 @@ defmodule ImagePipe.Parser.Imgproxy.SignatureTest do
   alias ImagePipe.Parser.Imgproxy.Signature
 
   test "imgproxy parser exposes parser-owned option validation" do
-    options = Imgproxy.validate_options!([])
+    options =
+      []
+      |> Imgproxy.validate_options!()
+      |> Keyword.fetch!(:imgproxy)
 
     assert %Signature{mode: :disabled} = Keyword.fetch!(options, :signature)
     assert %ImagePipe.Parser.Imgproxy.Presets{} = Keyword.fetch!(options, :presets)
@@ -251,17 +254,17 @@ defmodule ImagePipe.Parser.Imgproxy.SignatureTest do
   describe "Imgproxy.validate_options!/1" do
     test "rejects unknown top-level imgproxy options" do
       assert_raise ArgumentError, ~r/unknown options.*:trusted_signatures/, fn ->
-        Imgproxy.validate_options!(trusted_signatures: ["local-dev!"])
+        Imgproxy.validate_options!(imgproxy: [trusted_signatures: ["local-dev!"]])
       end
 
       assert_raise ArgumentError, ~r/unknown options.*:keys/, fn ->
-        Imgproxy.validate_options!(keys: ["74657374"], salts: ["73616c74"])
+        Imgproxy.validate_options!(imgproxy: [keys: ["74657374"], salts: ["73616c74"]])
       end
     end
 
     test "rejects explicit nil signature config" do
       assert_raise ArgumentError, ~r/invalid value for :signature option/, fn ->
-        Imgproxy.validate_options!(signature: nil)
+        Imgproxy.validate_options!(imgproxy: [signature: nil])
       end
     end
   end

--- a/test/parser/imgproxy/source_encryption_test.exs
+++ b/test/parser/imgproxy/source_encryption_test.exs
@@ -22,7 +22,10 @@ defmodule ImagePipe.Parser.Imgproxy.SourceEncryptionTest do
   @docs_segment "p5VjorNdhs7mRRw8gA9TWoRlGci3l1kuzqN43UQlRaRIQ0qtBKW3qFABIsx-ZRz_cVc8iVTYbhsNsxNBL1BHaQ"
 
   test "validates and stores decoded encryption key material" do
-    imgproxy_opts = Imgproxy.validate_options!(source_url_encryption_key: @aes128_key)
+    imgproxy_opts =
+      [imgproxy: [source_url_encryption_key: @aes128_key]]
+      |> Imgproxy.validate_options!()
+      |> Keyword.fetch!(:imgproxy)
 
     assert %SourceEncryption{key: decoded_key} =
              Keyword.fetch!(imgproxy_opts, :source_url_encryption)
@@ -35,11 +38,11 @@ defmodule ImagePipe.Parser.Imgproxy.SourceEncryptionTest do
   test "rejects malformed encryption keys without echoing the key value" do
     for key <- ["", "not-hex", String.duplicate("00", 15), String.duplicate("00", 33)] do
       assert_raise ArgumentError, ~r/invalid imgproxy config/, fn ->
-        Imgproxy.validate_options!(source_url_encryption_key: key)
+        Imgproxy.validate_options!(imgproxy: [source_url_encryption_key: key])
       end
 
       try do
-        Imgproxy.validate_options!(source_url_encryption_key: key)
+        Imgproxy.validate_options!(imgproxy: [source_url_encryption_key: key])
       rescue
         error in ArgumentError ->
           if key != "" do
@@ -143,7 +146,7 @@ defmodule ImagePipe.Parser.Imgproxy.SourceEncryptionTest do
   end
 
   defp parser_opts(imgproxy_opts) do
-    [imgproxy: Imgproxy.validate_options!(imgproxy_opts)]
+    Imgproxy.validate_options!(imgproxy: imgproxy_opts)
   end
 
   defp encrypted_segment(source, key, iv) do

--- a/test/parser/imgproxy_test.exs
+++ b/test/parser/imgproxy_test.exs
@@ -90,17 +90,20 @@ defmodule ImagePipe.Parser.ImgproxyTest do
           %{"foobar" => {FoobarTranslator, %{}}}
         ] do
       assert_raise ArgumentError, ~r/invalid imgproxy config/, fn ->
-        Imgproxy.validate_options!(source_schemes: source_schemes)
+        Imgproxy.validate_options!(imgproxy: [source_schemes: source_schemes])
       end
     end
   end
 
   test "validates imgproxy auto_rotate config" do
-    assert Imgproxy.validate_options!(auto_rotate: true)[:auto_rotate] == true
-    assert Imgproxy.validate_options!(auto_rotate: false)[:auto_rotate] == false
+    assert Imgproxy.validate_options!(imgproxy: [auto_rotate: true])[:imgproxy][:auto_rotate] ==
+             true
+
+    assert Imgproxy.validate_options!(imgproxy: [auto_rotate: false])[:imgproxy][:auto_rotate] ==
+             false
 
     assert_raise ArgumentError, ~r/invalid imgproxy config/, fn ->
-      Imgproxy.validate_options!(auto_rotate: "true")
+      Imgproxy.validate_options!(imgproxy: [auto_rotate: "true"])
     end
   end
 
@@ -1895,20 +1898,18 @@ defmodule ImagePipe.Parser.ImgproxyTest do
         signature: [keys: ["746573742d6b6579"], salts: ["746573742d73616c74"]]
       ]
       |> Keyword.merge(overrides)
-      |> Imgproxy.validate_options!()
 
-    [imgproxy: imgproxy_opts]
+    Imgproxy.validate_options!(imgproxy: imgproxy_opts)
   end
 
   defp preset_opts(definitions) do
-    [
-      imgproxy:
-        Imgproxy.validate_options!(
-          auto_rotate: false,
-          strip_color_profile: false,
-          presets: definitions
-        )
-    ]
+    Imgproxy.validate_options!(
+      imgproxy: [
+        auto_rotate: false,
+        strip_color_profile: false,
+        presets: definitions
+      ]
+    )
   end
 
   defp assert_error_status(reason, status) do


### PR DESCRIPTION
## Problem

`ImagePipe.Plug` aliased and pattern-matched the concrete `ImagePipe.Parser.Imgproxy` adapter to validate its host options, so the core did not satisfy the "an adapter can be ripped out into a standalone package without changing the core" principle. While here, two further core→imgproxy couplings were cleaned up so an adapter is **completely removable without changing a single line of core code**.

## Changes

**Generic parser option validation (the issue):**
- Add an optional `@callback validate_options!(keyword()) :: keyword()` to `ImagePipe.Parser`, plus a neutral dispatch facade `ImagePipe.Parser.validate_options!(parser, opts)` that invokes the callback when a parser implements it and is an identity otherwise. The optionality lives in the behaviour boundary, so the plug stays parser-agnostic and a no-option parser needs no boilerplate.
- `ImagePipe.Plug.init/1` now dispatches through the facade — no `alias`, no pattern-match on a concrete parser.
- `ImagePipe.Parser.Imgproxy.validate_options!/1` becomes the behaviour impl over the **full** host opts (`Keyword.get(:imgproxy) → validate → Keyword.put`); the imgproxy-schema validation moved to a private helper. The adapter owns its whole option contract.

**Remaining core→imgproxy couplings removed:**
- Dropped `exports: [Imgproxy]` from the `ImagePipe.Parser` behaviour boundary — the core never names a concrete adapter.
- Renamed the neutral `:auto` resize cache-key label `:imgproxy_orientation_match_v1` → `:auto_orientation_match_v1` so the Plan boundary's contract doesn't embed the vendor name (greenfield key reshape, in place).

Parity comments documenting imgproxy as a compatibility target across `transform/` and `output/` are intentionally retained — they're sanctioned conformance documentation, not couplings; removing the adapter doesn't break them.

## Tests / locking in
- Extended the architecture boundary test to forbid naming the imgproxy parser from **plug** and **plan** code (in addition to request/source/response/cache/output) and to assert the Parser boundary exports no concrete adapter.
- New `test/image_pipe/parser_test.exs` covering the facade: dispatch to an implementing parser, identity for one without the callback.
- Updated imgproxy option-validation call sites to the full-opts contract and synced the host-facing snippet in `docs/imgproxy_support_matrix.md`.

Full gate green: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, and the full `mix test` suite (1814 tests, 52 properties, 1 doctest).

Fixes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated guidance on parser option validation workflow to support configuration of encoded and encrypted source URLs with clearer instructions on the validation process.

* **Performance**
  * Refined cache key generation for improved consistency in automated image processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->