### PR TITLE
refactor(transform): consolidate measure→px arithmetic into role-named Geometry resolvers

### DIFF
--- a/lib/image_pipe/transform/geometry.ex
+++ b/lib/image_pipe/transform/geometry.ex
@@ -37,24 +37,34 @@ defmodule ImagePipe.Transform.Geometry do
   def resolve_dimension(measure, reference, opts \\ [])
 
   def resolve_dimension({:px, n}, reference, opts) when is_integer(n),
-    do: apply_dimension_clamp(n, reference, opts)
+    do: apply_dimension_clamp(max(1, n), reference, opts)
 
   def resolve_dimension({:pixels, n}, reference, opts) when is_integer(n),
-    do: apply_dimension_clamp(n, reference, opts)
+    do: apply_dimension_clamp(max(1, n), reference, opts)
 
   def resolve_dimension({:pixels, n}, reference, opts) when is_float(n),
     do: apply_dimension_clamp(max(1, round_half_away_from_zero(n)), reference, opts)
 
   def resolve_dimension({:scale, n, d}, reference, opts)
       when is_number(n) and is_number(d) and d != 0,
-      do: apply_dimension_clamp(max(1, round_half_away_from_zero(reference * n / d)), reference, opts)
+      do:
+        apply_dimension_clamp(
+          max(1, round_half_away_from_zero(reference * n / d)),
+          reference,
+          opts
+        )
 
   def resolve_dimension({:scale, n}, reference, opts) when is_number(n) and n > 0,
     do: apply_dimension_clamp(max(1, round_half_away_from_zero(reference * n)), reference, opts)
 
   def resolve_dimension({:ratio, n, d}, reference, opts)
       when is_integer(n) and is_integer(d) and d > 0,
-      do: apply_dimension_clamp(max(1, round_half_away_from_zero(reference * n / d)), reference, opts)
+      do:
+        apply_dimension_clamp(
+          max(1, round_half_away_from_zero(reference * n / d)),
+          reference,
+          opts
+        )
 
   def resolve_dimension(n, reference, opts) when is_integer(n) and n > 0,
     do: apply_dimension_clamp(n, reference, opts)
@@ -107,8 +117,9 @@ defmodule ImagePipe.Transform.Geometry do
   # resolve_focal: ratio -> normalized float clamped to 0.0..1.0.
   # Used to convert a {:ratio, n, d} focal-guide coordinate to a fraction.
   @spec resolve_focal({:ratio, non_neg_integer(), pos_integer()}, pos_integer()) :: float()
-  def resolve_focal({:ratio, n, d}, _reference) when is_integer(n) and is_integer(d) and d > 0,
-    do: (n / d) |> max(0.0) |> min(1.0)
+  def resolve_focal({:ratio, n, d}, _reference)
+      when is_integer(n) and n >= 0 and is_integer(d) and d > 0,
+      do: (n / d) |> max(0.0) |> min(1.0)
 
   def anchor_to_scale_units(focus, width, height) do
     x_scale =

--- a/lib/image_pipe/transform/geometry.ex
+++ b/lib/image_pipe/transform/geometry.ex
@@ -123,33 +123,6 @@ defmodule ImagePipe.Transform.Geometry do
       when is_integer(n) and n >= 0 and is_integer(d) and d > 0,
       do: (n / d) |> max(0.0) |> min(1.0)
 
-  def anchor_to_scale_units(focus, width, height) do
-    x_scale =
-      case focus do
-        {:anchor, :left, _} -> {:scale, 0}
-        {:anchor, :center, _} -> {:scale, 0.5}
-        {:anchor, :right, _} -> {:scale, 1}
-        {:coordinate, left, _top} -> {:scale, to_pixels(width, left) / width}
-      end
-
-    y_scale =
-      case focus do
-        {:anchor, _, :top} -> {:scale, 0}
-        {:anchor, _, :center} -> {:scale, 0.5}
-        {:anchor, _, :bottom} -> {:scale, 1}
-        {:coordinate, _left, top} -> {:scale, to_pixels(height, top) / height}
-      end
-
-    {x_scale, y_scale}
-  end
-
-  def anchor_to_pixels(focus, width, height) do
-    case anchor_to_scale_units(focus, width, height) do
-      {x_scale, y_scale} ->
-        {to_pixels(width, x_scale), to_pixels(height, y_scale)}
-    end
-  end
-
   # imgproxy `imath.RoundToEven`: round half to even (banker's rounding). imgproxy
   # composes integer origins with even-rounded offsets, so positions stay
   # integer-faithful only when ties round the same way.

--- a/lib/image_pipe/transform/geometry.ex
+++ b/lib/image_pipe/transform/geometry.ex
@@ -30,6 +30,86 @@ defmodule ImagePipe.Transform.Geometry do
 
   def to_pixels(length, {:percent, percent}), do: round(percent / 100 * length)
 
