### PR TITLE
fix(source): classify mid-body receive timeout as :receive_timeout

### DIFF
--- a/lib/image_pipe/source/req_stream.ex
+++ b/lib/image_pipe/source/req_stream.ex
@@ -157,6 +157,7 @@ defmodule ImagePipe.Source.ReqStream do
   defp parse_message(response, message) do
     case Req.parse_message(response, message) do
       {:ok, chunks} -> {:ok, chunks}
+      {:error, %{reason: :timeout}} -> {:error, :receive_timeout}
       {:error, _exception} -> {:error, :invalid_body}
       :unknown -> :unknown
     end


### PR DESCRIPTION
## Problem

`ImagePipe.Source.ReqStreamTest` "a mid-body receive timeout surfaces as `:receive_timeout`" is a CI flake (e.g. [run 27481524255](https://github.com/hlindset/image_pipe/actions/runs/27481524255/job/81230036706)), failing with:

```
left:  :invalid_body
right: :receive_timeout
```

Reproduced locally at ~1/3 of runs.

## Root cause

When a response body stalls, `ReqStream` arms **two** independent 100 ms timers:

1. Finch's internal `receive_timeout`, passed through at [`req_stream.ex:170`](https://github.com/hlindset/image_pipe/blob/fix/req-stream-classify-receive-timeout/lib/image_pipe/source/req_stream.ex#L170).
2. The manual `receive ... after state.receive_timeout` in `next_message/2`.

Both use the same value and start at nearly the same instant, so it's a race:

- Manual timer wins → `{:error, :receive_timeout}` ✓
- Finch's timer wins → it posts `{:error, %Mint.TransportError{reason: :timeout}}`, which `parse_message/2`'s `{:error, _exception}` catch-all bucketed as `:invalid_body` ✗

Under scheduler jitter Finch wins often enough to flake one shard. Beyond the test, this means a genuinely stalled origin was non-deterministically reported as `:receive_timeout` *or* `:invalid_body` — an incomplete failure-mode classification (cf. #285).

## Fix

Match the transport-timeout reason explicitly before the catch-all so both race outcomes converge on `:receive_timeout`:

```elixir
{:error, %{reason: :timeout}} -> {:error, :receive_timeout}
```

Genuine body-framing errors and other transport failures (`:closed`, etc.) still classify as `:invalid_body`.

## Scope / observability

Not client-observable: `send_source_error` returns a fixed **422** regardless of reason, so HTTP status and body are unchanged. This only sharpens internal and telemetry classification — no imgproxy support-matrix change.

## Verification

- Previously-flaky test: **60/60** seeds pass after the change (was failing ~1/3 before).
- `mix test test/image_pipe/source/req_stream_test.exs`: 11/11.
- Full suite: **2064 tests, 0 failures**.
- `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`: all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)