### PR TITLE
test(focus): fix CI flakes in orientation guided-crop tests

### DIFF
--- a/test/image_pipe/transform/focus_test.exs
+++ b/test/image_pipe/transform/focus_test.exs
@@ -15,6 +15,7 @@ defmodule ImagePipe.Transform.FocusTest do
   alias ImagePipe.Transform.PendingOrientation
   alias ImagePipe.Transform.PlanExecutor
   alias ImagePipe.Transform.State
+  alias Vix.Vips.Image, as: VipsImage
 
   describe "rational helpers" do
     test "default focus is nil and helpers no-op on nil" do
@@ -249,12 +250,34 @@ defmodule ImagePipe.Transform.FocusTest do
     end
 
     defp assert_images_equal(left, right, context) do
-      assert {Image.width(left), Image.height(left)} == {Image.width(right), Image.height(right)},
+      w = Image.width(left)
+      h = Image.height(left)
+
+      assert {w, h} == {Image.width(right), Image.height(right)},
              "#{context}: dimensions diverged"
 
-      for x <- 0..(Image.width(left) - 1), y <- 0..(Image.height(left) - 1) do
-        assert Image.get_pixel!(left, x, y) == Image.get_pixel!(right, x, y),
-               "#{context}: pixel mismatch at (#{x},#{y})"
+      # Read each frame to a raw row-major band buffer ONCE rather than crossing
+      # the libvips FFI boundary per pixel: across the 4×4 orientation×size matrix
+      # the old Image.get_pixel!/3 loop was ~20k operation_call/4 invocations,
+      # which tipped this async test past the 60s timeout under CI contention.
+      {:ok, lb} = VipsImage.write_to_binary(left)
+      {:ok, rb} = VipsImage.write_to_binary(right)
+
+      assert byte_size(lb) == byte_size(rb),
+             "#{context}: band layout mismatch #{byte_size(lb)} != #{byte_size(rb)}"
+
+      if lb != rb do
+        bands = div(byte_size(lb), w * h)
+
+        {x, y} =
+          Enum.find_value(for(y <- 0..(h - 1), x <- 0..(w - 1), do: {x, y}), fn {x, y} ->
+            offset = (y * w + x) * bands
+
+            if :binary.part(lb, offset, bands) != :binary.part(rb, offset, bands),
+              do: {x, y}
+          end)
+
+        flunk("#{context}: pixel mismatch at (#{x},#{y})")
       end
     end
 

--- a/test/image_pipe/transform/focus_test.exs
+++ b/test/image_pipe/transform/focus_test.exs
@@ -266,19 +266,17 @@ defmodule ImagePipe.Transform.FocusTest do
       assert byte_size(lb) == byte_size(rb),
              "#{context}: band layout mismatch #{byte_size(lb)} != #{byte_size(rb)}"
 
-      if lb != rb do
-        bands = div(byte_size(lb), w * h)
+      if lb != rb,
+        do: flunk("#{context}: pixel mismatch at #{inspect(first_pixel_mismatch(lb, rb, w, h))}")
+    end
 
-        {x, y} =
-          Enum.find_value(for(y <- 0..(h - 1), x <- 0..(w - 1), do: {x, y}), fn {x, y} ->
-            offset = (y * w + x) * bands
+    defp first_pixel_mismatch(lb, rb, w, h) do
+      bands = div(byte_size(lb), w * h)
 
-            if :binary.part(lb, offset, bands) != :binary.part(rb, offset, bands),
-              do: {x, y}
-          end)
-
-        flunk("#{context}: pixel mismatch at (#{x},#{y})")
-      end
+      Enum.find(for(y <- 0..(h - 1), x <- 0..(w - 1), do: {x, y}), fn {x, y} ->
+        offset = (y * w + x) * bands
+        :binary.part(lb, offset, bands) != :binary.part(rb, offset, bands)
+      end)
     end
 
     test "carried (nil focus) == center across axis-reversing orientations and odd extents" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -11,6 +11,22 @@
 # jobs, not unit coverage, so they are opt-in via `--include imgproxy_report` /
 # `--include twicpics_report` (or `mix imgproxy.gen_report` / `mix
 # twicpics.gen_report`). Their rendering logic is unit-tested separately.
