### PR TITLE
docs(fiddle): point IIIF ^max gating comment at #257 (not closed #296)

### DIFF
--- a/fiddle/assets/IiifControls.svelte
+++ b/fiddle/assets/IiifControls.svelte
@@ -48,7 +48,7 @@
     switch (kind) {
       case "max":
         iiifState.size = { kind: "max" };
-        // `^max` is inert until maxWidth/maxHeight/maxArea support lands (#296), so
+        // `^max` is inert until maxWidth/maxHeight/maxArea support lands (#257), so
         // don't emit it — `^` only meaningfully applies to an explicit target size.
         iiifState.upscale = false;
         break;


### PR DESCRIPTION
## Summary

After #294 merged, the IIIF upscale-gating comment in `fiddle/assets/IiifControls.svelte` still referenced **#296**, which has since been closed (its scope — `maxWidth`/`maxHeight`/`maxArea` size bounds + re-enabling `^max`) was folded into **#257**. Point the comment at #257 so it tracks where the work actually lives.

Comment-only; no behavior change.
