### PR TITLE
fix(cache): ETag detector identity, raising-adapter containment, content-disposition on hit

### DIFF
--- a/docs/cdn-http-cache.md
+++ b/docs/cdn-http-cache.md
@@ -226,6 +226,11 @@ inputs. The generated ETag identifies the client-visible representation. For
 example, `cachebuster` changes the internal cache key but leaves the generated
 ETag unchanged.
 
+Detector and model identity, by contrast, are part of *both* the internal cache
+key and the generated ETag: swapping a detector or model changes the rendition,
+so it must change the validator too — a conditional GET will not return `304`
+against a rendition produced by a different detector.
+
 `Plan.expires` is a parser validity field. It doesn't change generated
 `Cache-Control`.
 

--- a/docs/superpowers/plans/2026-06-19-cache-bug-trio.md
+++ b/docs/superpowers/plans/2026-06-19-cache-bug-trio.md
@@ -17,48 +17,62 @@
 - Modify: `lib/image_pipe/plug.ex:83-84` — call `Runner.with_detector_identity/2` before `HTTPCache.prepare`
 - Test: `test/image_pipe/request/http_cache_test.exs`
 
-- [ ] **Step 1: Write the failing test**
+> **Why a wire-level test, not a `HTTPCache.prepare`-direct test:** the bug lives in
+> `plug.ex`, which feeds *raw* opts (no `:detector_identity`) to `HTTPCache.prepare`. A test
+> that calls `HTTPCache.prepare` with `detector_identity` already in opts passes *before* the
+> fix — it pins `etag_material`'s contract (already covered by `cache/key_test.exs`), not the
+> broken plug wiring. The regression guard must drive the full `ImagePipe.Plug.call/2` so the
+> plug's opts-threading is exercised end-to-end. Three reviewers independently flagged this.
 
-Add to `test/image_pipe/request/http_cache_test.exs`, after the existing `use` / `alias` block. Add `alias ImagePipe.Plan.Pipeline` (already present) and `alias ImagePipe.Plan.Operation.CropGuided`:
+- [ ] **Step 1: Write the failing wire test**
+
+The test uses `ImagePipe.Test.FakeDetector` (`test/support/fake_detector.ex`), whose
+`identity/1` returns `{FakeDetector, Keyword.get(opts, :identity, :fake_v1)}`. The `:identity`
+opt is an unknown-but-tolerated extension key (`Options.validate_known_opts!` passes it
+through to the detector — same mechanism the imgproxy conformance suite uses for
+`face_ver`/`object_ver`). A `g:obj:face` URL parses to a `{:detect, …}` guide, so
+`with_detector_identity` resolves the identity into both the ETag and the cache key.
+
+Add to `test/image_pipe/cdn_http_cache_wire_test.exs`, after the
+`"internal cache hit returns 200 with current prepared etag"` test:
 
 ```elixir
-alias ImagePipe.Plan.Operation.CropGuided
+  test "detector identity change moves the generated ETag end-to-end (#181 regression)", _ctx do
+    etag_for = fn identity ->
+      opts =
+        ImagePipe.Plug.init(
+          parser: ImagePipe.Parser.Imgproxy,
+          sources: [path: {StableSource, test_pid: self()}],
+          cache: {CacheProbe, test_pid: self()},
+          http_cache: [mode: :enabled],
+          detector: ImagePipe.Test.FakeDetector,
+          identity: identity
+        )
+
+      conn =
+        ImagePipe.Plug.call(
+          conn(:get, "/_/rs:fill:50:50/g:obj:face/f:jpeg/plain/beach.jpg"),
+          opts
+        )
+
+      assert conn.status == 200
+      assert [etag] = get_resp_header(conn, "etag")
+      etag
+    end
+
+    assert etag_for.(:model_v1) != etag_for.(:model_v2)
+  end
 ```
 
-Then add these two tests after the existing `"set-cookie suppresses generated public cache headers"` test:
-
-```elixir
-test "detector_identity in opts produces a different ETag" do
-  base =
-    HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
-
-  with_identity =
-    HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(),
-      opts(detector_identity: {"MyDetector", "model-v2"})
-    )
-
-  assert base.etag != nil
-  assert with_identity.etag != nil
-  assert base.etag != with_identity.etag
-end
-
-test "changing detector_identity does not affect ETag when opts carry no identity" do
-  first = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
-  second = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
-
-  assert first.etag == second.etag
-end
-```
-
-- [ ] **Step 2: Run the tests to confirm they pass already**
-
-These tests exercise `HTTPCache.prepare` directly with the opts already containing `detector_identity`, so they pass before the fix — they document the contract of `etag_material`.
+- [ ] **Step 2: Run the test to confirm it FAILS before the fix**
 
 ```bash
-mise exec -- mix test test/image_pipe/request/http_cache_test.exs
+mise exec -- mix test test/image_pipe/cdn_http_cache_wire_test.exs
 ```
 
-Expected: all pass (including the two new ones).
+Expected: the new test FAILS — both calls produce the same ETag because `plug.ex` feeds raw
+opts (detector identity `nil`) to `HTTPCache.prepare`, so the `:model_v1`/`:model_v2`
+difference never reaches the ETag.
 
 - [ ] **Step 3: Update `runner.ex` — rename to public + remove inner call**
 
@@ -107,7 +121,20 @@ change to:
     send_conditional_response(conn, plan, resolved_source, prepared_http_cache, opts)
 ```
 
-- [ ] **Step 5: Run the full test suite**
+The plug now owns the single point of detector-identity resolution. `with_detector_identity`
+is idempotent (`Keyword.put` overwrites with the same value), so a stray second call would be
+harmless — but the inner call in `run_with_cache_config` was removed in Step 3 precisely so
+the key and ETag derive from one resolution. Don't re-introduce it.
+
+- [ ] **Step 5: Run the wire test to confirm it now PASSES**
+
+```bash
+mise exec -- mix test test/image_pipe/cdn_http_cache_wire_test.exs
+```
+
+Expected: the #181 regression test passes — the two ETags now differ.
+
+- [ ] **Step 6: Run the full test suite**
 
 ```bash
 mise exec -- mix test
@@ -115,10 +142,10 @@ mise exec -- mix test
 
 Expected: all green.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
-git add lib/image_pipe/request/runner.ex lib/image_pipe/plug.ex test/image_pipe/request/http_cache_test.exs
+git add lib/image_pipe/request/runner.ex lib/image_pipe/plug.ex test/image_pipe/cdn_http_cache_wire_test.exs
 git commit -m "fix(cache): resolve detector identity once in plug, feed same opts to ETag and cache key (#181)"
 ```
 
@@ -126,38 +153,65 @@ git commit -m "fix(cache): resolve detector identity once in plug, feed same opt
 
 ### Task 2: Fix #183 — Raising adapter fails closed
 
+> **Scope: raises only, deliberately.** `rescue` catches raised exceptions (class `:error`),
+> which is exactly what the issue describes and what realistic third-party adapters do (an
+> S3/Redis client raising on timeout). An adapter that `exit`s or `throw`s, or whose linked
+> process dies, is a *different* failure mode handled by OTP supervision, not by this fix —
+> we do **not** broaden to `try/catch :exit, :throw`, which would also swallow legitimate
+> shutdown/kill signals. The tests are raise-shaped to match.
+>
+> **Confirmed during planning:** `ImagePipe.Error.tag/1` (`lib/image_pipe/error.ex:9-12`) has a
+> catch-all `def tag(_reason), do: :error`, so passing a bare `%RuntimeError{}` into
+> `commit_stop_metadata({:error, exception}, …)` → `Error.tag(exception)` yields `:error` and
+> does **not** re-raise inside the telemetry lambda. Containment holds.
+
 **Files:**
 - Modify: `lib/image_pipe/cache.ex:152-165` — add `rescue` in `get_configured`
 - Modify: `lib/image_pipe/cache/sink.ex:139-157` — add `rescue` in `do_write_chunk`
 - Modify: `lib/image_pipe/cache/sink.ex:160-165` — add `rescue` inside the `Telemetry.span` lambda in `emit_commit_result`
 - Modify: `lib/image_pipe/cache/sink.ex:201-207` — add `rescue` in `abort_adapter`
-- Test: `test/image_pipe/cache_test.exs`
+- Test: `test/image_pipe/cache_test.exs` (unit) and `test/image_pipe/cdn_http_cache_wire_test.exs` (body-delivery)
 
 - [ ] **Step 1: Add raising adapter modules to `cache_test.exs`**
 
-Add these two module definitions alongside the existing adapter modules at the top of `test/image_pipe/cache_test.exs` (after `SinkAdmissionRejectedAdapter` around line 165):
+Add these two module definitions alongside the existing adapter modules at the top of `test/image_pipe/cache_test.exs` (after `SinkAdmissionRejectedAdapter` around line 165). The `@impl true` annotations match the existing adapter modules' style and keep `credo --strict` quiet:
 
 ```elixir
   defmodule RaisingGetAdapter do
     @behaviour ImagePipe.Cache
 
