### PR TITLE
test(imgproxy-differential): 16-bit-aware tolerance + pin auto-format divergence

### DIFF
--- a/docs/imgproxy_support_matrix.md
+++ b/docs/imgproxy_support_matrix.md
@@ -206,16 +206,16 @@ in that corner.
 
 **Differential coverage (behavioral/pixel).** The PNG path is OSS-differentiable:
 `rgb16_preserve_hdr` (`ph:1`, 16-bit PNG round-trip) and `rgb16_tonemap_8bit`
-(`ph:0`, 8-bit) both pixel-conform against the OSS bake (maxΔ 0), and the 8-bit
-RGBA case `rgba16_tonemap_8bit` also conforms. **Diverges (alpha band, [#229](https://github.com/hlindset/image_pipe/issues/229)):**
-`rgba16_preserve_hdr` is **quarantined** — on a uniformly fully-opaque 16-bit RGBA
-source (alpha = 65535 everywhere) imgproxy's `ph:1` path perturbs the alpha band
-(fixture avg 65435, down to ~65311 — maxΔ 224/65535 ≈ 0.34%) while ImagePipe
-preserves it pristine; the RGB bands match to Δ1, so the visible image agrees and
-ImagePipe is the more-correct side. The differential tol model also can't fairly
-judge it: it decomposes the 16-bit USHORT band into hi/lo bytes, so a 0.34% real
-alpha delta surfaces as Δ224 in the low byte across the whole band — an 8-bit
-Δ-threshold/budget can't express a 16-bit-channel tolerance.
+(`ph:0`, 8-bit) both pixel-conform against the OSS bake (maxΔ 0), and both RGBA
+cases — `rgba16_tonemap_8bit` (8-bit) and `rgba16_preserve_hdr` (16-bit) — conform
+within the default Δ2/64 tol. On the 16-bit RGBA case imgproxy premultiplies the RGB
+by the (uniformly opaque) alpha before the resize and rounds the alpha a hair off
+65535, where ImagePipe leaves a fully-opaque alpha untouched — ImagePipe is the
+more-correct side, and the decoded footprint of the difference is a handful of
+sub-tolerance skew samples (maxΔ ~9 levels). The differential comparator reconstructs
+16-bit samples and judges deltas in 8-bit-equivalent levels
+([#229](https://github.com/hlindset/image_pipe/issues/229)), so HDR fixtures get a
+fair pixel claim instead of a low-byte blow-out.
 
 ## Status legend
 
@@ -460,6 +460,19 @@ ImagePipe probes libvips AVIF/WebP write support at boot. Automatic negotiation
 filters out formats the build cannot write; a modern source format the client did
 not accept transcodes to raster (PNG/JPEG by alpha). An explicit `format` the
 build cannot write is rejected with `501` before source fetch.
+
+**Diverges (`extend`/`padding` + auto format, [#235](https://github.com/hlindset/image_pipe/issues/235)):**
+when that raster container is picked by alpha (a modern source the client did not
+accept, no explicit `format`), ImagePipe reads the **final image's** `has_alpha?`,
+while imgproxy predicts transparency from the **request** —
+`expectTransparency = HasAlpha || PaddingEnabled() || ExtendEnabled()`
+(`processing/processing.go`). So when `extend`/`padding` is requested but the result
+is opaque (an opaque `bg`, or an inert extend, [#220](https://github.com/hlindset/image_pipe/issues/220)),
+ImagePipe serves **JPEG** and imgproxy serves **PNG**. ImagePipe is the more-correct
+side — it ships the smaller opaque container, with no alpha to lose — and this is the
+same pre- vs post-transform resolution timing as the HDR `supports_hdr?` divergence
+above. Reachable only on the non-passthrough source path (jpeg/png sources
+short-circuit). Pinned by a wire test (`imgproxy_wire_conformance_test.exs`).
 
 - ✅ `IMGPROXY_AUTO_WEBP`
 - ✅ `IMGPROXY_ENABLE_WEBP_DETECTION`

--- a/test/image_pipe/imgproxy_differential/pixel_compare_test.exs
+++ b/test/image_pipe/imgproxy_differential/pixel_compare_test.exs
@@ -6,6 +6,12 @@ defmodule ImagePipe.Test.ImgproxyDifferential.PixelCompareTest do
 
   defp img(w, h, color), do: Image.new!(w, h, color: color)
 
+  # A 1-band USHORT image filled with a single value, for exact 16-bit-delta control.
+  defp u16_const(w, h, value) do
+    {:ok, base} = Operation.black(w, h)
+    base |> Operation.linear!([0.0], [value * 1.0]) |> Image.cast!({:u, 16})
+  end
+
   describe "dims/1" do
     test "returns width and height" do
       assert PixelCompare.dims(img(7, 3, :black)) == {7, 3}
@@ -85,6 +91,50 @@ defmodule ImagePipe.Test.ImgproxyDifferential.PixelCompareTest do
 
       # a full-range 16-bit edge (Δ65535) normalizes to ~255, not ~65535
       assert_in_delta PixelCompare.spatial_contrast(edge), 255.0, 0.5
+    end
+  end
+
+  describe "16-bit (USHORT) tolerance" do
+    test "a sub-level 16-bit delta is judged in 8-bit-equivalent levels, not raw low bytes" do
+      # raw Δ224/65535 ≈ 0.87 levels — the imgproxy opaque-alpha perturbation (#229).
+      # The low byte differs by 224, which a byte-wise comparison flags as a massive
+      # Δ224 outlier; reconstructed in USHORT space the sample is below Δ2.
+      a = u16_const(16, 16, 30_000)
+      b = u16_const(16, 16, 30_224)
+
+      assert PixelCompare.outliers(a, b, 2) == 0
+      assert PixelCompare.fraction_over(a, b, 2) == 0.0
+    end
+
+    test "a genuine 16-bit structural delta still trips the tolerance (anti-tautology)" do
+      # raw Δ32768 ≈ 127 levels — a real blow-out must stay visible, so the 16-bit
+      # path cannot pass simply by ignoring high bytes. One band → one sample per
+      # pixel, so the count is per-sample (256), not per-byte (512).
+      a = u16_const(16, 16, 20_000)
+      b = u16_const(16, 16, 52_768)
+
+      assert PixelCompare.outliers(a, b, 2) == 16 * 16
+      assert PixelCompare.fraction_over(a, b, 2) == 1.0
+    end
+
+    test "diagnose reports a sub-level 16-bit delta in 8-bit-equivalent levels" do
+      a = u16_const(8, 8, 10_000)
+      b = u16_const(8, 8, 10_224)
+      d = PixelCompare.diagnose(a, b)
+
+      # round(224 / 257) == 1 level; nothing exceeds Δ2.
+      assert d.max_delta == 1
+      assert d.over == %{2 => 0, 16 => 0, 32 => 0}
+    end
+
+    test "diagnose surfaces a structural 16-bit delta above every level threshold" do
+      a = u16_const(8, 8, 10_000)
+      b = u16_const(8, 8, 42_768)
+      d = PixelCompare.diagnose(a, b)
+
+      # round(32768 / 257) == 128 levels; every sample exceeds Δ2/Δ16/Δ32.
+      assert d.max_delta == 128
+      assert d.over == %{2 => 8 * 8, 16 => 8 * 8, 32 => 8 * 8}
     end
   end
 

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -2352,6 +2352,30 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
       end
     end
 
+    test "automatic format is state-driven: opaque padding on a non-passthrough source stays JPEG (#235)" do
+      base = [
+        parser: ImagePipe.Parser.Imgproxy,
+        sources: [
+          path:
+            {RootHTTPAdapter,
+             root_url: "http://origin.test", req_options: [plug: AvifOriginImage]}
+        ]
+      ]
+
+      # cat.avif is 64×64 solid red (opaque). An opaque padding fill keeps the result
+      # opaque, so ImagePipe's automatic format — resolved from the *final* image's
+      # `has_alpha?` — picks JPEG. imgproxy is request-driven: the mere presence of
+      # padding makes `determineOutputFormat` expect transparency (`PaddingEnabled()`,
+      # processing.go), so it would emit PNG here. ImagePipe deliberately diverges,
+      # serving the smaller opaque container; this pins that choice (a documented
+      # surface divergence — docs/imgproxy_support_matrix.md, #235).
+      conn = call_imgproxy("/_/pd:10/bg:255:0:0/plain/images/cat.avif", base, "image/jpeg")
+
+      assert conn.status == 200
+      assert content_type(conn) == ["image/jpeg"]
+      assert dimensions(conn) == {84, 84}
+    end
+
     test "an avif-capable and avif-less build caches distinct variants for the same Accept" do
       {base, cache_root} = cached_opts()
 

--- a/test/support/image_pipe/test/imgproxy_differential/README.md
+++ b/test/support/image_pipe/test/imgproxy_differential/README.md
@@ -90,7 +90,7 @@ itself: `mise exec -- mix test test/image_pipe/imgproxy_gen_report_test.exs --in
 ## Triage a bake (no Docker)
 
 When a freshly baked case fails the conformance lane, `mix imgproxy.diagnose` prints a
-one-line summary per constellation — output dims, band layout, the maximum band-byte
+one-line summary per constellation — output dims, band layout, the maximum per-sample
 delta, a `>Δ2`/`>Δ16`/`>Δ32` histogram, and PASS/over-budget against the authored tol —
 by rendering ImagePipe live against the committed fixture (the same `Harness` the
 conformance test uses):
@@ -115,7 +115,7 @@ flagged cases — a separate axis from `--failing` (correctness). It measures pe
 **Reading it — skew vs structural.** `maxΔ` is the deciding signal:
 
 - **Diffuse resampling skew** (a libvips-version difference, not a bug) keeps `maxΔ` low —
-  tens of levels — even when many band-bytes exceed Δ2. Absorb it with a tolerance.
+  tens of levels — even when many samples exceed Δ2. Absorb it with a tolerance.
 - **A placement/crop/scale shift** misaligns high-contrast edges, pushing `maxΔ` toward
   ~255. That is a real divergence — never widen a tol to hide it; quarantine (`:triage` +
   a tracking issue) or fix.
@@ -131,6 +131,11 @@ flagged cases — a separate axis from `--failing` (correctness). It measures pe
 - Zone-plate / heavy-downscale sources (`high_freq`, rotated EXIF blocks): the skew is
   diffuse and higher-amplitude, so set the **threshold just above the measured `maxΔ`**
   with a tight budget (Δ32 is typical; the worst cells need more).
+- 16-bit (HDR) sources (`rgb16`/`rgba16`): the comparison reconstructs each 16-bit
+  sample and normalizes deltas to **8-bit-equivalent levels**, so the same `Δ2`/budget
+  vocabulary applies across bit depths — author a 16-bit fixture's tol in levels, not in
+  raw 16-bit units. (Comparing raw bytes would split a sample into hi/lo halves and read
+  a hair of 16-bit noise as a low-byte blow-out.)
 
 After changing only a `tol`, refresh the authored hashes with `mix imgproxy.reauthor`
 (no Docker) rather than re-baking.

--- a/test/support/image_pipe/test/imgproxy_differential/constellations.ex
+++ b/test/support/image_pipe/test/imgproxy_differential/constellations.ex
@@ -424,37 +424,14 @@ defmodule ImagePipe.Test.ImgproxyDifferential.Constellations do
       # RGBA path.
       c("rgb16_preserve_hdr", :rgb16, "ph:1/rs:fit:200:200"),
       c("rgb16_tonemap_8bit", :rgb16, "ph:0/rs:fit:200:200"),
-      # rgba16_preserve_hdr DIVERGES (quarantined → #229). The source alpha is
-      # uniformly fully opaque (min=max=65535); ImagePipe preserves it pristine
-      # (live alpha a constant 65535), while imgproxy's ph:1 16-bit RGBA path
-      # perturbs it (fixture alpha down to 65311 — maxΔ 224/65535 ≈ 0.34%). imgproxy
-      # premultiplies the RGB by that perturbed alpha before the resize, so with the
-      # full-range source (#240) the RGB bands now also shift (maxΔ ~2240/65535 ≈
-      # 3.4%) — a downstream consequence of the same alpha quirk, not an independent
-      # divergence (the rgb16 no-alpha preserve case above is byte-identical, so the
-      # RGB resample itself matches imgproxy; the prior near-black source merely hid
-      # this because the premultiplied RGB stayed near zero). ImagePipe is the
-      # more-correct side (it leaves a fully-opaque alpha untouched). The conformance
-      # tol model can't fairly judge it either: it decomposes the 16-bit USHORT band
-      # into hi/lo bytes, so the real deltas surface as large LOW-byte deltas across
-      # the band — an 8-bit Δ-threshold/budget can't express a 16-bit tolerance (a
-      # harness limitation independent of the alpha quirk). Tracked under #229;
-      # imgproxy still bakes the fixture so the gap stays measured — distinct from
-      # #222 (a metadata/band-LAYOUT contract layer, blind to pixel values) and #220
-      # (a spurious alpha CHANNEL). The rgb16 (no alpha) preserve case above is a
-      # clean PASS, covering the core 16-bit PNG round-trip; the rgba16 TONEMAP case
-      # below also PASSES (8-bit, alpha 255 both sides).
-      %{
-        c("rgba16_preserve_hdr", :rgba16, "ph:1/rs:fit:200:200")
-        | verdict: :diverges,
-          divergence: %{metric: :fraction_over, threshold: 32, floor: 0.05},
-          triage: %{
-            reason:
-              "imgproxy perturbs a fully-opaque 16-bit alpha (maxΔ 224/65535); ImagePipe " <>
-                "preserves it. 8-bit band-byte tol can't express a 16-bit-channel tolerance.",
-            issue: "#229"
-          }
-      },
+      # rgba16_preserve_hdr is the rgb16 preserve case plus a 16-bit alpha band — the
+      # 16-bit RGBA preserve-HDR path. The source alpha is uniformly opaque (65535);
+      # ImagePipe leaves it untouched, while imgproxy premultiplies the RGB by the
+      # alpha before the resize and rounds the alpha a hair off 65535, nudging a few
+      # RGB(A) samples. The decoded footprint is a handful of sub-tolerance skew
+      # samples (maxΔ ~9 levels, well inside the default Δ2/64 tol), on par with the
+      # rgba16 tonemap sibling below — so it passes :equal.
+      c("rgba16_preserve_hdr", :rgba16, "ph:1/rs:fit:200:200"),
       c("rgba16_tonemap_8bit", :rgba16, "ph:0/rs:fit:200:200"),
 
       # --- stage-interaction probes: compositions verified alone but never crossed.

--- a/test/support/image_pipe/test/imgproxy_differential/manifest.exs
+++ b/test/support/image_pipe/test/imgproxy_differential/manifest.exs
@@ -646,7 +646,7 @@
       kind: :transform
     },
     "rgba16_preserve_hdr" => %{
-      authored_sha256: "3e74791885feb327fd58bd3607bff74bf1fc66959118cdc0286cac3171cbfb0d",
+      authored_sha256: "9d32615d0aa1fe406341cc06e536ea2feb2183b1b8f18b421d22599e80fa5ff2",
       fixture_filename: "rgba16_preserve_hdr.png",
       fixture_sha256: "2eed28ab08e3dfb2fd4441fbe6570fa2b5c0cf94a3611a5ad547add2c0c043ee",
       kind: :transform

--- a/test/support/image_pipe/test/imgproxy_differential/pixel_compare.ex
+++ b/test/support/image_pipe/test/imgproxy_differential/pixel_compare.ex
@@ -37,25 +37,41 @@ defmodule ImagePipe.Test.ImgproxyDifferential.PixelCompare do
       |> Enum.map(fn band -> Enum.at(vals, band * 10 + 1) - Enum.at(vals, band * 10) end)
       |> Enum.max()
 
-    max_band_range / format_max(image) * 255.0
+    max_band_range / format_max(VipsImage.format(image)) * 255.0
   end
 
-  defp format_max(image) do
-    case VipsImage.format(image) do
-      :VIPS_FORMAT_USHORT -> 65_535.0
-      :VIPS_FORMAT_SHORT -> 32_767.0
-      :VIPS_FORMAT_UINT -> 4_294_967_295.0
-      _ -> 255.0
-    end
-  end
+  defp format_max(:VIPS_FORMAT_USHORT), do: 65_535.0
+  defp format_max(:VIPS_FORMAT_SHORT), do: 32_767.0
+  defp format_max(:VIPS_FORMAT_UINT), do: 4_294_967_295.0
+  defp format_max(_), do: 255.0
+
+  # A band sample's width in the raw `write_to_binary` buffer. USHORT (16-bit)
+  # fixtures pack two bytes per sample; everything else the harness compares
+  # (8-bit PNG decode) is one byte. Comparing raw *bytes* would split a 16-bit
+  # sample into hi/lo halves and judge each as an 8-bit value, so a hair of 16-bit
+  # noise reads as a structural blow-out in the low byte (#229) — hence the
+  # per-format walk below.
+  defp sample_bytes(:VIPS_FORMAT_USHORT), do: 2
+  defp sample_bytes(_), do: 1
+
+  # 8-bit-equivalent level → raw sample threshold for this band format, so one
+  # tolerance vocabulary (0..255 levels) judges 8- and 16-bit fixtures alike
+  # (USHORT: ×257, since 65535/255 = 257).
+  defp raw_threshold(level, format), do: round(level * format_max(format) / 255.0)
+
+  # Inverse of raw_threshold: a raw sample delta back to 8-bit-equivalent levels.
+  defp to_levels(raw, format), do: round(raw / (format_max(format) / 255.0))
 
   @spec same_dims?(VipsImage.t(), VipsImage.t()) :: boolean()
   def same_dims?(a, b), do: dims(a) == dims(b)
 
   @doc """
-  Count of band-bytes whose absolute delta exceeds `threshold` (band-byte counting
-  upper-bounds pixel outliers — the stricter choice). Raises `ArgumentError` if the
-  two images differ in dimensions or band layout.
+  Count of band-samples whose absolute delta exceeds `threshold`, in 8-bit-equivalent
+  levels (per-sample counting upper-bounds pixel outliers — the stricter choice). A
+  16-bit (USHORT) sample is reconstructed and judged in 16-bit space, then compared
+  against `threshold` scaled into that space, so the count is per *sample*, not per
+  raw byte. Raises `ArgumentError` if the two images differ in dimensions or band
+  layout.
   """
   @spec outliers(VipsImage.t(), VipsImage.t(), non_neg_integer()) :: non_neg_integer()
   def outliers(a, b, threshold) do
@@ -70,20 +86,23 @@ defmodule ImagePipe.Test.ImgproxyDifferential.PixelCompare do
       raise ArgumentError, "band layout mismatch: #{byte_size(ab)} vs #{byte_size(bb)}"
     end
 
-    count_outliers(ab, bb, threshold, 0)
+    format = VipsImage.format(a)
+    count_outliers(format, ab, bb, raw_threshold(threshold, format), 0)
   end
 
   @doc """
-  Fraction (0.0..1.0) of band-bytes whose absolute delta exceeds `threshold` — a
-  whole-frame divergence metric. Raises on dimension/band-layout mismatch.
+  Fraction (0.0..1.0) of band-samples whose absolute delta exceeds `threshold` — a
+  whole-frame divergence metric. The denominator is the sample count (USHORT bands
+  carry one sample per two bytes), matching `outliers/3`. Raises on dimension/band-
+  layout mismatch.
   """
   @spec fraction_over(VipsImage.t(), VipsImage.t(), non_neg_integer()) :: float()
   def fraction_over(a, b, threshold) do
     {:ok, ab} = VipsImage.write_to_binary(a)
 
-    case byte_size(ab) do
+    case div(byte_size(ab), sample_bytes(VipsImage.format(a))) do
       0 -> 0.0
-      total -> outliers(a, b, threshold) / total
+      samples -> outliers(a, b, threshold) / samples
     end
   end
 
@@ -91,7 +110,9 @@ defmodule ImagePipe.Test.ImgproxyDifferential.PixelCompare do
 
   @doc """
   Single-pass triage summary for a live-vs-fixture comparison: dims, band layout,
-  the maximum absolute band-byte delta, and a band-byte count over each threshold.
+  the maximum absolute sample delta, and a sample count over each threshold — all
+  in 8-bit-equivalent levels (USHORT samples are reconstructed and normalized, so
+  8- and 16-bit fixtures share one vocabulary).
 
   Returns a map:
 
@@ -122,34 +143,62 @@ defmodule ImagePipe.Test.ImgproxyDifferential.PixelCompare do
     if comparable do
       {:ok, abin} = VipsImage.write_to_binary(a)
       {:ok, bbin} = VipsImage.write_to_binary(b)
-      {max_delta, over} = scan(abin, bbin, thresholds, 0, Map.new(thresholds, &{&1, 0}))
-      Map.merge(base, %{max_delta: max_delta, over: over})
+      format = VipsImage.format(a)
+      pairs = Enum.map(thresholds, &{&1, raw_threshold(&1, format)})
+      {max_raw, over} = scan(format, abin, bbin, pairs, 0, Map.new(thresholds, &{&1, 0}))
+      Map.merge(base, %{max_delta: to_levels(max_raw, format), over: over})
     else
       Map.merge(base, %{max_delta: nil, over: %{}})
     end
   end
 
-  # Counts band-bytes (not pixels) whose absolute delta exceeds the threshold.
-  # Band-byte counting upper-bounds pixel outliers — the stricter choice — and
-  # avoids needing the band count here.
-  defp count_outliers(<<>>, <<>>, _t, acc), do: acc
+  # Counts band-samples (not pixels) whose absolute delta exceeds the raw threshold.
+  # Per-sample counting upper-bounds pixel outliers — the stricter choice. A USHORT
+  # sample is reconstructed from its two native-endian bytes so the delta is judged
+  # in 16-bit space, not split across hi/lo bytes (#229).
+  defp count_outliers(_format, <<>>, <<>>, _t, acc), do: acc
 
-  defp count_outliers(<<av, arest::binary>>, <<bv, brest::binary>>, t, acc) do
+  defp count_outliers(
+         :VIPS_FORMAT_USHORT,
+         <<av::native-unsigned-16, ar::binary>>,
+         <<bv::native-unsigned-16, br::binary>>,
+         t,
+         acc
+       ) do
     acc = if abs(av - bv) > t, do: acc + 1, else: acc
-    count_outliers(arest, brest, t, acc)
+    count_outliers(:VIPS_FORMAT_USHORT, ar, br, t, acc)
   end
 
-  # One pass over both raw buffers, tracking the max delta and per-threshold counts.
-  defp scan(<<>>, <<>>, _thresholds, max_delta, counts), do: {max_delta, counts}
+  defp count_outliers(format, <<av, ar::binary>>, <<bv, br::binary>>, t, acc) do
+    acc = if abs(av - bv) > t, do: acc + 1, else: acc
+    count_outliers(format, ar, br, t, acc)
+  end
 
-  defp scan(<<av, arest::binary>>, <<bv, brest::binary>>, thresholds, max_delta, counts) do
+  # One pass over both raw buffers, tracking the max raw sample delta and per-level
+  # counts. `pairs` carries each {level, raw_threshold} so counts stay keyed by the
+  # caller's 8-bit-equivalent levels while the comparison runs in raw sample units.
+  defp scan(_format, <<>>, <<>>, _pairs, max_raw, counts), do: {max_raw, counts}
+
+  defp scan(
+         :VIPS_FORMAT_USHORT,
+         <<av::native-unsigned-16, ar::binary>>,
+         <<bv::native-unsigned-16, br::binary>>,
+         pairs,
+         max_raw,
+         counts
+       ) do
     delta = abs(av - bv)
+    scan(:VIPS_FORMAT_USHORT, ar, br, pairs, max(max_raw, delta), bump(pairs, delta, counts))
+  end
 
-    counts =
-      Enum.reduce(thresholds, counts, fn t, acc ->
-        if delta > t, do: Map.update!(acc, t, &(&1 + 1)), else: acc
-      end)
+  defp scan(format, <<av, ar::binary>>, <<bv, br::binary>>, pairs, max_raw, counts) do
+    delta = abs(av - bv)
+    scan(format, ar, br, pairs, max(max_raw, delta), bump(pairs, delta, counts))
+  end
 
-    scan(arest, brest, thresholds, max(max_delta, delta), counts)
+  defp bump(pairs, delta, counts) do
+    Enum.reduce(pairs, counts, fn {level, raw}, acc ->
+      if delta > raw, do: Map.update!(acc, level, &(&1 + 1)), else: acc
+    end)
   end
 end


### PR DESCRIPTION
Two related imgproxy differential-conformance changes. No `lib/` behavior change — entirely the differential test harness, a wire-level pin, and conformance docs.

## #229 — 16-bit-aware pixel tolerance

The differential `PixelCompare` wrote each band to a raw byte buffer and compared **bytes**, so a 16-bit (USHORT) sample was split into hi/lo halves and each half judged as an 8-bit value. A hair of real 16-bit noise surfaced as a structural low-byte blow-out, and there was no honest 8-bit threshold/budget for a 16-bit fixture (Finding 2).

- Reconstruct USHORT samples and judge deltas in **8-bit-equivalent levels**, so one tolerance vocabulary (`Δ2`/budget) spans 8- and 16-bit fixtures. 8-bit fixtures are unchanged (one byte = one sample).
- New tests, including an **anti-tautology** check: a genuine 16-bit structural delta still trips the tolerance, so the 16-bit path can't pass by ignoring high bytes.

Under the fair comparator, the quarantined `rgba16_preserve_hdr` measures as sub-tolerance skew — **maxΔ ~9 levels over 5 of 160,000 samples**, indistinguishable from the `rgba16_tonemap_8bit` sibling that already passes. imgproxy premultiplies the RGB by the (uniformly opaque) alpha before resize and rounds the alpha a hair off 65535; ImagePipe leaves a fully-opaque alpha untouched (the more-correct side). The "divergence" in #229's Finding 1 was an artifact of the broken byte-wise tolerance, not a real one — so the case **un-parks from `:triage` quarantine to a clean `:equal` PASS** (manifest reauthored). Differential conformance is now **126/126, nothing excluded**.

## #235 — auto-format transparency decision (documented divergence)

ImagePipe's automatic output format is **state-driven** — it inspects the final image's `Image.has_alpha?`. imgproxy is **request-driven**: `expectTransparency = HasAlpha || PaddingEnabled() || ExtendEnabled()` (`processing/processing.go`). So on a non-passthrough source with `extend`/`padding` requested but an **opaque** result (an opaque `bg`, or an inert extend) and auto format, ImagePipe serves **JPEG** where imgproxy serves **PNG**.

ImagePipe is the more-correct side — it ships the smaller opaque container, with no alpha to lose — so this is kept as a **deliberate surface divergence**, not matched:

- A wire-level test pins ImagePipe's JPEG choice (`AvifOriginImage` + opaque `pd:10/bg:…` + jpeg-only `Accept` → `image/jpeg`).
- Documented in `docs/imgproxy_support_matrix.md` (Output format detection), noting it's the same pre- vs post-transform resolution timing as the existing HDR `supports_hdr?` divergence.

## Verification

Full `mix` gate green: format, `compile --warnings-as-errors`, `credo --strict`, and `1818 tests, 0 failures`.

Fixes #229
Fixes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)
