### PR TITLE
test(cache): exercise ETag fast path with guide-bearing ops under strong identity

### DIFF
--- a/test/image_pipe/cache/key_test.exs
+++ b/test/image_pipe/cache/key_test.exs
@@ -161,6 +161,11 @@ defmodule ImagePipe.Cache.KeyTest do
   defp tagged_resize_dimension(:auto), do: :auto
   defp tagged_resize_dimension(pixels), do: {:px, pixels}
 
+  defp imgproxy_plan!(path) do
+    assert {:ok, plan} = Imgproxy.parse(conn(:get, path), [])
+    plan
+  end
+
   test "builds stable hash and key data from canonical plan fields and source identity" do
     conn = conn(:get, "/sig-one/w:100/plain/images/cat.jpg?ignored=true")
 
@@ -1264,6 +1269,62 @@ defmodule ImagePipe.Cache.KeyTest do
       {:ok, a} = Key.plan_material(twic_plan!([{"focus", "20x10"}, {"crop", "12x12"}]), [])
       {:ok, b} = Key.plan_material(twic_plan!([{"focus", "30x10"}, {"crop", "12x12"}]), [])
       refute a == b
+    end
+  end
+
+  # KeyData.data/1 and guide_data/1 are clause-based with no fallback: a missing
+  # clause for a gravity-derived guide shape raises FunctionClauseError on the
+  # cache-key / ETag fast path (only reached under a strong byte-identity origin),
+  # 500ing the request while staying green in CI. Pin plan_material for every
+  # guide shape the imgproxy parser emits so a future missing clause fails fast at
+  # the cache-key boundary rather than in production (#328, the dialect-agnostic
+  # twin of the TwicPics block above).
+  describe "imgproxy guide-bearing ops (#328)" do
+    test "focal-point resize gravity keys cleanly" do
+      assert {:ok, material} =
+               Key.plan_material(
+                 imgproxy_plan!("/_/rt:fill/w:200/h:100/g:fp:0.3:0.7/plain/images/cat.jpg"),
+                 []
+               )
+
+      assert inspect(material) =~ "focal"
+    end
+
+    test "smart resize gravity keys cleanly" do
+      assert {:ok, material} =
+               Key.plan_material(
+                 imgproxy_plan!("/_/rt:fill/w:200/h:100/g:sm/plain/images/cat.jpg"),
+                 []
+               )
+
+      assert inspect(material) =~ "smart"
+    end
+
+    test "object-detect resize gravity keys cleanly" do
+      assert {:ok, material} =
+               Key.plan_material(
+                 imgproxy_plan!("/_/rt:fill/w:200/h:100/g:obj:face/plain/images/cat.jpg"),
+                 []
+               )
+
+      assert inspect(material) =~ "detect"
+    end
+
+    test "raw-anchor resize gravity keys cleanly" do
+      assert {:ok, material} =
+               Key.plan_material(
+                 imgproxy_plan!("/_/rt:fill/w:200/h:100/g:noea/plain/images/cat.jpg"),
+                 []
+               )
+
+      assert inspect(material) =~ "anchor"
+    end
+
+    test "anchor crop gravity keys cleanly" do
+      assert {:ok, material} =
+               Key.plan_material(imgproxy_plan!("/_/c:100:50:noea/plain/images/cat.jpg"), [])
+
+      assert inspect(material) =~ "top_right"
     end
   end
 end

--- a/test/image_pipe/cdn_http_cache_wire_test.exs
+++ b/test/image_pipe/cdn_http_cache_wire_test.exs
@@ -224,6 +224,43 @@ defmodule ImagePipe.CDNHTTPCacheWireTest do
     refute_received :source_fetch_called
   end
 
