### PR TITLE
feat(request): HEAD cache-header parity and 405 for unsupported methods

### DIFF
--- a/docs/cdn-http-cache.md
+++ b/docs/cdn-http-cache.md
@@ -62,8 +62,8 @@ internal caching without generated HTTP cache headers.
 
 ## Generated Headers
 
-For successful `GET` responses with generated HTTP caching enabled and strong
-byte identity, ImagePipe emits:
+For successful `GET` and `HEAD` responses with generated HTTP caching enabled and
+strong byte identity, ImagePipe emits:
 
 ```http
 Cache-Control: public, max-age=31536000, immutable
@@ -100,12 +100,13 @@ generated public cache headers.
 
 ## Conditional Requests
 
-ImagePipe handles `If-None-Match` only for generated ETags. A matching `GET`
-returns `304 Not Modified` after source resolution and before cache lookup,
-source fetch, decode, transform, or encode.
+ImagePipe handles `If-None-Match` only for generated ETags. A matching `GET` or
+`HEAD` returns `304 Not Modified` after source resolution and before cache lookup,
+source fetch, decode, transform, or encode. HEAD response metadata
+(`ETag`/`Cache-Control`/`Vary`) matches the equivalent `GET`, per RFC 9110 §9.3.2.
 
-`If-None-Match` uses weak comparison for `GET`, so both of these match the
-generated ETag `"ip1-token"`:
+`If-None-Match` uses weak comparison for `GET` and `HEAD`, so both of these match
+the generated ETag `"ip1-token"`:
 
 ```http
 If-None-Match: "ip1-token"
@@ -113,7 +114,10 @@ If-None-Match: W/"ip1-token"
 ```
 
 v1 ignores `If-None-Match: *`, including on internal cache hits.
-Non-`GET` methods skip generated conditional handling.
+
+ImagePipe serves only `GET` and `HEAD`. Any other method receives
+`405 Method Not Allowed` with `Allow: GET, HEAD`, before parsing, source
+resolution, or cache access.
 
 ImagePipe doesn't interpret host-supplied ETags. If an earlier Plug sets
 `ETag`, ImagePipe preserves it, suppresses its generated ETag, and doesn't use
@@ -195,8 +199,8 @@ A conditional `304` emits:
 [:image_pipe, :http_cache, :conditional, :match]
 ```
 
-Metadata includes the method as `method: :get`. It doesn't include paths or
-ETag values.
+Metadata includes the method as `method: :get` or `method: :head`. It doesn't
+include paths or ETag values.
 
 Internal cache hits that receive freshly prepared HTTP cache headers emit:
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -504,7 +504,8 @@ Generated CDN HTTP cache handling emits non-span events:
 
 - `[:image_pipe, :http_cache, :prepare]` with `:effective_mode`,
   `:byte_identity`, and `:etag`.
-- `[:image_pipe, :http_cache, :conditional, :match]` with `method: :get`.
+- `[:image_pipe, :http_cache, :conditional, :match]` with `method: :get` or
+  `method: :head`.
 - `[:image_pipe, :http_cache, :fallback, :no_store]` with `:adapter`,
   `:source_kind`, and `:reason`.
 - `[:image_pipe, :http_cache, :cache_hit, :headers]` with booleans for `:etag`,

--- a/lib/image_pipe/plug.ex
+++ b/lib/image_pipe/plug.ex
@@ -47,6 +47,15 @@ defmodule ImagePipe.Plug do
     end)
   end
 
+  defp do_call(%Plug.Conn{method: method} = conn, opts) when method not in ["GET", "HEAD"] do
+    {conn, _send_metadata} =
+      send_response(conn, opts, :method_not_allowed, fn ->
+        Sender.send_method_not_allowed(conn)
+      end)
+
+    {conn, %{result: :method_not_allowed}}
+  end
+
   defp do_call(%Plug.Conn{} = conn, opts) do
     parser = Keyword.fetch!(opts, :parser)
 

