### PR TITLE
feat(source): classify ReqStream failure modes instead of :bad_status

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -109,7 +109,14 @@ Failure stop metadata (one of two shapes, by failure mode):
 
 - Source-side failure — `:result` is `:source_error`; `:error` is a stable
   category atom (e.g. `:body_too_large` when the source body crosses
-  `:max_body_bytes`).
+  `:max_body_bytes`). HTTP fetch failures are classified rather than collapsed
+  so an observer can tell them apart: `:connect_error` (DNS/TLS/refused/connect
+  or pool timeout), `:receive_timeout` (origin stalled mid-body),
+  `:invalid_body` (unparseable chunked framing), `:redirect_not_followed` /
+  `:invalid_redirect` / `:too_many_redirects` (redirect handling), and
+  `:bad_status` for a non-success origin status (the underlying error tuple
+  carries the numeric status as `{:bad_status, status}`; the metadata atom is
+  the `:bad_status` category).
 - Decode / input-validation failure — `:result` is `:processing_error`; `:error`
   is a stable category atom (e.g. `:input_limit` when the decoded image exceeds
   `:max_input_pixels`, `:decode` for an undecodable body).

--- a/lib/image_pipe/source/req_stream.ex
+++ b/lib/image_pipe/source/req_stream.ex
@@ -74,12 +74,12 @@ defmodule ImagePipe.Source.ReqStream do
           redirects_allowed?
         )
 
-      {:ok, %Req.Response{} = response} ->
+      {:ok, %Req.Response{status: status} = response} ->
         cancel_response(response)
-        {:error, :bad_status}
+        {:error, {:bad_status, status}}
 
       {:error, _exception} ->
-        {:error, :bad_status}
+        {:error, :connect_error}
     end
   end
 
@@ -96,10 +96,12 @@ defmodule ImagePipe.Source.ReqStream do
 
     cond do
       redirects_left <= 0 ->
-        if redirects_allowed?, do: {:error, :too_many_redirects}, else: {:error, :bad_status}
+        if redirects_allowed?,
+          do: {:error, :too_many_redirects},
+          else: {:error, :redirect_not_followed}
 
       is_nil(location) ->
-        {:error, :bad_status}
+        {:error, :invalid_redirect}
 
       true ->
         next_url =
@@ -148,14 +150,14 @@ defmodule ImagePipe.Source.ReqStream do
     receive do
       {^ref, _message} = message -> {:ok, message}
     after
-      receive_timeout -> {:error, :bad_status}
+      receive_timeout -> {:error, :receive_timeout}
     end
   end
 
   defp parse_message(response, message) do
     case Req.parse_message(response, message) do
       {:ok, chunks} -> {:ok, chunks}
-      {:error, _exception} -> {:error, :bad_status}
+      {:error, _exception} -> {:error, :invalid_body}
       :unknown -> :unknown
     end
   end

--- a/lib/image_pipe/source/stream_error.ex
+++ b/lib/image_pipe/source/stream_error.ex
@@ -3,7 +3,8 @@ defmodule ImagePipe.Source.StreamError do
 
   defexception [:reason]
 
-  @type t :: %__MODULE__{reason: atom()}
+  @type reason :: atom() | {:bad_status, non_neg_integer()}
+  @type t :: %__MODULE__{reason: reason()}
 
-  def message(%__MODULE__{reason: reason}), do: "source stream failed: #{reason}"
+  def message(%__MODULE__{reason: reason}), do: "source stream failed: #{inspect(reason)}"
 end

--- a/test/image_pipe/source/http_test.exs
+++ b/test/image_pipe/source/http_test.exs
@@ -317,7 +317,7 @@ defmodule ImagePipe.Source.HTTPTest do
              Source.fetch(resolved, [sources: %{https: {HTTP, opts}}], max_body_bytes: 20)
 
     error = assert_raise Source.StreamError, fn -> Enum.to_list(response.stream) end
-    assert error.reason == :bad_status
+    assert error.reason == :redirect_not_followed
   end
 
   test "fetch percent-encodes decoded path segments when building the request URL" do
@@ -406,7 +406,7 @@ defmodule ImagePipe.Source.HTTPTest do
              Source.fetch(resolved, [sources: %{https: {HTTP, opts}}], max_body_bytes: 20)
 
     error = assert_raise Source.StreamError, fn -> Enum.to_list(response.stream) end
