### PR TITLE
test(differential): :diverges verdict + structural-outlier triage signal (#333)

### DIFF
--- a/docs/twicpics_support_matrix.md
+++ b/docs/twicpics_support_matrix.md
@@ -187,11 +187,16 @@ access.
 
 - **`:equal`** cases assert that ImagePipe matches TwicPics within the per-case
   tolerance budget (minor cross-version resampling skew absorbed).
+- **`:diverges`** cases stay on the default lane but assert an *accepted, monitored*
+  divergence sits inside an expected two-sided band — failing if it grows (regression)
+  or shrinks toward a match (promote signal). The two `cover=2:3` fractional-area cases
+  (`cover_ratio_tall`, `focus_bottomright_cover_ratio`) are `:diverges`, tracked under
+  [#331](https://github.com/hlindset/image_pipe/issues/331): the divergence above is
+  real, understood, and permanent, so it is monitored within a band rather than excluded.
 - Quarantined cases (`@tag :twicpics_triage`) are excluded by default; they record a
-  divergence with a reason (+ tracking issue) while keeping the case exercised and its
-  fixture baked. There are currently **2**, both the accepted `cover=2:3` behavioral
-  divergence above (`cover_ratio_tall`, `focus_bottomright_cover_ratio`), tracked under
-  [#331](https://github.com/hlindset/image_pipe/issues/331). The third prior quarantine
+  divergence under active investigation with a reason (+ tracking issue) while keeping
+  the case exercised and its fixture baked. There are currently **0** — the `cover=2:3`
+  cases moved to `:diverges` (monitored), and the third prior quarantine
   (`crop=WxH@XxY` focus-carry) was a real bug, fixed to match live TwicPics — see the
   `crop=WxH@XxY` row.
 

--- a/test/image_pipe/differential/pixel_compare_test.exs
+++ b/test/image_pipe/differential/pixel_compare_test.exs
@@ -138,6 +138,100 @@ defmodule ImagePipe.Differential.PixelCompareTest do
     end
   end
 
+  describe "structural_outliers/3" do
+    # A 1-band grayscale image from horizontally-joined solid column blocks, each
+    # `{width, value}`. Lets us author exact vertical-edge geometry for the
+    # neighborhood-range math.
+    defp columns(blocks, height) do
+      blocks
+      |> Enum.map(fn {w, v} -> img(w, height, [v]) end)
+      |> Enum.reduce(fn block, acc -> Operation.join!(acc, block, :VIPS_DIRECTION_HORIZONTAL) end)
+    end
+
+    test "identical images have no structural outliers" do
+      a = columns([{4, 50}, {4, 200}], 8)
+      assert PixelCompare.structural_outliers(a, a) == 0
+    end
+
+    test "a haloed (antialiased) edge is neighborhood-explainable → ~0" do
+      # reference: sharp vertical edge between col 3 and 4 (50 | 200)
+      ref = columns([{4, 50}, {4, 200}], 8)
+      # test image: the two boundary columns are a 125 blend of their neighbours —
+      # every differing sample lies inside [local_min, local_max] of the reference.
+      test = columns([{3, 50}, {2, 125}, {3, 200}], 8)
+
+      assert PixelCompare.structural_outliers(test, ref) == 0
+    end
+
+    test "a ≥2px hard shift produces out-of-range samples → non-zero" do
+      # reference edge between col 3 and 4; test edge shifted 3px right (between 6 and 7).
+      # The interior shifted columns (5, 6) are wholly the wrong colour: their reference
+      # neighborhood is uniformly 200, so a value of 50 falls outside it.
+      ref = columns([{4, 50}, {4, 200}], 8)
+      test = columns([{7, 50}, {1, 200}], 8)
+
+      assert PixelCompare.structural_outliers(test, ref) > 0
+    end
+
+    test "overshoot within ε is not structural; beyond ε is" do
+      ref = columns([{4, 50}, {4, 200}], 8)
+      # a single boundary column that overshoots the neighborhood max (200) by 6 levels
+      within = columns([{3, 50}, {1, 206}, {4, 200}], 8)
+      assert PixelCompare.structural_outliers(within, ref, overshoot: 8) == 0
+      # tighten ε below the overshoot → the same sample now reads as structural
+      assert PixelCompare.structural_outliers(within, ref, overshoot: 2) > 0
+    end
+  end
+
+  describe "classify_divergence/3" do
+    # out=[10,20,30] vs fixture=[30,40,50]: every band-sample differs by exactly 20,
+    # so max_delta == 20 and over[2] == 16*16*3 == 768.
+    defp diverging_pair, do: {img(16, 16, [10, 20, 30]), img(16, 16, [30, 40, 50])}
+
+    test ":ok when both metrics fall inside their bands" do
+      {out, fixture} = diverging_pair()
+
+      assert PixelCompare.classify_divergence(out, fixture, %{
+               reason: "test",
+               max_delta: 10..30,
+               outliers: 700..800
+             }) == :ok
+    end
+
+    test "max_delta below the floor → :below_floor (promote signal)" do
+      {out, fixture} = diverging_pair()
+
+      assert {:error, :below_floor, %{metric: :max_delta, value: 20, band: 50..100}} =
+               PixelCompare.classify_divergence(out, fixture, %{
+                 reason: "test",
+                 max_delta: 50..100,
+                 outliers: 700..800
+               })
+    end
+
+    test "max_delta above the ceiling → :above_ceiling (regression)" do
+      {out, fixture} = diverging_pair()
+
+      assert {:error, :above_ceiling, %{metric: :max_delta, value: 20, band: 0..10}} =
+               PixelCompare.classify_divergence(out, fixture, %{
+                 reason: "test",
+                 max_delta: 0..10,
+                 outliers: 700..800
+               })
+    end
+
+    test "outlier count out of band is reported with the outliers metric" do
+      {out, fixture} = diverging_pair()
+
+      assert {:error, :below_floor, %{metric: :outliers, value: 768, band: 1000..2000}} =
+               PixelCompare.classify_divergence(out, fixture, %{
+                 reason: "test",
+                 max_delta: 10..30,
+                 outliers: 1000..2000
+               })
+    end
+  end
+
   describe "diagnose/3" do
     test "identical images: comparable, zero max delta, empty histogram" do
       a = img(16, 16, [10, 20, 30])

--- a/test/image_pipe/imgproxy_differential/manifest_test.exs
+++ b/test/image_pipe/imgproxy_differential/manifest_test.exs
@@ -90,10 +90,24 @@ defmodule ImagePipe.Test.ImgproxyDifferential.ManifestTest do
       verdict: :diverges,
       group: :transform,
       tol: nil,
-      divergence: %{metric: :fraction_over, threshold: 2, floor: 0.01, issue: "#124"}
+      divergence: %{
+        reason: "accepted resampling divergence",
+        max_delta: 60..160,
+        outliers: 3_000..4_600,
+        issue: 124
+      }
     }
 
-    b = %{a | divergence: %{issue: "#124", floor: 0.01, threshold: 2, metric: :fraction_over}}
+    b = %{
+      a
+      | divergence: %{
+          issue: 124,
+          outliers: 3_000..4_600,
+          max_delta: 60..160,
+          reason: "accepted resampling divergence"
+        }
+    }
+
     assert Manifest.authored_sha256(a) == Manifest.authored_sha256(b)
   end
 

--- a/test/image_pipe/imgproxy_differential_conformance_test.exs
+++ b/test/image_pipe/imgproxy_differential_conformance_test.exs
@@ -80,13 +80,7 @@ defmodule ImagePipe.ImgproxyDifferentialConformanceTest do
     out = Harness.render_image(c)
     fixture = fixture_image(c, entry)
     assert_same_dims!(c, out, fixture)
-
-    tol = c.tol || Constellations.default_tol()
-    outliers = PixelCompare.outliers(out, fixture, tol.threshold)
-
-    assert outliers <= tol.budget,
-           "#{c.id}: #{outliers} band-bytes over Δ#{tol.threshold} (budget #{tol.budget})" <>
-             libvips_drift_hint(manifest)
+    assert_verdict(c, out, fixture, manifest)
   end
 
   defp run_constellation(%{group: :lossy} = c, entry, _manifest) do
@@ -99,6 +93,36 @@ defmodule ImagePipe.ImgproxyDifferentialConformanceTest do
     assert content_type == entry.content_type,
            "#{c.id}: content-type #{inspect(content_type)} != #{inspect(entry.content_type)}"
   end
+
+  # Dispatch on verdict: `:equal` asserts a per-band tolerance budget; `:diverges`
+  # asserts the live diff sits inside its expected two-sided band (a monitored,
+  # accepted divergence). imgproxy has no `:diverges` constellation yet — this is the
+  # shared mechanism, wired uniformly so it works the moment one needs it. `:triage`
+  # cases never reach here (they are `@tag`-excluded above).
+  defp assert_verdict(%{verdict: :diverges} = c, out, fixture, manifest) do
+    case PixelCompare.classify_divergence(out, fixture, c.divergence) do
+      :ok ->
+        :ok
+
+      {:error, bound, %{metric: metric, value: value, band: band}} ->
+        flunk(
+          "#{c.id}: :diverges #{metric}=#{value} is #{band_msg(bound)} band #{inspect(band)}" <>
+            libvips_drift_hint(manifest)
+        )
+    end
+  end
+
+  defp assert_verdict(c, out, fixture, manifest) do
+    tol = c.tol || Constellations.default_tol()
+    outliers = PixelCompare.outliers(out, fixture, tol.threshold)
+
+    assert outliers <= tol.budget,
+           "#{c.id}: #{outliers} band-bytes over Δ#{tol.threshold} (budget #{tol.budget})" <>
+             libvips_drift_hint(manifest)
+  end
+
+  defp band_msg(:above_ceiling), do: "above its expected"
+  defp band_msg(:below_floor), do: "below its expected (consider promoting to :equal)"
 
   defp assert_same_dims!(c, out, fixture) do
     assert PixelCompare.same_dims?(out, fixture),

--- a/test/image_pipe/twicpics_differential/manifest_test.exs
+++ b/test/image_pipe/twicpics_differential/manifest_test.exs
@@ -35,6 +35,53 @@ defmodule ImagePipe.Test.TwicpicsDifferential.ManifestTest do
     assert_raise RuntimeError, ~r/cover_square/, fn -> Manifest.load!(path) end
   end
 
+  test "authored_sha256 is stable for a nested :divergence band regardless of key order" do
+    a = %{
+      source: :grid_4x4,
+      chain: "cover=2:3",
+      verdict: :diverges,
+      group: :cover,
+      tol: nil,
+      divergence: %{
+        reason: "fractional area",
+        max_delta: 60..160,
+        outliers: 3_000..4_600,
+        issue: 331
+      }
+    }
+
+    b = %{
+      a
+      | divergence: %{
+          issue: 331,
+          outliers: 3_000..4_600,
+          max_delta: 60..160,
+          reason: "fractional area"
+        }
+    }
+
+    assert Manifest.authored_sha256(a) == Manifest.authored_sha256(b)
+  end
+
+  test "authored_sha256 changes when the divergence band changes" do
+    a = %{
+      source: :grid_4x4,
+      chain: "cover=2:3",
+      verdict: :diverges,
+      group: :cover,
+      tol: nil,
+      divergence: %{
+        reason: "fractional area",
+        max_delta: 60..160,
+        outliers: 3_000..4_600,
+        issue: 331
+      }
+    }
+
+    b = %{a | divergence: %{a.divergence | max_delta: 60..200}}
+    refute Manifest.authored_sha256(a) == Manifest.authored_sha256(b)
+  end
+
   test "oracle_signature depends on chain + suffix + source identity, not tol/verdict" do
     base = %{
       chain: "cover=200x200",

--- a/test/image_pipe/twicpics_differential_conformance_test.exs
+++ b/test/image_pipe/twicpics_differential_conformance_test.exs
@@ -35,14 +35,38 @@ defmodule ImagePipe.TwicpicsDifferentialConformanceTest do
       assert PixelCompare.same_dims?(out, fixture),
              "#{@c.id}: dims #{inspect(PixelCompare.dims(out))} != fixture #{inspect(PixelCompare.dims(fixture))}"
 
-      tol = @c[:tol] || Constellations.default_tol()
-      outliers = PixelCompare.outliers(out, fixture, tol.threshold)
-
-      assert outliers <= tol.budget,
-             "#{@c.id}: #{outliers} band-bytes over Δ#{tol.threshold} (budget #{tol.budget})" <>
-               libvips_drift_hint(manifest)
+      assert_verdict(@c, out, fixture, manifest)
     end
   end
+
+  # Dispatch on verdict: `:equal` asserts a per-band tolerance budget; `:diverges`
+  # asserts the live diff sits inside its expected two-sided band (a monitored,
+  # accepted divergence). `:triage` cases never reach here — they are `@tag`-excluded
+  # above.
+  defp assert_verdict(%{verdict: :diverges} = c, out, fixture, manifest) do
+    case PixelCompare.classify_divergence(out, fixture, c.divergence) do
+      :ok ->
+        :ok
+
+      {:error, bound, %{metric: metric, value: value, band: band}} ->
+        flunk(
+          "#{c.id}: :diverges #{metric}=#{value} is #{band_msg(bound)} band #{inspect(band)}" <>
+            libvips_drift_hint(manifest)
+        )
+    end
+  end
+
+  defp assert_verdict(c, out, fixture, manifest) do
+    tol = c[:tol] || Constellations.default_tol()
+    outliers = PixelCompare.outliers(out, fixture, tol.threshold)
+
+    assert outliers <= tol.budget,
+           "#{c.id}: #{outliers} band-bytes over Δ#{tol.threshold} (budget #{tol.budget})" <>
+             libvips_drift_hint(manifest)
+  end
+
+  defp band_msg(:above_ceiling), do: "above its expected"
+  defp band_msg(:below_floor), do: "below its expected (consider promoting to :equal)"
 
   # Fixtures are baked against specific source bytes (the manifest records each
   # source's hash). If a committed source drifts, every fixture comparison silently

--- a/test/image_pipe/twicpics_gen_report_test.exs
+++ b/test/image_pipe/twicpics_gen_report_test.exs
@@ -24,6 +24,7 @@ defmodule ImagePipe.TwicpicsGenReportTest do
           failing?: false,
           hash_drift?: false,
           triage: nil,
+          divergence: nil,
           tol: nil,
           metric_text: "0 band-bytes over Δ2 (budget 64)",
           oracle_img: "data:image/png;base64,AAAA",
@@ -37,17 +38,23 @@ defmodule ImagePipe.TwicpicsGenReportTest do
         %{
           id: "cover_ratio_tall",
           group: :cover,
-          verdict: :equal,
+          verdict: :diverges,
           url: "/grid_4x4.png?twic=v1/cover=2:3/output=png",
           summary: "cover=2:3",
-          status: :over_budget,
+          status: :diverges,
+          # monitored divergence → noteworthy (flagged), in band → passes the lane
           flagged?: true,
-          # quarantined → noteworthy (flagged) but NOT a lane failure
           failing?: false,
           hash_drift?: false,
-          triage: %{reason: "centered 2:3 cover crop divergence", issue: 323},
+          triage: nil,
+          divergence: %{
+            reason: "fractional 2:3 area sub-pixel resampling",
+            max_delta: 60..160,
+            outliers: 3_000..4_600,
+            issue: 331
+          },
           tol: nil,
-          metric_text: "9001 band-bytes over Δ2 (budget 64)",
+          metric_text: "maxΔ 92 ∈ 60..160, 3869 over Δ2 ∈ 3000..4600 — within band",
           oracle_img: "data:image/png;base64,EEEE",
           pipe_img: "data:image/png;base64,FFFF",
           heat_banded: "data:image/png;base64,GGGG",
@@ -67,6 +74,7 @@ defmodule ImagePipe.TwicpicsGenReportTest do
           failing?: true,
           hash_drift?: false,
           triage: nil,
+          divergence: nil,
           tol: nil,
           metric_text: "dims 81×80 ≠ TwicPics 80×80",
           oracle_img: "data:image/png;base64,MMMM",
@@ -75,6 +83,29 @@ defmodule ImagePipe.TwicpicsGenReportTest do
           heat_raw: nil,
           heat_normalized: nil,
           pipe_dims: {81, 80},
+          fixture_dims: {80, 80}
+        },
+        %{
+          id: "quarantined_example",
+          group: :inside,
+          verdict: :equal,
+          url: "/grid_4x4.png?twic=v1/inside=80x80/output=png",
+          summary: "inside=80x80",
+          status: :over_budget,
+          flagged?: true,
+          # quarantined → noteworthy (flagged) but NOT a lane failure (excluded)
+          failing?: false,
+          hash_drift?: false,
+          triage: %{reason: "centered 2:3 cover crop divergence", issue: 323},
+          divergence: nil,
+          tol: nil,
+          metric_text: "9001 band-bytes over Δ2 (budget 64)",
+          oracle_img: "data:image/png;base64,QQQQ",
+          pipe_img: "data:image/png;base64,RRRR",
+          heat_banded: "data:image/png;base64,SSSS",
+          heat_raw: "data:image/png;base64,TTTT",
+          heat_normalized: "data:image/png;base64,UUUU",
+          pipe_dims: {80, 80},
           fixture_dims: {80, 80}
         }
       ]
@@ -113,9 +144,10 @@ defmodule ImagePipe.TwicpicsGenReportTest do
       html = ReportHtml.render(sample_doc())
       assert html =~ "2 cover"
       assert html =~ "1 crop"
-      # cover_ratio_tall (quarantined over-budget) + dims-mismatch are both flagged;
-      # only the non-quarantined dims-mismatch is a lane failure; only one is quarantined.
-      assert html =~ "2 flagged"
+      # cover_ratio_tall (monitored divergence), dims-mismatch, and quarantined_example
+      # are all flagged; only the dims-mismatch is a lane failure; only the triaged
+      # case is quarantined.
+      assert html =~ "3 flagged"
       assert html =~ "1 failing"
       assert html =~ "1 quarantined"
     end
@@ -160,6 +192,21 @@ defmodule ImagePipe.TwicpicsGenReportTest do
       refute html =~ "status-over_budget flagged failing"
     end
 
+    test "a monitored :diverges card carries the right status, badge, and band note" do
+      html = ReportHtml.render(sample_doc())
+      # status-diverges class (filterable), flagged but NOT failing/quarantined
+      assert html =~ "status-diverges flagged"
+      refute html =~ "status-diverges flagged failing"
+      # the monitored badge + the band note with a clickable issue link
+      assert html =~ ~s(<span class="badge monitored">monitored</span>)
+      assert html =~ "monitored divergence"
+      assert html =~ "60..160"
+      assert html =~ "3000..4600"
+      assert html =~ ~s(href="https://github.com/hlindset/image_pipe/issues/331")
+      # in-band → the metric reads as ok, not a failure
+      assert html =~ ~s(class="metric ok")
+    end
+
     test "slider panel is capped to the render width" do
       html = ReportHtml.render(sample_doc())
       assert html =~ ~s(class="panel slider" style="width:280px")
@@ -191,10 +238,12 @@ defmodule ImagePipe.TwicpicsGenReportTest do
     assert html =~ "band-bytes over Δ", "per-case metric text not rendered"
     assert html =~ "data:image/png;base64,", "no inlined PNG images in report"
 
-    # The quarantined divergences are exactly the ones worth eyeballing; the report
-    # must not drop them.
+    # The monitored `:diverges` divergences are exactly the ones worth eyeballing; the
+    # report must keep them, rendered under the monitored (status-diverges) state.
     for id <- ["cover_ratio_tall", "focus_bottomright_cover_ratio"] do
-      assert html =~ ~s(id="#{id}"), "quarantined case #{id} dropped from report"
+      assert html =~ ~s(id="#{id}"), "monitored divergence #{id} dropped from report"
     end
+
+    assert html =~ "status-diverges", "no card rendered under the monitored :diverges status"
   end
 end

--- a/test/support/image_pipe/test/differential/pixel_compare.ex
+++ b/test/support/image_pipe/test/differential/pixel_compare.ex
@@ -109,6 +109,151 @@ defmodule ImagePipe.Test.Differential.PixelCompare do
 
   @default_thresholds [2, 16, 32]
 
+  @typedoc """
+  An accepted-and-monitored divergence's expected band (authored on a `:diverges`
+  constellation). `max_delta` and `outliers` are the two-sided bands the live diff
+  must fall within; `reason`/`issue` are documentation carried alongside.
+  """
+  @type divergence_map :: %{
+          required(:reason) => String.t(),
+          required(:max_delta) => Range.t(),
+          required(:outliers) => Range.t(),
+          optional(:issue) => integer()
+        }
+
+  @doc """
+  Classify an accepted divergence against its expected two-sided band — the shared
+  gate for `verdict: :diverges` constellations. Returns `:ok` when both the
+  per-sample `max_delta` and the Δ2 `outliers` count from `diagnose/3` fall inside
+  their authored bands.
+
+  On a miss it reports *which* metric and *which* bound was crossed:
+
+  - `:above_ceiling` → the divergence **grew** (a likely regression — investigate).
+  - `:below_floor` → the divergence **shrank/vanished** (a libvips update may have
+    made it match — consider promoting the case back to `:equal`).
+
+  The two images must be dimension/band comparable (the conformance test asserts
+  same dims first); a `:diverges` case is by definition a same-frame pixel diff.
+  """
+  @spec classify_divergence(VipsImage.t(), VipsImage.t(), divergence_map()) ::
+          :ok
+          | {:error, :below_floor | :above_ceiling,
+             %{metric: :max_delta | :outliers, value: non_neg_integer(), band: Range.t()}}
+  def classify_divergence(out, fixture, %{max_delta: md_band, outliers: ol_band}) do
+    diag = diagnose(out, fixture, [2])
+
+    with :ok <- check_band(:max_delta, diag.max_delta, md_band) do
+      check_band(:outliers, Map.fetch!(diag.over, 2), ol_band)
+    end
+  end
+
+  defp check_band(metric, value, band) do
+    cond do
+      value < band.first -> {:error, :below_floor, %{metric: metric, value: value, band: band}}
+      value > band.last -> {:error, :above_ceiling, %{metric: metric, value: value, band: band}}
+      true -> :ok
+    end
+  end
+
+  @default_radius 1
+  @default_value_tol 2
+  @default_overshoot 8
+
+  @doc """
+  Count of differing band-samples **not** explainable by the reference's local
+  neighborhood — a neighborhood-aware triage signal (informational, never a gate)
+  that separates resampling/phase artifacts from genuine geometry shifts.
+
+  A differing sample is a *resampling artifact* (haloing/ringing) when its value is a
+  blend of its local neighborhood: it lies within `[local_min − ε, local_max + ε]` of
+  the corresponding window (square, half-width `radius`) in the reference image `b`
+  (`ε` = `overshoot`, absorbing Lanczos overshoot). A *geometry difference* moves an
+  edge, producing samples whose values fall outside that range — those are counted.
+  Only samples differing by more than `value_tol` (8-bit-equivalent levels) are
+  considered. `b` is the reference (the differential fixture); `a` is the candidate.
+
+  `radius` *defines* "negligible geometry difference": a ≤`radius`-px hard shift is
+  spatially indistinguishable from sub-pixel resampling, so keep it small (1–2) — a
+  ≥2px shift then reads as non-zero, sub-pixel/phase skew as ≈0.
+
+  Opts: `radius` (default `1`), `value_tol` (default `2` levels), `overshoot`
+  (default `8` levels). Raises on dimension/band-layout mismatch.
+  """
+  @spec structural_outliers(VipsImage.t(), VipsImage.t(), keyword()) :: non_neg_integer()
+  def structural_outliers(a, b, opts \\ []) do
+    unless same_dims?(a, b) do
+      raise ArgumentError, "dimension mismatch: #{inspect(dims(a))} vs #{inspect(dims(b))}"
+    end
+
+    radius = Keyword.get(opts, :radius, @default_radius)
+    value_tol = Keyword.get(opts, :value_tol, @default_value_tol)
+    overshoot = Keyword.get(opts, :overshoot, @default_overshoot)
+    format = VipsImage.format(a)
+
+    win = 2 * radius + 1
+    lo_img = Operation.rank!(b, win, win, 0)
+    hi_img = Operation.rank!(b, win, win, win * win - 1)
+
+    {:ok, ab} = VipsImage.write_to_binary(a)
+    {:ok, bb} = VipsImage.write_to_binary(b)
+    {:ok, lob} = VipsImage.write_to_binary(lo_img)
+    {:ok, hib} = VipsImage.write_to_binary(hi_img)
+
+    unless byte_size(ab) == byte_size(bb) do
+      raise ArgumentError, "band layout mismatch: #{byte_size(ab)} vs #{byte_size(bb)}"
+    end
+
+    count_structural(
+      format,
+      ab,
+      bb,
+      lob,
+      hib,
+      raw_threshold(value_tol, format),
+      raw_threshold(overshoot, format),
+      0
+    )
+  end
+
+  # A differing candidate sample (|a − b| > value_tol) is structural when it falls
+  # outside the reference neighborhood's [min − ε, max + ε]. Walks all four raw
+  # buffers (candidate, reference, reference local-min, reference local-max) in
+  # lockstep, per-format like the other scanners.
+  defp count_structural(_format, <<>>, <<>>, <<>>, <<>>, _vt, _eps, acc), do: acc
+
+  defp count_structural(
+         :VIPS_FORMAT_USHORT,
+         <<av::native-unsigned-16, ar::binary>>,
+         <<bv::native-unsigned-16, br::binary>>,
+         <<lo::native-unsigned-16, lr::binary>>,
+         <<hi::native-unsigned-16, hr::binary>>,
+         vt,
+         eps,
+         acc
+       ) do
+    acc = bump_structural(av, bv, lo, hi, vt, eps, acc)
+    count_structural(:VIPS_FORMAT_USHORT, ar, br, lr, hr, vt, eps, acc)
+  end
+
+  defp count_structural(
+         format,
+         <<av, ar::binary>>,
+         <<bv, br::binary>>,
+         <<lo, lr::binary>>,
+         <<hi, hr::binary>>,
+         vt,
+         eps,
+         acc
+       ) do
+    acc = bump_structural(av, bv, lo, hi, vt, eps, acc)
+    count_structural(format, ar, br, lr, hr, vt, eps, acc)
+  end
+
+  defp bump_structural(av, bv, lo, hi, vt, eps, acc) do
+    if abs(av - bv) > vt and (av < lo - eps or av > hi + eps), do: acc + 1, else: acc
+  end
+
   @doc """
   Single-pass triage summary for a live-vs-fixture comparison: dims, band layout,
   the maximum absolute sample delta, and a sample count over each threshold — all

--- a/test/support/image_pipe/test/differential/report_ui.ex
+++ b/test/support/image_pipe/test/differential/report_ui.ex
@@ -175,6 +175,8 @@ defmodule ImagePipe.Test.Differential.ReportUI do
     .badge { font-size:11px; padding:2px 7px; border-radius:999px;
       background:var(--surface-control); color:var(--text-muted); }
     .badge.triage { background:color-mix(in srgb, var(--danger) 25%, transparent); color:var(--text-primary); }
+    /* a monitored, accepted divergence (verdict :diverges) — on the lane, in band */
+    .badge.monitored { background:color-mix(in srgb, var(--accent) 22%, transparent); color:var(--text-primary); }
     .summary { margin:8px 0 2px; }
     .url { margin:0 0 8px; color:var(--text-muted); font-size:12px; word-break:break-all; }
     .triage-note { font-size:12px; color:var(--text-primary); margin:6px 0; }

--- a/test/support/image_pipe/test/imgproxy_differential/README.md
+++ b/test/support/image_pipe/test/imgproxy_differential/README.md
@@ -112,15 +112,26 @@ inside, since its signal is the output dimensions. `--undiscriminating` lists on
 flagged cases — a separate axis from `--failing` (correctness). It measures per-band
 *spatial* range, not band-byte range, so a uniform `[200,180,60]` fill reads 0, not 140.
 
-**Reading it — skew vs structural.** `maxΔ` is the deciding signal:
+**Reading it — skew vs structural.** Each comparable line ends with a
+`structural=N (r1) → …` field, the neighborhood-aware
+`PixelCompare.structural_outliers/3` count (radius 1): differing band-samples whose value
+is **not** explainable by the reference's local range. It makes the call below
+quantitative rather than eyeballing `maxΔ` alone:
 
 - **Diffuse resampling skew** (a libvips-version difference, not a bug) keeps `maxΔ` low —
-  tens of levels — even when many samples exceed Δ2. Absorb it with a tolerance.
+  tens of levels — and `structural` a small minority of the Δ2 diff (`→ resampling/phase`).
+  Absorb it with a tolerance.
 - **A placement/crop/scale shift** misaligns high-contrast edges, pushing `maxΔ` toward
-  ~255. That is a real divergence — never widen a tol to hide it; quarantine (`:triage` +
-  a tracking issue) or fix.
+  ~255 and making `structural` the *majority* of the diff (`→ geometry shift`). That is a
+  real divergence — never widen a tol to hide it; quarantine (`:triage` + a tracking
+  issue) or fix.
 - **A band/dim mismatch** prints `FINDING` (not pixel-comparable) — itself a divergence
   (e.g. an extend that adds a spurious alpha channel, #220).
+
+`structural_outliers` is a triage aid only — it is **not** asserted by the conformance
+test. (For an accepted, permanent divergence rather than a bug, a `verdict: :diverges`
+case asserts the diff inside an expected two-sided band on the lane instead of being
+excluded — the shared mechanism is wired here, though no imgproxy case uses it yet.)
 
 **Tolerance conventions** (`tol: %{threshold, budget}` on the constellation; default
 `Δ2 / budget 64`):

--- a/test/support/image_pipe/test/twicpics_differential/README.md
+++ b/test/support/image_pipe/test/twicpics_differential/README.md
@@ -9,11 +9,11 @@ TwicPics is **libvips-based** — the same engine ImagePipe renders with — so 
 comparison is the right, stricter gate, not the foreign-engine mismatch the suite
 originally assumed. This was discovered empirically: of the 30 committed fixtures 20 are
 byte-identical to ImagePipe's libvips output, 8 show only low resampling skew (maxΔ=12,
-absorbed by per-case tolerance), and 2 are quarantined as an accepted behavioral
-divergence (the `cover=2:3` fractional-area resampling — see *Quarantine mechanism*
-below). The third originally-surfaced divergence (`crop=WxH@XxY` focus-carry) was a real
-ImagePipe bug, now fixed to match live TwicPics
-([#331](https://github.com/hlindset/image_pipe/issues/331)).
+absorbed by per-case tolerance), and 2 are a `:diverges` (monitored) accepted behavioral
+divergence kept on the default lane inside an expected band (the `cover=2:3`
+fractional-area resampling — see *Verdicts* below). The third originally-surfaced
+divergence (`crop=WxH@XxY` focus-carry) was a real ImagePipe bug, now fixed to match live
+TwicPics ([#331](https://github.com/hlindset/image_pipe/issues/331)).
 
 ## Bake (requires network)
 
@@ -156,15 +156,41 @@ mise exec -- mix twicpics.diagnose cover_wide contain_tall   # specific cases
 mise exec -- mix twicpics.diagnose                            # whole suite
 ```
 
-**Reading it — skew vs structural.** `maxΔ` is the deciding signal:
+**Reading it — skew vs structural.** Each comparable line ends with a
+`structural=N (r1) → …` field, the neighborhood-aware
+`PixelCompare.structural_outliers/3` count (radius 1): differing band-samples whose
+value is **not** explainable by the reference's local range, i.e. not a blend of its
+neighborhood. It makes the skew-vs-structural call quantitative rather than
+eyeballing `maxΔ`:
 
-- **Diffuse resampling skew** (a libvips-version difference, not a bug) keeps `maxΔ`
-  low — tens of levels — even when many samples exceed Δ2. Absorb it with a tolerance.
+- **Diffuse resampling/sub-pixel skew** (a libvips-version difference or fractional-area
+  phase, not a bug) keeps `maxΔ` low — tens of levels — and `structural` a small
+  minority of the Δ2 diff (the line reads `→ resampling/phase`). Absorb with a tolerance,
+  or — for an accepted permanent difference — a `:diverges` band (see *Verdicts*).
 - **A placement/crop/scale shift** misaligns high-contrast edges, pushing `maxΔ`
-  toward ~255. That is a real divergence — never widen a tol to hide it; quarantine
-  (`:triage` + a tracking issue) or fix.
+  toward ~255 and making `structural` the *majority* of the diff (`→ geometry shift`).
+  That is a real divergence — never widen a tol to hide it; fix it, or quarantine
+  (`:triage` + a tracking issue) while investigating.
 - **A band/dim mismatch** prints `FINDING` (not pixel-comparable) — itself a
   divergence.
+
+`structural_outliers` is a triage aid only — it is **not** asserted by the conformance
+test (it has tuning knobs: `radius`, `value_tol`, `overshoot`).
+
+### Verdicts
+
+- **`:equal`** (default) → assert ImagePipe matches TwicPics within the per-case `tol`
+  budget. On the lane.
+- **`:diverges`** → an *accepted, monitored* divergence: assert the live diff sits inside
+  an expected two-sided band (`divergence: %{reason, max_delta: lo..hi, outliers: lo..hi,
+  issue}`, evaluated by `PixelCompare.classify_divergence/3`). Stays **on the lane** — it
+  fails if the divergence *grows* (regression, above the ceiling) or *shrinks/vanishes*
+  (promote signal, below the floor → consider returning the case to `:equal`). Use it for
+  a real, understood, permanent difference (the `cover=2:3` fractional-area cases), not
+  one under active investigation. `:divergence` is an authored field, so editing a band
+  needs `mix twicpics.reauthor` (no re-bake — bands don't change pixels).
+- **`:triage`** → a divergence *under investigation*: `@tag :twicpics_triage`, **excluded**
+  from the default lane (see *Quarantine mechanism*).
 
 **Tolerance conventions** (`tol: %{threshold, budget}` on the constellation; default
 `Δ2 / budget 64`):
@@ -192,21 +218,23 @@ require a manifest reauthor. The bake still fetches oracle output for triaged ca
 (the parse gate skips them, but the bake runs them — only the conformance comparison
 is quarantined).
 
-**Current quarantined cases (2)** — both an accepted, permanent behavioral divergence
-(not "under investigation"), tracked under
+**Current quarantined cases (0).** The two `cover=2:3` fractional-area cases are no
+longer quarantined — they moved to `verdict: :diverges` (monitored on the lane, see
+*Verdicts* above), tracked under
 [#331](https://github.com/hlindset/image_pipe/issues/331):
 
 - `cover_ratio_tall` (`cover=2:3`) and `focus_bottomright_cover_ratio`
   (`focus=bottom-right/cover=2:3`) — the largest 2:3 area on the 400×400 source is
   266.667-wide (fractional). TwicPics sub-pixel-resamples that float area to the rounded
   267-wide output, antialiasing the cropped-axis cell edges; ImagePipe does a sharp
-  integer crop. Placement matches to sub-pixel — only the boundary lines differ — so
-  this is a resampling divergence, not a placement bug. It is **not** absorbed by
-  widening tolerance: the haloing spans whole boundary lines (~thousands of band-bytes
-  over Δ2), so a tolerance large enough to pass would also mask a real half-cell shift.
-  The integer-area direction (`cover=16:9` → `cover_ratio_wide`) stays a live `:equal`
-  case and is byte-identical. See the `cover=W:H` "Diverges" note in
-  `docs/twicpics_support_matrix.md`.
+  integer crop. Placement matches to sub-pixel — only the boundary lines differ
+  (`structural` ≈ a small minority of the diff) — so this is a resampling divergence,
+  not a placement bug. It is **not** absorbed by widening tolerance: the haloing spans
+  whole boundary lines (~thousands of band-bytes over Δ2), so a tolerance large enough to
+  pass would also mask a real half-cell shift — hence a two-sided `:diverges` band, which
+  rejects both a growing shift and a now-byte-identical match. The integer-area direction
+  (`cover=16:9` → `cover_ratio_wide`) stays a live `:equal` case and is byte-identical.
+  See the `cover=W:H` "Diverges" note in `docs/twicpics_support_matrix.md`.
 
 The third originally-quarantined case, `crop_region_reset`, was a real ImagePipe bug,
 not a sub-pixel skew: `crop=WxH@XxY` was **resetting** the carried focus to the

--- a/test/support/image_pipe/test/twicpics_differential/constellations.ex
+++ b/test/support/image_pipe/test/twicpics_differential/constellations.ex
@@ -83,17 +83,20 @@ defmodule ImagePipe.Test.TwicpicsDifferential.Constellations do
       ),
       # --- cover-RATIO steered by focus (the documented ratio consumer, #321) ---
       c("focus_topleft_cover_ratio", "focus=top-left/cover=16:9", :focus),
-      # QUARANTINED — accepted behavioral divergence (#331), same root cause as
-      # `cover_ratio_tall`: the largest 2:3 area on the 400×400 source is 266.667-wide
-      # (fractional), so TwicPics sub-pixel-resamples it to the rounded integer output,
-      # antialiasing the cropped-axis cell edges; ImagePipe does a sharp integer crop.
-      # Placement matches to sub-pixel — see the `cover=W:H` "Diverges" note in the
-      # support matrix. Kept (not deleted) so the input stays exercised and the diff
-      # stays visible under `--include twicpics_triage`.
+      # MONITORED DIVERGENCE (#331), same root cause as `cover_ratio_tall`: the largest
+      # 2:3 area on the 400×400 source is 266.667-wide (fractional), so TwicPics
+      # sub-pixel-resamples it to the rounded integer output, antialiasing the
+      # cropped-axis cell edges; ImagePipe does a sharp integer crop. Placement matches
+      # to sub-pixel. Accepted and permanent — stays on the default lane inside a
+      # two-sided band (regresses if it grows toward a real shift, promotes if a libvips
+      # update makes it match). See the `cover=W:H` "Diverges" note in the support matrix.
       c("focus_bottomright_cover_ratio", "focus=bottom-right/cover=2:3", :focus,
-        triage: %{
+        verdict: :diverges,
+        divergence: %{
           reason:
-            "accepted behavioral divergence (~Δ43): bottom-right focus on the 2:3 cover-ratio crop. The largest matching area is fractional (266.667w), so TwicPics sub-pixel-resamples it to the integer output (cell-edge antialiasing); ImagePipe integer-crops. Placement matches to sub-pixel. Permanent — see the cover=W:H Diverges note in docs/twicpics_support_matrix.md.",
+            "Bottom-right focus on the 2:3 cover-ratio crop. The largest matching area is fractional (266.667w), so TwicPics sub-pixel-resamples it to the integer output (cell-edge antialiasing); ImagePipe integer-crops. Placement matches to sub-pixel. Permanent — see the cover=W:H Diverges note in docs/twicpics_support_matrix.md.",
+          max_delta: 24..96,
+          outliers: 2_700..4_400,
           issue: 331
         }
       ),
@@ -111,16 +114,19 @@ defmodule ImagePipe.Test.TwicpicsDifferential.Constellations do
       # `cover=16:9` on the 400×400 source extracts a 400×225 area — an exact integer
       # crop, byte-identical to TwicPics, so it stays a live `:equal` case.
       c("cover_ratio_wide", "cover=16:9", :cover),
-      # QUARANTINED — accepted behavioral divergence (#331). The largest 2:3 area is
-      # 266.667-wide (fractional); TwicPics sub-pixel-resamples that float area to the
-      # rounded 267-wide output, antialiasing the vertical cell edges, where ImagePipe
-      # does a sharp integer crop. Placement matches to sub-pixel (only the boundary
-      # lines differ) — see the `cover=W:H` "Diverges" note in the support matrix. Kept
-      # quarantined (not deleted) so the input stays exercised and the diff stays visible.
+      # MONITORED DIVERGENCE (#331). The largest 2:3 area is 266.667-wide (fractional);
+      # TwicPics sub-pixel-resamples that float area to the rounded 267-wide output,
+      # antialiasing the vertical cell edges, where ImagePipe does a sharp integer crop.
+      # Placement matches to sub-pixel (only the boundary lines differ) — see the
+      # `cover=W:H` "Diverges" note in the support matrix. Accepted and permanent: stays
+      # on the default lane inside a two-sided band rather than excluded.
       c("cover_ratio_tall", "cover=2:3", :cover,
-        triage: %{
+        verdict: :diverges,
+        divergence: %{
           reason:
-            "accepted behavioral divergence (~Δ92, confined to the cell-boundary lines): the largest 2:3 area is fractional (266.667w), so TwicPics sub-pixel-resamples it to the integer output (cell-edge antialiasing); ImagePipe integer-crops. Placement matches to sub-pixel. Permanent — see the cover=W:H Diverges note in docs/twicpics_support_matrix.md.",
+            "Confined to the cell-boundary lines (~Δ92): the largest 2:3 area is fractional (266.667w), so TwicPics sub-pixel-resamples it to the integer output (cell-edge antialiasing); ImagePipe integer-crops. Placement matches to sub-pixel. Permanent — see the cover=W:H Diverges note in docs/twicpics_support_matrix.md.",
+          max_delta: 60..160,
+          outliers: 3_000..4_600,
           issue: 331
         }
       ),

--- a/test/support/image_pipe/test/twicpics_differential/manifest.exs
+++ b/test/support/image_pipe/test/twicpics_differential/manifest.exs
@@ -29,7 +29,7 @@
       oracle_signature: "761a5b9a4e222d5a0e890d77c17377cac0aba130d8166f9ee2d4c3f66e02f719"
     },
     "cover_ratio_tall" => %{
-      authored_sha256: "101d0c5d657ab1fdb6b620e33816f2a69495aceec447569fe7cdc3553c1a7cc6",
+      authored_sha256: "63b43b3b290e6d71fbc52aa41557003d974a27030278a2f860e3b5a6051c7f72",
       fixture_filename: "cover_ratio_tall.png",
       fixture_sha256: "7f96a5653fc31537669d0f4669c0dbdf103b40f9ef528d361109e5b40461412d",
       oracle_signature: "3961b4a682439215cabedb1ebbc71d7ac9e550bb69517aef815f70c6015c51a9"
@@ -83,7 +83,7 @@
       oracle_signature: "eb7e5842e0b850fa0a470e40c60efee97e1eec1697e62641214611eb8d52f03d"
     },
     "focus_bottomright_cover_ratio" => %{
-      authored_sha256: "61a683c0c4a41d4017b1760cf49ddf3a9a53319ead2a69346877ba44aa75171a",
+      authored_sha256: "a962578a779e39fea8425340153034eeba2552e40686c94bbc8f72ed4cd28717",
       fixture_filename: "focus_bottomright_cover_ratio.png",
       fixture_sha256: "cb36b7be93f44c3543513a4d75fae21a78d56dfcc12d5866253363d8fb7b48ef",
       oracle_signature: "64f9e4b76fbd3efc934f87ac6e7c17eda7fa61f6ae9ef9773fb48db992c0ccca"

--- a/test/support/image_pipe/test/twicpics_differential/report_html.ex
+++ b/test/support/image_pipe/test/twicpics_differential/report_html.ex
@@ -84,6 +84,7 @@ defmodule ImagePipe.Test.TwicpicsDifferential.ReportHtml do
       <p class="summary">#{esc(c.summary)}</p>
       <p class="url"><code>#{esc(c.url)}</code></p>
       #{triage(c)}
+      #{divergence(c)}
       #{drift_banner(c)}
       <p class="metric #{metric_class(c)}">#{esc(c.metric_text)}</p>
       #{visuals(c)}
@@ -104,7 +105,10 @@ defmodule ImagePipe.Test.TwicpicsDifferential.ReportHtml do
 
     triage = if c.triage, do: [~s(<span class="badge triage">quarantined</span>)], else: []
 
-    Enum.join(base ++ tol ++ triage, " ")
+    monitored =
+      if c.divergence, do: [~s(<span class="badge monitored">monitored</span>)], else: []
+
+    Enum.join(base ++ tol ++ triage ++ monitored, " ")
   end
 
   defp triage(%{triage: nil}), do: ""
@@ -116,13 +120,28 @@ defmodule ImagePipe.Test.TwicpicsDifferential.ReportHtml do
     ~s(<p class="triage-note">⚠ quarantined: #{esc(reason)} — <a href="#{@issue_base}#{esc(n)}">##{esc(n)}</a></p>)
   end
 
+  defp divergence(%{divergence: nil}), do: ""
+
+  # A monitored, accepted divergence (`verdict: :diverges`): reason + band + issue
+  # link. Unlike `:triage` it stays on the default lane, asserted inside its band.
+  defp divergence(%{divergence: %{reason: reason, max_delta: md, outliers: ol} = div}) do
+    issue = div |> Map.get(:issue) |> to_string() |> String.trim_leading("#")
+
+    link =
+      if issue == "",
+        do: "",
+        else: ~s| — <a href="#{@issue_base}#{esc(issue)}">##{esc(issue)}</a>|
+
+    ~s|<p class="triage-note">↔ monitored divergence (maxΔ #{esc(inspect(md))}, outliers #{esc(inspect(ol))}): #{esc(reason)}#{link}</p>|
+  end
+
   defp drift_banner(%{hash_drift?: true}),
     do:
       ~s(<p class="banner drift">authored fields changed since generation — run <code>mix twicpics.reauthor</code> or regenerate.</p>)
 
   defp drift_banner(_), do: ""
 
-  defp metric_class(c), do: if(c.status == :pass, do: "ok", else: "bad")
+  defp metric_class(c), do: if(c.status in [:pass, :diverges], do: "ok", else: "bad")
 
   # Dims mismatch: the two renders side by side; no slider/heatmap (the mismatch is
   # the finding).

--- a/test/support/mix/tasks/imgproxy.diagnose.ex
+++ b/test/support/mix/tasks/imgproxy.diagnose.ex
@@ -107,18 +107,20 @@ defmodule Mix.Tasks.Imgproxy.Diagnose do
     contrast = PixelCompare.spatial_contrast(fixture)
     flat? = contrast < @min_contrast
     attention? = not d.comparable or Map.fetch!(d.over, tol.threshold) > tol.budget
+    structural = if d.comparable, do: PixelCompare.structural_outliers(out, fixture)
 
-    {attention?, flat?, pad(c.id) <> body_for(d, tol) <> contrast_suffix(contrast, flat?)}
+    {attention?, flat?,
+     pad(c.id) <> body_for(d, tol, structural) <> contrast_suffix(contrast, flat?)}
   end
 
-  defp body_for(%{comparable: false} = d, _tol) do
+  defp body_for(%{comparable: false} = d, _tol, _structural) do
     {{wa, ha}, {wb, hb}} = d.dims
     {ba, bb} = d.bands
     dims = if {wa, ha} == {wb, hb}, do: "#{wa}×#{ha}", else: "#{wa}×#{ha}≠#{wb}×#{hb}"
     "FINDING — bands #{ba}/#{bb}, dims #{dims} (not pixel-comparable)"
   end
 
-  defp body_for(%{comparable: true} = d, tol) do
+  defp body_for(%{comparable: true} = d, tol, structural) do
     {{w, h}, _} = d.dims
     {ba, _} = d.bands
     over = d.over
@@ -126,7 +128,23 @@ defmodule Mix.Tasks.Imgproxy.Diagnose do
     pass? = Map.fetch!(over, tol.threshold) <= tol.budget
 
     "dims #{w}×#{h}  bands #{ba}  maxΔ=#{d.max_delta}  #{hist}  " <>
-      "tol Δ#{tol.threshold}/#{tol.budget} → #{if pass?, do: "PASS", else: "OVER BUDGET"}"
+      "tol Δ#{tol.threshold}/#{tol.budget} → #{if pass?, do: "PASS", else: "OVER BUDGET"}  " <>
+      structural_suffix(structural, Map.fetch!(over, 2))
+  end
+
+  # The neighborhood-aware triage signal (`PixelCompare.structural_outliers/3`, radius
+  # 1): differing samples NOT explainable by the reference's local range. A small
+  # minority of the Δ2 diff means resampling/phase skew (sub-pixel); a majority means a
+  # real geometry shift. Informational — never gated.
+  defp structural_suffix(structural, over2) do
+    label =
+      cond do
+        over2 == 0 -> "—"
+        structural * 2 >= over2 -> "geometry shift"
+        true -> "resampling/phase"
+      end
+
+    "structural=#{structural} (r1) → #{label}"
   end
 
   defp contrast_suffix(contrast, flat?) do

--- a/test/support/mix/tasks/twicpics.diagnose.ex
+++ b/test/support/mix/tasks/twicpics.diagnose.ex
@@ -80,18 +80,19 @@ defmodule Mix.Tasks.Twicpics.Diagnose do
     contrast = PixelCompare.spatial_contrast(fixture)
     flat? = contrast < @min_contrast
     attention? = not d.comparable or Map.fetch!(d.over, tol.threshold) > tol.budget
+    structural = if d.comparable, do: PixelCompare.structural_outliers(out, fixture)
 
-    {attention?, pad(c.id) <> body_for(d, tol) <> contrast_suffix(contrast, flat?)}
+    {attention?, pad(c.id) <> body_for(d, tol, structural) <> contrast_suffix(contrast, flat?)}
   end
 
-  defp body_for(%{comparable: false} = d, _tol) do
+  defp body_for(%{comparable: false} = d, _tol, _structural) do
     {{wa, ha}, {wb, hb}} = d.dims
     {ba, bb} = d.bands
     dims = if {wa, ha} == {wb, hb}, do: "#{wa}×#{ha}", else: "#{wa}×#{ha}≠#{wb}×#{hb}"
     "FINDING — bands #{ba}/#{bb}, dims #{dims} (not pixel-comparable)"
   end
 
-  defp body_for(%{comparable: true} = d, tol) do
+  defp body_for(%{comparable: true} = d, tol, structural) do
     {{w, h}, _} = d.dims
     {ba, _} = d.bands
     over = d.over
@@ -99,7 +100,23 @@ defmodule Mix.Tasks.Twicpics.Diagnose do
     pass? = Map.fetch!(over, tol.threshold) <= tol.budget
 
     "dims #{w}×#{h}  bands #{ba}  maxΔ=#{d.max_delta}  #{hist}  " <>
-      "tol Δ#{tol.threshold}/#{tol.budget} → #{if pass?, do: "PASS", else: "OVER BUDGET"}"
+      "tol Δ#{tol.threshold}/#{tol.budget} → #{if pass?, do: "PASS", else: "OVER BUDGET"}  " <>
+      structural_suffix(structural, Map.fetch!(over, 2))
+  end
+
+  # The neighborhood-aware triage signal (`PixelCompare.structural_outliers/3`, radius
+  # 1): differing samples NOT explainable by the reference's local range. A small
+  # minority of the Δ2 diff means resampling/phase skew (sub-pixel); a majority means a
+  # real geometry shift. Informational — never gated.
+  defp structural_suffix(structural, over2) do
+    label =
+      cond do
+        over2 == 0 -> "—"
+        structural * 2 >= over2 -> "geometry shift"
+        true -> "resampling/phase"
+      end
+
+    "structural=#{structural} (r1) → #{label}"
   end
 
   defp contrast_suffix(contrast, flat?) do

--- a/test/support/mix/tasks/twicpics.gen_report.ex
+++ b/test/support/mix/tasks/twicpics.gen_report.ex
@@ -75,45 +75,76 @@ defmodule Mix.Tasks.Twicpics.GenReport do
         url: Constellations.twicpics_path(c),
         summary: c.chain,
         triage: c[:triage],
+        divergence: c[:divergence],
         tol: c[:tol],
         hash_drift?: Manifest.authored_sha256(c) != entry.authored_sha256,
         pipe_dims: PixelCompare.dims(pipe)
       }
-      |> Map.merge(status_fields(pipe, fixture, tol))
+      |> Map.merge(status_fields(c, pipe, fixture, tol))
       |> finalize_flags()
 
     attach_images(card, body, content_type, pipe, entry, tol)
   end
 
-  defp status_fields(pipe, fixture, tol) do
+  defp status_fields(c, pipe, fixture, tol) do
     fixture_dims = PixelCompare.dims(fixture)
 
-    if PixelCompare.dims(pipe) != fixture_dims do
-      %{
-        fixture_dims: fixture_dims,
-        status: :dims_mismatch,
-        metric_text:
-          "dims #{fmt_dims(PixelCompare.dims(pipe))} ≠ TwicPics #{fmt_dims(fixture_dims)}"
-      }
-    else
-      outliers = PixelCompare.outliers(pipe, fixture, tol.threshold)
+    cond do
+      PixelCompare.dims(pipe) != fixture_dims ->
+        %{
+          fixture_dims: fixture_dims,
+          status: :dims_mismatch,
+          metric_text:
+            "dims #{fmt_dims(PixelCompare.dims(pipe))} ≠ TwicPics #{fmt_dims(fixture_dims)}"
+        }
 
-      %{
-        fixture_dims: fixture_dims,
-        status: if(outliers <= tol.budget, do: :pass, else: :over_budget),
-        metric_text: "#{outliers} band-bytes over Δ#{tol.threshold} (budget #{tol.budget})"
-      }
+      c.verdict == :diverges ->
+        Map.put(diverges_fields(pipe, fixture, c.divergence), :fixture_dims, fixture_dims)
+
+      true ->
+        outliers = PixelCompare.outliers(pipe, fixture, tol.threshold)
+
+        %{
+          fixture_dims: fixture_dims,
+          status: if(outliers <= tol.budget, do: :pass, else: :over_budget),
+          metric_text: "#{outliers} band-bytes over Δ#{tol.threshold} (budget #{tol.budget})"
+        }
+    end
+  end
+
+  # A `:diverges` case is gated by its two-sided band (`classify_divergence/3`), not
+  # the `:equal` tolerance budget. In band → `:diverges` (monitored, passes the lane);
+  # out of band → `:diverges_out_of_band` (a regression or promote signal — lane red).
+  defp diverges_fields(pipe, fixture, divergence) do
+    d = PixelCompare.diagnose(pipe, fixture, [2])
+
+    case PixelCompare.classify_divergence(pipe, fixture, divergence) do
+      :ok ->
+        %{
+          status: :diverges,
+          metric_text:
+            "maxΔ #{d.max_delta} ∈ #{inspect(divergence.max_delta)}, " <>
+              "#{Map.fetch!(d.over, 2)} over Δ2 ∈ #{inspect(divergence.outliers)} — within band"
+        }
+
+      {:error, bound, %{metric: metric, value: value, band: band}} ->
+        %{
+          status: :diverges_out_of_band,
+          metric_text: "#{metric}=#{value} #{bound} band #{inspect(band)}"
+        }
     end
   end
 
   defp finalize_flags(card) do
-    failure? = card.hash_drift? or card.status in [:over_budget, :dims_mismatch]
+    failure? =
+      card.hash_drift? or card.status in [:over_budget, :dims_mismatch, :diverges_out_of_band]
 
-    # `flagged?` is anything noteworthy (a divergence, quarantined or not). `failing?`
-    # is the stricter "would the default `mix test` lane go red" subset: a quarantined
-    # (`:triage`) case is excluded from the lane, so it is flagged but not failing.
+    # `flagged?` is anything noteworthy (any divergence — quarantined, monitored, or a
+    # failure). `failing?` is the stricter "would the default `mix test` lane go red"
+    # subset: a quarantined (`:triage`) case is excluded from the lane, and an in-band
+    # `:diverges` case passes it, so both are flagged but not failing.
     card
-    |> Map.put(:flagged?, failure?)
+    |> Map.put(:flagged?, failure? or card.status == :diverges)
     |> Map.put(:failing?, failure? and is_nil(card.triage))
   end
 


### PR DESCRIPTION
Implements #333 (design spec: `docs/superpowers/specs/2026-06-18-differential-diverges-verdict-and-structural-triage-design.md`). Two additions to the shared `ImagePipe.Test.Differential` layer, so imgproxy and TwicPics share the behavior. **Test-infra + docs only — no ImagePipe rendering change.**

## 1. `:diverges` verdict (conformance gate)

A third case state alongside `:equal` and `:triage` that **stays on the default lane** and asserts the divergence sits in an expected two-sided band — failing if it grows (regression, above ceiling) or shrinks toward a match (promote signal, below floor). The right treatment for a divergence that's accepted and permanent (not under investigation), where widening `:equal` tolerance can't tell a haloed boundary from a real 1px shift.

- New pure `PixelCompare.classify_divergence/3` (built on `diagnose/3`), the single definition of "is this divergence within its band". Returns `:ok`, or `{:error, :below_floor | :above_ceiling, %{metric, value, band}}` with enough detail for an actionable failure.
- Both `*_differential_conformance_test.exs` dispatch on verdict: `:equal`→tolerance, `:diverges`→band, `:triage`→excluded.
- **Migration:** the two TwicPics `cover=2:3` fractional-area cases (`cover_ratio_tall`, `focus_bottomright_cover_ratio`) move `:triage` → `verdict: :diverges`, back on the default lane. Bands calibrated from measured values (maxΔ 92 / >Δ2 3869 → `60..160` / `3_000..4_600`; 43 / 3469 → `24..96` / `2_700..4_400`): floors above the ~±12 cross-libvips skew, ceilings well below a 255 / half-cell shift.
- imgproxy gets the evaluator + dispatch (no-op until it has a `:diverges` case) and its `manifest_test` sample divergence map updated to the two-sided shape.

## 2. `structural_outliers` triage signal (informational, **not** a gate)

New pure `PixelCompare.structural_outliers/3` (radius / value-tol / overshoot ε) counts differing band-samples not explainable by the reference's local neighborhood range — separating resampling/phase artifacts (`cover_ratio_tall` = 400, a small minority of 3869 → resampling/phase) from real geometry shifts. Surfaced as one extra `structural=N (r1) → …` field per case in `mix twicpics.diagnose` / `mix imgproxy.diagnose`; documented in both suite READMEs' "skew vs structural" guide. Not asserted in conformance (it has tuning knobs).

## No re-bake

`verdict`/`divergence` are authored-but-not-baked, so editing a band trips the existing `authored_sha256` "run reauthor" guard — no pixels change. Authored hashes refreshed via `mix twicpics.reauthor` (2 entries).

## Docs / report

Suite READMEs (verdicts section + structural reference), `docs/twicpics_support_matrix.md` (quarantined → monitored, 0 quarantined now), and the report UI (`monitored` badge + `status-diverges` so `:diverges` cards render in-band, not as lane failures).

## Tests

TDD: `classify_divergence`/`structural_outliers` unit tests on hand-built buffers (haloed edge ≈0; ≥2px shift non-zero; in/out-of-band); imgproxy + new TwicPics nested-`:divergence` `authored_sha256` round-trip tests; a `:diverges` report-card test. The two `cover=2:3` cases exercise the band live on the default lane.

Gate: `mise run precommit` green (format, `compile --warnings-as-errors`, `credo --strict`, full suite — 1 doctest, 69 properties, 2323 tests, 0 failures).

Moving the two `cover=2:3` cases onto the default lane fully closes #331.

Fixes #331
Fixes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)