### PR TITLE
test: thin near-tautological output_capabilities seam unit tests

### DIFF
--- a/test/image_pipe/output_capabilities_test.exs
+++ b/test/image_pipe/output_capabilities_test.exs
@@ -20,19 +20,13 @@ defmodule ImagePipe.Output.CapabilitiesTest do
   end
 
   describe "supports?/2 with an injected capability map" do
-    test "the override decides avif/webp" do
-      opts = [output_capabilities: %{avif: false, webp: true}]
-      refute Capabilities.supports?(:avif, opts)
-      assert Capabilities.supports?(:webp, opts)
-    end
-
-    test "falls back to the probe when the format is absent from the map" do
-      opts = [output_capabilities: %{webp: false}]
-      assert is_boolean(Capabilities.supports?(:avif, opts))
-    end
-
-    test "without the key, behaves like supports?/1" do
-      assert Capabilities.supports?(:jpeg, [])
+    # The override branch (injected verdict decides) is exercised end-to-end at
+    # the consumer layer (output negotiation, output policy, wire conformance).
+    # Only the fall-through branch — a format absent from a non-empty map still
+    # gets its real capability — is pinned directly here.
+    test "a format absent from the injected map falls through to the real capability" do
+      opts = [output_capabilities: %{avif: false}]
+      assert Capabilities.supports?(:jpeg, opts)
     end
   end
 


### PR DESCRIPTION
## What

Prunes the near-tautological unit tests for the `:output_capabilities` test-injection seam on `ImagePipe.Output.Capabilities`. Test-only change — no production code touched.

## Why

`supports?/2` is the production function with one extra override branch: an injected `:output_capabilities` map (absent in production) lets `async: true` tests force a per-format verdict without mutating global `:persistent_term`. The seam's real value is exercised **end-to-end at the consumer layer** — output negotiation (`output_negotiation_test.exs`), output policy (`output_policy_test.exs`), and the wire conformance suite all inject the map and assert user-visible outcomes. The seam's own `describe "supports?/2 with an injected capability map"` block was largely re-asserting "the map I injected decides the answer."

The wrapper has exactly two branches:
- **override** (`{:ok, supported?} -> supported?`) — thoroughly covered by every consumer injection test.
- **fall-through** (`:error -> supports?(format)`) — only *incidentally* covered at the consumer layer (negotiation keeps `webp` when it's absent from a `%{avif: false}` map), never intentionally pinned.

## Change

- Drop the tautological "override decides avif/webp" test (redundant with consumer-layer coverage).
- Drop the `is_boolean`-only "falls back when absent" test (the assertion was itself tautological).
- Drop "without the key, behaves like supports?/1" (duplicates the `supports?/1` baseline test).
- Keep **one** focused test pinning the `:error -> supports?(format)` fall-through: a format absent from a *non-empty* injected map still gets its real verdict, using a deterministic baseline format (env-independent).
- `supports?/1` and `probe/0` blocks (the real probe path) left intact.

## Verify

`mise run precommit` passes — format, `compile --warnings-as-errors`, `credo --strict`, full suite (`2065 tests, 0 failures`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)