### PR TITLE
Spike (#263): source-overlap probe — NO-GO for the seekable spool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ mise.local.toml
 
 # Generated benchmark output
 bench/results/
+bench/.cache/
 tmp/
 
 # Generated imgproxy differential visual-diff report (regenerate on demand)

--- a/bench/source_overlap_probe.exs
+++ b/bench/source_overlap_probe.exs
@@ -23,15 +23,33 @@
 #   # more samples, custom rates (Mbps; "unlimited" allowed):
 #   mise exec -- mix run bench/source_overlap_probe.exs 5 unlimited,40,8,2
 #
+#   # conservative full-res decode instead of the real shrink-on-load path:
+#   mise exec -- mix run bench/source_overlap_probe.exs full
+#
 #   # machine-readable rows for collation (suppresses the human tables):
 #   mise exec -- mix run bench/source_overlap_probe.exs --csv
 #
 #   # force regeneration of the cached fixtures:
 #   mise exec -- mix run bench/source_overlap_probe.exs --regen
 #
+# SINK — what work the decode does (the operation that consumes the source):
+#   * shrink (default) — models the REAL pipeline: open `access: :sequential` and
+#     shrink-on-load to ~1024px where the format supports it (JPEG `shrink:`),
+#     then read every (shrunk) pixel. Seek-heavy formats (HEIF/AVIF, TIFF) have NO
+#     shrink-on-load, so they decode full-res either way — exactly what the real
+#     pipeline pays for them.
+#   * full — conservative: sequential full-res decode, no shrink-on-load. A LARGER
+#     decode is the win-favorable choice for hunting overlap (more work that could
+#     hide under the download), so a NO-GO under `full` is the stronger result.
+#   Overlap is destroyed by the loader having to BUFFER THE WHOLE INPUT before it can
+#   produce output (seek-heavy via :pipe) or by a MONOLITHIC decode (AV1), NOT by
+#   "needing all pixels": a sequential forward decode overlaps fine (it is the
+#   positive control here).
+#
 # METHODOLOGY (overlap measured without a fragile decode-start hook):
-#   For each (fixture, rate) we time, around wall-clock, a forced FULL decode
-#   (`Operation.avg/1` reads every pixel) reached three ways, plus two references:
+#   For each (fixture, rate) we time, around wall-clock, the chosen decode sink
+#   (`Operation.avg/1` reads every pixel of the sequential/shrunk load) reached
+#   three ways, plus two references:
 #     * download_only  — drain the throttled enum, no decode      → the download floor
 #     * decode_cold    — new_from_buffer + avg from an in-RAM copy → pure decode cost
 #                        (rate-independent; measured once per fixture)
@@ -59,6 +77,8 @@ defmodule SourceOverlapProbe do
 
   @default_samples 3
   @default_rates [:unlimited, 100, 16, 4]
+  # Realistic downscale target (long side, px) for the shrink-on-load sink.
+  @target_long 1024
   # Aim for ~15 ms per throttle tick: small enough for a smooth rate, large enough
   # that BEAM timer jitter (~1 ms) is a minor fraction.
   @chunk_target_ms 15
@@ -72,7 +92,7 @@ defmodule SourceOverlapProbe do
   def main(argv) do
     {csv?, argv} = pop_flag(argv, "--csv")
     {regen?, argv} = pop_flag(argv, "--regen")
-    {samples, rates} = parse(argv)
+    {samples, rates, sink} = parse(argv)
 
     # Remove cross-iteration noise from the libvips operation cache.
     Vix.Vips.cache_set_max(0)
@@ -80,15 +100,21 @@ defmodule SourceOverlapProbe do
 
     assert_vix_fork!()
 
-    fixtures = ensure_fixtures(regen?, samples)
+    fixtures = ensure_fixtures(regen?, samples, sink)
     results = for fx <- fixtures, rate <- rates, do: measure_cell(fx, rate, samples)
 
+    unless csv?, do: IO.puts("\nsink = #{sink} (#{sink_desc(sink)})")
     checks = self_checks(fixtures, results)
     unless csv?, do: print_self_checks(checks)
     abort_on_hard_failures(checks)
 
-    if csv?, do: emit_csv(results), else: report(fixtures, results, rates)
+    if csv?, do: emit_csv(results, sink), else: report(fixtures, results, rates)
   end
+
+  defp sink_desc(:shrink),
+    do: "real path: sequential + shrink-on-load to ~#{@target_long}px where supported"
+
+  defp sink_desc(:full), do: "conservative: sequential, full-res decode (no shrink-on-load)"
 
   # ── fork capability gate ──────────────────────────────────────────────────
 
@@ -106,7 +132,7 @@ defmodule SourceOverlapProbe do
 
   # ── fixtures (cached, gitignored) ─────────────────────────────────────────
 
-  defp ensure_fixtures(regen?, samples) do
+  defp ensure_fixtures(regen?, samples, sink) do
     File.mkdir_p!(@cache_dir)
     if regen?, do: Enum.each(@fixtures, fn {_, _, f} -> File.rm(Path.join(@cache_dir, f)) end)
 
@@ -118,9 +144,14 @@ defmodule SourceOverlapProbe do
     Enum.map(@fixtures, fn {class, fmt, file} ->
       path = Path.join(@cache_dir, file)
       bin = File.read!(path)
+      dims = dims(bin)
+      opts = decode_opts(sink, fmt, dims)
       # decode_cold / header-open are rate-independent: measure once per fixture.
-      decode_cold = median(for _ <- 1..(samples + 1), do: time_us(fn -> decode_buffer(bin) end))
-      header_open = median(for _ <- 1..(samples + 1), do: time_us(fn -> open_buffer(bin) end))
+      decode_cold =
+        median(for _ <- 1..(samples + 1), do: time_us(fn -> decode_buffer(bin, opts) end))
+
+      header_open =
+        median(for _ <- 1..(samples + 1), do: time_us(fn -> open_buffer(bin, opts) end))
 
       %{
         class: class,
@@ -128,10 +159,17 @@ defmodule SourceOverlapProbe do
         path: path,
         bin: bin,
         size: byte_size(bin),
+        dims: dims,
+        decode_opts: opts,
         decode_cold: decode_cold,
         header_open: header_open
       }
     end)
+  end
+
+  defp dims(bin) do
+    img = open_buffer(bin, access: :VIPS_ACCESS_SEQUENTIAL)
+    {Vix.Vips.Image.width(img), Vix.Vips.Image.height(img)}
   end
 
   # One materialized source -> three encodings of the SAME pixels. JPEG is forward
@@ -189,51 +227,71 @@ defmodule SourceOverlapProbe do
   end
 
   # ── the four timed operations ─────────────────────────────────────────────
+  #
+  # `decode_opts` are the loader options the real pipeline opens with: always
+  # `access: :sequential` (Processor opens sequential; random access is per-op and
+  # lazy), plus shrink-on-load where the format supports it (DecodePlanner). avg/1
+  # then reads every (possibly shrunk) pixel — the work the request must do before
+  # it can transform/encode. The `:full` sink drops shrink (a conservative, larger
+  # decode); seek-heavy formats have no shrink-on-load, so both sinks decode them
+  # identically — exactly what the real pipeline pays.
 
   defp download_only(bin, rate_bps) do
     throttled(bin, rate_bps) |> Enum.reduce(0, fn c, acc -> acc + byte_size(c) end)
   end
 
-  defp baseline(bin, rate_bps) do
+  defp baseline(bin, rate_bps, decode_opts) do
     data = throttled(bin, rate_bps) |> Enum.to_list() |> IO.iodata_to_binary()
-    decode_buffer(data)
+    decode_buffer(data, decode_opts)
   end
 
-  defp overlap(bin, rate_bps, :pipe) do
-    {:ok, img} = Vix.Vips.Image.new_from_enum(throttled(bin, rate_bps), mode: :pipe)
-    sink(img)
-  end
-
-  defp overlap(bin, rate_bps, :spool) do
-    size = byte_size(bin)
-
+  defp overlap(bin, rate_bps, :pipe, decode_opts) do
     {:ok, img} =
-      Vix.Vips.Image.new_from_enum(throttled(bin, rate_bps),
-        mode: :spool,
-        content_length: size,
-        max_bytes: size * 2
-      )
+      Vix.Vips.Image.new_from_enum(throttled(bin, rate_bps), [mode: :pipe] ++ decode_opts)
 
     sink(img)
   end
 
-  defp decode_buffer(bin), do: bin |> open_buffer() |> sink()
-  defp open_buffer(bin), do: with({:ok, img} <- Vix.Vips.Image.new_from_buffer(bin, []), do: img)
+  defp overlap(bin, rate_bps, :spool, decode_opts) do
+    size = byte_size(bin)
+    spool_opts = [mode: :spool, content_length: size, max_bytes: size * 2]
+    {:ok, img} = Vix.Vips.Image.new_from_enum(throttled(bin, rate_bps), spool_opts ++ decode_opts)
+    sink(img)
+  end
+
+  defp decode_buffer(bin, decode_opts), do: bin |> open_buffer(decode_opts) |> sink()
+
+  defp open_buffer(bin, decode_opts),
+    do: with({:ok, img} <- Vix.Vips.Image.new_from_buffer(bin, decode_opts), do: img)
+
   # avg/1 reads every pixel — forces the full decode the lazy image defers.
   defp sink(img), do: Vix.Vips.Operation.avg!(img)
+
+  # The real-pipeline loader options for this sink/format. Always sequential.
+  defp decode_opts(:shrink, :jpg, {w, h}),
+    do: [access: :VIPS_ACCESS_SEQUENTIAL, shrink: jpeg_shrink(max(w, h))]
+
+  defp decode_opts(_sink, _fmt, _dims), do: [access: :VIPS_ACCESS_SEQUENTIAL]
+
+  # Largest power-of-two DCT shrink that keeps the long side ≥ the target (the coarse
+  # step DecodePlanner uses before the residual resize).
+  defp jpeg_shrink(long), do: Enum.find([8, 4, 2, 1], 1, &(long / &1 >= @target_long))
 
   # ── measurement ───────────────────────────────────────────────────────────
 
   # samples + 1: the first run is a discarded warmup.
   defp measure_cell(fx, rate, samples) do
     bps = rate_bps(rate)
+    opts = fx.decode_opts
     dl = median(for _ <- 1..(samples + 1), do: time_us(fn -> download_only(fx.bin, bps) end))
-    base = median(for _ <- 1..(samples + 1), do: time_us(fn -> baseline(fx.bin, bps) end))
+    base = median(for _ <- 1..(samples + 1), do: time_us(fn -> baseline(fx.bin, bps, opts) end))
 
     modes =
       for mode <- [:pipe, :spool], into: %{} do
         total =
-          median(for _ <- 1..(samples + 1), do: time_us(fn -> overlap(fx.bin, bps, mode) end))
+          median(
+            for _ <- 1..(samples + 1), do: time_us(fn -> overlap(fx.bin, bps, mode, opts) end)
+          )
 
         tail = total - dl
         overlap_pct = pct_clamped(fx.decode_cold - tail, fx.decode_cold)
@@ -453,11 +511,12 @@ defmodule SourceOverlapProbe do
   defp material?(m),
     do: m.saving >= @material_saving_ms * 1000 and m.saving_pct >= @material_saving_pct
 
-  defp emit_csv(results) do
+  defp emit_csv(results, sink) do
     for r <- results, {mode, m} <- r.modes do
       IO.puts(
         Enum.join(
           [
+            sink,
             r.class,
             r.fmt,
             rate_label(r.rate),
@@ -527,7 +586,9 @@ defmodule SourceOverlapProbe do
         spec -> spec |> String.split(",", trim: true) |> Enum.map(&to_rate/1)
       end
 
-    {samples, rates}
+    sink = if "full" in argv, do: :full, else: :shrink
+
+    {samples, rates, sink}
   end
 
   defp rate_token?(s), do: s == "unlimited"

--- a/bench/source_overlap_probe.exs
+++ b/bench/source_overlap_probe.exs
@@ -1,0 +1,543 @@
+# Source-overlap probe (#263, Phase 1 — the gate).
+#
+# Answers the one question that gates the whole streaming/seekable-source spike:
+#
+#     Does decode actually OVERLAP a slow download — and for seek-heavy formats
+#     (HEIF/AVIF, tiled TIFF), only via `mode: :spool`?
+#
+# It is deliberately a *synthetic, Vix-level* probe: the source is an Elixir
+# enumerable fed straight to `Vix.Vips.Image.new_from_enum/2`, so no HTTP/pipeline
+# wiring is needed. `:pipe` runs the bytes through the real OS-pipe feeder; `:spool`
+# fills the real native seekable buffer (`Vix.SourceSpool`). If overlap is absent
+# here, it cannot appear in the real pipeline either, so we stop before building the
+# expensive real-`ImagePipe.call` harness (Phase 2, deferred).
+#
+# Requires the vix fork that ships `new_from_enum(mode: :pipe | :spool | :auto)`
+# (hlindset/vix @ my-experimental-fixes). The probe asserts that at startup.
+#
+# Run with mise so tool versions match:
+#
+#   # default matrix (3 samples, rates unlimited/100/16/4 Mbps):
+#   mise exec -- mix run bench/source_overlap_probe.exs
+#
+#   # more samples, custom rates (Mbps; "unlimited" allowed):
+#   mise exec -- mix run bench/source_overlap_probe.exs 5 unlimited,40,8,2
+#
+#   # machine-readable rows for collation (suppresses the human tables):
+#   mise exec -- mix run bench/source_overlap_probe.exs --csv
+#
+#   # force regeneration of the cached fixtures:
+#   mise exec -- mix run bench/source_overlap_probe.exs --regen
+#
+# METHODOLOGY (overlap measured without a fragile decode-start hook):
+#   For each (fixture, rate) we time, around wall-clock, a forced FULL decode
+#   (`Operation.avg/1` reads every pixel) reached three ways, plus two references:
+#     * download_only  — drain the throttled enum, no decode      → the download floor
+#     * decode_cold    — new_from_buffer + avg from an in-RAM copy → pure decode cost
+#                        (rate-independent; measured once per fixture)
+#     * baseline       — drain enum to a binary, THEN decode       → today's ImagePipe
+#                        shape (serial: ≈ download_only + decode_cold)
+#     * pipe / spool   — new_from_enum(mode:) + avg, end-to-end    → the overlapped path
+#   Derived per overlapped mode:
+#     saving   = baseline - mode_total              (wall-clock saved vs serial)
+#     tail     = mode_total - download_only         (decode cost NOT hidden under download)
+#     overlap% = (decode_cold - tail) / decode_cold (fraction of decode hidden)
+#   The win scales with source slowness, so overlap% is read at the SLOWEST rate.
+#
+# SELF-CHECKS (printed; hard failures abort — this is the anti-tautology gate):
+#   1. sink-decodes   — decode_cold >> header-only open  (avg really forces decode)
+#   2. throttle-floor — throttled download_only ≈ size/rate (the enum really throttles)
+#   3. baseline-serial— baseline ≈ download_only + decode_cold (the timing model holds)
+#
+# This probe measures LATENCY/overlap only (the gate). Peak-RSS / N×content_length
+# memory ceilings and the /info early-abort tension are Phase-2 concerns, deferred.
+
+defmodule SourceOverlapProbe do
+  @cache_dir "bench/.cache"
+  @gen_source "priv/static/images/waterfall.jpg"
+  @thumb_width 3600
+
+  @default_samples 3
+  @default_rates [:unlimited, 100, 16, 4]
+  # Aim for ~15 ms per throttle tick: small enough for a smooth rate, large enough
+  # that BEAM timer jitter (~1 ms) is a minor fraction.
+  @chunk_target_ms 15
+
+  @fixtures [
+    {:forward, :jpg, "probe.jpg"},
+    {:seek_heavy, :avif, "probe.avif"},
+    {:seek_heavy, :tiff, "probe.tif"}
+  ]
+
+  def main(argv) do
+    {csv?, argv} = pop_flag(argv, "--csv")
+    {regen?, argv} = pop_flag(argv, "--regen")
+    {samples, rates} = parse(argv)
+
+    # Remove cross-iteration noise from the libvips operation cache.
+    Vix.Vips.cache_set_max(0)
+    Vix.Vips.cache_set_max_mem(0)
+
+    assert_vix_fork!()
+
+    fixtures = ensure_fixtures(regen?, samples)
+    results = for fx <- fixtures, rate <- rates, do: measure_cell(fx, rate, samples)
+
+    checks = self_checks(fixtures, results)
+    unless csv?, do: print_self_checks(checks)
+    abort_on_hard_failures(checks)
+
+    if csv?, do: emit_csv(results), else: report(fixtures, results, rates)
+  end
+
+  # ── fork capability gate ──────────────────────────────────────────────────
+
+  defp assert_vix_fork! do
+    Code.ensure_loaded(Vix.Vips.Image)
+
+    unless function_exported?(Vix.Vips.Image, :new_from_enum, 2) and
+             Code.ensure_loaded?(Vix.SourceSpool) do
+      abort("""
+      This probe requires the vix fork with new_from_enum(mode: :pipe | :spool | :auto).
+      Pin {:vix, git: "https://github.com/hlindset/vix.git", ref: "<my-experimental-fixes HEAD>"}.
+      """)
+    end
+  end
+
+  # ── fixtures (cached, gitignored) ─────────────────────────────────────────
+
+  defp ensure_fixtures(regen?, samples) do
+    File.mkdir_p!(@cache_dir)
+    if regen?, do: Enum.each(@fixtures, fn {_, _, f} -> File.rm(Path.join(@cache_dir, f)) end)
+
+    missing? =
+      Enum.any?(@fixtures, fn {_, _, f} -> not File.exists?(Path.join(@cache_dir, f)) end)
+
+    if missing?, do: generate_fixtures()
+
+    Enum.map(@fixtures, fn {class, fmt, file} ->
+      path = Path.join(@cache_dir, file)
+      bin = File.read!(path)
+      # decode_cold / header-open are rate-independent: measure once per fixture.
+      decode_cold = median(for _ <- 1..(samples + 1), do: time_us(fn -> decode_buffer(bin) end))
+      header_open = median(for _ <- 1..(samples + 1), do: time_us(fn -> open_buffer(bin) end))
+
+      %{
+        class: class,
+        fmt: fmt,
+        path: path,
+        bin: bin,
+        size: byte_size(bin),
+        decode_cold: decode_cold,
+        header_open: header_open
+      }
+    end)
+  end
+
+  # One materialized source -> three encodings of the SAME pixels. JPEG is forward
+  # (decodes as bytes arrive). AVIF (AV1-in-HEIF) and tiled TIFF are seek-heavy: the
+  # loader seeks, so `:pipe` must buffer the whole stream before decoding.
+  defp generate_fixtures do
+    IO.puts("generating fixtures from #{@gen_source} (#{@thumb_width}px wide)…")
+
+    {:ok, img} =
+      Vix.Vips.Image.copy_memory(Vix.Vips.Operation.thumbnail!(@gen_source, @thumb_width))
+
+    Vix.Vips.Operation.jpegsave!(img, Path.join(@cache_dir, "probe.jpg"), Q: 90)
+
+    Vix.Vips.Operation.heifsave!(img, Path.join(@cache_dir, "probe.avif"),
+      compression: :VIPS_FOREIGN_HEIF_COMPRESSION_AV1,
+      Q: 63
+    )
+
+    # Tiled + JPEG-compressed TIFF: random-access tiles, non-trivial per-tile decode,
+    # and a moderate encoded size (uncompressed/deflate would be far larger and skew
+    # the download axis).
+    Vix.Vips.Operation.tiffsave!(img, Path.join(@cache_dir, "probe.tif"),
+      tile: true,
+      tile_width: 256,
+      tile_height: 256,
+      compression: :VIPS_FOREIGN_TIFF_COMPRESSION_JPEG,
+      Q: 90
+    )
+  end
+
+  # ── throttled source ──────────────────────────────────────────────────────
+
+  # A fresh enum each call; the consumer (feeder / producer / our drain) paces on the
+  # per-chunk sleep. `binary_part/3` returns a sub-binary (no copy).
+  defp throttled(bin, :unlimited), do: chunk_stream(bin, 65_536, 0)
+
+  defp throttled(bin, rate_bps) do
+    chunk = max(4096, round(rate_bps * @chunk_target_ms / 1000))
+    sleep_ms = max(1, round(chunk / rate_bps * 1000))
+    chunk_stream(bin, chunk, sleep_ms)
+  end
+
+  defp chunk_stream(bin, chunk, sleep_ms) do
+    size = byte_size(bin)
+
+    Stream.unfold(0, fn
+      off when off >= size ->
+        nil
+
+      off ->
+        if sleep_ms > 0, do: Process.sleep(sleep_ms)
+        len = min(chunk, size - off)
+        {binary_part(bin, off, len), off + len}
+    end)
+  end
+
+  # ── the four timed operations ─────────────────────────────────────────────
+
+  defp download_only(bin, rate_bps) do
+    throttled(bin, rate_bps) |> Enum.reduce(0, fn c, acc -> acc + byte_size(c) end)
+  end
+
+  defp baseline(bin, rate_bps) do
+    data = throttled(bin, rate_bps) |> Enum.to_list() |> IO.iodata_to_binary()
+    decode_buffer(data)
+  end
+
+  defp overlap(bin, rate_bps, :pipe) do
+    {:ok, img} = Vix.Vips.Image.new_from_enum(throttled(bin, rate_bps), mode: :pipe)
+    sink(img)
+  end
+
+  defp overlap(bin, rate_bps, :spool) do
+    size = byte_size(bin)
+
+    {:ok, img} =
+      Vix.Vips.Image.new_from_enum(throttled(bin, rate_bps),
+        mode: :spool,
+        content_length: size,
+        max_bytes: size * 2
+      )
+
+    sink(img)
+  end
+
+  defp decode_buffer(bin), do: bin |> open_buffer() |> sink()
+  defp open_buffer(bin), do: with({:ok, img} <- Vix.Vips.Image.new_from_buffer(bin, []), do: img)
+  # avg/1 reads every pixel — forces the full decode the lazy image defers.
+  defp sink(img), do: Vix.Vips.Operation.avg!(img)
+
+  # ── measurement ───────────────────────────────────────────────────────────
+
+  # samples + 1: the first run is a discarded warmup.
+  defp measure_cell(fx, rate, samples) do
+    bps = rate_bps(rate)
+    dl = median(for _ <- 1..(samples + 1), do: time_us(fn -> download_only(fx.bin, bps) end))
+    base = median(for _ <- 1..(samples + 1), do: time_us(fn -> baseline(fx.bin, bps) end))
+
+    modes =
+      for mode <- [:pipe, :spool], into: %{} do
+        total =
+          median(for _ <- 1..(samples + 1), do: time_us(fn -> overlap(fx.bin, bps, mode) end))
+
+        tail = total - dl
+        overlap_pct = pct_clamped(fx.decode_cold - tail, fx.decode_cold)
+
+        {mode,
+         %{
+           total: total,
+           saving: base - total,
+           saving_pct: pct_clamped(base - total, base),
+           tail: tail,
+           overlap_pct: overlap_pct
+         }}
+      end
+
+    %{
+      class: fx.class,
+      fmt: fx.fmt,
+      size: fx.size,
+      rate: rate,
+      download_only: dl,
+      baseline: base,
+      decode_cold: fx.decode_cold,
+      modes: modes
+    }
+  end
+
+  # ── self-checks (anti-tautology gate) ─────────────────────────────────────
+
+  defp self_checks(fixtures, results) do
+    sink = Enum.map(fixtures, &sink_decodes_check/1)
+
+    throttle =
+      results |> Enum.reject(&(&1.rate == :unlimited)) |> Enum.map(&throttle_floor_check/1)
+
+    serial = Enum.map(results, &baseline_serial_check/1)
+    sink ++ throttle ++ serial
+  end
+
+  # decode_cold must dwarf a header-only open, or `avg` isn't forcing a decode.
+  defp sink_decodes_check(fx) do
+    ratio = safe_ratio(fx.decode_cold, fx.header_open)
+
+    %{
+      name: "sink-decodes #{fx.fmt}",
+      ok: ratio >= 3.0,
+      hard: true,
+      detail:
+        "decode_cold #{ms(fx.decode_cold)} / header_open #{ms(fx.header_open)} = #{f2(ratio)}x (want ≥3x)"
+    }
+  end
+
+  # The throttled drain must take roughly size/rate; otherwise the enum isn't pacing.
+  defp throttle_floor_check(r) do
+    expected_us = r.size / rate_bps(r.rate) * 1_000_000
+    ratio = safe_ratio(r.download_only, expected_us)
+
+    %{
+      name: "throttle-floor #{r.fmt}@#{rate_label(r.rate)}",
+      ok: ratio >= 0.6,
+      hard: true,
+      detail:
+        "download_only #{ms(r.download_only)} vs expected #{ms(expected_us)} = #{f2(ratio)}x (want ≥0.6x)"
+    }
+  end
+
+  # baseline is serial by construction, so it must ≈ download_only + decode_cold.
+  # A loose bound (this validates the timing model, not a tight SLA).
+  defp baseline_serial_check(r) do
+    expected = r.download_only + r.decode_cold
+    rel = abs(r.baseline - expected) / max(expected, 1)
+
+    %{
+      name: "baseline-serial #{r.fmt}@#{rate_label(r.rate)}",
+      ok: rel <= 0.35,
+      hard: false,
+      detail:
+        "baseline #{ms(r.baseline)} vs dl+decode #{ms(expected)} (Δ #{f2(rel * 100)}%, want ≤35%)"
+    }
+  end
+
+  defp print_self_checks(checks) do
+    IO.puts("\nself-checks:")
+
+    Enum.each(checks, fn c ->
+      mark = if c.ok, do: "ok  ", else: if(c.hard, do: "FAIL", else: "warn")
+      IO.puts("  [#{mark}] #{c.name}: #{c.detail}")
+    end)
+  end
+
+  defp abort_on_hard_failures(checks) do
+    hard = Enum.filter(checks, &(&1.hard and not &1.ok))
+
+    unless hard == [] do
+      abort(
+        "hard self-check failure(s): #{Enum.map_join(hard, "; ", & &1.name)} — results not trustworthy"
+      )
+    end
+  end
+
+  # ── reporting ─────────────────────────────────────────────────────────────
+
+  defp report(fixtures, results, rates) do
+    IO.puts(
+      "\nsource-overlap probe  (samples median; saving = baseline − mode; overlap% = decode hidden under download)\n"
+    )
+
+    Enum.each(fixtures, fn fx ->
+      cells = Enum.filter(results, &(&1.fmt == fx.fmt))
+
+      IO.puts(
+        "#{String.upcase(to_string(fx.class))}  #{fx.fmt}  (#{kb(fx.size)}, decode_cold #{ms(fx.decode_cold)})"
+      )
+
+      IO.puts(
+        "  " <>
+          col("rate", 11) <>
+          col("download", 11) <>
+          col("baseline", 11) <>
+          col("pipe", 11) <> col("(save/ovl)", 16) <> col("spool", 11) <> col("(save/ovl)", 16)
+      )
+
+      Enum.each(cells, fn r ->
+        p = r.modes.pipe
+        s = r.modes.spool
+
+        IO.puts(
+          "  " <>
+            col(rate_label(r.rate), 11) <>
+            col(ms(r.download_only), 11) <>
+            col(ms(r.baseline), 11) <>
+            col(ms(p.total), 11) <>
+            col("#{f0(p.saving_pct)}%/#{f0(p.overlap_pct)}%", 16) <>
+            col(ms(s.total), 11) <>
+            col("#{f0(s.saving_pct)}%/#{f0(s.overlap_pct)}%", 16)
+        )
+      end)
+
+      IO.puts("")
+    end)
+
+    verdict(fixtures, results, rates)
+  end
+
+  # The decision metric is the ABSOLUTE wall-clock saving, not overlap%. overlap% is
+  # the fraction of decode hidden under the download — but the most any overlap can
+  # save is the decode cost itself (decode_cold), so a high overlap% of a cheap decode
+  # is still a negligible win. The fork (the SourceSpool seekable buffer) is justified
+  # only if :spool delivers a MATERIAL saving on a SEEK-HEAVY fixture (forward overlap
+  # needs no spool — :pipe already gives it). Read at the slowest rate, where the win
+  # is largest in relative terms.
+  @material_saving_ms 100
+  @material_saving_pct 5
+
+  defp verdict(fixtures, results, rates) do
+    slow = rates |> Enum.reject(&(&1 == :unlimited)) |> List.last()
+    if is_nil(slow), do: throw(:no_throttled_rate)
+
+    IO.puts(
+      "verdict @ #{rate_label(slow)}  (max possible saving = decode_cold; spool justified only by a material seek-heavy saving)\n"
+    )
+
+    IO.puts(
+      "  " <>
+        col("fixture", 18) <>
+        col("max(decode)", 13) <>
+        col("pipe save", 18) <> col("spool save", 18) <> "overlap p/s"
+    )
+
+    rows =
+      Enum.map(fixtures, fn fx ->
+        {fx, Enum.find(results, &(&1.fmt == fx.fmt and &1.rate == slow))}
+      end)
+
+    Enum.each(rows, fn {fx, r} ->
+      p = r.modes.pipe
+      s = r.modes.spool
+
+      IO.puts(
+        "  " <>
+          col("#{fx.fmt} (#{fx.class})", 18) <>
+          col("#{ms(fx.decode_cold)}ms", 13) <>
+          col("#{ms(p.saving)}ms/#{f0(p.saving_pct)}%", 18) <>
+          col("#{ms(s.saving)}ms/#{f0(s.saving_pct)}%", 18) <>
+          "#{f0(p.overlap_pct)}%/#{f0(s.overlap_pct)}%"
+      )
+    end)
+
+    decide(rows)
+  end
+
+  defp decide(rows) do
+    material =
+      Enum.filter(rows, fn {fx, r} ->
+        fx.class == :seek_heavy and material?(r.modes.spool)
+      end)
+
+    IO.puts("")
+
+    if material == [] do
+      IO.puts("""
+      NO-GO: no seek-heavy fixture shows a material :spool saving (≥#{@material_saving_ms}ms and ≥#{@material_saving_pct}%).
+      The overlappable formats (forward) decode too cheaply to matter and need only :pipe;
+      the expensive seek-heavy decode (AVIF/AV1) is monolithic and cannot overlap a download.
+      ⇒ Do not adopt the forked native dep for slow-source latency. Document and stay on the
+        drain baseline. (The spool may still have a separate memory-shape case — out of scope.)
+      """)
+    else
+      names = Enum.map_join(material, ", ", fn {fx, _} -> to_string(fx.fmt) end)
+
+      IO.puts("""
+      GREENLIGHT: material :spool saving on seek-heavy fixture(s): #{names}.
+      ⇒ Proceed to Phase 2 (real-pipeline harness) to confirm the win end-to-end.
+      """)
+    end
+  end
+
+  defp material?(m),
+    do: m.saving >= @material_saving_ms * 1000 and m.saving_pct >= @material_saving_pct
+
+  defp emit_csv(results) do
+    for r <- results, {mode, m} <- r.modes do
+      IO.puts(
+        Enum.join(
+          [
+            r.class,
+            r.fmt,
+            rate_label(r.rate),
+            r.size,
+            ms(r.download_only),
+            ms(r.decode_cold),
+            ms(r.baseline),
+            mode,
+            ms(m.total),
+            ms(m.saving),
+            f0(m.saving_pct),
+            f0(m.overlap_pct)
+          ],
+          ","
+        )
+      )
+    end
+  end
+
+  # ── helpers ───────────────────────────────────────────────────────────────
+
+  defp time_us(fun) do
+    t0 = System.monotonic_time(:microsecond)
+    _ = fun.()
+    System.monotonic_time(:microsecond) - t0
+  end
+
+  defp rate_bps(:unlimited), do: :unlimited
+  defp rate_bps(mbps) when is_integer(mbps), do: mbps * 125_000
+
+  defp rate_label(:unlimited), do: "unlimited"
+  defp rate_label(mbps), do: "#{mbps}Mbps"
+
+  defp median([]), do: 0
+
+  defp median(list) do
+    # drop the warmup (first sample), then take the median of the rest
+    sorted = list |> Enum.drop(1) |> Enum.sort()
+    n = length(sorted)
+    if n == 0, do: hd(list), else: Enum.at(sorted, div(n, 2))
+  end
+
+  defp pct_clamped(_num, 0), do: 0.0
+  defp pct_clamped(num, den), do: max(0.0, num / den * 100)
+
+  defp safe_ratio(_a, b) when b in [0, 0.0], do: 0.0
+  defp safe_ratio(a, b), do: a / b
+
+  defp ms(us), do: :erlang.float_to_binary(us / 1000, decimals: 1)
+  defp kb(bytes), do: "#{:erlang.float_to_binary(bytes / 1024, decimals: 0)}KB"
+  defp f0(x), do: :erlang.float_to_binary(x * 1.0, decimals: 0)
+  defp f2(x), do: :erlang.float_to_binary(x * 1.0, decimals: 2)
+  defp col(s, w), do: String.pad_trailing(to_string(s), w)
+
+  defp pop_flag(argv, flag), do: {flag in argv, Enum.reject(argv, &(&1 == flag))}
+
+  defp parse(argv) do
+    samples =
+      case Enum.find(argv, &(Integer.parse(&1) != :error)) do
+        nil -> @default_samples
+        s -> s |> Integer.parse() |> elem(0) |> max(1)
+      end
+
+    rates =
+      case Enum.find(argv, &String.contains?(&1, ",")) || Enum.find(argv, &rate_token?/1) do
+        nil -> @default_rates
+        spec -> spec |> String.split(",", trim: true) |> Enum.map(&to_rate/1)
+      end
+
+    {samples, rates}
+  end
+
+  defp rate_token?(s), do: s == "unlimited"
+  defp to_rate("unlimited"), do: :unlimited
+  defp to_rate(s), do: s |> Integer.parse() |> elem(0)
+
+  defp abort(msg) do
+    IO.puts(:stderr, "\n#{msg}\n")
+    System.halt(1)
+  end
+end
+
+SourceOverlapProbe.main(System.argv())

--- a/bench/source_overlap_probe.exs
+++ b/bench/source_overlap_probe.exs
@@ -26,6 +26,9 @@
 #   # conservative full-res decode instead of the real shrink-on-load path:
 #   mise exec -- mix run bench/source_overlap_probe.exs full
 #
+#   # crop / prefix early-termination phase (bytes pulled per crop region × mode):
+#   mise exec -- mix run bench/source_overlap_probe.exs crop
+#
 #   # machine-readable rows for collation (suppresses the human tables):
 #   mise exec -- mix run bench/source_overlap_probe.exs --csv
 #
@@ -83,6 +86,11 @@ defmodule SourceOverlapProbe do
   # that BEAM timer jitter (~1 ms) is a minor fraction.
   @chunk_target_ms 15
 
+  # `crop` phase: fraction of image height to crop, and the rate to run it at. The
+  # bytes-pulled % is structural (rate-independent); the rate only sets wall time.
+  @crop_fraction 0.10
+  @crop_rate 16
+
   @fixtures [
     {:forward, :jpg, "probe.jpg"},
     {:seek_heavy, :avif, "probe.avif"},
@@ -92,7 +100,7 @@ defmodule SourceOverlapProbe do
   def main(argv) do
     {csv?, argv} = pop_flag(argv, "--csv")
     {regen?, argv} = pop_flag(argv, "--regen")
-    {samples, rates, sink} = parse(argv)
+    {samples, rates, sink, phase} = parse(argv)
 
     # Remove cross-iteration noise from the libvips operation cache.
     Vix.Vips.cache_set_max(0)
@@ -101,6 +109,14 @@ defmodule SourceOverlapProbe do
     assert_vix_fork!()
 
     fixtures = ensure_fixtures(regen?, samples, sink)
+
+    case phase do
+      :crop -> run_crop(fixtures, samples, csv?)
+      :overlap -> run_overlap(fixtures, rates, samples, sink, csv?)
+    end
+  end
+
+  defp run_overlap(fixtures, rates, samples, sink, csv?) do
     results = for fx <- fixtures, rate <- rates, do: measure_cell(fx, rate, samples)
 
     unless csv?, do: IO.puts("\nsink = #{sink} (#{sink_desc(sink)})")
@@ -115,6 +131,134 @@ defmodule SourceOverlapProbe do
     do: "real path: sequential + shrink-on-load to ~#{@target_long}px where supported"
 
   defp sink_desc(:full), do: "conservative: sequential, full-res decode (no shrink-on-load)"
+
+  # ── crop / prefix early-termination phase ─────────────────────────────────
+  #
+  # A different lever from overlap: in sequential mode an operation that depends only
+  # on an early prefix of the stream (a TOP crop of a top-to-bottom forward format)
+  # lets libvips stop reading once it has those rows — so a streamed source never pulls
+  # the rest of the download. The win is bounded by how much download is SKIPPED (not
+  # by decode cost). We tally bytes actually pulled from the throttled source per
+  # (fixture × crop-region × mode); << 100% means early termination fired.
+
+  @crops [:full, :top, :bottom]
+
+  defp run_crop(fixtures, samples, csv?) do
+    bps = rate_bps(@crop_rate)
+    pct = round(@crop_fraction * 100)
+
+    rows =
+      for fx <- fixtures, region <- @crops, mode <- [:pipe, :spool] do
+        pulled =
+          median(
+            for _ <- 1..(samples + 1),
+                do: time_pulled(fn ctr -> crop_run(fx, bps, region, mode, ctr) end)
+          )
+
+        %{fx: fx, region: region, mode: mode, pulled_pct: pulled / fx.size * 100}
+      end
+
+    if csv?, do: crop_csv(rows), else: crop_report(fixtures, rows, pct)
+  end
+
+  # Runs one crop decode under a counting throttle; returns bytes pulled from source.
+  defp crop_run(fx, bps, region, mode, ctr) do
+    {:ok, img} = Vix.Vips.Image.new_from_enum(throttled(fx.bin, bps, ctr), enum_opts(mode, fx))
+    sink(crop(img, region))
+  end
+
+  defp enum_opts(:pipe, _fx), do: [mode: :pipe, access: :VIPS_ACCESS_SEQUENTIAL]
+
+  defp enum_opts(:spool, fx),
+    do: [
+      mode: :spool,
+      content_length: fx.size,
+      max_bytes: fx.size * 2,
+      access: :VIPS_ACCESS_SEQUENTIAL
+    ]
+
+  defp crop(img, :full), do: img
+
+  defp crop(img, :top) do
+    {w, h} = {Vix.Vips.Image.width(img), Vix.Vips.Image.height(img)}
+    Vix.Vips.Operation.extract_area!(img, 0, 0, w, crop_h(h))
+  end
+
+  defp crop(img, :bottom) do
+    {w, h} = {Vix.Vips.Image.width(img), Vix.Vips.Image.height(img)}
+    ch = crop_h(h)
+    Vix.Vips.Operation.extract_area!(img, 0, h - ch, w, ch)
+  end
+
+  defp crop_h(h), do: max(1, round(h * @crop_fraction))
+
+  defp crop_report(fixtures, rows, pct) do
+    IO.puts(
+      "\ncrop / prefix early-termination @ #{rate_label(@crop_rate)}  (% of file pulled from the throttled source; << 100% = early stop)\n"
+    )
+
+    IO.puts(
+      "  " <>
+        col("fixture", 18) <>
+        col("full p/s", 14) <> col("top#{pct}% p/s", 14) <> col("bottom#{pct}% p/s", 14)
+    )
+
+    Enum.each(fixtures, fn fx ->
+      cell = fn region, mode ->
+        r = Enum.find(rows, &(&1.fx.fmt == fx.fmt and &1.region == region and &1.mode == mode))
+        f0(r.pulled_pct)
+      end
+
+      pair = fn region -> "#{cell.(region, :pipe)}/#{cell.(region, :spool)}%" end
+
+      IO.puts(
+        "  " <>
+          col("#{fx.fmt} (#{fx.class})", 18) <>
+          col(pair.(:full), 14) <> col(pair.(:top), 14) <> col(pair.(:bottom), 14)
+      )
+    end)
+
+    crop_verdict(fixtures, rows)
+  end
+
+  defp crop_verdict(fixtures, rows) do
+    pulled = fn fmt, region, mode ->
+      Enum.find(rows, &(&1.fx.fmt == fmt and &1.region == region and &1.mode == mode)).pulled_pct
+    end
+
+    IO.puts("\nverdict (top-crop pull % — low = the rest of the download is skipped):")
+
+    Enum.each(fixtures, fn fx ->
+      top = pulled.(fx.fmt, :top, :pipe)
+
+      read =
+        cond do
+          fx.class == :forward and top < 50 ->
+            "early stop ✓ (forward prefix — skips #{f0(100 - top)}% of download)"
+
+          fx.class == :forward ->
+            "no early stop ✗ (unexpected for a forward format)"
+
+          true ->
+            "no partial read ✗ (seek-heavy reads the whole file)"
+        end
+
+      IO.puts("  #{fx.fmt} (#{fx.class}): top pulls #{f0(top)}% → #{read}")
+    end)
+
+    IO.puts("""
+
+    :pipe and :spool pull the same — the spool adds nothing. The win is a :pipe (read-
+    once, on-demand) property, applies only to forward formats with a top-of-stream
+    crop, and survives shrink-on-load. Same mechanism as a header-only /info answer.
+    """)
+  end
+
+  defp crop_csv(rows) do
+    for r <- rows do
+      IO.puts(Enum.join([r.fx.class, r.fx.fmt, r.region, r.mode, f0(r.pulled_pct)], ","))
+    end
+  end
 
   # ── fork capability gate ──────────────────────────────────────────────────
 
@@ -203,16 +347,12 @@ defmodule SourceOverlapProbe do
   # ── throttled source ──────────────────────────────────────────────────────
 
   # A fresh enum each call; the consumer (feeder / producer / our drain) paces on the
-  # per-chunk sleep. `binary_part/3` returns a sub-binary (no copy).
-  defp throttled(bin, :unlimited), do: chunk_stream(bin, 65_536, 0)
-
-  defp throttled(bin, rate_bps) do
-    chunk = max(4096, round(rate_bps * @chunk_target_ms / 1000))
-    sleep_ms = max(1, round(chunk / rate_bps * 1000))
-    chunk_stream(bin, chunk, sleep_ms)
-  end
-
-  defp chunk_stream(bin, chunk, sleep_ms) do
+  # per-chunk sleep. `binary_part/3` returns a sub-binary (no copy). An optional
+  # `:counters` ref tallies bytes actually pulled — the consumer stops pulling when
+  # libvips stops reading (the crop early-termination signal), so the tally reveals
+  # how much of the source was downloaded.
+  defp throttled(bin, rate_bps, ctr \\ nil) do
+    {chunk, sleep_ms} = throttle_params(rate_bps)
     size = byte_size(bin)
 
     Stream.unfold(0, fn
@@ -222,8 +362,16 @@ defmodule SourceOverlapProbe do
       off ->
         if sleep_ms > 0, do: Process.sleep(sleep_ms)
         len = min(chunk, size - off)
+        if ctr, do: :counters.add(ctr, 1, len)
         {binary_part(bin, off, len), off + len}
     end)
+  end
+
+  defp throttle_params(:unlimited), do: {65_536, 0}
+
+  defp throttle_params(rate_bps) do
+    chunk = max(4096, round(rate_bps * @chunk_target_ms / 1000))
+    {chunk, max(1, round(chunk / rate_bps * 1000))}
   end
 
   # ── the four timed operations ─────────────────────────────────────────────
@@ -544,6 +692,13 @@ defmodule SourceOverlapProbe do
     System.monotonic_time(:microsecond) - t0
   end
 
+  # Runs `fun` with a fresh byte counter; returns bytes pulled from the throttled source.
+  defp time_pulled(fun) do
+    ctr = :counters.new(1, [])
+    _ = fun.(ctr)
+    :counters.get(ctr, 1)
+  end
+
   defp rate_bps(:unlimited), do: :unlimited
   defp rate_bps(mbps) when is_integer(mbps), do: mbps * 125_000
 
@@ -587,8 +742,9 @@ defmodule SourceOverlapProbe do
       end
 
     sink = if "full" in argv, do: :full, else: :shrink
+    phase = if "crop" in argv, do: :crop, else: :overlap
 
-    {samples, rates, sink}
+    {samples, rates, sink, phase}
   end
 
   defp rate_token?(s), do: s == "unlimited"

--- a/docs/superpowers/specs/2026-06-13-source-streaming-overlap-probe-findings.md
+++ b/docs/superpowers/specs/2026-06-13-source-streaming-overlap-probe-findings.md
@@ -25,58 +25,86 @@ straight to `Vix.Vips.Image.new_from_enum/2`. `:pipe` exercises the real OS-pipe
 feeder; `:spool` fills the real native seekable buffer (`Vix.SourceSpool`). A
 `Stream.unfold` throttle paces delivery to a target bytes/sec.
 
-Per `(fixture, rate)` we time a forced **full** decode (`Operation.avg/1` reads every
-pixel) reached three ways, plus two references:
+Per `(fixture, rate)` we time the decode **sink** reached three ways, plus two
+references:
 
 - `download_only` — drain the throttled enum, no decode → the download floor.
-- `decode_cold` — `new_from_buffer` + `avg` from an in-RAM copy → pure decode cost
+- `decode_cold` — open + `avg` from an in-RAM copy → pure decode cost
   (rate-independent; the **ceiling on any overlap saving**).
 - `baseline` — drain to a binary, *then* decode → today's ImagePipe shape (serial).
-- `pipe` / `spool` — `new_from_enum(mode:)` + `avg`, end-to-end → the overlapped path.
+- `pipe` / `spool` — `new_from_enum(mode:)` + sink, end-to-end → the overlapped path.
 
 Derived per overlapped mode: `saving = baseline − total`;
 `tail = total − download_only` (decode not hidden); `overlap% = (decode_cold − tail) /
 decode_cold` (fraction of decode hidden under the download).
 
-Fixtures (same pixels, three encodings; generated on the fly into the gitignored
-`bench/.cache/`): **JPEG** (forward), **AVIF** = AV1-in-HEIF (seek-heavy, expensive
-decode), **tiled JPEG-compressed TIFF** (seek-heavy, cheap decode).
+**The sink models the real pipeline, not a synthetic full decode.** The default
+`shrink` sink opens `access: :sequential` (the Processor always opens sequential) and
+shrink-on-loads to ~1024px where the format supports it (`DecodePlanner`), then reads
+every (shrunk) pixel with `Operation.avg/1` — the work a request must do before it can
+transform/encode. A `full` sink (sequential, no shrink-on-load) is also available; it
+is a *conservative* choice for hunting overlap (a larger decode = more work that could
+hide under the download), and gives the same verdict. **Crucially, only JPEG has
+shrink-on-load; HEIF/AVIF and TIFF have none** (see the support table below), so for
+the seek-heavy formats both sinks decode full-res — exactly what the real pipeline
+pays.
+
+Fixtures (2400×3600, same pixels, three encodings; generated on the fly into the
+gitignored `bench/.cache/`): **JPEG** (forward), **AVIF** = AV1-in-HEIF (seek-heavy,
+expensive decode), **tiled JPEG-compressed TIFF** (seek-heavy, cheap decode).
 
 **Anti-tautology self-checks** (all passed on every cell): `avg` really forces a
-decode (`decode_cold` ≫ header-only open, 28–700×); the enum really throttles
+decode (`decode_cold` ≫ header-only open, 22–700×); the enum really throttles
 (`download_only` ≈ `size/rate`, ratio ~1.07); `baseline` is serial
-(`≈ download_only + decode_cold`, Δ < 10%). The forward-`:pipe` cell is the positive
-control — it *does* overlap (64–74%), so the harness detects overlap when present.
+(`≈ download_only + decode_cold`, Δ < 15%). The forward cell is the positive
+control — it *does* overlap (40–95%), so the harness detects overlap when present.
 
-## Results (local macOS, libvips with heif/avif/tiff; medians, 3 samples + warmup)
+### Shrink-on-load support (the decisive structural fact)
+
+| format | source loader shrink-on-load | real-pipeline decode |
+|---|---|---|
+| JPEG (forward) | `shrink:` (DCT, powers of 2) | shrink-decode (still entropy-decodes the whole stream) |
+| AVIF / HEIF (seek-heavy) | **none** (only `page`/`n`/`thumbnail`) | **full-res decode**, then resize |
+| TIFF (seek-heavy) | **none** (only `page`/`n`) | **full-res decode**, then resize |
+
+So the probe's seek-heavy decode is not an artifact of a heavy synthetic sink — it is
+what the pipeline genuinely does for those formats.
+
+## Results — realistic `shrink` sink (local macOS, libvips w/ heif/avif/tiff; medians, 3 samples + warmup)
 
 Rates in Mbps (1 Mbps = 125 KB/s). `save` = wall-clock saved vs baseline; `ovl` =
 fraction of decode hidden.
 
 ```
-FORWARD  jpg  (3433KB, decode_cold 49.0ms)
+FORWARD  jpg  (3433KB, decode_cold 40.2ms — shrink-on-load to ~1200px)
   rate       download   baseline   pipe (save/ovl)   spool (save/ovl)
-  unlimited     0.0ms     50.3ms    52.9 ( 0%/ 0%)    50.8 ( 0%/ 0%)
-  100Mbps     304.0ms    355.2ms   334.5 ( 6%/38%)   313.1 (12%/81%)
-  16Mbps     1889.0ms   1938.8ms  1903.1 ( 2%/71%)  1893.3 ( 2%/91%)
-  4Mbps      7528.0ms   7560.3ms  7545.5 ( 0%/64%)  7534.2 ( 0%/87%)
+  unlimited     0.0ms     38.5ms    42.0 ( 0%/  0%)   41.3 ( 0%/  0%)
+  100Mbps     304.1ms    342.5ms   328.3 ( 4%/ 40%)  306.2 (11%/ 95%)
+  16Mbps     1888.1ms   1928.1ms  1895.2 ( 2%/ 82%) 1900.5 ( 1%/ 69%)
+  4Mbps      7511.0ms   7550.3ms  7534.6 ( 0%/ 41%) 7509.3 ( 1%/104%)
 
-SEEK_HEAVY  avif  (1160KB, decode_cold 226.1ms)
+SEEK_HEAVY  avif  (1160KB, decode_cold 223.7ms — no shrink-on-load, full decode)
   rate       download   baseline   pipe (save/ovl)   spool (save/ovl)
-  unlimited     0.0ms    237.1ms   232.6 ( 2%/ 0%)   239.2 ( 0%/ 0%)
-  100Mbps     112.0ms    344.2ms   339.4 ( 1%/ 0%)   348.1 ( 0%/ 0%)
-  16Mbps      639.9ms    872.7ms   874.4 ( 0%/ 0%)   872.4 ( 0%/ 0%)
-  4Mbps      2544.9ms   2786.7ms  2778.7 ( 0%/ 0%)  2781.8 ( 0%/ 0%)
+  unlimited     0.0ms    212.1ms   232.6 ( 0%/ 0%)   234.2 ( 0%/ 0%)
+  100Mbps     112.0ms    339.2ms   346.1 ( 0%/ 0%)   341.6 ( 0%/ 0%)
+  16Mbps      640.7ms    870.3ms   879.3 ( 0%/ 0%)   866.5 ( 0%/ 0%)
+  4Mbps      2546.2ms   2766.9ms  2780.9 ( 0%/ 0%)  2782.9 ( 0%/ 0%)
 
-SEEK_HEAVY  tiff  (7105KB, decode_cold 14.2ms)
+SEEK_HEAVY  tiff  (7105KB, decode_cold 14.0ms — no shrink-on-load, full decode)
   rate       download   baseline   pipe (save/ovl)   spool (save/ovl)
-  unlimited     0.0ms     13.4ms    17.6 ( 0%/ 0%)    14.0 ( 0%/ 2%)
-  100Mbps     624.0ms    638.0ms   646.3 ( 0%/ 0%)   641.4 ( 0%/ 0%)
-  16Mbps     3889.9ms   3908.9ms  3907.9 ( 0%/ 0%)  3912.1 ( 0%/ 0%)
-  4Mbps     15551.2ms  15560.9ms 15582.0 ( 0%/ 0%) 15588.7 ( 0%/ 0%)
+  unlimited     0.0ms     11.9ms    19.4 ( 0%/ 0%)   13.1 ( 0%/ 7%)
+  100Mbps     624.0ms    643.3ms   647.7 ( 0%/ 0%)   642.7 ( 0%/ 0%)
+  16Mbps     3888.0ms   3910.5ms  3910.9 ( 0%/ 0%)  3908.8 ( 0%/ 0%)
+  4Mbps     15546.8ms  15576.4ms 15696.9 ( 0%/ 0%) 15593.7 ( 0%/ 0%)
 ```
 
-These are local timings; treat the **pattern**, not the absolute ms, as the result.
+These are local timings; treat the **pattern**, not the absolute ms, as the result. In
+the tiny-decode / long-download regime the `save`/`ovl` figures carry jitter of order a
+few % (e.g. spool `ovl` 104% and pipe tiff `−120ms` at 4 Mbps are noise about a ~0 ms
+true value) — the verdict reads the materiality threshold, not these point values.
+
+The conservative `full` sink (`… full`) gives the same NO-GO: JPEG `decode_cold` 49 ms
+(vs 40 ms), AVIF/TIFF identical; seek-heavy overlap still 0% at every rate.
 
 ## Interpretation
 
@@ -84,13 +112,14 @@ These are local timings; treat the **pattern**, not the absolute ms, as the resu
 hide the entire decode. That bound is what kills the case:
 
 1. **Forward (JPEG) overlaps well — but decode is cheap, so the win is negligible.**
-   `overlap%` climbs to 64–91% as bandwidth drops; `:spool` even beats `:pipe` (87% vs
-   64% at 4 Mbps). But JPEG `decode_cold` is only ~49 ms, so the wall-clock saving is
-   ~26 ms on a 7.5 s download — **0%**. The mechanism works; there is just nothing
-   worth hiding. And forward overlap needs only `:pipe` — the spool adds no latency
-   advantage here.
+   `overlap%` climbs to 40–95%+ as bandwidth drops (`:spool` and `:pipe` comparable).
+   But JPEG `decode_cold` is only ~40 ms (and shrink-on-load barely shrinks it — DCT
+   shrink still entropy-decodes the whole stream, 56 ms → 39 ms for `shrink: 4`), so the
+   wall-clock saving is ≤41 ms on a 7.5 s download — **≤1%**. The mechanism works; there
+   is just nothing worth hiding. And forward overlap needs only `:pipe` — the spool adds
+   no latency advantage here.
 
-2. **AVIF — the seek-heavy format with *expensive* decode (226 ms), exactly where
+2. **AVIF — the seek-heavy format with *expensive* decode (224 ms), exactly where
    overlap would pay — shows 0% overlap via `:pipe` AND `:spool`, at every rate.**
    AV1 intra decode needs the complete compressed bitstream before it can produce
    pixels: it is a monolithic CPU step that runs *after* arrival, seekable buffer or
@@ -100,6 +129,16 @@ hide the entire decode. That bound is what kills the case:
 
 3. **Tiled TIFF decode is too cheap (~14 ms) to register any overlap**, so it cannot
    adjudicate the spool either way; nothing observed.
+
+**What actually destroys overlap is not "needing all pixels."** The real pipeline does
+stay sequential and shrink-on-load where it can — but a *sequential forward* decode
+overlaps fine (the positive control proves it). Overlap is destroyed by either (a) the
+loader having to **buffer the whole input before producing any output** — seek-heavy
+formats via `:pipe`, which `:spool` is meant to fix — or (b) a **monolithic decode**
+that needs the complete bitstream (AV1). For AVIF, `:spool` fixes (a) but (b) remains,
+so there is still nothing to overlap. And because the seek-heavy formats have **no
+shrink-on-load**, staying sequential does not let the pipeline consume *less* of the
+source early either — it needs all of it before the monolithic decode.
 
 The cell the issue expected to justify the spool — *seek-heavy × slow source ⇒ `:spool`
 overlap, the biggest win* — **is empty**. The overlappable formats decode cheaply and
@@ -124,16 +163,24 @@ seek-heavy fixture (≥100 ms and ≥5% at the slow rate); none is present.
   baseline forfeits). It rides on `new_from_enum` itself, not on `SourceSpool`. Whether
   it is worth wiring into the real pipeline depends on whether forward decode is ever a
   meaningful fraction of request latency — these numbers say usually not.
+- **`/info` (header-only) is the one genuine "don't read all pixels" case** and is the
+  most promising place for a streaming win: the header arrives in the first bytes, so a
+  seekable/streamed source could answer and *abort the rest of a slow download*. The
+  probe does **not** measure this (its sink decodes pixels). It is in tension with
+  reporting `size` (which needs the full byte count — see #260) and should get its own
+  header-only / early-abort measurement if pursued. For HEIF specifically the `thumbnail`
+  load flag (embedded preview) is a related untested early-availability path.
 - **Not exercised:** the real `ImagePipe.call`/`Processor` path, the two-open →
-  single-open resolution (#170), the `/info` early-abort vs `size` tension, a
-  genuinely *expensive* incremental-seek decode (e.g. a very large multipage/pyramidal
-  TIFF), and HEIF preview/thumbnail-box early reads.
+  single-open resolution (#170), and a genuinely *expensive* incremental-seek decode
+  (e.g. a very large multipage/pyramidal TIFF) — though no common web format offers
+  expensive-and-incrementally-decodable, which is what the spool would need.
 
 ## Reproduce
 
 ```bash
-mise exec -- mix run bench/source_overlap_probe.exs            # default matrix
+mise exec -- mix run bench/source_overlap_probe.exs            # default matrix (shrink sink)
 mise exec -- mix run bench/source_overlap_probe.exs 5 unlimited,40,8,2
+mise exec -- mix run bench/source_overlap_probe.exs full       # conservative full-res decode
 mise exec -- mix run bench/source_overlap_probe.exs --csv      # machine-readable
 mise exec -- mix run bench/source_overlap_probe.exs --regen    # rebuild fixtures
 ```

--- a/docs/superpowers/specs/2026-06-13-source-streaming-overlap-probe-findings.md
+++ b/docs/superpowers/specs/2026-06-13-source-streaming-overlap-probe-findings.md
@@ -1,0 +1,145 @@
+# Source streaming/seekable overlap — synthetic probe findings (#263, Phase 1)
+
+**Status: gate complete — NO-GO for slow-source latency.** The synthetic Vix-level
+probe does not find a slow-source latency win that justifies adopting the forked
+native dependency (`hlindset/vix` `SourceSpool`). Recommendation: document and stay on
+the current drain-to-binary baseline. Phase 2 (the real-`ImagePipe.call` harness,
+single-open resolution, `/info` early-abort) is **not** greenlit by these numbers.
+
+Harness: [`bench/source_overlap_probe.exs`](../../../bench/source_overlap_probe.exs).
+
+## The question this gates
+
+imgproxy's stated headline win for a seekable source buffer is **slow-download
+overlap**: decode overlaps the download instead of following it, so total ≈
+`T_download` and you save ~`T_decode`. The issue framed the decisive case as
+*seek-heavy formats* (HEIF/AVIF, multipage/tiled TIFF), where `:pipe` must buffer the
+whole stream (`read_to_memory`) before decoding and therefore *only* `:spool` could
+overlap. The probe answers, cheaply and before any pipeline wiring: **does decode
+actually overlap a slow download, and for seek-heavy formats only via `:spool`?**
+
+## Method
+
+A synthetic, Vix-level probe (no HTTP / pipeline): an Elixir enumerable is fed
+straight to `Vix.Vips.Image.new_from_enum/2`. `:pipe` exercises the real OS-pipe
+feeder; `:spool` fills the real native seekable buffer (`Vix.SourceSpool`). A
+`Stream.unfold` throttle paces delivery to a target bytes/sec.
+
+Per `(fixture, rate)` we time a forced **full** decode (`Operation.avg/1` reads every
+pixel) reached three ways, plus two references:
+
+- `download_only` — drain the throttled enum, no decode → the download floor.
+- `decode_cold` — `new_from_buffer` + `avg` from an in-RAM copy → pure decode cost
+  (rate-independent; the **ceiling on any overlap saving**).
+- `baseline` — drain to a binary, *then* decode → today's ImagePipe shape (serial).
+- `pipe` / `spool` — `new_from_enum(mode:)` + `avg`, end-to-end → the overlapped path.
+
+Derived per overlapped mode: `saving = baseline − total`;
+`tail = total − download_only` (decode not hidden); `overlap% = (decode_cold − tail) /
+decode_cold` (fraction of decode hidden under the download).
+
+Fixtures (same pixels, three encodings; generated on the fly into the gitignored
+`bench/.cache/`): **JPEG** (forward), **AVIF** = AV1-in-HEIF (seek-heavy, expensive
+decode), **tiled JPEG-compressed TIFF** (seek-heavy, cheap decode).
+
+**Anti-tautology self-checks** (all passed on every cell): `avg` really forces a
+decode (`decode_cold` ≫ header-only open, 28–700×); the enum really throttles
+(`download_only` ≈ `size/rate`, ratio ~1.07); `baseline` is serial
+(`≈ download_only + decode_cold`, Δ < 10%). The forward-`:pipe` cell is the positive
+control — it *does* overlap (64–74%), so the harness detects overlap when present.
+
+## Results (local macOS, libvips with heif/avif/tiff; medians, 3 samples + warmup)
+
+Rates in Mbps (1 Mbps = 125 KB/s). `save` = wall-clock saved vs baseline; `ovl` =
+fraction of decode hidden.
+
+```
+FORWARD  jpg  (3433KB, decode_cold 49.0ms)
+  rate       download   baseline   pipe (save/ovl)   spool (save/ovl)
+  unlimited     0.0ms     50.3ms    52.9 ( 0%/ 0%)    50.8 ( 0%/ 0%)
+  100Mbps     304.0ms    355.2ms   334.5 ( 6%/38%)   313.1 (12%/81%)
+  16Mbps     1889.0ms   1938.8ms  1903.1 ( 2%/71%)  1893.3 ( 2%/91%)
+  4Mbps      7528.0ms   7560.3ms  7545.5 ( 0%/64%)  7534.2 ( 0%/87%)
+
+SEEK_HEAVY  avif  (1160KB, decode_cold 226.1ms)
+  rate       download   baseline   pipe (save/ovl)   spool (save/ovl)
+  unlimited     0.0ms    237.1ms   232.6 ( 2%/ 0%)   239.2 ( 0%/ 0%)
+  100Mbps     112.0ms    344.2ms   339.4 ( 1%/ 0%)   348.1 ( 0%/ 0%)
+  16Mbps      639.9ms    872.7ms   874.4 ( 0%/ 0%)   872.4 ( 0%/ 0%)
+  4Mbps      2544.9ms   2786.7ms  2778.7 ( 0%/ 0%)  2781.8 ( 0%/ 0%)
+
+SEEK_HEAVY  tiff  (7105KB, decode_cold 14.2ms)
+  rate       download   baseline   pipe (save/ovl)   spool (save/ovl)
+  unlimited     0.0ms     13.4ms    17.6 ( 0%/ 0%)    14.0 ( 0%/ 2%)
+  100Mbps     624.0ms    638.0ms   646.3 ( 0%/ 0%)   641.4 ( 0%/ 0%)
+  16Mbps     3889.9ms   3908.9ms  3907.9 ( 0%/ 0%)  3912.1 ( 0%/ 0%)
+  4Mbps     15551.2ms  15560.9ms 15582.0 ( 0%/ 0%) 15588.7 ( 0%/ 0%)
+```
+
+These are local timings; treat the **pattern**, not the absolute ms, as the result.
+
+## Interpretation
+
+**The absolute saving from overlap is bounded by `decode_cold`** — overlap can at best
+hide the entire decode. That bound is what kills the case:
+
+1. **Forward (JPEG) overlaps well — but decode is cheap, so the win is negligible.**
+   `overlap%` climbs to 64–91% as bandwidth drops; `:spool` even beats `:pipe` (87% vs
+   64% at 4 Mbps). But JPEG `decode_cold` is only ~49 ms, so the wall-clock saving is
+   ~26 ms on a 7.5 s download — **0%**. The mechanism works; there is just nothing
+   worth hiding. And forward overlap needs only `:pipe` — the spool adds no latency
+   advantage here.
+
+2. **AVIF — the seek-heavy format with *expensive* decode (226 ms), exactly where
+   overlap would pay — shows 0% overlap via `:pipe` AND `:spool`, at every rate.**
+   AV1 intra decode needs the complete compressed bitstream before it can produce
+   pixels: it is a monolithic CPU step that runs *after* arrival, seekable buffer or
+   not. The spool lets libvips *seek* the arriving bytes, but seeking-during-arrival is
+   not decode-overlap — the issue's hypothesis conflated the two. `total ≈ baseline ≈
+   download + decode` confirms full serialization.
+
+3. **Tiled TIFF decode is too cheap (~14 ms) to register any overlap**, so it cannot
+   adjudicate the spool either way; nothing observed.
+
+The cell the issue expected to justify the spool — *seek-heavy × slow source ⇒ `:spool`
+overlap, the biggest win* — **is empty**. The overlappable formats decode cheaply and
+need only `:pipe`; the one expensive-decode seek-heavy format cannot overlap at all.
+
+## Decision
+
+**NO-GO on adopting the forked native dependency for slow-source latency.** Stay on the
+current drain-to-binary baseline ([`processor.ex`](../../../lib/image_pipe/request/processor.ex)).
+The gate (`bench/source_overlap_probe.exs`) requires a material `:spool` saving on a
+seek-heavy fixture (≥100 ms and ≥5% at the slow rate); none is present.
+
+## Caveats / not measured (deliberately out of scope for the gate)
+
+- **Memory shape, not latency.** The spool holds the encoded bytes in a native buffer
+  instead of on the BEAM heap (and avoids the transient ~2× concat spike of
+  `Enum.to_list |> IO.iodata_to_binary`). That is a *separate* question from slow-source
+  latency and is **not** measured here; it would need the #164-style peak-RSS /
+  high-water probes and a concurrency (`N × content_length`) ceiling. If the spool is
+  ever revisited, it should be on the memory axis, not latency.
+- **`:pipe` for forward formats is a real, fork-light win** (overlap that the drain
+  baseline forfeits). It rides on `new_from_enum` itself, not on `SourceSpool`. Whether
+  it is worth wiring into the real pipeline depends on whether forward decode is ever a
+  meaningful fraction of request latency — these numbers say usually not.
+- **Not exercised:** the real `ImagePipe.call`/`Processor` path, the two-open →
+  single-open resolution (#170), the `/info` early-abort vs `size` tension, a
+  genuinely *expensive* incremental-seek decode (e.g. a very large multipage/pyramidal
+  TIFF), and HEIF preview/thumbnail-box early reads.
+
+## Reproduce
+
+```bash
+mise exec -- mix run bench/source_overlap_probe.exs            # default matrix
+mise exec -- mix run bench/source_overlap_probe.exs 5 unlimited,40,8,2
+mise exec -- mix run bench/source_overlap_probe.exs --csv      # machine-readable
+mise exec -- mix run bench/source_overlap_probe.exs --regen    # rebuild fixtures
+```
+
+Requires the vix fork that ships `new_from_enum(mode: :pipe | :spool | :auto)`:
+`{:vix, git: "https://github.com/hlindset/vix.git", ref: "c5be4745bb5a24ee998d3221c84dfd75d41f8f0d"}`
+(`my-experimental-fixes`). The probe asserts the capability at startup. The bump from
+the prior pin also brings the `tracked_get_mem_highwater` NIF fix the memory benches
+rely on.

--- a/docs/superpowers/specs/2026-06-13-source-streaming-overlap-probe-findings.md
+++ b/docs/superpowers/specs/2026-06-13-source-streaming-overlap-probe-findings.md
@@ -1,10 +1,13 @@
 # Source streaming/seekable overlap — synthetic probe findings (#263, Phase 1)
 
-**Status: gate complete — NO-GO for slow-source latency.** The synthetic Vix-level
-probe does not find a slow-source latency win that justifies adopting the forked
-native dependency (`hlindset/vix` `SourceSpool`). Recommendation: document and stay on
-the current drain-to-binary baseline. Phase 2 (the real-`ImagePipe.call` harness,
-single-open resolution, `/info` early-abort) is **not** greenlit by these numbers.
+**Status: gate complete — NO-GO for slow-source *overlap* / the forked spool.** The
+synthetic Vix-level probe does not find a slow-source *overlap* win that justifies
+adopting the forked native dependency (`hlindset/vix` `SourceSpool`). Recommendation:
+document and stay on the current drain-to-binary baseline; do not build the
+overlap-motivated Phase 2 spool harness. **However**, a *different* streaming lever —
+**prefix early-termination** (a top crop, or header-only `/info`, skipping the rest of a
+slow download) — is a real win, and it rides on `new_from_enum(:pipe)`, not the spool
+(see that section below).
 
 Harness: [`bench/source_overlap_probe.exs`](../../../bench/source_overlap_probe.exs).
 
@@ -151,6 +154,55 @@ current drain-to-binary baseline ([`processor.ex`](../../../lib/image_pipe/reque
 The gate (`bench/source_overlap_probe.exs`) requires a material `:spool` saving on a
 seek-heavy fixture (≥100 ms and ≥5% at the slow rate); none is present.
 
+This NO-GO is about *overlap* and about the *forked spool specifically*. It is **not**
+"streaming buys nothing" — see the next section for a real `:pipe` win on a different
+axis.
+
+## A real streaming win the overlap axis missed: prefix early-termination (crop / `/info`)
+
+Probed separately (`bench/source_overlap_probe.exs crop`). A different lever entirely:
+in sequential mode, an operation whose output depends only on an **early prefix** of the
+stream lets libvips stop reading once it has those bytes — so a *streamed* source never
+pulls the rest of the download. Unlike overlap, this win is **not bounded by decode
+cost** — it is bounded by how much download is **skipped**.
+
+Bytes pulled from a throttled source for a 10%-height crop (`probe.*`, 2400×3600):
+
+| fixture | full | **top 10%** | bottom 10% |
+|---|---|---|---|
+| JPEG (forward) | 100% | **10%** | 100% |
+| AVIF (seek-heavy) | 100% | 100% | 100% |
+| TIFF tiled (seek-heavy) | 100% | 100% | 100% |
+
+A top-10% crop of the forward JPEG pulled **10%** of the file and finished in ~10% of
+the download time; libvips decoded only the top scanlines and the rest was never
+downloaded. It is real but **conditional**:
+
+- **Position (storage order).** Top wins; bottom reads the whole file; a middle crop
+  reads up to its bottom edge. This is *storage* order — EXIF auto-orient (deferred and
+  compensated into the storage frame, issue #146) can map a display-top crop to a
+  storage-bottom region and defeat it.
+- **Format/encoding.** Forward, top-to-bottom only: **baseline JPEG ✓** (non-interlaced
+  PNG should match). Seek-heavy gets **nothing** — AVIF (monolithic) and tiled TIFF
+  (tested `:pipe` *and* `:spool` × sequential *and* random) all pull 100%; the
+  spool's seekability does not enable a cheap top-tile read here (the TIFF directory /
+  tile-offset structure forces a full read). Progressive JPEG / interlaced PNG would
+  also lose it (data spans the whole stream).
+- **Survives shrink-on-load.** `shrink: 2` + top crop still pulled 10%, so crop+resize
+  requests get it too, not just crop-alone.
+- **Needs a streamed source.** The current drain-to-binary baseline reads the whole body
+  first, so it *cannot* skip — this is precisely the value `new_from_enum(:pipe)` adds.
+- **`:pipe` is the enabler, not `:spool`.** Both pull identically; the spool (lazy-fill,
+  confirmed — it also stopped at 10% for JPEG) adds nothing and does not rescue
+  seek-heavy.
+
+The general principle: **streaming enables early-termination for any request whose
+output depends only on a prefix of the source.** The strongest, most common instance is
+header-only **`/info`** (the header is at the very start of every format); a top-region
+crop is a narrower demonstrative one. Both ride on `new_from_enum(:pipe)` — no forked
+spool. `/info` is the natural place to pursue this (mind the `size` / full-drain tension,
+#260); it is itself untested here (the probe's sinks decode pixels).
+
 ## Caveats / not measured (deliberately out of scope for the gate)
 
 - **Memory shape, not latency.** The spool holds the encoded bytes in a native buffer
@@ -163,13 +215,10 @@ seek-heavy fixture (≥100 ms and ≥5% at the slow rate); none is present.
   baseline forfeits). It rides on `new_from_enum` itself, not on `SourceSpool`. Whether
   it is worth wiring into the real pipeline depends on whether forward decode is ever a
   meaningful fraction of request latency — these numbers say usually not.
-- **`/info` (header-only) is the one genuine "don't read all pixels" case** and is the
-  most promising place for a streaming win: the header arrives in the first bytes, so a
-  seekable/streamed source could answer and *abort the rest of a slow download*. The
-  probe does **not** measure this (its sink decodes pixels). It is in tension with
-  reporting `size` (which needs the full byte count — see #260) and should get its own
-  header-only / early-abort measurement if pursued. For HEIF specifically the `thumbnail`
-  load flag (embedded preview) is a related untested early-availability path.
+- **`/info` early-abort is covered above** (prefix early-termination) but not directly
+  measured — the probe's sinks decode pixels; a header-only sink + `size`-tension run is
+  the follow-up. For HEIF the `thumbnail` load flag (embedded preview) is a related,
+  untested early-availability path.
 - **Not exercised:** the real `ImagePipe.call`/`Processor` path, the two-open →
   single-open resolution (#170), and a genuinely *expensive* incremental-seek decode
   (e.g. a very large multipage/pyramidal TIFF) — though no common web format offers

--- a/docs/superpowers/specs/2026-06-13-source-streaming-overlap-probe-findings.md
+++ b/docs/superpowers/specs/2026-06-13-source-streaming-overlap-probe-findings.md
@@ -203,6 +203,18 @@ crop is a narrower demonstrative one. Both ride on `new_from_enum(:pipe)` — no
 spool. `/info` is the natural place to pursue this (mind the `size` / full-drain tension,
 #260); it is itself untested here (the probe's sinks decode pixels).
 
+**The remaining work is single-open, not the spool.** Today the source-open drains to a
+binary and opens twice: a libvips header read for dims (feeding `DecodePlanner`'s shrink
+factor) then the shrink decode — and a `:pipe` enum is consume-once, so it cannot be
+opened twice. #170 (closed) added Elixir-side *format* detection but **not dims**, so it
+does not by itself collapse the two opens. Two routes to single-open over a stream: (a)
+peek dims from the prefix for the formats where that is cheap/reliable (PNG `IHDR` is
+trivial; JPEG `SOF` usually within a bounded peek) and fall back to the current
+drain/two-open path otherwise; or (b) let libvips do header+shrink in one pass
+(`thumbnail_source`), format-agnostic but moving shrink planning into libvips. Note the
+fallback in (a) loses nothing: the formats whose dims are hard to peek (TIFF/HEIC/AVIF)
+are exactly the seek-heavy formats that get no streaming win anyway.
+
 ## Caveats / not measured (deliberately out of scope for the gate)
 
 - **Memory shape, not latency.** The spool holds the encoded bytes in a native buffer
@@ -220,7 +232,7 @@ spool. `/info` is the natural place to pursue this (mind the `size` / full-drain
   the follow-up. For HEIF the `thumbnail` load flag (embedded preview) is a related,
   untested early-availability path.
 - **Not exercised:** the real `ImagePipe.call`/`Processor` path, the two-open →
-  single-open resolution (#170), and a genuinely *expensive* incremental-seek decode
+  single-open resolution (see the prefix section above), and a genuinely *expensive* incremental-seek decode
   (e.g. a very large multipage/pyramidal TIFF) — though no common web format offers
   expensive-and-incrementally-decodable, which is what the spool would need.
 

--- a/mix.exs
+++ b/mix.exs
@@ -126,7 +126,7 @@ defmodule ImagePipe.MixProject do
       {:image, "~> 0.67"},
       {:vix,
        git: "https://github.com/hlindset/vix.git",
-       ref: "1b9d9f9619a4fcc45bce0c4958bfa1168a7ac1c2",
+       ref: "c5be4745bb5a24ee998d3221c84dfd75d41f8f0d",
        override: true},
       {:color, "~> 0.13"},
       {:req, "~> 0.5"},

--- a/mix.lock
+++ b/mix.lock
@@ -54,7 +54,7 @@
   "thousand_island": {:hex, :thousand_island, "1.4.3", "2158209580f633be38d43ec4e3ce0a01079592b9657afff9080d5d8ca149a3af", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "6e4ce09b0fd761a58594d02814d40f77daff460c48a7354a15ab353bb998ea0b"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.1", "a48703a25c170eedadca83b11e88985af08d35f37c6f664d6dcfb106a97782fc", [:rebar3], [], "hexpm", "b3a917854ce3ae233619744ad1e0102e05673136776fb2fa76234f3e03b23642"},
   "uniq": {:hex, :uniq, "0.6.3", "68acff834cce1817b52928ef346662735c5413a4fec9c3b0d4a9126de5b2b489", [:mix], [{:ecto, "~> 3.0", [hex: :ecto, repo: "hexpm", optional: true]}], "hexpm", "2b2a900d0a20f3a55d3de0bc8150495e4a71255734dfb23889991bda5aca6c7d"},
-  "vix": {:git, "https://github.com/hlindset/vix.git", "1b9d9f9619a4fcc45bce0c4958bfa1168a7ac1c2", [ref: "1b9d9f9619a4fcc45bce0c4958bfa1168a7ac1c2"]},
+  "vix": {:git, "https://github.com/hlindset/vix.git", "c5be4745bb5a24ee998d3221c84dfd75d41f8f0d", [ref: "c5be4745bb5a24ee998d3221c84dfd75d41f8f0d"]},
   "websock": {:hex, :websock, "0.5.3", "2f69a6ebe810328555b6fe5c831a851f485e303a7c8ce6c5f675abeb20ebdadc", [:mix], [], "hexpm", "6105453d7fac22c712ad66fab1d45abdf049868f253cf719b625151460b8b453"},
   "xla": {:hex, :xla, "0.10.0", "41121e9f011456242d3a79b9289910ce43419be0b0e7ebe67cc1292c6b3f232f", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "f57d91aea6e661b52bf12239316c598679e9170628122bbd941235f040122bc6"},
 }


### PR DESCRIPTION
Deliverable for the #263 spike (now **closed** — answered NO). Opened for posterity / review; **merge is optional** (the value is the harness + numbers + recorded rationale, not a feature).

## What this adds
- `bench/source_overlap_probe.exs` — synthetic Vix-level probe: throttled-enum source → `new_from_enum(:pipe|:spool)`, real-pipeline sink (sequential + shrink-on-load), anti-tautology self-checks, `--csv`, plus a `crop` phase (instrumented byte-counter) for prefix early-termination.
- `docs/superpowers/specs/2026-06-13-source-streaming-overlap-probe-findings.md` — method, full matrix, interpretation, decision, caveats.
- vix bump `1b9d9f9` → `c5be474` (`my-experimental-fixes`): `new_from_enum(mode: :pipe | :spool | :auto)` + the `tracked_get_mem_highwater` NIF fix the memory benches rely on. `.gitignore`: `bench/.cache/`.

## Outcome
- **Overlap is bounded by decode cost, and that bound is empty where it matters:** forward (JPEG) overlaps but decodes too cheaply to save (≤1%); AVIF/AV1 shows **0% overlap even via `:spool`** (monolithic decode). ⇒ **the `SourceSpool` fork is not justified on any latency axis.** Stay on the drain-to-binary baseline.
- **A real `:pipe` streaming win surfaced — prefix early-termination** (top crop / `/info`), bounded by download skipped, not decode cost, and gated on single-open rather than the fork. Carried forward in #275.

Full rationale in the closing comment on #263 and the findings doc.

Verification: `mise run precommit` green (1864 tests, 0 failures); the vix bump regresses nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)