+    @impl true
     def get(%Key{}, _opts), do: raise("adapter get crashed")
+    @impl true
     def open_sink(%Key{}, %Entry.Metadata{}, _opts), do: {:ok, %{}}
+    @impl true
     def write_chunk(state, _chunk, _opts), do: {:ok, state}
+    @impl true
     def commit_sink(_state, _opts), do: :ok
+    @impl true
     def abort_sink(_state, _opts), do: :ok
   end
 
   defmodule RaisingCommitAdapter do
     @behaviour ImagePipe.Cache
 
+    @impl true
     def get(%Key{}, _opts), do: :miss
+    @impl true
     def open_sink(%Key{}, %Entry.Metadata{}, _opts), do: {:ok, %{}}
+    @impl true
     def write_chunk(state, _chunk, _opts), do: {:ok, state}
+    @impl true
     def commit_sink(_state, _opts), do: raise("adapter commit crashed")
+    @impl true
     def abort_sink(_state, _opts), do: :ok
   end
 ```
+
+> Note: the existing adapter modules in this file use bare `def` without `@impl`. If `credo
+> --strict` does not flag the missing `@impl` on those (it currently passes), the `@impl true`
+> additions here are optional consistency. Match whatever the existing modules do — if they
+> stay bare, drop the `@impl true` lines to match. Verify with `mise exec -- mix credo --strict`.
 
 - [ ] **Step 2: Write failing test for `get` raise**
 
@@ -305,7 +359,7 @@ In `lib/image_pipe/cache/sink.ex`, change `abort_adapter/2`:
   end
 ```
 
-- [ ] **Step 9: Run the tests to confirm they pass**
+- [ ] **Step 9: Run the unit tests to confirm they pass**
 
 ```bash
 mise exec -- mix test test/image_pipe/cache_test.exs
@@ -313,10 +367,77 @@ mise exec -- mix test test/image_pipe/cache_test.exs
 
 Expected: all green including the two new tests.
 
-- [ ] **Step 10: Commit**
+- [ ] **Step 10: Add the wire-level body-delivery test**
+
+The unit tests above prove `Cache.commit_sink/2` returns `:ok` on a raise, but the issue's
+actual user-visible symptom is a **truncated streamed response** when `commit_sink` raises
+after the body was fully encoded. Prove the complete body still reaches the client by
+comparing the raising-adapter response against a clean-adapter baseline for the same URL —
+byte-identical bodies means no truncation, and no image decode is needed.
+
+Add a raising-commit probe alongside the other probe modules at the top of
+`test/image_pipe/cdn_http_cache_wire_test.exs`:
+
+```elixir
+  defmodule RaisingCommitProbe do
+    @behaviour ImagePipe.Cache
+
+    def get(%Key{}, _opts), do: :miss
+    def open_sink(%Key{}, _metadata, _opts), do: {:ok, %{}}
+    def write_chunk(state, _chunk, _opts), do: {:ok, state}
+    def commit_sink(_state, _opts), do: raise("commit boom")
+    def abort_sink(_state, _opts), do: :ok
+  end
+```
+
+Then add this test after the #181 regression test:
+
+```elixir
+  test "commit_sink raise still delivers the complete body, byte-identical to a clean cache (#183)" do
+    url = "/_/rs:fill:50:50/f:jpeg/plain/beach.jpg"
+
+    clean =
+      ImagePipe.Plug.call(
+        conn(:get, url),
+        ImagePipe.Plug.init(
+          parser: ImagePipe.Parser.Imgproxy,
+          sources: [path: {StableSource, test_pid: self()}],
+          cache: {CacheProbe, test_pid: self()},
+          http_cache: [mode: :enabled]
+        )
+      )
+
+    raising =
+      ImagePipe.Plug.call(
+        conn(:get, url),
+        ImagePipe.Plug.init(
+          parser: ImagePipe.Parser.Imgproxy,
+          sources: [path: {StableSource, test_pid: self()}],
+          cache: {RaisingCommitProbe, []},
+          http_cache: [mode: :enabled]
+        )
+      )
+
+    assert clean.status == 200
+    assert raising.status == 200
+    assert byte_size(raising.resp_body) > 0
+    assert raising.resp_body == clean.resp_body
+  end
+```
+
+- [ ] **Step 11: Run the wire test to confirm it passes**
 
 ```bash
-git add lib/image_pipe/cache.ex lib/image_pipe/cache/sink.ex test/image_pipe/cache_test.exs
+mise exec -- mix test test/image_pipe/cdn_http_cache_wire_test.exs
+```
+
+Expected: green. (Before the Step 6 fix this test would 500 / truncate on the raising path;
+with the fix the bodies match.)
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add lib/image_pipe/cache.ex lib/image_pipe/cache/sink.ex test/image_pipe/cache_test.exs test/image_pipe/cdn_http_cache_wire_test.exs
 git commit -m "fix(cache): rescue raises from host cache adapter callbacks, translate to fail-open paths (#183)"
 ```
 
@@ -486,15 +607,34 @@ git commit -m "fix(cache): preserve host-set content-disposition on cache-hit re
 ### Task 4: Gate, docs update, and branch rename
 
 **Files:**
-- Modify: `docs/cdn-http-cache.md` — verify key/ETag divergence list is still accurate after #181 fix
+- Modify: `docs/cdn-http-cache.md` — clarify that detector/model identity is part of *both* the key and the ETag
 
-- [ ] **Step 1: Check the cdn-http-cache doc divergence section**
+> **Why an edit is required (not just a verify):** the #181 fix changes a doc-relevant fact.
+> Pre-fix, detector identity reached the cache key but not the ETag — an accidental key/ETag
+> divergence. Post-fix it's folded into both. The divergence section currently names only the
+> cachebuster and "configured cache key inputs" as key-only, which a reader could wrongly read
+> as also covering detector identity. The compatibility reviewer flagged this as a required
+> `cdn-http-cache.md` edit; `docs/imgproxy_support_matrix.md` needs **no** change (#184 restores
+> the already-documented "host plugs can add fixed response headers" promise; #181 is an
+> ImagePipe-internal cache concern with no imgproxy surface).
 