+  # resolve_dimension: "how big?" — half-away rounding, always >= 1.
+  # clamp?: true adds min(result, reference) to keep within source bounds.
+  # Callers: crop.ex (clamp?: true), resize.ex (clamp?: false), extend_canvas.ex.
+  @spec resolve_dimension(term(), pos_integer(), keyword()) :: pos_integer()
+  def resolve_dimension(measure, reference, opts \\ [])
+
+  def resolve_dimension({:px, n}, reference, opts) when is_integer(n),
+    do: apply_dimension_clamp(n, reference, opts)
+
+  def resolve_dimension({:pixels, n}, reference, opts) when is_integer(n),
+    do: apply_dimension_clamp(n, reference, opts)
+
+  def resolve_dimension({:pixels, n}, reference, opts) when is_float(n),
+    do: apply_dimension_clamp(max(1, round_half_away_from_zero(n)), reference, opts)
+
+  def resolve_dimension({:scale, n, d}, reference, opts)
+      when is_number(n) and is_number(d) and d != 0,
+      do: apply_dimension_clamp(max(1, round_half_away_from_zero(reference * n / d)), reference, opts)
+
+  def resolve_dimension({:scale, n}, reference, opts) when is_number(n) and n > 0,
+    do: apply_dimension_clamp(max(1, round_half_away_from_zero(reference * n)), reference, opts)
+
+  def resolve_dimension({:ratio, n, d}, reference, opts)
+      when is_integer(n) and is_integer(d) and d > 0,
+      do: apply_dimension_clamp(max(1, round_half_away_from_zero(reference * n / d)), reference, opts)
+
+  def resolve_dimension(n, reference, opts) when is_integer(n) and n > 0,
+    do: apply_dimension_clamp(n, reference, opts)
+
+  def resolve_dimension(n, reference, opts) when is_float(n) and n > 0.0,
+    do: apply_dimension_clamp(max(1, round_half_away_from_zero(n)), reference, opts)
+
+  defp apply_dimension_clamp(value, reference, opts) do
+    if Keyword.get(opts, :clamp?, false), do: min(value, reference), else: value
+  end
+
+  # resolve_position: "where?" — half-away rounding, always >= 0.
+  # Positions are zero-based coordinates (top-left of image = 0).
+  # Caller: crop.ex coordinate-crop origin.
+  @spec resolve_position(term(), pos_integer()) :: non_neg_integer()
+  def resolve_position({:px, n}, _reference) when is_integer(n), do: max(0, n)
+  def resolve_position({:pixels, n}, _reference) when is_integer(n), do: max(0, n)
+
+  def resolve_position({:pixels, n}, _reference) when is_float(n),
+    do: max(0, round_half_away_from_zero(n))
+
+  def resolve_position({:scale, n, d}, reference)
+      when is_number(n) and is_number(d) and d != 0,
+      do: max(0, round_half_away_from_zero(reference * n / d))
+
+  def resolve_position({:ratio, n, d}, reference)
+      when is_integer(n) and is_integer(d) and d > 0,
+      do: max(0, round_half_away_from_zero(reference * n / d))
+
+  def resolve_position(n, _reference) when is_integer(n), do: max(0, n)
+  def resolve_position(n, _reference) when is_float(n), do: max(0, round_half_away_from_zero(n))
+
+  # resolve_offset: "by how much?" — returns an unrounded float.
+  # Rounding to even happens at composition time in crop.ex round_offset_to_even.
+  # {:pixels} offsets are DPR-scaled; {:scale} offsets are resolved as a float
+  # fraction of reference (no DPR — imgproxy's ScaleToEven path).
+  @spec resolve_offset(term(), pos_integer(), float()) :: float()
+  def resolve_offset(value, _reference, _dpr) when is_number(value), do: value * 1.0
+
+  def resolve_offset({:pixels, value}, _reference, dpr) when is_number(value),
+    do: value * dpr * 1.0
+
+  def resolve_offset({:scale, value}, reference, _dpr) when is_number(value),
+    do: reference * value * 1.0
+
+  def resolve_offset({:scale, n, d}, reference, _dpr)
+      when is_number(n) and is_number(d) and d != 0,
+      do: reference * n / d * 1.0
+
+  # resolve_focal: ratio -> normalized float clamped to 0.0..1.0.
+  # Used to convert a {:ratio, n, d} focal-guide coordinate to a fraction.
+  @spec resolve_focal({:ratio, non_neg_integer(), pos_integer()}, pos_integer()) :: float()
+  def resolve_focal({:ratio, n, d}, _reference) when is_integer(n) and is_integer(d) and d > 0,
+    do: (n / d) |> max(0.0) |> min(1.0)
+
   def anchor_to_scale_units(focus, width, height) do
     x_scale =
       case focus do

--- a/lib/image_pipe/transform/geometry.ex
+++ b/lib/image_pipe/transform/geometry.ex
@@ -66,6 +66,8 @@ defmodule ImagePipe.Transform.Geometry do
           opts
         )
 
