### PR TITLE
fix(iiif): percent-decode all path tokens, not just the identifier (RFC 3986)

### DIFF
--- a/docs/iiif_3_support_matrix.md
+++ b/docs/iiif_3_support_matrix.md
@@ -102,6 +102,7 @@ Emitted from the **display** dimensions (`SourceInfo.display_dimensions/1`, so E
 | --- | --- | --- |
 | `baseUriRedirect` | ✅ | `{identifier}` (bare) → **303** to `{identifier}/info.json`. Short-circuits before any source fetch (`{:redirect, 303, location}` parse outcome). |
 | `cors` | ✅ | `Access-Control-Allow-Origin: *` on every IIIF response (image, info.json, redirect, errors) + `OPTIONS` preflight → 200, applied by the mount-level `ImagePipe.Parser.IIIF.CORS` plug (the parser's `parse/2` returns a tuple, not a conn, so CORS *must* be mount-level). |
+| Percent-encoded path segments | ✅ | Every token (`{identifier}`/`{region}`/`{size}`/`{rotation}`/`{quality}`/`{format}`) is percent-decoded per RFC 3986, so e.g. `^` sent as `%5E` or `:` as `%3A` is treated identically to its literal form (`ImagePipe.Parser.IIIF.Path.classify/1`). |
 | `jsonldMediaType` | ✅ | See info.json negotiation. |
 | Canonical `Link` header (`rel="canonical"`) | ➖ | Optional (`may` per spec); not implemented. Computing the canonical-spelling URL and threading a per-request response header is deferred; the validator does not require it. |
 

--- a/lib/image_pipe/parser/iiif/path.ex
+++ b/lib/image_pipe/parser/iiif/path.ex
@@ -16,10 +16,20 @@ defmodule ImagePipe.Parser.IIIF.Path do
     do: {:info, decode(id)}
 
   def classify(%Plug.Conn{path_info: [id, region, size, rotation, quality_format]}) do
+    # Percent-decode every token (not just the id): path_info segments may arrive
+    # encoded (e.g. a browser sends `^` as `%5E`, `:` as `%3A`), and RFC 3986 requires
+    # treating the encoded and literal forms identically. Split quality/format on the
+    # structural `.` first, then decode each part, so an encoded `.` can't mis-split.
     case split_quality_format(quality_format) do
       {:ok, quality, format} ->
         {:image, decode(id),
-         %{region: region, size: size, rotation: rotation, quality: quality, format: format}}
+         %{
+           region: decode(region),
+           size: decode(size),
+           rotation: decode(rotation),
+           quality: decode(quality),
+           format: decode(format)
+         }}
 
       :error ->
         :not_found

--- a/test/parser/iiif/path_test.exs
+++ b/test/parser/iiif/path_test.exs
@@ -25,4 +25,18 @@ defmodule ImagePipe.Parser.IIIF.PathTest do
   test "unescaped-slash identifier (extra segment) -> :not_found" do
     assert :not_found = Path.classify(conn_for("/a/b/full/max/0/default.jpg"))
   end
+
+  test "percent-encoded tokens are decoded (RFC 3986), not just the id" do
+    # `:` -> %3A and `,` -> %2C (pct region), `^` -> %5E (upscaling size). path_info
+    # arrives undecoded, so classify must decode every token, not only the identifier.
+    assert {:image, "abc",
+            %{
+              region: "pct:10,10,50,50",
+              size: "^400,",
+              rotation: "0",
+              quality: "default",
+              format: "jpg"
+            }} =
+             Path.classify(conn_for("/abc/pct%3A10%2C10,50,50/%5E400,/0/default.jpg"))
+  end
 end

--- a/test/parser/iiif_wire_test.exs
+++ b/test/parser/iiif_wire_test.exs
@@ -414,6 +414,15 @@ defmodule ImagePipe.Parser.IIIFWireTest do
     assert conn.status == 400
   end
 
+  test "contract 9b2: percent-encoded ^ upscale (%5E400,) → 200, decoded width == 400" do
+    # `^` arrives as %5E; classify must percent-decode the size token so the upscale
+    # flag is honored. Without decoding, `%5E400,` is an invalid size → 400. Source is
+    # 200×300, so `^400,` upscales width 200 → 400.
+    conn = call_iiif("/img/full/%5E400,/0/default.jpg", iiif_opts(OriginImage))
+    assert conn.status == 200
+    assert elem(dimensions(conn), 0) == 400
+  end
+
   test "contract 9c: bad rotation (45) → 400" do
     conn = call_iiif("/img/full/max/45/default.jpg", iiif_opts(OriginImage))
     assert conn.status == 400


### PR DESCRIPTION
## Summary

`ImagePipe.Parser.IIIF.Path.classify/1` previously percent-decoded only the `{identifier}` token of an image request, leaving `{region}`/`{size}`/`{rotation}`/`{quality}`/`{format}` raw. Since `path_info` segments arrive percent-**un**decoded (Plug splits on literal `/` and never decodes), a client/browser sending a reserved char encoded — `^` as `%5E` (size upscaling), `:` as `%3A` or `,` as `%2C` (pct region) — got a **400**, even though RFC 3986 requires treating the encoded and literal forms identically.

This fix decodes **every** token. The structural `.` between quality and format is still split **before** decoding, so an encoded `%2E` can't masquerade as the separator. The strict `Grammar` still validates the decoded string, so nothing newly-invalid is accepted.

## Context

Surfaced while testing the two-provider fiddle demo (#254): the demo's "Allow upscaling (`^`)" toggle produced `…/^400,/…`, which the browser sends as `%5E400,` → 400. Split out of that PR as a standalone core-parser conformance fix.

## Test plan

- [x] `mix test test/parser/iiif/path_test.exs test/parser/iiif_wire_test.exs` (27 tests, 0 failures)
- [x] Unit test: `classify/1` decodes `%3A`/`%2C`/`%5E` across tokens
- [x] Wire test: `…/full/%5E400,/0/default.jpg` → 200, decoded width == 400 (was 400 Bad Request)
- [x] Existing behavior preserved: `a/b` (unescaped slash) → 404; encoded-dot can't mis-split quality/format
- [x] `docs/iiif_3_support_matrix.md` HTTP-behavior row added

🤖 Generated with [Claude Code](https://claude.com/claude-code)