-```bash
-grep -n "diverge\|cachebuster\|detector\|ETag\|etag" docs/cdn-http-cache.md | head -30
+- [ ] **Step 1: Edit the key-vs-ETag divergence section in `docs/cdn-http-cache.md`**
+
+Find the "Cache Key Relationship" section (around line 223). After the sentence:
+
+> For example, `cachebuster` changes the internal cache key but leaves the generated ETag unchanged.
+
+add a new sentence:
+
+```markdown
+Detector and model identity, by contrast, are part of *both* the internal cache key and the
+generated ETag: swapping a detector or model changes the rendition, so it must change the
+validator too — a conditional GET will not return `304` against a rendition produced by a
+different detector.
 ```
 
-If the doc lists only the cachebuster and vary inputs as deliberate key/ETag divergences (and now detector identity is no longer a divergence — it's included in both), confirm the text is accurate. No changes needed if the doc says "ETag excludes the cachebuster and vary inputs" — that remains true. Detector identity is now correctly included in both.
+Re-read the surrounding paragraph after editing to confirm it still flows and that no other
+sentence now contradicts it (e.g. any wording implying detector identity is key-only).
 
 - [ ] **Step 2: Run the full precommit gate**
 
@@ -504,13 +644,20 @@ mise run precommit
 
 Expected: format ✓, compile ✓, credo ✓, tests ✓.
 
-- [ ] **Step 3: Rename the branch**
+- [ ] **Step 3: Commit the doc edit**
+
+```bash
+git add docs/cdn-http-cache.md
+git commit -m "docs(cache): note detector identity is part of both cache key and ETag (#181)"
+```
+
+- [ ] **Step 4: Rename the branch**
 
 ```bash
 git branch -m fix/cache-etag-detector-raising-adapter-content-disposition
 ```
 
-- [ ] **Step 4: Push to remote**
+- [ ] **Step 5: Push to remote**
 
 ```bash
 git push -u origin fix/cache-etag-detector-raising-adapter-content-disposition

