### PR TITLE
fix(output): malformed Accept q-value must not veto a valid media type

### DIFF
--- a/lib/image_pipe/output/negotiation.ex
+++ b/lib/image_pipe/output/negotiation.ex
@@ -110,10 +110,13 @@ defmodule ImagePipe.Output.Negotiation do
     |> parse_quality()
   end
 
+  # An invalid or out-of-range weight (`q=1.5`, `q=abc`) is ignored, not treated
+  # as an explicit `q=0` exclusion: drop the parameter and fall back to the
+  # default q=1 (RFC 9110 §12.4.2). Only a well-formed in-range `q=0` excludes.
   defp parse_quality(value) do
     case value |> String.trim() |> Float.parse() do
       {quality, ""} when quality >= 0.0 and quality <= 1.0 -> quality
-      _ -> 0.0
+      _ -> 1.0
     end
   end
 

--- a/test/image_pipe/output_negotiation_property_test.exs
+++ b/test/image_pipe/output_negotiation_property_test.exs
@@ -124,6 +124,10 @@ defmodule ImagePipe.Output.NegotiationPropertyTest do
     ])
   end
 
+  # Only well-formed in-range weights: this property pins order/preference
+  # invariants over valid input. Malformed weights (`q=1.5`, `q=abc`) are covered
+  # by the example suite — don't add them here, the oracle's `String.to_float/1`
+  # would raise on them.
   defp media_range_with_optional_quality do
     one_of([
       media_range(),

--- a/test/image_pipe/output_negotiation_test.exs
+++ b/test/image_pipe/output_negotiation_test.exs
@@ -59,6 +59,25 @@ defmodule ImagePipe.Output.NegotiationTest do
     end
   end
 
+  describe "modern_candidates/2 malformed q-values" do
+    test "an out-of-range q-value is ignored, not treated as an exclusion" do
+      # q=1.5 is invalid; it must not veto a duplicate valid webp entry.
+      assert Negotiation.modern_candidates("image/webp;q=1.5,image/webp", []) == [:webp]
+      # ...nor make webp unacceptable on its own.
+      assert Negotiation.modern_candidates("image/webp;q=1.5", []) == [:webp]
+    end
+
+    test "an unparseable q-value is ignored, not treated as an exclusion" do
+      assert Negotiation.modern_candidates("image/avif;q=abc", []) == [:avif]
+      assert Negotiation.modern_candidates("image/avif;q=abc,image/avif", []) == [:avif]
+    end
+
+    test "a genuine in-range q=0 still excludes, unlike a malformed weight" do
+      assert Negotiation.modern_candidates("image/webp;q=0,image/webp;q=1", []) == []
+      assert Negotiation.modern_candidates("image/avif;q=0", []) == []
+    end
+  end
+
   describe "modern_candidates/2 capability filtering" do
     test "drops avif when the build cannot write it" do
       opts = [output_capabilities: %{avif: false}]


### PR DESCRIPTION
Peeled off from #185 (HTTP semantics).

`Negotiation.parse_quality/1` mapped any unparseable or out-of-range Accept weight (`q=1.5`, `q=abc`) to `0.0`, and `acceptable_quality?/1` treats `0.0` as an explicit exclusion that vetoes duplicate positive entries of the same specificity. So `Accept: image/webp;q=1.5, image/webp` **rejected** webp outright instead of serving it.

## Fix

Per RFC 9110 §12.4.2, an invalid weight is *ignored* — drop the parameter and fall back to the default `q=1`. The fix is the `parse_quality/1` fallback (`0.0` → `1.0`). A well-formed in-range `q=0` still parses to `0.0` via the in-range guard and **still excludes** — that path is untouched.

| `Accept` | before | after |
|---|---|---|
| `image/webp;q=1.5, image/webp` | webp rejected ❌ | webp served ✅ |
| `image/webp;q=abc` | rejected ❌ | served ✅ |
| `image/webp;q=0` (genuine) | excluded | excluded *(unchanged)* |
| `image/webp;q=0.5` | served | served *(unchanged)* |

## Compatibility

Verified against the real imgproxy source: `clientfeatures/detector.go` decides webp/avif by `strings.Contains(accept, "image/webp")` and parses no q-values at all. This change introduces **no new divergence** — for the malformed-q case it moves ImagePipe's de-facto behavior *toward* imgproxy's leniency. ImagePipe's pre-existing q=0-honoring negotiation (a more-correct divergence from imgproxy's substring match) is unchanged, and is below the resolution `docs/imgproxy_support_matrix.md` documents — so no conformance-doc update is required for this change.

## Tests

Three new `output_negotiation_test.exs` cases at the public `modern_candidates/2` boundary: out-of-range and unparseable weights are ignored (fail before the fix, pass after), plus a guard that a genuine in-range `q=0` still excludes. Grammar edge cases belong in unit tests per the test guidelines; the property suite stays on valid weights (with a note explaining why). Full gate green: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix test` (2056 tests + 57 properties, 0 failures).

Part of #185.

Fixes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)