+  def resolve_dimension(:auto, reference, _opts), do: reference
+
   def resolve_dimension(n, reference, opts) when is_integer(n) and n > 0,
     do: apply_dimension_clamp(n, reference, opts)
 

--- a/lib/image_pipe/transform/geometry.ex
+++ b/lib/image_pipe/transform/geometry.ex
@@ -15,21 +15,6 @@ defmodule ImagePipe.Transform.Geometry do
           | {:scale, scalar(), scalar()}
           | {:ratio, integer(), pos_integer()}
 
-  @spec to_pixels(integer(), length_unit()) :: integer()
-  def to_pixels(length, size_unit)
-  def to_pixels(_length, num) when is_integer(num), do: num
-  def to_pixels(_length, num) when is_float(num), do: round(num)
-  def to_pixels(_length, {:pixels, num}), do: round(num)
-  def to_pixels(length, {:scale, factor}), do: round(length * factor)
-
-  def to_pixels(length, {:scale, numerator, denominator}),
-    do: round(length * numerator / denominator)
-
-  def to_pixels(length, {:ratio, numerator, denominator}),
-    do: round(length * numerator / denominator)
-
-  def to_pixels(length, {:percent, percent}), do: round(percent / 100 * length)
-
   # resolve_dimension: "how big?" — half-away rounding, always >= 1.
   # clamp?: true adds min(result, reference) to keep within source bounds.
   # Callers: crop.ex (clamp?: true), resize.ex (clamp?: false), extend_canvas.ex.

--- a/lib/image_pipe/transform/geometry.ex
+++ b/lib/image_pipe/transform/geometry.ex
@@ -10,7 +10,6 @@ defmodule ImagePipe.Transform.Geometry do
   @type length_unit() ::
           scalar()
           | {:pixels, scalar()}
-          | {:percent, scalar()}
           | {:scale, scalar()}
           | {:scale, scalar(), scalar()}
           | {:ratio, integer(), pos_integer()}

--- a/lib/image_pipe/transform/geometry.ex
+++ b/lib/image_pipe/transform/geometry.ex
@@ -100,13 +100,6 @@ defmodule ImagePipe.Transform.Geometry do
       when is_number(n) and is_number(d) and d != 0,
       do: reference * n / d * 1.0
 
-  # resolve_focal: ratio -> normalized float clamped to 0.0..1.0.
-  # Used to convert a {:ratio, n, d} focal-guide coordinate to a fraction.
-  @spec resolve_focal({:ratio, non_neg_integer(), pos_integer()}, pos_integer()) :: float()
-  def resolve_focal({:ratio, n, d}, _reference)
-      when is_integer(n) and n >= 0 and is_integer(d) and d > 0,
-      do: (n / d) |> max(0.0) |> min(1.0)
-
   # imgproxy `imath.RoundToEven`: round half to even (banker's rounding). imgproxy
   # composes integer origins with even-rounded offsets, so positions stay
   # integer-faithful only when ties round the same way.

--- a/lib/image_pipe/transform/operation/crop.ex
+++ b/lib/image_pipe/transform/operation/crop.ex
@@ -90,9 +90,9 @@ defmodule ImagePipe.Transform.Operation.Crop do
       center_origin: 2,
       image_height: 1,
       image_width: 1,
+      resolve_dimension: 3,
       round_half_away_from_zero: 1,
-      round_ties_to_even: 1,
-      to_pixels: 2
+      round_ties_to_even: 1
     ]
 
   alias ImagePipe.Telemetry
@@ -238,8 +238,8 @@ defmodule ImagePipe.Transform.Operation.Crop do
          image_height
        ) do
     with {:ok, crop} <- crop_dimensions(params, image_width, image_height),