--- a/docs/superpowers/plans/2026-06-19-cache-bug-trio.md
+++ b/docs/superpowers/plans/2026-06-19-cache-bug-trio.md
@@ -1,0 +1,517 @@
+# Cache Bug Trio Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix three independent cache correctness bugs (#181 ETag/detector divergence, #183 raising adapter crashes, #184 content-disposition overwrite on cache hit) in one PR.
+
+**Architecture:** Each fix is local to one call site. #181 lifts a private function to a public one and moves the call earlier in the plug pipeline. #183 adds `rescue` blocks at each adapter call boundary. #184 reorders the content-disposition computation relative to the merge/reject step.
+
+**Tech Stack:** Elixir, Plug, `:telemetry`
+
+---
+
+### Task 1: Fix #181 — ETag missing detector identity
+
+**Files:**
+- Modify: `lib/image_pipe/request/runner.ex:257-270` — rename `put_detector_identity/2` to public `with_detector_identity/2`; remove its call from `run_with_cache_config`
+- Modify: `lib/image_pipe/plug.ex:83-84` — call `Runner.with_detector_identity/2` before `HTTPCache.prepare`
+- Test: `test/image_pipe/request/http_cache_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test/image_pipe/request/http_cache_test.exs`, after the existing `use` / `alias` block. Add `alias ImagePipe.Plan.Pipeline` (already present) and `alias ImagePipe.Plan.Operation.CropGuided`:
+
+```elixir
+alias ImagePipe.Plan.Operation.CropGuided
+```
+
+Then add these two tests after the existing `"set-cookie suppresses generated public cache headers"` test:
+
+```elixir
+test "detector_identity in opts produces a different ETag" do
+  base =
+    HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
+
+  with_identity =
+    HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(),
+      opts(detector_identity: {"MyDetector", "model-v2"})
+    )
+
+  assert base.etag != nil
+  assert with_identity.etag != nil
+  assert base.etag != with_identity.etag
+end
+
+test "changing detector_identity does not affect ETag when opts carry no identity" do
+  first = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
+  second = HTTPCache.prepare(conn(:get, "/image"), plan(), resolved(), opts())
+
+  assert first.etag == second.etag
+end
+```
+
+- [ ] **Step 2: Run the tests to confirm they pass already**
+
+These tests exercise `HTTPCache.prepare` directly with the opts already containing `detector_identity`, so they pass before the fix — they document the contract of `etag_material`.
+
+```bash
+mise exec -- mix test test/image_pipe/request/http_cache_test.exs
+```
+
+Expected: all pass (including the two new ones).
+
+- [ ] **Step 3: Update `runner.ex` — rename to public + remove inner call**
+
+Both changes go in one edit to keep the file compiling throughout.
+
+In `lib/image_pipe/request/runner.ex`:
+
+1. Change `defp put_detector_identity(opts, plan) do` → `def with_detector_identity(opts, plan) do`
+
+2. In `run_with_cache_config`, change the `Cache.lookup` call (lines ~92–97) from:
+
+```elixir
+              Cache.lookup(
+                conn,
+                plan,
+                resolved_source.identity,
+                put_detector_identity(opts, plan)
+              )
+```
+
+to:
+
+```elixir
+              Cache.lookup(
+                conn,
+                plan,
+                resolved_source.identity,
+                opts
+              )
+```
+
+- [ ] **Step 4: Call `Runner.with_detector_identity` in `plug.ex` before `HTTPCache.prepare`**
+
+In `lib/image_pipe/plug.ex`, inside `do_call_with_plan/4`, in the `with` success block (after `Source.resolve`):
+
+```elixir
+    prepared_http_cache = HTTPCache.prepare(conn, plan, resolved_source, opts)
+    send_conditional_response(conn, plan, resolved_source, prepared_http_cache, opts)
+```
+
+change to:
+
+```elixir
+    opts = Runner.with_detector_identity(opts, plan)
+    prepared_http_cache = HTTPCache.prepare(conn, plan, resolved_source, opts)
+    send_conditional_response(conn, plan, resolved_source, prepared_http_cache, opts)
+```
+
+- [ ] **Step 5: Run the full test suite**
+
+```bash
+mise exec -- mix test
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/image_pipe/request/runner.ex lib/image_pipe/plug.ex test/image_pipe/request/http_cache_test.exs
+git commit -m "fix(cache): resolve detector identity once in plug, feed same opts to ETag and cache key (#181)"
+```
+
+---
+
+### Task 2: Fix #183 — Raising adapter fails closed
+
+**Files:**
+- Modify: `lib/image_pipe/cache.ex:152-165` — add `rescue` in `get_configured`
+- Modify: `lib/image_pipe/cache/sink.ex:139-157` — add `rescue` in `do_write_chunk`
+- Modify: `lib/image_pipe/cache/sink.ex:160-165` — add `rescue` inside the `Telemetry.span` lambda in `emit_commit_result`
+- Modify: `lib/image_pipe/cache/sink.ex:201-207` — add `rescue` in `abort_adapter`
+- Test: `test/image_pipe/cache_test.exs`
+
+- [ ] **Step 1: Add raising adapter modules to `cache_test.exs`**
+
+Add these two module definitions alongside the existing adapter modules at the top of `test/image_pipe/cache_test.exs` (after `SinkAdmissionRejectedAdapter` around line 165):
+
+```elixir
+  defmodule RaisingGetAdapter do
+    @behaviour ImagePipe.Cache
+
+    def get(%Key{}, _opts), do: raise("adapter get crashed")
+    def open_sink(%Key{}, %Entry.Metadata{}, _opts), do: {:ok, %{}}
+    def write_chunk(state, _chunk, _opts), do: {:ok, state}
+    def commit_sink(_state, _opts), do: :ok
+    def abort_sink(_state, _opts), do: :ok
+  end
+
+  defmodule RaisingCommitAdapter do
+    @behaviour ImagePipe.Cache
+
+    def get(%Key{}, _opts), do: :miss
+    def open_sink(%Key{}, %Entry.Metadata{}, _opts), do: {:ok, %{}}
+    def write_chunk(state, _chunk, _opts), do: {:ok, state}
+    def commit_sink(_state, _opts), do: raise("adapter commit crashed")
+    def abort_sink(_state, _opts), do: :ok
+  end
+```
+
+- [ ] **Step 2: Write failing test for `get` raise**
+
+Add to `test/image_pipe/cache_test.exs` alongside the existing `"read errors fail open by default and are logged"` test:
+
+```elixir
+  test "lookup returns miss when adapter.get raises" do
+    log =
+      capture_log(fn ->
+        assert {:miss, %Key{}, {:cache_read, %RuntimeError{message: "adapter get crashed"}}} =
+                 Cache.lookup(
+                   conn(:get, "/_/f:webp/plain/images/cat.jpg"),
+                   plan(),
+                   source_identity(),
+                   cache: {RaisingGetAdapter, []}
+                 )
+      end)
+
+    assert log =~ "cache read error"
+  end
+```
+
+- [ ] **Step 3: Write failing test for `commit_sink` raise**
+
+Add to `test/image_pipe/cache_test.exs` alongside the existing `"commit_sink fails open and logs commit errors"` test:
+
+```elixir
+  test "commit_sink returns :ok and logs when adapter.commit_sink raises" do
+    attach_telemetry([[:image_pipe, :cache, :write, :stop]])
+
+    sink =
+      cache_key()
+      |> Cache.open_sink(resolved_output(), cache: {RaisingCommitAdapter, []})
+      |> Cache.write_chunk("abc", cache: {RaisingCommitAdapter, []})
+
+    log =
+      capture_log(fn ->
+        assert :ok = Cache.commit_sink(sink, cache: {RaisingCommitAdapter, []})
+      end)
+
+    assert log =~ "cache sink commit error"
+
+    assert_receive {:telemetry_event, [:image_pipe, :cache, :write, :stop], _measurements,
+                    %{result: :cache_error, cache: :write_error}}
+  end
+```
+
+- [ ] **Step 4: Run new tests to confirm they fail**
+
+```bash
+mise exec -- mix test test/image_pipe/cache_test.exs
+```
+
+Expected: the two new tests fail — the `get` raise propagates (test crashes instead of pattern-matching a miss), and the commit raise propagates (test crashes instead of matching `:ok`).
+
+- [ ] **Step 5: Add `rescue` to `Cache.get_configured`**
+
+In `lib/image_pipe/cache.ex`, change `get_configured/3`:
+
+```elixir
+  defp get_configured(adapter, key, cache_opts) do
+    case adapter.get(key, cache_opts) do
+      {:hit, %Entry{} = entry} ->
+        handle_hit(entry, key, cache_opts)
+
+      :miss ->
+        {:miss, key}
+
+      {:error, reason} ->
+        handle_read_error(reason, key, cache_opts)
+
+      unexpected ->
+        handle_read_error({:invalid_adapter_result, unexpected}, key, cache_opts)
+    end
+  rescue
+    exception -> handle_read_error(exception, key, cache_opts)
+  end
+```
+
+- [ ] **Step 6: Add `rescue` inside the `Telemetry.span` lambda in `Sink.emit_commit_result`**
+
+In `lib/image_pipe/cache/sink.ex`, change `emit_commit_result/2`:
+
+```elixir
+  defp emit_commit_result(%__MODULE__{} = sink, opts) do
+    Telemetry.span(Telemetry.telemetry_opts(opts), [:cache, :write], %{}, fn ->
+      result =
+        try do
+          sink.adapter.commit_sink(sink.state, sink.adapter_opts)
+        rescue
+          exception -> {:error, exception}
+        end
+
+      {:ok, commit_stop_metadata(result, sink)}
+    end)
+  end
+```
+
+- [ ] **Step 7: Add `rescue` to `Sink.do_write_chunk`**
+
+In `lib/image_pipe/cache/sink.ex`, change `do_write_chunk/3`:
+
+```elixir
+  defp do_write_chunk(%__MODULE__{} = sink, chunk, opts) do
+    case sink.adapter.write_chunk(sink.state, chunk, sink.adapter_opts) do
+      {:ok, adapter_state} ->
+        {:ok, %{sink | state: adapter_state}}
+
+      {:error, reason, adapter_state} ->
+        sink = %{sink | state: adapter_state}
+        emit_abort_cleanup(abort_adapter(sink, opts), :write_error, sink, opts)
+        Logger.warning("cache sink write error: #{inspect(reason)}")
+        emit_stage_event(:stage_error, :write, reason, sink, opts)
+        {:error, reason}
+
+      unexpected ->
+        reason = {:invalid_adapter_result, unexpected}
+        emit_abort_cleanup(abort_adapter(sink, opts), :write_error, sink, opts)
+        Logger.warning("cache sink write error: #{inspect(reason)}")
+        emit_stage_event(:stage_error, :write, reason, sink, opts)
+        {:error, reason}
+    end
+  rescue
+    exception ->
+      emit_abort_cleanup(abort_adapter(sink, opts), :write_error, sink, opts)
+      Logger.warning("cache sink write error: #{inspect(exception)}")
+      emit_stage_event(:stage_error, :write, exception, sink, opts)
+      {:error, exception}
+  end
+```
+
+- [ ] **Step 8: Add `rescue` to `Sink.abort_adapter`**
+
+In `lib/image_pipe/cache/sink.ex`, change `abort_adapter/2`:
+
+```elixir
+  defp abort_adapter(%__MODULE__{} = sink, _opts) do
+    case sink.adapter.abort_sink(sink.state, sink.adapter_opts) do
+      :ok = ok -> ok
+      {:error, _reason} = error -> error
+      unexpected -> {:error, {:invalid_adapter_result, unexpected}}
+    end
+  rescue
+    exception -> {:error, exception}
+  end
+```
+
+- [ ] **Step 9: Run the tests to confirm they pass**
+
+```bash
+mise exec -- mix test test/image_pipe/cache_test.exs
+```
+
+Expected: all green including the two new tests.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add lib/image_pipe/cache.ex lib/image_pipe/cache/sink.ex test/image_pipe/cache_test.exs
+git commit -m "fix(cache): rescue raises from host cache adapter callbacks, translate to fail-open paths (#183)"
+```
+
+---
+
+### Task 3: Fix #184 — Cache-hit overwrites host-set content-disposition
+
+**Files:**
+- Modify: `lib/image_pipe/response/sender.ex:268-293` — restructure `send_cache_entry/5`; delete `delivery_headers/3`
+- Test: `test/image_pipe/cdn_http_cache_wire_test.exs`
+
+- [ ] **Step 1: Write the failing wire test**
+
+Add to `test/image_pipe/cdn_http_cache_wire_test.exs` after the existing `"internal cache hit returns 200 with current prepared etag"` test:
+
+```elixir
+  test "host-set content-disposition is preserved on both miss and cache-hit responses" do
+    probe_opts =
+      ImagePipe.Plug.init(
+        parser: ImagePipe.Parser.Imgproxy,
+        sources: [path: {StableSource, test_pid: self()}],
+        cache: {CacheProbe, test_pid: self()},
+        http_cache: [mode: :enabled]
+      )
+
+    miss_conn =
+      conn(:get, "/_/plain/beach.jpg")
+      |> put_resp_header("content-disposition", ~s(attachment; filename="custom.jpg"))
+      |> ImagePipe.Plug.call(probe_opts)
+
+    assert miss_conn.status == 200
+
+    assert get_resp_header(miss_conn, "content-disposition") == [
+             ~s(attachment; filename="custom.jpg")
+           ]
+
+    assert_received {:cache_put, %Entry{} = entry}
+
+    hit_opts =
+      ImagePipe.Plug.init(
+        parser: ImagePipe.Parser.Imgproxy,
+        sources: [path: {StableSource, test_pid: self()}],
+        cache: {CacheHitProbe, test_pid: self(), entry: entry},
+        http_cache: [mode: :enabled]
+      )
+
+    hit_conn =
+      conn(:get, "/_/plain/beach.jpg")
+      |> put_resp_header("content-disposition", ~s(attachment; filename="custom.jpg"))
+      |> ImagePipe.Plug.call(hit_opts)
+
+    assert hit_conn.status == 200
+
+    assert get_resp_header(hit_conn, "content-disposition") == [
+             ~s(attachment; filename="custom.jpg")
+           ]
+  end
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+mise exec -- mix test test/image_pipe/cdn_http_cache_wire_test.exs
+```
+
+Expected: the new test fails — the hit response has ImagePipe's auto-generated content-disposition instead of the host's value.
+
+- [ ] **Step 3: Restructure `send_cache_entry/5` in `sender.ex`**
+
+Replace the current `send_cache_entry/5` body:
+
+```elixir
+  defp send_cache_entry(
+         %Plug.Conn{} = conn,
+         %Entry{} = entry,
+         %Response{} = response,
+         %CacheHeaders{} = prepared,
+         opts
+       ) do
+    with {:ok, headers} <- Entry.cacheable_headers(entry.headers),
+         merged_headers <- merge_delivery_headers(conn, headers, prepared),
+         {:ok, headers} <- delivery_headers(merged_headers, response, entry.content_type) do
+      Telemetry.execute(
+        Telemetry.telemetry_opts(opts),
+        [:http_cache, :cache_hit, :headers],
+        %{},
+        %{
+          etag: prepared.etag != nil,
+          generated_cache_headers: prepared.headers != [],
+          representation_headers: prepared.representation_headers != []
+        }
+      )
+
+      send_normalized_cache_entry(conn, entry, headers)
+    else
+      {:error, error} -> send_cache_error(conn, error)
+    end
+  end
+```
+
+with:
+
+```elixir
+  defp send_cache_entry(
+         %Plug.Conn{} = conn,
+         %Entry{} = entry,
+         %Response{} = response,
+         %CacheHeaders{} = prepared,
+         opts
+       ) do
+    with {:ok, entry_headers} <- Entry.cacheable_headers(entry.headers),
+         {:ok, content_disposition} <- Response.content_disposition(response, entry.content_type) do
+      merged =
+        merge_delivery_headers(
+          conn,
+          entry_headers ++ [{"content-disposition", content_disposition}],
+          prepared
+        )
+
+      Telemetry.execute(
+        Telemetry.telemetry_opts(opts),
+        [:http_cache, :cache_hit, :headers],
+        %{},
+        %{
+          etag: prepared.etag != nil,
+          generated_cache_headers: prepared.headers != [],
+          representation_headers: prepared.representation_headers != []
+        }
+      )
+
+      send_normalized_cache_entry(conn, entry, merged)
+    else
+      {:error, error} -> send_cache_error(conn, error)
+    end
+  end
+```
+
+- [ ] **Step 4: Delete `delivery_headers/3`**
+
+`delivery_headers/3` is now dead code — its only call site was the `with` chain above. Delete these lines from `lib/image_pipe/response/sender.ex`:
+
+```elixir
+  defp delivery_headers(response_headers, %Response{} = response, content_type) do
+    with {:ok, content_disposition} <- Response.content_disposition(response, content_type) do
+      {:ok, response_headers ++ [{"content-disposition", content_disposition}]}
+    end
+  end
+```
+
+- [ ] **Step 5: Run the tests to confirm they pass**
+
+```bash
+mise exec -- mix test test/image_pipe/cdn_http_cache_wire_test.exs
+```
+
+Expected: all green including the new test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/image_pipe/response/sender.ex test/image_pipe/cdn_http_cache_wire_test.exs
+git commit -m "fix(cache): preserve host-set content-disposition on cache-hit responses (#184)"
+```
+
+---
+
+### Task 4: Gate, docs update, and branch rename
+
+**Files:**
+- Modify: `docs/cdn-http-cache.md` — verify key/ETag divergence list is still accurate after #181 fix
+
+- [ ] **Step 1: Check the cdn-http-cache doc divergence section**
+
+```bash
+grep -n "diverge\|cachebuster\|detector\|ETag\|etag" docs/cdn-http-cache.md | head -30
+```
+
+If the doc lists only the cachebuster and vary inputs as deliberate key/ETag divergences (and now detector identity is no longer a divergence — it's included in both), confirm the text is accurate. No changes needed if the doc says "ETag excludes the cachebuster and vary inputs" — that remains true. Detector identity is now correctly included in both.
+
+- [ ] **Step 2: Run the full precommit gate**
+
+```bash
+mise run precommit
+```
+
+Expected: format ✓, compile ✓, credo ✓, tests ✓.
+
+- [ ] **Step 3: Rename the branch**
+
+```bash
+git branch -m fix/cache-etag-detector-raising-adapter-content-disposition
+```
+
+- [ ] **Step 4: Push to remote**
+
+```bash
+git push -u origin fix/cache-etag-detector-raising-adapter-content-disposition
+```

--- a/docs/superpowers/specs/2026-06-19-cache-bug-trio-design.md
+++ b/docs/superpowers/specs/2026-06-19-cache-bug-trio-design.md
@@ -1,0 +1,148 @@
+# Cache Bug Trio Design
+
+**Issues**: #181, #183, #184
+**PR scope**: one PR, three independent fixes
+
+---
+
+## Bug #181 — ETag missing detector identity
+
+### Problem
+
+`plug.ex` calls `HTTPCache.prepare(conn, plan, resolved_source, opts)` with raw opts, so
+`etag_material/4` sees `detector_identity: nil` and produces a stable ETag. Later,
+`Runner.run` enriches opts via `put_detector_identity(opts, plan)` only for the internal
+cache key. After a detector/model swap the key changes (fresh bytes stored) but the ETag
+does not — conditional GET clients and CDNs receive `304 Not Modified` against the old
+rendition indefinitely.
+
+### Fix
+
+Extract `put_detector_identity/2` from its private scope in `Runner` into a public
+`Runner.with_detector_identity(opts, plan)`. Call it in `plug.ex` before `HTTPCache.prepare`
+and thread the enriched opts through to `Runner.run`. Remove the inner call from
+`run_with_cache_config` — one resolution, one source of truth.
+
+**Changed files**
+
+- `lib/image_pipe/request/runner.ex` — make `put_detector_identity` public as
+  `with_detector_identity/2`; remove its call from `run_with_cache_config`
+- `lib/image_pipe/plug.ex` — call `Runner.with_detector_identity(opts, plan)` after
+  `validate_detector_capability` and before `HTTPCache.prepare`; pass enriched opts
+  throughout `do_call_with_plan`
+
+### Tests
+
+`test/image_pipe/request/http_cache_test.exs`:
+
+- Detect/face-assist plan with `detector_identity: {"MyDetector", "v2"}` in opts produces a
+  different ETag than the same plan with no detector identity.
+- Non-detect plan is unaffected (ETag identical regardless of `detector_identity` in opts).
+
+---
+
+## Bug #183 — Raising adapter fails closed
+
+### Problem
+
+Tuple errors from host-implementable `ImagePipe.Cache` callbacks are handled everywhere,
+but raises are not caught at any call site. Three paths are exposed:
+
+1. `Cache.get_configured` → `adapter.get/2` raise propagates out of `Runner.run` → 500.
+2. `Sink.do_write_chunk` → `adapter.write_chunk/3` raise crashes the `SourceSession`
+   GenServer mid-chunk; the client receives a truncated body.
+3. `Sink.emit_commit_result` → `adapter.commit_sink/2` raise propagates through
+   `Telemetry.span` (which re-raises after emitting the `:exception` event); the
+   client receives a truncated body even though every byte was already sent successfully.
+4. `Sink.abort_adapter` → `adapter.abort_sink/2` raise propagates through cleanup paths
+   that would otherwise emit telemetry cleanly.
+
+### Fix
+
+Add `rescue` at each adapter call site. Translate exceptions into the existing
+tuple-error paths so downstream handling is unchanged.
+
+**`Cache.get_configured`** — rescue around `adapter.get(key, cache_opts)`; translate
+exception to `{:miss, key, {:cache_read, exception}}`.
+
+**`Sink.do_write_chunk`** — rescue around `adapter.write_chunk(sink.state, chunk,
+sink.adapter_opts)`; translate exception to the existing `{:error, reason}` branch
+(abort, log, emit `stage_error`).
+
+**`Sink.emit_commit_result`** — rescue the lambda body *inside* the `Telemetry.span`
+call so the span emits `:stop` with error metadata (not the `:exception` event).
+Translate exception to `commit_stop_metadata({:error, exception}, sink)`. `Sink.commit/2`
+still returns `:ok` — the fail-open contract is preserved.
+
+**`Sink.abort_adapter`** — rescue around `adapter.abort_sink(sink.state, sink.adapter_opts)`;
+translate exception to `{:error, exception}`.
+
+**Changed files**
+
+- `lib/image_pipe/cache.ex` — rescue in `get_configured`
+- `lib/image_pipe/cache/sink.ex` — rescue in `do_write_chunk`, `emit_commit_result`,
+  `abort_adapter`
+
+### Tests
+
+`test/image_pipe/cache_test.exs` (or a dedicated `cache_raise_test.exs` if it keeps the
+existing file focused):
+
+Use an inline raising adapter module defined in the test. Two scenarios:
+
+1. `adapter.get/2` raises → `Cache.lookup/4` returns `{:miss, key, {:cache_read, exception}}`
+   (not a raise).
+2. `adapter.commit_sink/2` raises after full successful drain → `Sink.commit/2` returns `:ok`
+   (no raise); the caller receives the complete response body.
+
+---
+
+## Bug #184 — Cache-hit path overwrites host-set content-disposition
+
+### Problem
+
+`Sender.send_cache_entry/5` runs content-disposition *after* `merge_delivery_headers` /
+`reject_existing_conn_headers`:
+
+```
+cacheable_headers → merge_delivery_headers (reject step runs here) → delivery_headers appends content-disposition
+```
+
+The host's pre-set `content-disposition` is dropped by the reject step, but then
+ImagePipe's value is unconditionally appended afterwards — host loses.
+
+On the miss (stream) path, content-disposition is included in `PreparedStream.headers`
+*before* `merge_delivery_headers` runs, so the reject step correctly honours the host
+value.
+
+### Fix
+
+Compute content-disposition before the merge step in `send_cache_entry`. Fold it into
+the headers list passed to `merge_delivery_headers` so the reject step handles it the
+same way as any other delivery header.
+
+Replace the two-stage `with` (`delivery_headers` call) with:
+
+```elixir
+with {:ok, entry_headers} <- Entry.cacheable_headers(entry.headers),
+     {:ok, content_disposition} <- Response.content_disposition(response, entry.content_type) do
+  merged = merge_delivery_headers(conn, entry_headers ++ [{"content-disposition", content_disposition}], prepared)
+  send_normalized_cache_entry(conn, entry, merged)
+end
+```
+
+Delete `delivery_headers/3` — its only call site is the `send_cache_entry` `with` chain
+being restructured; no other path calls it.
+
+**Changed files**
+
+- `lib/image_pipe/response/sender.ex` — restructure `send_cache_entry/5`
+
+### Tests
+
+`test/image_pipe/cdn_http_cache_wire_test.exs` (or imgproxy wire conformance test):
+
+Wire-level test using `ImagePipe.call/2` with a host plug that pre-sets
+`content-disposition: attachment; filename="custom.jpg"`. Make two requests to the same
+URL (first a miss, second a hit). Assert that both responses carry the host-set
+`content-disposition` value unchanged.

--- a/lib/image_pipe/cache.ex
+++ b/lib/image_pipe/cache.ex
@@ -163,6 +163,8 @@ defmodule ImagePipe.Cache do
       unexpected ->
         handle_read_error({:invalid_adapter_result, unexpected}, key, cache_opts)
     end
+  rescue
+    exception -> handle_read_error(exception, key, cache_opts)
   end
 
   defp handle_hit(%Entry{} = entry, key, cache_opts) do

--- a/lib/image_pipe/cache/sink.ex
+++ b/lib/image_pipe/cache/sink.ex
@@ -155,11 +155,23 @@ defmodule ImagePipe.Cache.Sink do
         emit_stage_event(:stage_error, :write, reason, sink, opts)
         {:error, reason}
     end
+  rescue
+    exception ->
+      emit_abort_cleanup(abort_adapter(sink, opts), :write_error, sink, opts)
+      Logger.warning("cache sink write error: #{inspect(exception)}")
+      emit_stage_event(:stage_error, :write, exception, sink, opts)
+      {:error, exception}
   end
 
   defp emit_commit_result(%__MODULE__{} = sink, opts) do
     Telemetry.span(Telemetry.telemetry_opts(opts), [:cache, :write], %{}, fn ->
-      result = sink.adapter.commit_sink(sink.state, sink.adapter_opts)
+      result =
+        try do
+          sink.adapter.commit_sink(sink.state, sink.adapter_opts)
+        rescue
+          exception -> {:error, exception}
+        end
+
       {:ok, commit_stop_metadata(result, sink)}
     end)
   end
@@ -204,6 +216,8 @@ defmodule ImagePipe.Cache.Sink do
       {:error, _reason} = error -> error
       unexpected -> {:error, {:invalid_adapter_result, unexpected}}
     end
+  rescue
+    exception -> {:error, exception}
   end
 
   defp emit_abort_cleanup(:ok, _reason, _sink, _opts), do: :ok

--- a/lib/image_pipe/plug.ex
+++ b/lib/image_pipe/plug.ex
@@ -79,6 +79,7 @@ defmodule ImagePipe.Plug do
          :ok <- validate_detector_capability(plan, opts),
          {:ok, %Source.Resolved{} = resolved_source} <-
            Source.resolve(plan.source, opts, Options.source_runtime_opts(opts)) do
+      opts = Runner.with_detector_identity(opts, plan)
       prepared_http_cache = HTTPCache.prepare(conn, plan, resolved_source, opts)
       send_conditional_response(conn, plan, resolved_source, prepared_http_cache, opts)
     else

--- a/lib/image_pipe/request/runner.ex
+++ b/lib/image_pipe/request/runner.ex
@@ -93,7 +93,7 @@ defmodule ImagePipe.Request.Runner do
                 conn,
                 plan,
                 resolved_source.identity,
-                put_detector_identity(opts, plan)
+                opts
               )
           end
 