--- a/lib/image_pipe/request/http_cache.ex
+++ b/lib/image_pipe/request/http_cache.ex
@@ -78,17 +78,17 @@ defmodule ImagePipe.Request.HTTPCache do
   @spec evaluate_conditional(Plug.Conn.t(), CacheHeaders.t(), keyword()) ::
           :proceed | {:not_modified, CacheHeaders.t()}
   def evaluate_conditional(
-        %Plug.Conn{method: "GET"} = conn,
+        %Plug.Conn{method: method} = conn,
         %CacheHeaders{etag: etag} = prepared,
         opts
       )
-      when is_binary(etag) do
+      when method in ["GET", "HEAD"] and is_binary(etag) do
     if if_none_match?(conn, etag) do
       Telemetry.execute(
         Telemetry.telemetry_opts(opts),
         [:http_cache, :conditional, :match],
         %{},
-        %{method: :get}
+        %{method: conditional_method(method)}
       )
 
       {:not_modified, prepared}
@@ -98,6 +98,9 @@ defmodule ImagePipe.Request.HTTPCache do
   end
 
   def evaluate_conditional(%Plug.Conn{}, %CacheHeaders{}, _opts), do: :proceed
+
+  defp conditional_method("GET"), do: :get
+  defp conditional_method("HEAD"), do: :head
 
   defp effective_mode(%Resolved{http_cache: :inherit}, opts),
     do: opts |> Keyword.fetch!(:http_cache) |> Keyword.fetch!(:mode)
@@ -123,7 +126,7 @@ defmodule ImagePipe.Request.HTTPCache do
          :enabled,
          _representation_headers
        )
-       when method != "GET",
+       when method not in ["GET", "HEAD"],
        do: {[], nil, nil}
 
   defp generated_cache_headers(conn, plan, resolved, opts, :enabled, representation_headers) do

--- a/lib/image_pipe/response/sender.ex
+++ b/lib/image_pipe/response/sender.ex
@@ -109,6 +109,14 @@ defmodule ImagePipe.Response.Sender do
     |> send_resp(status, "")
   end
 
+  @spec send_method_not_allowed(Plug.Conn.t()) :: Plug.Conn.t()
+  def send_method_not_allowed(%Plug.Conn{} = conn) do
+    conn
+    |> put_resp_header("allow", "GET, HEAD")
+    |> put_resp_content_type("text/plain")
+    |> send_resp(405, "method not allowed")
+  end
+
   @spec send_not_modified(Plug.Conn.t(), CacheHeaders.t()) :: Plug.Conn.t()
   def send_not_modified(%Plug.Conn{} = conn, %CacheHeaders{} = prepared) do
     prepared

--- a/test/image_pipe/cdn_http_cache_wire_test.exs
+++ b/test/image_pipe/cdn_http_cache_wire_test.exs
@@ -124,6 +124,38 @@ defmodule ImagePipe.CDNHTTPCacheWireTest do
     refute_received :source_fetch_called
   end
 
+  test "HEAD emits the same cache-control and etag as GET", %{opts: opts} do
+    get = ImagePipe.Plug.call(conn(:get, "/_/plain/beach.jpg"), opts)
+    flush_messages()
+
+    head = ImagePipe.Plug.call(conn(:head, "/_/plain/beach.jpg"), opts)
+
+    assert head.status == 200
+    assert get_resp_header(head, "etag") != []
+    assert get_resp_header(head, "etag") == get_resp_header(get, "etag")
+    assert get_resp_header(head, "cache-control") == get_resp_header(get, "cache-control")
+  end
+
+  test "matching if-none-match on a HEAD returns 304 before cache lookup and source fetch",
+       %{opts: opts} do
+    first = ImagePipe.Plug.call(conn(:get, "/_/plain/beach.jpg"), opts)
+    [etag] = get_resp_header(first, "etag")
+
+    assert_received :source_fetch_called
+    flush_messages()
+
+    conn =
+      :head
+      |> conn("/_/plain/beach.jpg")
+      |> put_req_header("if-none-match", etag)
+      |> ImagePipe.Plug.call(opts)
+
+    assert conn.status == 304
+    assert get_resp_header(conn, "etag") == [etag]
+    refute_received {:cache_get, %Key{}}
+    refute_received :source_fetch_called
+  end
+
   test "existing vary is merged in the final response", %{opts: opts} do
     conn =
       :get

