### PR TITLE
test: drop dead top-level test_pid: opt from cdn http cache wire test

### DIFF
--- a/test/image_pipe/cdn_http_cache_wire_test.exs
+++ b/test/image_pipe/cdn_http_cache_wire_test.exs
@@ -87,7 +87,6 @@ defmodule ImagePipe.CDNHTTPCacheWireTest do
         parser: ImagePipe.Parser.Imgproxy,
         sources: [path: {StableSource, test_pid: self()}],
         cache: {CacheProbe, test_pid: self()},
-        test_pid: self(),
         http_cache: [mode: :enabled]
       )
 


### PR DESCRIPTION
## What

`ImagePipe`'s library code never reads `:test_pid` from the top-level request/init opts. Only the test-support adapters read `test_pid` from **their own nested config** (inside a `{Adapter, [test_pid: self()]}` tuple under `:sources` / `:cache`). So a bare top-level `test_pid: self()` in a plug option list is dead — silently ignored.

This removes the one such dead entry, in `test/image_pipe/cdn_http_cache_wire_test.exs`:

```elixir
sources: [path: {StableSource, test_pid: self()}],   # KEPT — nested, the source adapter reads it
cache: {CacheProbe, test_pid: self()},               # KEPT — nested, consumed by the cache probe
test_pid: self(),                                     # REMOVED — top-level, dead/ignored
```

A repo-wide `grep -rn "test_pid" test` confirmed this was the only bare top-level dead copy. Every other `test_pid:` is nested in an adapter/source/cache tuple, a helper-function argument, a telemetry-handler arg, or a local variable — all of which are real and stay.

## Why now

Surfaced while reviewing request-option validation (#283 / tracking #185). This is a standalone test-only cleanup and does **not** resolve either issue.

## Verification

- `mise exec -- mix test test/image_pipe/cdn_http_cache_wire_test.exs` — 10 tests, 0 failures
- `mise run precommit` (format, compile --warnings-as-errors, credo --strict, full `mix test`) — green: 1 doctest, 60 properties, 2067 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)