+# Disable libvips' global operation cache for the test run. The cache keys
+# operations (notably `vips_autorot`) by their input image's pixel/argument
+# hash and is BLIND to mutable EXIF `orientation` metadata. Tests synthesize
+# multiple orientations from one base image via `Image.set_orientation!`,
+# producing pixel-identical images that differ only in their orientation tag —
+# which collide in the cache, so `autorot` can return a rotation computed for a
+# different orientation. Under the async suite the shared global cache
+# intermittently serves such a stale result, flaking any test that compares
+# across synthesized orientations (the deferred-orientation / guided-crop focus
+# tests). The library never calls `set_orientation` — production orientation
+# comes from each source's own decoded EXIF, so real requests never produce
+# pixel-identical images with differing orientation, and the cache stays correct
+# (and enabled) in production. Disabling it here only removes a test-only
+# aliasing artifact; correct code is cache-transparent.
+Vix.Vips.cache_set_max(0)
+
 ExUnit.start(
   capture_log: true,
   assert_receive_timeout: 2_000,


### PR DESCRIPTION
Fixes three CI flakes surfacing in `focus_test.exs`, in the order they were uncovered. Test-only changes — no production behavior touched.

## 1. Per-pixel compare timeout (`ExUnit.TimeoutError`)

The `"carried (nil focus) == center"` test compared images with a nested per-pixel `Image.get_pixel!/2` loop. Across its 4×4 orientation×size matrix that is ~20k libvips FFI `operation_call/4` round-trips in one async test, tipping past the 60s per-test timeout under CI contention (a timeout, not an assertion failure).

**Fix:** read each frame to a raw row-major band buffer **once** via `Vix.Vips.Image.write_to_binary/1` and compare the buffers directly, locating the offending `(x,y)` only on mismatch to preserve the failure message. Same exact-equality semantics; ~20k FFI calls become 2. Mirrors the existing fix in the imgproxy wire conformance suite (`assert_sharp_oracle_match/3`).

## 2. Credo nesting

The inline `if`-in-`fn`-in-`if` in the new helper nested 3 deep (`credo --strict` max is 2). Pulled the buffer scan into a `first_pixel_mismatch/4` helper; same behaviour, flatter bodies.

## 3. Intermittent "dimensions diverged" (the real puzzle)

After the timeout fix, the test began failing intermittently with `orient=6 … dimensions diverged`, landing on a **different Elixir matrix job each run** (so a real nondeterministic flake, not version-specific).

**Root cause:** libvips' global **operation cache** keys operations — notably `vips_autorot` — by the input image's pixel/argument hash and is **blind to mutable EXIF `orientation` metadata**. The test synthesizes orientations [2,4,6,7] from one shared `fine_pattern` base via `Image.set_orientation!`, producing **pixel-identical images that differ only in their orientation tag**. They collide in the cache, so `autorot` returns a rotation computed for a *different* orientation. Under the async suite the shared global cache intermittently serves a stale rotation to one of the compared crops (carried vs center) but not the other → "dimensions diverged" on the axis-swapping orientations 6/7, or a pixel mismatch on orientation 4.

Proven, not guessed:
- **Deterministic:** looping orientations 2→8 on a shared base single-threaded, `autorot` returns the cached orientation-2 (unrotated) result for all of them; with the cache off, every orientation rotates correctly.
- **Faithful concurrent repro** (own materialized base per task, sequential inner loop like the real test, concurrency across tasks for cache pressure): **153** carried≠center divergences with the cache on, **0** with it off (×3 runs, N=400–600).

**Fix:** `Vix.Vips.cache_set_max(0)` in `test/test_helper.exs` — disables the operation cache for the whole test run, fixing the entire class of orientation-synthesis tests.

**Not a production bug / not masking one:** the library never calls `set_orientation` — orientation comes from each source's own decoded EXIF, so real requests never produce pixel-identical images with differing orientation (different sources get different cache keys; identical sources carry identical orientation). The cache stays **enabled in production**; correct code is cache-transparent, so disabling it in tests only removes the test-only aliasing artifact.

## Verification

- `mix test test/image_pipe/transform/focus_test.exs` → 23 tests, 0 failures, 0.8s (was timing out at 60s).
- Full suite ×3 (varying seeds) → 2330 tests, 0 failures; no meaningful slowdown.
- `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)