--- a/test/image_pipe/plug_test.exs
+++ b/test/image_pipe/plug_test.exs
@@ -837,6 +837,29 @@ defmodule ImagePipe.PlugTest do
     assert byte_size(conn.resp_body) > 0
   end
 
+  test "a non-GET/HEAD method returns 405 with an Allow header before any processing" do
+    test_pid = self()
+
+    conn =
+      :post
+      |> conn("/_/plain/images/beach.jpg")
+      |> call_image_pipe(
+        root_url: "http://origin.test",
+        parser: ImagePipe.Parser.Imgproxy,
+        origin_req_options: [
+          plug: fn conn ->
+            send(test_pid, :origin_fetched)
+            Plug.Conn.send_resp(conn, 200, "x")
+          end
+        ]
+      )
+
+    assert conn.status == 405
+    assert get_resp_header(conn, "allow") == ["GET, HEAD"]
+    # The 405 short-circuits before source resolution/fetch — the origin is never hit.
+    refute_received :origin_fetched
+  end
+
   test "streaming sends headers once and resumes for subsequent chunks" do
     conn = conn(:get, "/_/f:jpeg/plain/images/beach.jpg")
     test_pid = self()


### PR DESCRIPTION
Peeled off from #185 (HTTP semantics).

A HEAD request ran the full pipeline but got **no** `ETag`/`Cache-Control`: `generated_cache_headers` gated on `method != "GET"` (sweeping HEAD into the no-headers branch) and `evaluate_conditional` matched only GET. Per RFC 9110 §9.3.2, HEAD response metadata should match GET — so a CDN HEAD probe paid a full fetch/decode/encode and got uncacheable metadata disagreeing with GET.

## Change

- **HEAD cache parity:** cache-header generation and conditional handling now cover `GET` and `HEAD`. HEAD emits the same `ETag`/`Cache-Control`/`Vary` as GET, and a matching `If-None-Match` HEAD returns **304 before source fetch, decode, or encode** (the efficiency win for CDN revalidation probes).
- **405 for unsupported methods:** the plug now serves only GET/HEAD. Any other method gets `405 Method Not Allowed` with `Allow: GET, HEAD`, before parsing/source/cache — via `Sender.send_method_not_allowed/1` (the plug keeps delegating to the response `Sender`, per the architecture boundary test). Previously POST/DELETE were silently processed as GET.

## Compatibility (verified against the real imgproxy source)

Both are deliberate, **product-neutral Plug-level divergences** from imgproxy — HTTP method/status handling is not an imgproxy-parser conformance axis (the support matrix treats transport/router concerns as host-owned), so this is documented in [`docs/cdn-http-cache.md`](docs/cdn-http-cache.md), not the matrix:

- imgproxy's HEAD route maps to a stub `OkHandler` (empty 200, no cache headers, no conditional handling) — so ImagePipe's GET-mirrored HEAD metadata + 304 is an RFC-correct **improvement that diverges from** imgproxy's HEAD, not parity with it.
- imgproxy falls through to **404** for unmatched methods (a router artifact); ImagePipe returns the RFC-correct **405** with `Allow`.

## Notes

A non-conditional HEAD (no `If-None-Match`) still runs the full pipeline and streams a body the HTTP adapter strips for HEAD — status/headers are correct; optimizing HEAD to skip encode is separate scope. The headline win is the 304 fast path.

## Tests / verification

Wire-level tests: HEAD emits the same ETag/Cache-Control as GET; a matching-`If-None-Match` HEAD 304s before cache lookup and source fetch (`refute_received`); a non-GET/HEAD method returns 405 + `Allow`. Full gate green: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix test` (2070 tests + 60 properties, 0 failures). Reviewed for correctness (zero issues) and observable imgproxy compatibility.

Part of #185.

Fixes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP HEAD requests now receive consistent caching headers and conditional request handling with GET requests.
  * Unsupported HTTP methods now return 405 Method Not Allowed responses with proper Allow headers.

* **Documentation**
  * Updated CDN HTTP cache documentation to clarify HEAD request caching behavior and HTTP method validation.

* **Tests**
  * Added test coverage for HEAD request caching and unsupported method responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->