+  # #328: the only guide that reached do_generated_etag under a strong byte
+  # identity before this was :center (the order-invariance test below). A
+  # gravity-derived guide (focal/smart/detect/anchor/carried) exercises the
+  # KeyData.guide_data clauses end-to-end — a missing clause 500s here instead of
+  # staying green. Focal needs no detector, so the 200 body path executes too.
+  test "guide-bearing focal gravity emits an etag on the strong-identity path", %{opts: opts} do
+    conn =
+      ImagePipe.Plug.call(
+        conn(:get, "/_/rt:fill/w:200/h:100/g:fp:0.3:0.7/plain/beach.jpg"),
+        opts
+      )
+
+    assert conn.status == 200
+    assert [etag] = get_resp_header(conn, "etag")
+    assert etag =~ ~r/^"ip1-[A-Za-z0-9_-]+"$/
+  end
+
+  test "TwicPics carried-focus cover emits an etag on the strong-identity path" do
+    opts =
+      ImagePipe.Plug.init(
+        parser: ImagePipe.Parser.TwicPics,
+        sources: [path: {StableSource, test_pid: self()}],
+        cache: {CacheProbe, test_pid: self()},
+        http_cache: [mode: :enabled]
+      )
+
+    conn =
+      ImagePipe.Plug.call(
+        conn(:get, "/beach.jpg?twic=v1/focus=20x10/cover=100x100"),
+        opts
+      )
+
+    assert conn.status == 200
+    assert [etag] = get_resp_header(conn, "etag")
+    assert etag =~ ~r/^"ip1-[A-Za-z0-9_-]+"$/
+  end
+
   test "transform option order variants produce the same etag", %{opts: opts} do
     left =
       ImagePipe.Plug.call(


### PR DESCRIPTION
## Problem

The cache-key / ETag fast path — `Request.HTTPCache.do_generated_etag` → `Cache.Key.plan_material` → `Plan.KeyData.data/1` (and `guide_data/1`) per op — is **clause-based with no fallback**, but no test ever drove it with a geometry op carrying a **non-`:center` guide** under a **strong byte identity**.

So a missing `KeyData` clause for a newly added op or guide shape raises `FunctionClauseError` at request time on *any* strong byte-identity origin (S3, HTTP with ETag/Last-Modified, stable file) — a 500 — while staying **green in CI**. This is the exact near-miss from #321/#327: `KeyData` had no clause for the `:carried` guide or `%Plan.Operation.SetFocus{}`, so every TwicPics `cover`/`crop` request would have 500'd on a strong-identity origin. Fixed there; the coverage hole that hid it stayed open and is dialect-agnostic.

Why it slipped: the imgproxy/TwicPics wire conformance origins resolve to `byte_identity: :none` (skipping the ETag path), and the tests that *do* drive the strong path use no-geometry plans only.

## Change (test-only, no production change)

Two complementary levels, both dialects:

1. **Fail-fast at the cache-key boundary** — `cache/key_test.exs`: a new `imgproxy guide-bearing ops (#328)` block pins `Key.plan_material` for every gravity-derived guide the imgproxy parser emits — focal (`g:fp`), smart (`g:sm`), object-detect (`g:obj`), raw anchor (`g:noea` on fill), and the crop anchor atom (`c:…:noea`). The dialect-agnostic twin of the existing TwicPics carried-focus block.
2. **End-to-end under strong identity** — `cdn_http_cache_wire_test.exs`: full `Plug.call` ETag emission via the existing `StableSource` — imgproxy focal gravity (executes the 200 body; no detector needed) and TwicPics carried-focus cover. Previously only `:center` reached the strong path.

## Verification

- Both files green (65 tests); full `mise run precommit` green (format, `compile --warnings-as-errors`, `credo --strict` clean, 2330 tests + 69 properties + 1 doctest, 0 failures).
- **Not tautological:** temporarily breaking the `:focal` and `:carried` `guide_data` clauses turns the new tests red with the production signature `do_generated_etag → plan_material → KeyData.guide_data` raising `FunctionClauseError`. Restored.

No conformance-doc update needed — pure coverage, no surface/stage/pixel behavior change.

Fixes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)