### PR TITLE
fix(request): catch option typos and normalize allowed_hosts case

### DIFF
--- a/lib/image_pipe/request/options.ex
+++ b/lib/image_pipe/request/options.ex
@@ -38,6 +38,27 @@ defmodule ImagePipe.Request.Options do
     :request_id,
     :telemetry_prefix
   ]
+  # Real top-level options read directly by downstream consumers (negotiation,
+  # cache key, capabilities) with their own defaults rather than this schema.
+  # Listed so a near-miss typo of them is caught too.
+  @passthrough_option_keys [:auto_avif, :auto_webp, :output_capabilities]
+
+  # Names a typo is matched against. Not a closed allowlist: the option surface
+  # is deliberately open (parser config namespaces, DI/runtime seams, detector
+  # extension keys), so we only flag an unknown key that is a close edit-distance
+  # match to one of these — closing the silent-typo footgun (e.g. a misspelled
+  # safety limit) without rejecting legitimately-unknown extension keys.
+  @known_option_names Enum.uniq(
+                        @validated_option_keys ++
+                          @source_runtime_option_keys ++
+                          @passthrough_option_keys ++
+                          [:cache, :sources]
+                      )
+  # A name is a likely typo of a known option when it is a near edit-distance
+  # match and a similar length (guards against false positives on keys that
+  # merely share a long prefix, e.g. `max_result_width`/`max_result_height`).
+  @typo_jaro_threshold 0.9
+  @typo_max_length_diff 2
   @options_schema NimbleOptions.new!(
                     parser: [type: :atom, required: true],
                     clock: [type: {:custom, __MODULE__, :validate_clock, []}],
@@ -87,6 +108,7 @@ defmodule ImagePipe.Request.Options do
     |> Cache.validate_config!()
     |> Source.validate_config!()
     |> reject_stale_origin_opts!()
+    |> reject_typo_opts!()
     |> validate_known_opts!()
   end
 
@@ -121,6 +143,42 @@ defmodule ImagePipe.Request.Options do
 
       {:error, %NimbleOptions.ValidationError{} = error} ->
         raise ArgumentError, "invalid ImagePipe options: #{Exception.message(error)}"
+    end
+  end
+
+  defp reject_typo_opts!(opts) do
+    opts
+    |> Keyword.keys()
+    |> Enum.uniq()
+    |> Enum.reject(&(&1 in @known_option_names))
+    |> Enum.each(fn key ->
+      case nearest_known_option(key) do
+        nil ->
+          :ok
+
+        suggestion ->
+          raise ArgumentError,
+                "unknown ImagePipe option #{inspect(key)} — did you mean #{inspect(suggestion)}?"
+      end
+    end)
+
+    opts
+  end
+
+  defp nearest_known_option(key) do
+    key_string = Atom.to_string(key)
+
+    @known_option_names
+    |> Enum.map(fn known -> {known, String.jaro_distance(Atom.to_string(known), key_string)} end)
+    |> Enum.filter(fn {known, distance} ->
+      distance >= @typo_jaro_threshold and
+        abs(String.length(Atom.to_string(known)) - String.length(key_string)) <=
+          @typo_max_length_diff
+    end)
+    |> Enum.max_by(fn {_known, distance} -> distance end, fn -> nil end)
+    |> case do
+      nil -> nil
+      {known, _distance} -> known
     end
   end
 

--- a/lib/image_pipe/source/http.ex
+++ b/lib/image_pipe/source/http.ex
@@ -50,8 +50,16 @@ defmodule ImagePipe.Source.HTTP do
   @impl Source
   def validate_options(opts) do
     case NimbleOptions.validate(opts, @options_schema) do
-      {:ok, validated} -> {:ok, Keyword.put(validated, :telemetry_kind, :http)}
-      {:error, error} -> {:error, {:invalid_source_config, Exception.message(error)}}
+      {:ok, validated} ->
+        normalized =
+          validated
+          |> Keyword.update!(:allowed_hosts, fn hosts -> Enum.map(hosts, &String.downcase/1) end)
+          |> Keyword.put(:telemetry_kind, :http)
+
+        {:ok, normalized}
+
+      {:error, error} ->
+        {:error, {:invalid_source_config, Exception.message(error)}}
     end
   end
 

--- a/test/image_pipe/request_options_test.exs
+++ b/test/image_pipe/request_options_test.exs
@@ -35,6 +35,34 @@ defmodule ImagePipe.RequestOptionsTest do
     end
   end
 
+  test "validate! rejects a near-miss typo of a validated option" do
+    assert_raise ArgumentError, ~r/did you mean :max_input_pixels/, fn ->
+      Options.validate!(Keyword.put(@base_opts, :max_input_pixles, 100))
+    end
+  end
+
+  test "validate! rejects a near-miss typo of a source-runtime option" do
+    assert_raise ArgumentError, ~r/did you mean :receive_timeout/, fn ->
+      Options.validate!(Keyword.put(@base_opts, :recieve_timeout, 1_000))
+    end
+  end
+
+  test "validate! rejects a near-miss typo of a modern-format option" do
+    assert_raise ArgumentError, ~r/did you mean :auto_webp/, fn ->
+      Options.validate!(Keyword.put(@base_opts, :auto_webpp, false))
+    end
+  end
+
+  test "validate! ignores an unknown option that is not close to any known option" do
+    # Parser config namespaces and DI/runtime seams are far from every known
+    # key, so they pass through untouched (preserving today's behavior).
+    opts =
+      Options.validate!(Keyword.merge(@base_opts, imgproxy: [], image_open_module: __MODULE__))
+
+    assert Keyword.fetch!(opts, :imgproxy) == []
+    assert Keyword.fetch!(opts, :image_open_module) == __MODULE__
+  end
+
   test "request safety limits have defaults" do
     opts = Options.validate!(@base_opts)
 

--- a/test/image_pipe/source/http_test.exs
+++ b/test/image_pipe/source/http_test.exs
@@ -99,6 +99,21 @@ defmodule ImagePipe.Source.HTTPTest do
     assert resolved.identity[:host] == "assets.example.com"
   end
 
+  test "resolve matches a mixed-case allowed_hosts config entry against a lowercased host" do
+    assert {:ok, opts} = HTTP.validate_options(allowed_hosts: ["Assets.Example.Com"])
+
+    source = %URL{
+      scheme: :https,
+      host: "assets.example.com",
+      port: nil,
+      path: ["cat.jpg"],
+      query: nil
+    }
+
+    assert {:ok, %Resolved{} = resolved} = HTTP.resolve(source, opts, [])
+    assert resolved.identity[:host] == "assets.example.com"
+  end
+
   test "resolve honors HTTP internal cache disabled option" do
     assert {:ok, opts} =
              HTTP.validate_options(


### PR DESCRIPTION
Peeled off from #185 (configuration validation) — two host-config-boundary footguns.

## 1. Unknown top-level options were silently dropped

`Options.validate!` only validated `Keyword.take(opts, @validated_option_keys)`, so a typo like `max_input_pixles: 100` was ignored and the default safety limit silently applied.

A strict closed-set allowlist was explored and rejected: ImagePipe's top-level option surface is **deliberately open** — it legitimately includes parser config namespaces (`:imgproxy`, `:iiif`, …), DI/runtime seams (`:image_open_module`, …), and a detector-identity-from-opts extension point. A closed allowlist would be brittle and impose ongoing maintenance (every new option/seam must be registered or boot breaks).

Instead, `reject_typo_opts!/1` flags an unknown key **only when it's a close edit-distance match** (`String.jaro_distance/2 >= 0.9`, plus a length guard) to a known option name. Keys far from every known name pass through untouched, preserving today's behavior for extension keys. The comparison set spans the validated schema, source-runtime keys, `:cache`/`:sources`, and the real-but-unvalidated `auto_avif`/`auto_webp`/`output_capabilities`.

```
max_input_pixles: 100  →  ** (ArgumentError) unknown ImagePipe option :max_input_pixles — did you mean :max_input_pixels?
imgproxy: [...]         →  passes (far from every known name)
```

## 2. `allowed_hosts` compared case-sensitively

`Source.HTTP` downcased the incoming host but matched it against the **raw** configured list, so `allowed_hosts: ["Example.com"]` never matched. Normalized to lowercase at `validate_options`, covering both the resolve check and the redirect-hop `TargetGuard` check (both read `opts[:allowed_hosts]`). Fails closed today, so a config footgun, not a bypass.

## Notes / scope

Two genuine things this review surfaced are spun off into their own PRs (not bundled here): deleting dead top-level `test_pid` test opts, and adding `auto_avif`/`auto_webp`/`output_capabilities` to the validation schema.

## Tests / verification

Unit tests at the `Options.validate!` boundary (typo of a validated, source-runtime, and modern-format option all raise with a "did you mean"; an extension key passes) and an `allowed_hosts` mixed-case resolve test. Full gate green: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix test` (2069 tests + 60 properties, 0 failures). Reviewed for false positives across ~40 plausible host keys — none.

Part of #185.

Fixes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)