-    assert error.reason == :bad_status
+    assert error.reason == {:bad_status, 404}
   end
 
   test "an enabled redirect to an off-allowlist host is denied" do

--- a/test/image_pipe/source/req_stream_test.exs
+++ b/test/image_pipe/source/req_stream_test.exs
@@ -124,6 +124,82 @@ defmodule ImagePipe.Source.ReqStreamTest do
     assert_received {:got, "hop.example", "/other.jpg"}
   end
 
+  test "an origin non-success status surfaces as {:bad_status, status}" do
+    plug = fn conn -> Plug.Conn.send_resp(conn, 404, "nope") end
+
+    stream =
+      ReqStream.stream(
+        [url: "https://assets.example.com/missing.jpg", plug: plug],
+        validate_target: fn _ -> :ok end
+      )
+
+    error = assert_raise StreamError, fn -> Enum.to_list(stream) end
+    assert error.reason == {:bad_status, 404}
+  end
+
+  test "a connection failure surfaces as :connect_error" do
+    port = closed_port()
+
+    stream =
+      ReqStream.stream(
+        [url: "http://127.0.0.1:#{port}/x.jpg", connect_options: [timeout: 200]],
+        validate_target: fn _ -> :ok end
+      )
+
+    error = assert_raise StreamError, fn -> Enum.to_list(stream) end
+    assert error.reason == :connect_error
+  end
+
+  test "a 3xx without a Location header surfaces as :invalid_redirect" do
+    plug = fn conn -> Plug.Conn.send_resp(conn, 302, "") end
+
+    stream =
+      ReqStream.stream(
+        [url: "https://assets.example.com/r.jpg", plug: plug],
+        validate_target: fn _ -> :ok end,
+        max_redirects: 1
+      )
+
+    error = assert_raise StreamError, fn -> Enum.to_list(stream) end
+    assert error.reason == :invalid_redirect
+  end
+
+  test "a 3xx with redirects disabled surfaces as :redirect_not_followed" do
+    plug = fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("location", "https://assets.example.com/other.jpg")
+      |> Plug.Conn.send_resp(302, "")
+    end
+
+    stream =
+      ReqStream.stream(
+        [url: "https://assets.example.com/r.jpg", plug: plug],
+        validate_target: fn _ -> :ok end,
+        max_redirects: 0
+      )
+
+    error = assert_raise StreamError, fn -> Enum.to_list(stream) end
+    assert error.reason == :redirect_not_followed
+  end
+
+  test "a mid-body receive timeout surfaces as :receive_timeout" do
+    {url, server} = start_stalling_origin()
+    server_ref = Process.monitor(server)
+
+    stream =
+      ReqStream.stream(
+        [url: url],
+        validate_target: fn _ -> :ok end,
+        receive_timeout: 100
+      )
+
+    error = assert_raise StreamError, fn -> Enum.to_list(stream) end
+    assert error.reason == :receive_timeout
+
+    Process.exit(server, :kill)
+    assert_receive {:DOWN, ^server_ref, :process, ^server, _reason}
+  end
+
   test "a scheme-downgrade redirect is normalized and validated with the new scheme" do
     plug = fn
       %{request_path: "/r.jpg"} = conn ->
@@ -152,5 +228,40 @@ defmodule ImagePipe.Source.ReqStreamTest do
     assert_received {:validated, "https://assets.example.com/r.jpg"}
     assert_received {:validated, "http://assets.example.com/plain.jpg"}
     assert_received {:got, :http, "/plain.jpg"}
+  end
+
+  # Binds an ephemeral port, then frees it so a connection attempt is refused.
+  defp closed_port do
+    {:ok, listen_socket} = :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true])
+    {:ok, {_address, port}} = :inet.sockname(listen_socket)
+    :gen_tcp.close(listen_socket)
+    port
+  end
+
+  # A raw origin that returns a chunked 200 head and then never sends a body
+  # chunk, holding the connection open until the client gives up — the mid-body
+  # receive-timeout path.
+  defp start_stalling_origin do
+    {:ok, listen_socket} =
+      :gen_tcp.listen(0, [:binary, packet: :raw, active: false, reuseaddr: true])
+
+    {:ok, {_address, port}} = :inet.sockname(listen_socket)
+
+    server =
+      spawn(fn ->
+        {:ok, socket} = :gen_tcp.accept(listen_socket)
+        {:ok, _request} = :gen_tcp.recv(socket, 0)
+
+        head =
+          "HTTP/1.1 200 OK\r\n" <>
+            "content-type: image/jpeg\r\n" <>
+            "transfer-encoding: chunked\r\n\r\n"
+
+        :ok = :gen_tcp.send(socket, head)
+        # Block until the client closes, without ever sending a body chunk.
+        :gen_tcp.recv(socket, 0, :infinity)
+      end)
+
+    {"http://127.0.0.1:#{port}", server}
   end
 end

