### PR TITLE
ci(iiif): stop IIIF validator firing on unrelated mise.toml changes

### DIFF
--- a/.github/workflows/iiif-validator.yml
+++ b/.github/workflows/iiif-validator.yml
@@ -7,7 +7,6 @@ on:
       - "lib/image_pipe/parser/iiif/**"
       - "lib/image_pipe/parser/iiif.ex"
       - "validator/**"
-      - "mise.toml"
       - ".github/workflows/iiif-validator.yml"
   pull_request:
     branches: ["main"]


### PR DESCRIPTION
## Problem

The **IIIF Level 2 image-validator** check was running on changes unrelated to IIIF. `mise.toml` was listed in the workflow's trigger `paths`, so any touch to it — tool bumps, the fiddle's node/pnpm pins, validator-task edits — fired the validator even when no IIIF parser or validator code changed.

Concrete case: [#291](https://github.com/hlindset/image_pipe/pull/291), a fiddle/Svelte refactor, ran the IIIF validator solely because it edited `mise.toml`.

## Fix

Drop `mise.toml` from the IIIF validator's trigger paths. It now runs only when:

- `lib/image_pipe/parser/iiif/**` / `lib/image_pipe/parser/iiif.ex`
- `validator/**`
- `.github/workflows/iiif-validator.yml`

change. This mirrors how `elixir.yml` and `lint.yml` insulate themselves from the project `mise.toml` (they pin tools inline via `mise_toml:`).

The job's inline comment about needing the project `mise.toml`'s `[tasks.validator]` stays — that's about why the `mise-action` step avoids an inline `mise_toml:` block (a runtime dependency), unrelated to the trigger paths.

## Trade-off

If someone edits the validator task or erlang pin *in `mise.toml` alone* (no IIIF/validator file touched), the validator won't re-run on that PR; it'll next run when an IIIF/validator file changes. Acceptable, and consistent with the other workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)