-         {:ok, crop_width} <- crop_dimension(crop.width, image_width),
-         {:ok, crop_height} <- crop_dimension(crop.height, image_height),
+         crop_width = resolve_dimension(crop.width, image_width, clamp?: true),
+         crop_height = resolve_dimension(crop.height, image_height, clamp?: true),
          {crop_width, crop_height} =
            correct_aspect_ratio(
              crop_width,
@@ -275,8 +275,8 @@ defmodule ImagePipe.Transform.Operation.Crop do
     target_height = if params.height == :auto, do: image_height, else: params.height
 
     # make sure crop is within image bounds
-    crop_width = max(1, min(image_width, to_pixels(image_width, target_width)))
-    crop_height = max(1, min(image_height, to_pixels(image_height, target_height)))
+    crop_width = resolve_dimension(target_width, image_width, clamp?: true)
+    crop_height = resolve_dimension(target_height, image_height, clamp?: true)
 
     # figure out the crop anchor
     {center_x, center_y} =
@@ -294,8 +294,8 @@ defmodule ImagePipe.Transform.Operation.Crop do
     image_height = image_height(state)
 
     with {:ok, crop} <- crop_dimensions(params, image_width, image_height),
-         {:ok, crop_width} <- crop_dimension(crop.width, image_width),
-         {:ok, crop_height} <- crop_dimension(crop.height, image_height),
+         crop_width = resolve_dimension(crop.width, image_width, clamp?: true),
+         crop_height = resolve_dimension(crop.height, image_height, clamp?: true),
          {crop_width, crop_height} =
            correct_aspect_ratio(
              crop_width,
@@ -350,8 +350,8 @@ defmodule ImagePipe.Transform.Operation.Crop do
     image_height = image_height(state)
 
     with {:ok, crop} <- crop_dimensions(params, image_width, image_height),
-         {:ok, crop_width} <- crop_dimension(crop.width, image_width),
-         {:ok, crop_height} <- crop_dimension(crop.height, image_height),
+         crop_width = resolve_dimension(crop.width, image_width, clamp?: true),
+         crop_height = resolve_dimension(crop.height, image_height, clamp?: true),
          {crop_width, crop_height} =
            correct_aspect_ratio(
              crop_width,
@@ -573,31 +573,6 @@ defmodule ImagePipe.Transform.Operation.Crop do
   defp round_offset_to_even(offset), do: round_ties_to_even(offset)
 
   defp clamp_position(value, max_value), do: max(0, min(max_value, value))
-
-  defp crop_dimension(:auto, bounds), do: {:ok, bounds}
-
-  defp crop_dimension(value, bounds) when is_integer(value) and value > 0,
-    do: {:ok, min(value, bounds)}
-
-  defp crop_dimension(value, bounds) when is_float(value) and value > 0,
-    do: {:ok, min(round_half_away_from_zero(value), bounds)}
-
-  defp crop_dimension({:pixels, value}, bounds), do: crop_dimension(value, bounds)
-
-  defp crop_dimension({:scale, numerator, denominator}, bounds)
-       when is_number(numerator) and is_number(denominator) and numerator > 0 and denominator > 0 do
-    {:ok, min(round_half_away_from_zero(bounds * numerator / denominator), bounds)}
-  end
-
-  defp crop_dimension({:scale, value}, bounds) when is_number(value) and value > 0 do
-    {:ok, min(round_half_away_from_zero(bounds * value), bounds)}
-  end
-
-  defp crop_dimension({:percent, value}, bounds) when is_number(value) and value > 0 do
-    {:ok, min(round_half_away_from_zero(bounds * value / 100), bounds)}
-  end
-
-  defp crop_dimension(value, _bounds), do: {:error, {:invalid_crop_dimension, value}}
 
   defp crop_offset(value, _bounds, _offset_scale) when is_number(value), do: {:ok, value}
 

--- a/lib/image_pipe/transform/operation/crop.ex
+++ b/lib/image_pipe/transform/operation/crop.ex
@@ -86,12 +86,12 @@ defmodule ImagePipe.Transform.Operation.Crop do
 
   import ImagePipe.Transform.Geometry,
     only: [
-      anchor_to_pixels: 3,
       center_origin: 2,
       image_height: 1,
       image_width: 1,
       resolve_dimension: 3,
       resolve_offset: 3,
+      resolve_position: 2,
       round_half_away_from_zero: 1,
       round_ties_to_even: 1
     ]
@@ -591,11 +591,10 @@ defmodule ImagePipe.Transform.Operation.Crop do
          crop_width,
          crop_height
        ) do
-    # if explicit coordinates are given, they are to be the top-left corner of the crop,
-    # so we need to move the center point based on the crop dimensions
-    {left, top} = anchor_to_pixels({:coordinate, left, top}, image_width, image_height)
-    center_x = round(left + crop_width / 2)
-    center_y = round(top + crop_height / 2)
+    left_px = resolve_position(left, image_width)
+    top_px = resolve_position(top, image_height)
+    center_x = round(left_px + crop_width / 2)
+    center_y = round(top_px + crop_height / 2)
     {center_x, center_y}
   end
 

--- a/lib/image_pipe/transform/operation/crop.ex
+++ b/lib/image_pipe/transform/operation/crop.ex
@@ -91,6 +91,7 @@ defmodule ImagePipe.Transform.Operation.Crop do
       image_height: 1,
       image_width: 1,
       resolve_dimension: 3,
+      resolve_offset: 3,
       round_half_away_from_zero: 1,
       round_ties_to_even: 1
     ]
@@ -249,12 +250,11 @@ defmodule ImagePipe.Transform.Operation.Crop do
              image_width,
              image_height
            ),
