### PR TITLE
docs(imgproxy): note q=0 Accept-negotiation divergence

### DIFF
--- a/docs/imgproxy_support_matrix.md
+++ b/docs/imgproxy_support_matrix.md
@@ -903,7 +903,7 @@ transforms or output encoding.
 | `avif_options` | `avifo` | Missing | Pro advanced AVIF encoder controls. |
 | `format` | `f`, `ext` | Partial | Supports `webp`, `avif`, `jpeg`, `jpg`, and `png`. Planning rejects parsed `best`. |
 | Extension path suffix | | Partial | Plain sources use `@extension`; Base64 and encrypted sources use `.extension`. Both request explicit output format and bypass `Accept` negotiation. |
-| Automatic output via `Accept` | | Supported | Omitted format negotiates explicit AVIF/WebP support and `image/*`; missing, empty, and global wildcard-only `Accept` values fall back to source output. Responses use `Vary: Accept`. |
+| Automatic output via `Accept` | | Supported | Omitted format negotiates explicit AVIF/WebP support and `image/*`; missing, empty, and global wildcard-only `Accept` values fall back to source output. Responses use `Vary: Accept`. **Diverges (behavioral):** a well-formed in-range `q=0` on a matched media type (e.g. `image/webp;q=0`) excludes that format here per RFC 9110 weight semantics, falling back to source; imgproxy ignores `q` entirely (substring match on `image/webp`/`image/avif`) and still serves the format. |
 | `best` output | | Rejected | Parsed as an output value, rejected by planning. |
 
 ## Video


### PR DESCRIPTION
## Summary

Documents a pre-existing behavioral divergence between ImagePipe and imgproxy in `Accept`-header output negotiation.

ImagePipe's negotiation (`lib/image_pipe/output/negotiation.ex`, `acceptable_quality?/1`) honors a well-formed in-range `q=0` on a matched media type as an explicit exclusion per RFC 9110 weight semantics — so `Accept: image/webp;q=0` falls back to source format instead of serving WebP.

imgproxy diverges: its client-features detector (`clientfeatures/detector.go`) decides WebP/AVIF purely by `strings.Contains(headerAccept, "image/webp")` / `"image/avif"` and never parses q-values, so it still serves WebP for `image/webp;q=0`.

This was undocumented; the support matrix covered `Accept` negotiation only at format-presence granularity. Added a one-line **Diverges (behavioral)** note to the Accept-negotiation row.

Docs only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)