@@ -246,15 +246,19 @@ defmodule ImagePipe.Request.Runner do
   defp cache_lookup_stop_metadata({:miss, %Key{}, {:cache_read, error}}),
     do: %{result: :cache_error, cache: :read_error, error: Error.tag(error)}
 
-  # When the plan's output depends on the configured detector, fold the
-  # detector's opaque {module, term} identity into the cache key so a
-  # detector/model change (or availability change) produces a different key
-  # instead of colliding. This covers both {:detect, _} guides and
-  # {:smart, :face_assist} guides: face-assist blends the detected face centroid
-  # into the attention point, so its output also depends on the detector. The
-  # cache boundary never resolves identity itself; the request layer passes it
-  # as a key option.
-  defp put_detector_identity(opts, plan) do
+  @doc """
+  Returns `opts` augmented with the resolved detector identity when the plan's
+  output depends on the configured detector — `{:detect, _}` guides or
+  `{:smart, :face_assist}` (face-assist blends the detected face centroid into
+  the attention point). The identity is folded in as the `:detector_identity`
+  key option so a detector/model change (or availability change) yields a
+  different cache key instead of colliding.
+
+  The request entry point (the plug) calls this once, before `HTTPCache.prepare`
+  and `Runner.run/5`, so the ETag and cache key both derive from a single
+  detector resolution.
+  """
+  def with_detector_identity(opts, plan) do
     detect_classes = Plan.detect_classes(plan)
 
     if detect_classes != nil or Plan.face_assist?(plan) do

