### PR TITLE
feat(options): validate auto_avif and auto_webp host options

### DIFF
--- a/lib/image_pipe/request/options.ex
+++ b/lib/image_pipe/request/options.ex
@@ -22,7 +22,9 @@ defmodule ImagePipe.Request.Options do
     :max_input_pixels,
     :max_result_width,
     :max_result_height,
-    :max_result_pixels
+    :max_result_pixels,
+    :auto_avif,
+    :auto_webp
   ]
   @stale_origin_option_keys [
     :root_url,
@@ -79,6 +81,14 @@ defmodule ImagePipe.Request.Options do
                     detector_required: [
                       type: :boolean,
                       default: false
+                    ],
+                    auto_avif: [
+                      type: :boolean,
+                      default: true
+                    ],
+                    auto_webp: [
+                      type: :boolean,
+                      default: true
                     ]
                   )
 

--- a/test/image_pipe/request_options_test.exs
+++ b/test/image_pipe/request_options_test.exs
@@ -117,6 +117,29 @@ defmodule ImagePipe.RequestOptionsTest do
     end
   end
 
+  test "auto format options default to true" do
+    opts = Options.validate!(@base_opts)
+
+    assert Keyword.fetch!(opts, :auto_avif) == true
+    assert Keyword.fetch!(opts, :auto_webp) == true
+  end
+
+  test "auto format options accept explicit booleans" do
+    opts =
+      Options.validate!(Keyword.merge(@base_opts, auto_avif: false, auto_webp: false))
+
+    assert Keyword.fetch!(opts, :auto_avif) == false
+    assert Keyword.fetch!(opts, :auto_webp) == false
+  end
+
+  test "auto format options reject non-boolean values" do
+    for key <- [:auto_avif, :auto_webp] do
+      assert_raise ArgumentError, ~r/invalid ImagePipe options/, fn ->
+        Options.validate!(Keyword.put(@base_opts, key, "yes"))
+      end
+    end
+  end
+
   test "request options accept sources without root_url" do
     assert opts =
              Options.validate!(


### PR DESCRIPTION
## Summary

`auto_avif` and `auto_webp` are real host options read directly by their consumers with hardcoded `true` defaults but **absent from the request `Options` validation schema**, so a malformed value (e.g. `auto_avif: "yes"`) was silently accepted at init:

- `:auto_avif` / `:auto_webp` — boolean, default `true`. Read by output negotiation (`lib/image_pipe/output/negotiation.ex`) and the cache key (`lib/image_pipe/cache/key.ex`).

This change adds both to `@options_schema` (`[type: :boolean, default: true]`) and `@validated_option_keys`, so malformed values are rejected with the existing `invalid ImagePipe options` `ArgumentError`.

## Behavior

No behavior change for valid input: the consumer-side hardcoded defaults already matched the new schema defaults, so the validated opts simply now carry explicit values; malformed input is rejected at init.

## On `output_capabilities`

An earlier draft of this PR also validated `:output_capabilities`. That was reverted: unlike the two auto-format options, `output_capabilities` is **not a host option** — it is an internal test-injection seam (`Capabilities.supports?/2`) that overrides the boot-time libvips capability probe, which is the real feature-detection gate. It has no production caller and is explicitly documented as "not a documented/validated public option", consistent with its sibling seam `:source_session_supervisor` (also unvalidated). Adding it to the public schema would have contradicted that contract.

## Tests

Added focused TDD coverage in `test/image_pipe/request_options_test.exs` (defaults, explicit booleans, rejection of non-boolean values). Watched the new tests fail before implementing.

`mise run precommit` passes: format, compile `--warnings-as-errors`, `credo --strict` (no issues), full suite (2070 tests + 60 properties + 1 doctest, 0 failures).

## Context

Surfaced while reviewing request-option validation (#283 / #185); standalone and does **not** close them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)