### PR TITLE
test(focus): compare image pixels instead of raw bytes in guided-crop assertion

### DIFF
--- a/test/image_pipe/transform/focus_test.exs
+++ b/test/image_pipe/transform/focus_test.exs
@@ -230,7 +230,7 @@ defmodule ImagePipe.Transform.FocusTest do
       end
     end
 
-    defp guided_crop_bytes(image, orient, guide, {w, h}) do
+    defp guided_crop_image(image, orient, guide, {w, h}) do
       plan = %Plan{
         source: %Source.Path{segments: ["x.png"]},
         pipelines: [
@@ -245,7 +245,17 @@ defmodule ImagePipe.Transform.FocusTest do
           seed_orientation: true
         )
 
-      Image.write!(state.image, :memory, suffix: ".png")
+      state.image
+    end
+
+    defp assert_images_equal(left, right, context) do
+      assert {Image.width(left), Image.height(left)} == {Image.width(right), Image.height(right)},
+             "#{context}: dimensions diverged"
+
+      for x <- 0..(Image.width(left) - 1), y <- 0..(Image.height(left) - 1) do
+        assert Image.get_pixel!(left, x, y) == Image.get_pixel!(right, x, y),
+               "#{context}: pixel mismatch at (#{x},#{y})"
+      end
     end
 
     test "carried (nil focus) == center across axis-reversing orientations and odd extents" do
@@ -254,9 +264,9 @@ defmodule ImagePipe.Transform.FocusTest do
       # orientations 2/4/6/7 reverse an axis (or quarter-turn) where center_bias
       # bites; odd-extent crops give the centre an extra pixel to discard.
       for orient <- [2, 4, 6, 7], size <- [{20, 30}, {21, 31}, {20, 31}, {21, 30}] do
-        carried = guided_crop_bytes(image, orient, :carried, size)
-        centered = guided_crop_bytes(image, orient, :center, size)
-        assert carried == centered, "orient=#{orient} crop=#{inspect(size)} diverged"
+        carried = guided_crop_image(image, orient, :carried, size)
+        centered = guided_crop_image(image, orient, :center, size)
+        assert_images_equal(carried, centered, "orient=#{orient} crop=#{inspect(size)}")
       end
     end
   end


### PR DESCRIPTION
## Summary

- Rename `guided_crop_bytes/4` → `guided_crop_image/4` — the helper now returns the `Vix.Vips.Image` instead of PNG bytes
- Add `assert_images_equal/3` helper that compares dimension and every pixel via `Image.get_pixel!/3`
- Switch the nil-focus == center-focus assertion to use the new pixel comparison

## Why

Raw PNG encoding is not guaranteed to be deterministic — two identical-pixel images can produce different byte sequences depending on encoder state. The previous assertion (`assert carried == centered`) was comparing PNG bytes, which caused flaky failures when the bytes differed despite pixels being identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)