--- a/lib/image_pipe/response/sender.ex
+++ b/lib/image_pipe/response/sender.ex
@@ -272,9 +272,15 @@ defmodule ImagePipe.Response.Sender do
          %CacheHeaders{} = prepared,
          opts
        ) do
-    with {:ok, headers} <- Entry.cacheable_headers(entry.headers),
-         merged_headers <- merge_delivery_headers(conn, headers, prepared),
-         {:ok, headers} <- delivery_headers(merged_headers, response, entry.content_type) do
+    with {:ok, entry_headers} <- Entry.cacheable_headers(entry.headers),
+         {:ok, content_disposition} <- Response.content_disposition(response, entry.content_type) do
+      merged =
+        merge_delivery_headers(
+          conn,
+          entry_headers ++ [{"content-disposition", content_disposition}],
+          prepared
+        )
+
       Telemetry.execute(
         Telemetry.telemetry_opts(opts),
         [:http_cache, :cache_hit, :headers],
@@ -286,7 +292,7 @@ defmodule ImagePipe.Response.Sender do
         }
       )
 
-      send_normalized_cache_entry(conn, entry, headers)
+      send_normalized_cache_entry(conn, entry, merged)
     else
       {:error, error} -> send_cache_error(conn, error)
     end
@@ -453,12 +459,6 @@ defmodule ImagePipe.Response.Sender do
   defp mark_prepared_stream_error(%Plug.Conn{} = conn, reason) do
     Logger.error("prepared_stream_error: #{inspect(reason)}")
     mark_send_processing_error(conn)
