### PR TITLE
test(transform): close sequential-safety gate gaps for crop/resize shapes

### DIFF
--- a/test/image_pipe/transform/sequential_access_test.exs
+++ b/test/image_pipe/transform/sequential_access_test.exs
@@ -54,10 +54,44 @@ defmodule ImagePipe.Transform.SequentialAccessTest do
     )
   end
 
+  test "focal-point gravity crop streams" do
+    assert_sequential_matches_random(
+      [
+        %Crop{
+          width: {:pixels, 120},
+          height: {:pixels, 90},
+          crop_from: :gravity,
+          gravity: {:fp, 0.25, 0.75}
+        }
+      ],
+      File.read!(@beach)
+    )
+  end
+
+  test "region crop streams" do
+    assert_sequential_matches_random(
+      [
+        %Crop{
+          width: {:pixels, 120},
+          height: {:pixels, 90},
+          crop_from: %{left: {:pixels, 30}, top: {:pixels, 20}}
+        }
+      ],
+      File.read!(@beach)
+    )
+  end
+
   test "fit resize streams" do
     assert_sequential_matches_random(
       [%Resize{mode: :fit, width: {:pixels, 120}, height: :auto}],
       File.read!(@dog)
+    )
+  end
+
+  test "fill resize streams" do
+    assert_sequential_matches_random(
+      [%Resize{mode: :fill, width: {:pixels, 100}, height: {:pixels, 100}}],
+      File.read!(@beach)
     )
   end
 
@@ -195,6 +229,68 @@ defmodule ImagePipe.Transform.SequentialAccessTest do
     check all(w <- integer(16..400), max_runs: 12) do
       assert_sequential_matches_random(
         [%Resize{mode: :fit, width: {:pixels, w}, height: :auto}],
+        body
+      )
+    end
+  end
+
+  property "focal-point crop streams across varied focal points and sizes" do
+    body = File.read!(@beach)
+
+    check all(
+            w <- integer(8..200),
+            h <- integer(8..150),
+            fx_tenths <- integer(0..10),
+            fy_tenths <- integer(0..10),
+            max_runs: 18
+          ) do
+      assert_sequential_matches_random(
+        [
+          %Crop{
+            width: {:pixels, w},
+            height: {:pixels, h},
+            crop_from: :gravity,
+            gravity: {:fp, fx_tenths / 10, fy_tenths / 10}
+          }
+        ],
+        body
+      )
+    end
+  end
+
+  property "region crop streams across varied origins and sizes" do
+    body = File.read!(@beach)
+
+    check all(
+            left <- integer(0..200),
+            top <- integer(0..150),
+            w <- integer(8..200),
+            h <- integer(8..150),
+            max_runs: 18
+          ) do
+      assert_sequential_matches_random(
+        [
+          %Crop{
+            width: {:pixels, w},
+            height: {:pixels, h},
+            crop_from: %{left: {:pixels, left}, top: {:pixels, top}}
+          }
+        ],
+        body
+      )
+    end
+  end
+
+  property "fill resize streams across varied targets" do
+    body = File.read!(@beach)
+
+    check all(
+            w <- integer(16..400),
+            h <- integer(16..300),
+            max_runs: 12
+          ) do
+      assert_sequential_matches_random(
+        [%Resize{mode: :fill, width: {:pixels, w}, height: {:pixels, h}}],
         body
       )
     end


### PR DESCRIPTION
Peeled off from #185 (transforms).

The documented sequential-safety gate requires every transform shape claiming `requires_materialization?: false` to be **proven** so by a sequential-vs-random pixel-equivalence test (opened from a genuinely streamed source, with the harness self-check guaranteeing non-tautology). `sequential_access_test.exs` was missing three wire-reachable shapes:

- **focal-point gravity crop** — `gravity: {:fp, _, _}`
- **region crop** — `crop_from: %{left:, top:}`
- **`:fill`-mode resize** — the cover intermediate (only `:fit` and `:force` were tested)

## What this adds

Example + property coverage for each, using the **exact struct shapes real producers build**:
- fp crop / region crop match `lib/image_pipe/transform/operation/crop.ex` and the `CropRegion` producer at `plan_executor.ex:546-557` (`crop_from: %{left: {:pixels,_}, top: {:pixels,_}}`).
- `:fill` resize is reachable via `resize_mode(:cover) => :fill` (`plan_executor.ex:807`).

All three confirmed `requires_materialization?: false` (they fall under the gate's obligation, not the `:smart`/`:detect` materialize path).

## Result

All three **stream correctly** — the existing `requires_materialization?: false` claims hold, so **no production change**. Teeth were verified empirically: temporarily injecting a random read into the sequential branch makes `Materializer.materialize` error (`"Failed to memory copy image"`) and fails these exact assertions, then reverted.

Full gate green: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix test` (2061 tests + 60 properties, 0 failures).

Part of #185.

Fixes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)