--- a/test/support/image_pipe/source_test/root_http_adapter.ex
+++ b/test/support/image_pipe/source_test/root_http_adapter.ex
@@ -88,12 +88,12 @@ defmodule ImagePipe.SourceTest.RootHTTPAdapter do
       {:ok, %Req.Response{status: status} = response} when status in 200..299 ->
         %{response: response, receive_timeout: receive_timeout}
 
-      {:ok, %Req.Response{} = response} ->
+      {:ok, %Req.Response{status: status} = response} ->
         cancel_response(response)
-        {:error, :bad_status}
+        {:error, {:bad_status, status}}
 
       {:error, _exception} ->
-        {:error, :bad_status}
+        {:error, :connect_error}
     end
   end
 
@@ -119,14 +119,14 @@ defmodule ImagePipe.SourceTest.RootHTTPAdapter do
     receive do
       {^ref, _message} = message -> {:ok, message}
     after
-      receive_timeout -> {:error, :bad_status}
+      receive_timeout -> {:error, :receive_timeout}
     end
   end
 
   defp parse_message(response, message) do
     case Req.parse_message(response, message) do
       {:ok, chunks} -> {:ok, chunks}
-      {:error, _exception} -> {:error, :bad_status}
+      {:error, _exception} -> {:error, :invalid_body}
       :unknown -> :unknown
     end
   end


### PR DESCRIPTION
Peeled off from #185 (source fetch / streaming bounds).

`ImagePipe.Source.ReqStream` collapsed every source-fetch failure — DNS/TLS/connect errors, a stalled mid-body read, chunked-parse errors, a non-success origin status, and unfollowable redirects — into `StreamError{reason: :bad_status}`. Telemetry and the default Logger couldn't tell "origin timed out mid-body" from "origin returned 503", and distinct reasons are a prerequisite for #160's per-failure status codes.

## Change

Split by **what the call site reliably observes** — no Req/Mint exception introspection (brittle across versions, and #160 maps the transport bucket to one status anyway):

| Failure | Reason |
|---|---|
| Non-success origin status | `{:bad_status, status}` (carries the code) |
| `Req.request` transport error | `:connect_error` |
| Mid-body receive timeout | `:receive_timeout` |
| Chunked/body parse error | `:invalid_body` |
| 3xx, no `Location` | `:invalid_redirect` |
| 3xx, redirects disabled | `:redirect_not_followed` |
| Redirects exhausted | `:too_many_redirects` (unchanged) |

## Invariant preserved

**Status codes are unchanged.** `Response.Sender.send_source_error/3` ignores the reason and returns 422 for every source reason; `Error.tag({:bad_status, status})` reduces to the `:bad_status` category atom, so telemetry metadata stays a stable category atom. Mapping reasons to 404/502/504 is deliberately out of scope — that's #160, which now has the distinct reasons it needs.

## Notes

- `StreamError.reason` type widened to `atom() | {:bad_status, non_neg_integer()}`; `message/1` uses `inspect/1` for the tuple case.
- The `RootHTTPAdapter` test double mirrors the same taxonomy so it stays a faithful stand-in.
- `docs/telemetry.md` names the new source-fetch categories.
- `:invalid_body` is classified but has no dedicated wire test — it requires malformed chunked framing that survives Req/Mint's own parser, not deterministically reproducible at this boundary.

## Tests

5 new `req_stream_test.exs` cases drive real `ReqStream.stream/2` against a Plug / raw socket (connection-refused via a freed ephemeral port; a stalling chunked origin for the receive-timeout path). Full gate green: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix test` (2058 tests + 57 properties, 0 failures).

Part of #185.

Fixes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)