-  end
-
-  defp delivery_headers(response_headers, %Response{} = response, content_type) do
-    with {:ok, content_disposition} <- Response.content_disposition(response, content_type) do
-      {:ok, response_headers ++ [{"content-disposition", content_disposition}]}
-    end
   end
 
   defp merge_prepared_stream_headers(

--- a/test/image_pipe/cache_test.exs
+++ b/test/image_pipe/cache_test.exs
@@ -163,6 +163,26 @@ defmodule ImagePipe.CacheTest do
     def abort_sink(_state, _opts), do: :ok
   end
 
+  defmodule RaisingGetAdapter do
+    @behaviour ImagePipe.Cache
+
+    def get(%Key{}, _opts), do: raise("adapter get crashed")
+    def open_sink(%Key{}, %Entry.Metadata{}, _opts), do: {:ok, %{}}
+    def write_chunk(state, _chunk, _opts), do: {:ok, state}
+    def commit_sink(_state, _opts), do: :ok
+    def abort_sink(_state, _opts), do: :ok
+  end
+
+  defmodule RaisingCommitAdapter do
+    @behaviour ImagePipe.Cache
+
+    def get(%Key{}, _opts), do: :miss
+    def open_sink(%Key{}, %Entry.Metadata{}, _opts), do: {:ok, %{}}
+    def write_chunk(state, _chunk, _opts), do: {:ok, state}
+    def commit_sink(_state, _opts), do: raise("adapter commit crashed")
+    def abort_sink(_state, _opts), do: :ok
+  end
+
   defmodule LegacyPutOnlyAdapter do
     def get(%Key{}, _opts), do: :miss
     def put(%Key{}, %Entry{}, _opts), do: :ok
@@ -423,6 +443,21 @@ defmodule ImagePipe.CacheTest do
     assert log =~ ":read_failed"
   end
 
+  test "lookup returns miss when adapter.get raises" do
+    log =
+      capture_log(fn ->
+        assert {:miss, %Key{}, {:cache_read, %RuntimeError{message: "adapter get crashed"}}} =
+                 Cache.lookup(
+                   conn(:get, "/_/f:webp/plain/images/cat.jpg"),
+                   plan(),
+                   source_identity(),
+                   cache: {RaisingGetAdapter, []}
+                 )
+      end)
+
+    assert log =~ "cache read error"
+  end
+
   test "unexpected adapter get result is handled as a cache read error" do
     log =
       capture_log(fn ->
@@ -549,6 +584,25 @@ defmodule ImagePipe.CacheTest do
 
     assert_receive {:telemetry_event, [:image_pipe, :cache, :write, :stop], _measurements,
                     %{result: :cache_error, cache: :write_error, error: :commit_failed}}
+  end
+
+  test "commit_sink returns :ok and logs when adapter.commit_sink raises" do
+    attach_telemetry([[:image_pipe, :cache, :write, :stop]])
+
+    sink =
+      cache_key()
+      |> Cache.open_sink(resolved_output(), cache: {RaisingCommitAdapter, []})
+      |> Cache.write_chunk("abc", cache: {RaisingCommitAdapter, []})
+
+    log =
+      capture_log(fn ->
+        assert :ok = Cache.commit_sink(sink, cache: {RaisingCommitAdapter, []})
+      end)
+
+    assert log =~ "cache sink commit error"
+
+    assert_receive {:telemetry_event, [:image_pipe, :cache, :write, :stop], _measurements,
+                    %{result: :cache_error, cache: :write_error}}
   end
 
   test "commit_sink reports admission rejection on the cache write span" do

--- a/test/image_pipe/cdn_http_cache_wire_test.exs
+++ b/test/image_pipe/cdn_http_cache_wire_test.exs
@@ -81,6 +81,16 @@ defmodule ImagePipe.CDNHTTPCacheWireTest do
     def abort_sink(_state, _opts), do: :ok
   end
 
+  defmodule RaisingCommitProbe do
+    @behaviour ImagePipe.Cache
+
+    def get(%Key{}, _opts), do: :miss
+    def open_sink(%Key{}, _metadata, _opts), do: {:ok, %{}}
+    def write_chunk(state, _chunk, _opts), do: {:ok, state}
+    def commit_sink(_state, _opts), do: raise("commit boom")
+    def abort_sink(_state, _opts), do: :ok
+  end
+
   setup do
     opts =
       ImagePipe.Plug.init(
@@ -248,6 +258,37 @@ defmodule ImagePipe.CDNHTTPCacheWireTest do
     end
 
     assert etag_for.(:model_v1) != etag_for.(:model_v2)
+  end
+
+  test "commit_sink raise still delivers the complete body, byte-identical to a clean cache (#183)" do
+    url = "/_/rs:fill:50:50/f:jpeg/plain/beach.jpg"
+
+    clean =
+      ImagePipe.Plug.call(
+        conn(:get, url),
+        ImagePipe.Plug.init(
+          parser: ImagePipe.Parser.Imgproxy,
+          sources: [path: {StableSource, test_pid: self()}],
+          cache: {CacheProbe, test_pid: self()},
+          http_cache: [mode: :enabled]
+        )
+      )
+
+    raising =
+      ImagePipe.Plug.call(
+        conn(:get, url),
+        ImagePipe.Plug.init(
+          parser: ImagePipe.Parser.Imgproxy,
+          sources: [path: {StableSource, test_pid: self()}],
+          cache: {RaisingCommitProbe, []},
+          http_cache: [mode: :enabled]
+        )
+      )
+
+    assert clean.status == 200
+    assert raising.status == 200
+    assert byte_size(raising.resp_body) > 0
+    assert raising.resp_body == clean.resp_body
   end
 
   # #328: the only guide that reached do_generated_etag under a strong byte

--- a/test/image_pipe/cdn_http_cache_wire_test.exs
+++ b/test/image_pipe/cdn_http_cache_wire_test.exs
@@ -234,6 +234,48 @@ defmodule ImagePipe.CDNHTTPCacheWireTest do
     refute_received :source_fetch_called
   end
 
+  test "host-set content-disposition is preserved on both miss and cache-hit responses" do
+    probe_opts =
+      ImagePipe.Plug.init(
+        parser: ImagePipe.Parser.Imgproxy,
+        sources: [path: {StableSource, test_pid: self()}],
+        cache: {CacheProbe, test_pid: self()},
+        http_cache: [mode: :enabled]
+      )
+
+    miss_conn =
+      conn(:get, "/_/plain/beach.jpg")
+      |> put_resp_header("content-disposition", ~s(attachment; filename="custom.jpg"))
+      |> ImagePipe.Plug.call(probe_opts)
+
+    assert miss_conn.status == 200
+
+    assert get_resp_header(miss_conn, "content-disposition") == [
+             ~s(attachment; filename="custom.jpg")
+           ]
+
+    assert_received {:cache_put, %Entry{} = entry}
+
+    hit_opts =
+      ImagePipe.Plug.init(
+        parser: ImagePipe.Parser.Imgproxy,
+        sources: [path: {StableSource, test_pid: self()}],
+        cache: {CacheHitProbe, test_pid: self(), entry: entry},
+        http_cache: [mode: :enabled]
+      )
+
+    hit_conn =
+      conn(:get, "/_/plain/beach.jpg")
+      |> put_resp_header("content-disposition", ~s(attachment; filename="custom.jpg"))
+      |> ImagePipe.Plug.call(hit_opts)
+
+    assert hit_conn.status == 200
+
+    assert get_resp_header(hit_conn, "content-disposition") == [
+             ~s(attachment; filename="custom.jpg")
+           ]
+  end
+
   test "detector identity change moves the generated ETag end-to-end (#181 regression)", _ctx do
     etag_for = fn identity ->
       opts =

--- a/test/image_pipe/cdn_http_cache_wire_test.exs
+++ b/test/image_pipe/cdn_http_cache_wire_test.exs
@@ -224,6 +224,32 @@ defmodule ImagePipe.CDNHTTPCacheWireTest do
     refute_received :source_fetch_called
   end
 
+  test "detector identity change moves the generated ETag end-to-end (#181 regression)", _ctx do
+    etag_for = fn identity ->
+      opts =
+        ImagePipe.Plug.init(
+          parser: ImagePipe.Parser.Imgproxy,
+          sources: [path: {StableSource, test_pid: self()}],
+          cache: {CacheProbe, test_pid: self()},
+          http_cache: [mode: :enabled],
+          detector: ImagePipe.Test.FakeDetector,
+          identity: identity
+        )
+
+      conn =
+        ImagePipe.Plug.call(
+          conn(:get, "/_/rs:fill:50:50/g:obj:face/f:jpeg/plain/beach.jpg"),
+          opts
+        )
+
+      assert conn.status == 200
+      assert [etag] = get_resp_header(conn, "etag")
+      etag
+    end
+
+    assert etag_for.(:model_v1) != etag_for.(:model_v2)
+  end
+
   # #328: the only guide that reached do_generated_etag under a strong byte
   # identity before this was :center (the order-invariance test below). A
   # gravity-derived guide (focal/smart/detect/anchor/carried) exercises the

--- a/test/image_pipe/request_runner_test.exs
+++ b/test/image_pipe/request_runner_test.exs
@@ -1333,14 +1333,22 @@ defmodule ImagePipe.Request.RunnerTest do
     plan = plan(pipelines: [%Pipeline{operations: [face_assist_crop_operation(200, 100)]}])
 
     run_lookup = fn fake_identity ->
+      opts =
+        Runner.with_detector_identity(
+          [
+            cache: {CacheReadProbe, entry: entry},
+            detector: ImagePipe.Test.FakeDetector,
+            identity: fake_identity
+          ],
+          plan
+        )
+
       assert {:ok, {:cache_entry, ^entry, %ImagePipe.Plan.Response{}, %CacheHeaders{}}} =
                run(
                  conn(:get, "/_/g:sm/w:200/h:100/f:jpeg/plain/images/beach.jpg"),
                  plan,
                  resolved_source(),
-                 cache: {CacheReadProbe, entry: entry},
-                 detector: ImagePipe.Test.FakeDetector,
-                 identity: fake_identity
+                 opts
                )
 
       assert_received {:cache_lookup, key}


### PR DESCRIPTION
## Summary

Three independent cache-correctness fixes found in the request-cycle review, delivered as one PR. Each is localized and test-driven; the design spec and implementation plan went through a parallel multi-reviewer cycle before implementation, and each fix passed a per-task spec + code-quality review.

### #181 — ETag missing detector identity
Detector/model identity was folded into the internal cache key but **not** the generated ETag, so after a detector or model swap new bytes were stored under the same strong ETag and revalidating clients/CDNs kept the stale rendition (`304`). The fix resolves detector identity **once** in the plug (`Runner.with_detector_identity/2`, before `HTTPCache.prepare`) and threads the same enriched opts into both the ETag and the cache key — a single resolution, no divergence. Guarded by an end-to-end wire test asserting the ETag moves when the detector identity changes.

### #183 — Raising cache adapter failed closed
Tuple errors from host `ImagePipe.Cache` callbacks were handled everywhere, but **raises** were contained nowhere — a raising third-party adapter (e.g. S3/Redis timeout) turned the documented fail-open contract into a crashed request or a truncated streamed response. Added `rescue` at each adapter call boundary (`get`, `write_chunk`, `commit_sink`, `abort_sink`), translating exceptions into the existing fail-open tuple paths. Scope is raises only by design (exit/throw remain OTP's concern). Covered by unit tests plus a wire test proving the complete body is still delivered byte-identical when `commit_sink` raises after a full drain.

### #184 — Cache-hit overwrote host-set content-disposition
A host-set `content-disposition` was honored on the miss (streamed) response but overwritten on the cache-hit response. The hit path computed content-disposition *after* the header merge/reject step; the fix folds it into the header list *before* `merge_delivery_headers`, so the same host-wins reject rule applies on both paths. Wire test asserts the host value survives on both miss and hit.

Also updates `docs/cdn-http-cache.md` to note that detector/model identity is part of both the cache key and the ETag.

## Test Plan
- [x] `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, `mix test` all green (2382 tests, 0 failures)
- [x] #181: wire-level ETag regression test (fails before fix, passes after)
- [x] #183: unit tests (get/commit raise → fail open) + wire body-delivery test
- [x] #184: miss→hit wire test asserting host content-disposition preserved on both paths

Fixes #181
Fixes #183
Fixes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cache now correctly invalidates when detector or model configuration changes.
  * Service is more robust to cache adapter failures.
  * Host-provided content-disposition headers preserved on cache hits.
* **Documentation**
  * Clarified detector and model identity in cache key and ETag generation.
* **Tests**
  * Added verification tests for cache correctness and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->