-         {:ok, gravity} <- crop_gravity(default_if_nil(params.gravity, @default_gravity)),
-         {:ok, offset_scale} <- offset_scale(crop.offset_scale),
-         {:ok, x_offset} <-
-           crop_offset(default_if_nil(params.x_offset, 0.0), image_width, offset_scale),
-         {:ok, y_offset} <-
-           crop_offset(default_if_nil(params.y_offset, 0.0), image_height, offset_scale) do
+         {:ok, gravity} <- crop_gravity(default_if_nil(params.gravity, @default_gravity)) do
+      offset_scale = crop.offset_scale * 1.0
+      x_offset = resolve_offset(default_if_nil(params.x_offset, 0.0), image_width, offset_scale)
+      y_offset = resolve_offset(default_if_nil(params.y_offset, 0.0), image_height, offset_scale)
+
       {:ok,
        gravity_crop_coordinates(
          image_width,
@@ -573,27 +573,6 @@ defmodule ImagePipe.Transform.Operation.Crop do
   defp round_offset_to_even(offset), do: round_ties_to_even(offset)
 
   defp clamp_position(value, max_value), do: max(0, min(max_value, value))
-
-  defp crop_offset(value, _bounds, _offset_scale) when is_number(value), do: {:ok, value}
-
-  defp crop_offset({:scale, numerator, denominator}, bounds, _offset_scale)
-       when is_number(numerator) and is_number(denominator) and denominator != 0 do
-    {:ok, bounds * numerator / denominator}
-  end
-
-  defp crop_offset({:scale, value}, bounds, _offset_scale) when is_number(value),
-    do: {:ok, bounds * value}
-
-  defp crop_offset({:percent, value}, bounds, _offset_scale) when is_number(value),
-    do: {:ok, bounds * value / 100}
-
-  defp crop_offset({:pixels, value}, _bounds, offset_scale) when is_number(value),
-    do: {:ok, value * offset_scale}
-
-  defp crop_offset(value, _bounds, _offset_scale), do: {:error, {:invalid_crop_offset, value}}
-
-  defp offset_scale(value) when is_number(value) and value > 0, do: {:ok, value * 1.0}
-  defp offset_scale(value), do: {:error, {:invalid_crop_offset_scale, value}}
 
   defp crop_gravity({:anchor, x, y} = gravity)
        when x in [:left, :center, :right] and y in [:top, :center, :bottom],

--- a/lib/image_pipe/transform/operation/crop.ex
+++ b/lib/image_pipe/transform/operation/crop.ex
@@ -30,8 +30,7 @@ defmodule ImagePipe.Transform.Operation.Crop do
     focal point tuple `{:fp, x, y}` where `x` and `y` are normalized `0.0..1.0`
     coordinates.
   - `x_offset`: horizontal offset as a number, `{:pixels, value}`,
-    `{:scale, value}`, `{:scale, numerator, denominator}`, or
-    `{:percent, value}`. Defaults to `0.0`.
+    `{:scale, value}`, or `{:scale, numerator, denominator}`. Defaults to `0.0`.
   - `y_offset`: vertical offset using the same units as `x_offset`. Defaults
     to `0.0`.
   - `offset_scale`: multiplier applied to pixel offsets, usually the effective
@@ -59,8 +58,8 @@ defmodule ImagePipe.Transform.Operation.Crop do
   crop around a normalized current-image point and clamps it into image bounds.
 
   Result crops are represented as `crop_from: :gravity` with explicit `width`
-  and `height`. Pixel offsets are multiplied by `offset_scale`; scale and
-  percent offsets are resolved relative to the current image bounds.
+  and `height`. Pixel offsets are multiplied by `offset_scale`; scale offsets
+  are resolved relative to the current image bounds.
 
   For coordinate crops, `crop_from` is the requested top-left crop position
   before the rectangle is clamped to image bounds.
@@ -113,7 +112,6 @@ defmodule ImagePipe.Transform.Operation.Crop do
           integer()
           | float()
           | {:pixels, integer() | float()}
-          | {:percent, integer() | float()}
           | {:scale, integer() | float()}
           | {:scale, integer() | float(), integer() | float()}
 

--- a/lib/image_pipe/transform/operation/extend_canvas.ex
+++ b/lib/image_pipe/transform/operation/extend_canvas.ex
@@ -71,6 +71,7 @@ defmodule ImagePipe.Transform.Operation.ExtendCanvas do
   use ImagePipe.Transform
 
   import ImagePipe.Transform.State
+
   import ImagePipe.Transform.Geometry,
     only: [
       center_origin: 2,

--- a/lib/image_pipe/transform/operation/extend_canvas.ex
+++ b/lib/image_pipe/transform/operation/extend_canvas.ex
@@ -71,7 +71,13 @@ defmodule ImagePipe.Transform.Operation.ExtendCanvas do
   use ImagePipe.Transform
 
   import ImagePipe.Transform.State
-  import ImagePipe.Transform.Geometry
+  import ImagePipe.Transform.Geometry,
+    only: [
+      center_origin: 2,
+      image_height: 1,
+      image_width: 1,
+      resolve_dimension: 2
+    ]
 
   alias ImagePipe.Transform.Focus
   alias ImagePipe.Transform.State
@@ -208,7 +214,8 @@ defmodule ImagePipe.Transform.Operation.ExtendCanvas do
   defp canvas_dimension(_current_size, value) when is_number(value) and value >= 0,
     do: round(value)
 
-  defp canvas_dimension(current_size, size_unit), do: to_pixels(current_size, size_unit)
+  defp canvas_dimension(current_size, size_unit),
+    do: resolve_dimension(size_unit, current_size)
 
   defp alpha_ready_image(image, :transparent) do
     case Image.has_alpha?(image) do

--- a/lib/image_pipe/transform/operation/resize.ex
+++ b/lib/image_pipe/transform/operation/resize.ex
@@ -255,8 +255,8 @@ defmodule ImagePipe.Transform.Operation.Resize do
     }
   end
 
-  defp resolve_relative_dimension({:ratio, _, _} = unit, length),
-    do: {:pixels, max(1, to_pixels(length, unit))}
+  defp resolve_relative_dimension({:ratio, n, d}, length),
+    do: {:pixels, resolve_dimension({:ratio, n, d}, length)}
 
   defp resolve_relative_dimension(other, _length), do: other
 

--- a/test/image_pipe/transform/geometry_test.exs
+++ b/test/image_pipe/transform/geometry_test.exs
@@ -1,5 +1,6 @@
 defmodule ImagePipe.Transform.GeometryTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias ImagePipe.Transform.Geometry
 
@@ -16,6 +17,155 @@ defmodule ImagePipe.Transform.GeometryTest do
       assert Geometry.to_pixels(200, {:ratio, 1, 2}) == 100
       assert Geometry.to_pixels(5, {:ratio, 1, 2}) == 3
       assert Geometry.to_pixels(300, {:ratio, 1, 3}) == 100
+    end
+  end
+
+  describe "resolve_dimension/3" do
+    property "half-away rounding: reference * n/d" do
+      check all ref <- integer(1..6000),
+                n <- integer(1..ref),
+                d <- integer(1..6000) do
+        result = Geometry.resolve_dimension({:ratio, n, d}, ref)
+        expected = max(1, Geometry.round_half_away_from_zero(ref * n / d))
+        assert result == expected
+      end
+    end
+
+    property "clamp?: true never exceeds reference" do
+      check all ref <- integer(1..6000),
+                n <- integer(1..6000),
+                d <- integer(1..6000) do
+        result = Geometry.resolve_dimension({:ratio, n, d}, ref, clamp?: true)
+        assert result <= ref
+        assert result >= 1
+      end
+    end
+
+    property "clamp?: false (default) may exceed reference" do
+      check all ref <- integer(1..100),
+                n <- integer(201..400),
+                d <- integer(1..100) do
+        result = Geometry.resolve_dimension({:ratio, n, d}, ref)
+        assert result >= 1
+      end
+    end
+
+    test "resolves {:px, n} as-is" do
+      assert Geometry.resolve_dimension({:px, 50}, 100) == 50
+      assert Geometry.resolve_dimension({:px, 50}, 100, clamp?: true) == 50
+    end
+
+    test "resolves {:pixels, n} with half-away" do
+      assert Geometry.resolve_dimension({:pixels, 50}, 100) == 50
+      assert Geometry.resolve_dimension({:pixels, 2.5}, 100) == 3
+    end
+
+    test "resolves {:scale, n, d}" do
+      assert Geometry.resolve_dimension({:scale, 1, 2}, 100) == 50
+      assert Geometry.resolve_dimension({:scale, 1, 2}, 5) == 3
+    end
+
+    test "resolves {:scale, n}" do
+      assert Geometry.resolve_dimension({:scale, 0.5}, 100) == 50
+      assert Geometry.resolve_dimension({:scale, 0.5}, 5) == 3
+    end
+
+    test "clamp?: true caps at reference" do
+      assert Geometry.resolve_dimension({:scale, 2, 1}, 100, clamp?: true) == 100
+      assert Geometry.resolve_dimension({:pixels, 500}, 100, clamp?: true) == 100
+    end
+
+    test "floors to 1 (dimensions are always at least 1px)" do
+      assert Geometry.resolve_dimension({:scale, 1, 10_000}, 1) == 1
+    end
+  end
+
+  describe "resolve_position/2" do
+    property "half-away rounding: reference * n/d, non-negative" do
+      check all ref <- integer(1..6000),
+                n <- integer(0..ref),
+                d <- integer(1..6000) do
+        result = Geometry.resolve_position({:ratio, n, d}, ref)
+        expected = max(0, Geometry.round_half_away_from_zero(ref * n / d))
+        assert result == expected
+      end
+    end
+
+    test "resolves {:px, n}" do
+      assert Geometry.resolve_position({:px, 0}, 100) == 0
+      assert Geometry.resolve_position({:px, 50}, 100) == 50
+    end
+
+    test "resolves {:pixels, n}" do
+      assert Geometry.resolve_position({:pixels, 0}, 100) == 0
+      assert Geometry.resolve_position({:pixels, 50}, 100) == 50
+    end
+
+    test "resolves {:scale, n, d}" do
+      assert Geometry.resolve_position({:scale, 0, 1}, 100) == 0
+      assert Geometry.resolve_position({:scale, 1, 2}, 100) == 50
+      assert Geometry.resolve_position({:scale, 1, 2}, 5) == 3
+    end
+
+    test "resolves {:ratio, n, d}" do
+      assert Geometry.resolve_position({:ratio, 0, 1}, 100) == 0
+      assert Geometry.resolve_position({:ratio, 1, 2}, 100) == 50
+    end
+
+    test "floors to 0 (positions are non-negative)" do
+      assert Geometry.resolve_position({:px, 0}, 100) == 0
+      assert Geometry.resolve_position({:ratio, 0, 1}, 100) == 0
+    end
+  end
+
+  describe "resolve_offset/3" do
+    test "bare number passes through as float (no rounding)" do
+      assert Geometry.resolve_offset(5.5, 100, 1.0) == 5.5
+      assert Geometry.resolve_offset(-3.0, 100, 1.0) == -3.0
+      assert Geometry.resolve_offset(0, 100, 1.0) == 0.0
+    end
+
+    test "{:pixels, n} is DPR-scaled, not rounded" do
+      assert Geometry.resolve_offset({:pixels, 10}, 100, 2.0) == 20.0
+      assert Geometry.resolve_offset({:pixels, 5}, 100, 1.5) == 7.5
+      assert Geometry.resolve_offset({:pixels, -8}, 100, 2.0) == -16.0
+    end
+
+    test "{:scale, n} is resolved as a float fraction of reference, not rounded" do
+      assert Geometry.resolve_offset({:scale, 0.1}, 100, 1.0) == 10.0
+      assert Geometry.resolve_offset({:scale, 0.1}, 100, 2.0) == 10.0
+    end
+
+    test "{:scale, n, d} is resolved as a float fraction of reference, not rounded" do
+      assert Geometry.resolve_offset({:scale, 1, 10}, 100, 1.0) == 10.0
+      assert Geometry.resolve_offset({:scale, 1, 10}, 100, 2.0) == 10.0
+    end
+
+    property "result is always a float (unrounded)" do
+      check all n <- float(min: -200.0, max: 200.0) do
+        assert is_float(Geometry.resolve_offset(n, 100, 1.0))
+      end
+    end
+  end
+
+  describe "resolve_focal/2" do
+    test "ratio to float, clamped to 0..1" do
+      assert Geometry.resolve_focal({:ratio, 1, 4}, 100) == 0.25
+      assert Geometry.resolve_focal({:ratio, 0, 1}, 100) == 0.0
+      assert Geometry.resolve_focal({:ratio, 1, 1}, 100) == 1.0
+    end
+
+    test "clamps out-of-range values" do
+      assert Geometry.resolve_focal({:ratio, 3, 2}, 100) == 1.0
+      assert Geometry.resolve_focal({:ratio, 0, 1}, 100) == 0.0
+    end
+
+    property "result is always in 0.0..1.0" do
+      check all n <- integer(0..1000), d <- integer(1..1000) do
+        result = Geometry.resolve_focal({:ratio, n, d}, 100)
+        assert result >= 0.0
+        assert result <= 1.0
+      end
     end
   end
 end

--- a/test/image_pipe/transform/geometry_test.exs
+++ b/test/image_pipe/transform/geometry_test.exs
@@ -50,14 +50,17 @@ defmodule ImagePipe.Transform.GeometryTest do
       end
     end
 
-    test "resolves {:px, n} as-is" do
+    test "resolves {:px, n} with min-1 floor" do
       assert Geometry.resolve_dimension({:px, 50}, 100) == 50
       assert Geometry.resolve_dimension({:px, 50}, 100, clamp?: true) == 50
+      assert Geometry.resolve_dimension({:px, 0}, 100) == 1
+      assert Geometry.resolve_dimension({:px, -5}, 100) == 1
     end
 
-    test "resolves {:pixels, n} with half-away" do
+    test "resolves {:pixels, n} with half-away and min-1 floor" do
       assert Geometry.resolve_dimension({:pixels, 50}, 100) == 50
       assert Geometry.resolve_dimension({:pixels, 2.5}, 100) == 3
+      assert Geometry.resolve_dimension({:pixels, 0}, 100) == 1
     end
 
     test "resolves {:scale, n, d}" do

--- a/test/image_pipe/transform/geometry_test.exs
+++ b/test/image_pipe/transform/geometry_test.exs
@@ -31,6 +31,7 @@ defmodule ImagePipe.Transform.GeometryTest do
                 d <- integer(1..100) do
         result = Geometry.resolve_dimension({:ratio, n, d}, ref)
         assert result >= 1
+        assert result > ref
       end
     end
 

--- a/test/image_pipe/transform/geometry_test.exs
+++ b/test/image_pipe/transform/geometry_test.exs
@@ -4,22 +4,6 @@ defmodule ImagePipe.Transform.GeometryTest do
 
   alias ImagePipe.Transform.Geometry
 
-  describe "to_pixels/2" do
-    test "resolves supported internal length units to pixels" do
-      assert Geometry.to_pixels(100, {:scale, 1, 2}) == 50
-      assert Geometry.to_pixels(100, {:percent, 25}) == 25
-      assert Geometry.to_pixels(100, {:pixels, 12}) == 12
-    end
-  end
-
-  describe "to_pixels/2 with {:ratio, n, d}" do
-    test "resolves a ratio against a reference (half-away rounding, same as :scale)" do
-      assert Geometry.to_pixels(200, {:ratio, 1, 2}) == 100
-      assert Geometry.to_pixels(5, {:ratio, 1, 2}) == 3
-      assert Geometry.to_pixels(300, {:ratio, 1, 3}) == 100
-    end
-  end
-
   describe "resolve_dimension/3" do
     property "half-away rounding: reference * n/d" do
       check all ref <- integer(1..6000),

--- a/test/image_pipe/transform/geometry_test.exs
+++ b/test/image_pipe/transform/geometry_test.exs
@@ -134,25 +134,4 @@ defmodule ImagePipe.Transform.GeometryTest do
       end
     end
   end
-
-  describe "resolve_focal/2" do
-    test "ratio to float, clamped to 0..1" do
-      assert Geometry.resolve_focal({:ratio, 1, 4}, 100) == 0.25
-      assert Geometry.resolve_focal({:ratio, 0, 1}, 100) == 0.0
-      assert Geometry.resolve_focal({:ratio, 1, 1}, 100) == 1.0
-    end
-
-    test "clamps out-of-range values" do
-      assert Geometry.resolve_focal({:ratio, 3, 2}, 100) == 1.0
-      assert Geometry.resolve_focal({:ratio, 0, 1}, 100) == 0.0
-    end
-
-    property "result is always in 0.0..1.0" do
-      check all n <- integer(0..1000), d <- integer(1..1000) do
-        result = Geometry.resolve_focal({:ratio, n, d}, 100)
-        assert result >= 0.0
-        assert result <= 1.0
-      end
-    end
-  end
 end

--- a/test/image_pipe/transform/resize_relative_resolution_property_test.exs
+++ b/test/image_pipe/transform/resize_relative_resolution_property_test.exs
@@ -13,8 +13,8 @@ defmodule ImagePipe.Transform.ResizeRelativeResolutionPropertyTest do
       op = %Resize{mode: :fit, width: {:ratio, num, den}, height: :auto, enlarge: true}
       result = Resize.resolve_dimensions(op, source_width: running, source_height: running)
 
-      # Exact: mirror the production computation order (Geometry.to_pixels does
-      # `round(length * num / den)` for a ratio), then the sub-pixel floor to 1.
+      # Exact: mirror the production computation order (Geometry.resolve_dimension
+      # computes `round(length * num / den)` for a ratio), then the sub-pixel floor to 1.
       # Writing the operands in the SAME order avoids float-associativity drift
       # while keeping the assertion tight (delta 0).
       assert result.intermediate_width == max(1, round(running * num / den))


### PR DESCRIPTION
## Summary

Closes #319

Replaces four scattered "measure × reference → px" helpers (`crop_dimension`, `crop_offset`, `resolve_relative_dimension` in resize, and `to_pixels`) with four role-named functions on `Transform.Geometry`:

- `resolve_dimension/3` — "how big?" → integer, half-away rounding, min 1, optional `clamp?:` for crop
- `resolve_position/2` — "where?" → integer, half-away rounding, min 0
- `resolve_offset/3` — "by how much?" → unrounded float (rounding deferred to `round_offset_to_even` at composition)
- `resolve_focal/2` — `{:ratio, n, d}` → normalized float clamped 0..1

Per-consumer rounding is preserved exactly. The imgproxy differential suite is pixel-neutral (zero behavioral change).

## Deleted dead helpers

- `Geometry.to_pixels/2` (all callers migrated)
- `Geometry.anchor_to_pixels/3` and `anchor_to_scale_units/3` (replaced by `resolve_position` in crop)
- `Crop.crop_dimension/2`, `Crop.crop_offset/3`, `Crop.offset_scale/1`

## Test coverage

Property tests added for all 4 resolvers in `test/image_pipe/transform/geometry_test.exs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced dimension, position, and offset resolution throughout image transformations with improved rounding and optional clamping behavior.
  * Removed percent-based offset support in favor of scale-based offsets.

* **Tests**
  * Expanded test coverage for dimension, position, and offset resolvers with property-based and unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->