### PR TITLE
chore(autoquality): benchmark ssim2 search cost + accuracy

### DIFF
--- a/docs/autoquality_benchmark.md
+++ b/docs/autoquality_benchmark.md
@@ -173,6 +173,36 @@ win:**
   bytes by +56%. The earlier caveat (no large real sources) was the right one to
   flag — the cross-scale signal reverses the conclusion.
 
+### Part D — cheap full-res metric narrowing (#6)
+
+Can a *cheap* full-res metric (PSNR — no XYB/multiscale-SSIM cost) narrow the
+search so SSIMULACRA2 runs ~once instead of ~4–6×, while the final decision stays
+full-res SSIMULACRA2 (no resolution bias)? Viability hinges on one statistic:
+**is the cheap metric's value at the SSIMULACRA2 boundary stable across images?**
+If yes, a single calibrated threshold locates the boundary; if it drifts per image,
+a global threshold mis-picks.
+
+It drifts — badly. The cheap value at the boundary spans **11–22 dB**:
+
+| corpus | metric | cheap@boundary spread | exact-q | underpick (worst) | overpick byte waste (worst) | cheaper |
+|--------|--------|------------------------|---------|-------------------|-----------------------------|---------|
+| committed ≤2 MP | PSNR-RGB  | 38.8 … 50.0 dB (11 dB) | 2/6 | 3/6 (−28q) | +87%  | 9.2× |
+| committed ≤2 MP | PSNR-luma | 38.8 … 58.3 dB (20 dB) | 1/6 | 3/6 (−27q) | +136% | 9.2× |
+| large 16 MP     | PSNR-RGB  | 43.9 … 65.9 dB (22 dB) | 2/3 | 0/3       | +27%  | 11.3× |
+
+A high-frequency photo clears SSIMULACRA2 = 88 at ~39 dB PSNR; clean line-art
+(`marker`) needs ~50 dB; a 16 MP photo ~66 dB. So any single PSNR threshold either
+**underpicks** (ships visibly under-compressed images — up to −28q) or **overpicks**
+(wastes >100% bytes), depending on content. The metric *is* genuinely ~9–11×
+cheaper than SSIMULACRA2 (the cost premise holds) — it just doesn't track the
+*perceptual* boundary, which is exactly the gap SSIMULACRA2 exists to close.
+
+**Conclusion:** PSNR-class narrowing is a non-starter with a global threshold. The
+only ways forward both have caveats: a cheaper *perceptual* metric (MS-SSIM,
+butteraugli) that tracks the boundary — **not in our stack** today — or per-image
+SSIMULACRA2 anchoring (2 anchors + cheap interpolation + 1 confirm), which saves
+~0 probes on the shipped narrow `[70,80]` bracket and only ~2–3 on a wide one.
+
 ## Findings & recommendations
 
 ### 1. Ship a non-zero `autoquality_max_resolution` default
@@ -234,3 +264,26 @@ So the earlier "ship `k≈2`" read was wrong — it was an artifact of testing o
 
 The benchmark now ships with `--proxy-files` so this can be re-run on any corpus of
 large images when the calibrated variant is prototyped.
+
+### 4. Cheap-metric narrowing (#6) doesn't work with PSNR — needs a cheaper *perceptual* metric
+
+Part D tested the other cost lever — keep the decision on full-res SSIMULACRA2 but
+use a cheap full-res metric to cut the number of SSIMULACRA2 probes. PSNR is ~9–11×
+cheaper but its value at the SSIMULACRA2 boundary varies 11–22 dB across content, so
+a global threshold under/over-picks badly (−28q to +136% bytes). PSNR-class
+narrowing is therefore not viable. The lever is only worth revisiting with a
+cheaper *perceptual* metric (MS-SSIM, butteraugli) — neither is in our stack today —
+or per-image SSIMULACRA2 anchoring, which saves ~0 probes on the shipped narrow
+`[70,80]` bracket. Net: no change; the cost story stays as Parts A/C describe it.
+
+## The bottom line across A–D
+
+The SSIMULACRA2 quality boundary is **genuinely content-dependent and not cheaply
+predictable** — neither by reducing resolution (Part C) nor by a cheap pixel metric
+(Part D). The metric cost (~83% of wall-clock, Part A) is therefore largely
+intrinsic. The robust, shippable lever is the **resolution cap** (#1); the
+search/objective defaults are sound (#2); and the two "make it cheaper" shortcuts
+(proxy seed, cheap-metric narrowing) both founder on the same rock — a cheap or
+low-res stand-in for SSIMULACRA2 doesn't track its boundary. A real speedup needs
+either a cheaper perceptual metric in-stack or a learned per-content quality
+predictor (the endgame), both larger efforts than this benchmark.

--- a/docs/autoquality_benchmark.md
+++ b/docs/autoquality_benchmark.md
@@ -15,11 +15,22 @@ mise exec -- mix autoquality.bench            # parts A+B, default sizes, prints
 mise exec -- mix autoquality.bench --part a   # cost curve only
 mise exec -- mix autoquality.bench --part b   # accuracy/behavior only
 mise exec -- mix autoquality.bench --part c   # downscaled-proxy-seed method + accuracy
-mise exec -- mix autoquality.bench --part all # A + B + C
+mise exec -- mix autoquality.bench --part d   # cheap full-res metric narrowing
+mise exec -- mix autoquality.bench --part e --corpus DIR  # crop-based scoring
+mise exec -- mix autoquality.bench --part all # A + B + C + D + E
 mise exec -- mix autoquality.bench --mps 1,4  # custom Part A megapixels
 mise exec -- mix autoquality.bench --proxy-factors 2,4 --proxy-mp 25  # Part C knobs
-mise exec -- mix autoquality.bench --csv      # also write /tmp/autoquality_bench_part_{a,b,c}.csv
+mise exec -- mix autoquality.bench --csv      # also write /tmp/autoquality_bench_part_{a,b,c,e}.csv
 ```
+
+> **Part E corpus.** Part E needs a content-diverse corpus the committed sources
+> can't provide (they're synthetic/uniform). Assemble one spanning smooth /
+> heterogeneous / dark / busy / text content — the harness reports per measured
+> heterogeneity, so coverage of the *smooth+detail* (banding-prone) case is what
+> matters, not labels. The reference run used ~16 license-clean photos from Lorem
+> Picsum (varied sizes) selected by measured texture profile, plus a synthetic
+> smooth gradient (`O.grey`) and a text block (`O.text`) for the banding and
+> sharp-edge cases. Point `--corpus` at the directory.
 
 [`mix autoquality.bench`](../test/support/mix/tasks/autoquality.bench.ex) is
 gated off the default `mix test` lane: it is a `test/support` Mix task (compiled
@@ -203,6 +214,60 @@ butteraugli) that tracks the boundary — **not in our stack** today — or per-
 SSIMULACRA2 anchoring (2 anchors + cheap interpolation + 1 confirm), which saves
 ~0 probes on the shipped narrow `[70,80]` bracket and only ~2–3 on a wide one.
 
+### Part E — crop-based scoring vs full-frame (#1)
+
+Score SSIMULACRA2 on native-resolution tiles of the *actual full-res encode*, not
+the whole frame. Unlike Part C's proxy this keeps native resolution, so per-pixel
+artifact statistics match — the only error is *which regions* you look at. Run over
+a curated 19-subject corpus (16 Lorem Picsum photos selected by texture profile +
+a synthetic gradient + a text block + the zone-plate), 512 px tiles, K=16
+sub-sample, reported by measured heterogeneity (HET).
+
+**This is the first lever that tracks.** The honest tracking metric is the *offset*
+`tile_aggregate − full_frame_score` at the boundary (a calibrated global threshold
+rides on it; the raw aggregate spread is inflated by `full_score`'s integer-quality
+quantization):
+
+| aggregate | median offset | offset spread (residual) |
+|-----------|---------------|--------------------------|
+| worst-tile | −0.12 | −2.21 … 1.03 (3.24) |
+| **p10-tile** | **0.12** | **−0.87 … 1.49 (2.36)** |
+| mean-tile | 1.83 | 0.22 … 4.64 (4.42) |
+
+**p10 holds within ±~1.5 pts** (≈ ±2 q) across content — versus Part C's ±18 q and
+Part D's hopeless spread. A single threshold `≈ target + 0.1` reproduces the
+full-frame decision. Mean is too optimistic; worst-tile is noisier.
+
+Sub-sampling and cost:
+
+- **K=16-tile sub-sampling penalty is small:** mean +0.17 / worst +0.86 on uniform
+  images, mean +0.28 / worst +1.58 on heterogeneous ones. A sparse sample mostly
+  catches the worst region — because at the autoquality target (q≈75–90) the worst
+  tiles are *textured*, not smooth (the worst tile sat in a smooth region in only
+  **2/19** subjects; banding-in-smooth is a low-quality phenomenon, below this regime).
+- **Cost is a fixed, size-independent budget** (K=16 ≈ 260 ms here). Full tile
+  *coverage* saves nothing (same pixels as the frame), but the fixed K-tile budget
+  beats full-frame above a **~4 MP crossover**:
+
+  | size | full-frame metric | K=16 tiles | result |
+  |------|-------------------|------------|--------|
+  | ≤ 2.7 MP | 33–106 ms | ~260 ms | **loss** (use full-frame) |
+  | 10.7 MP | ~415 ms | ~263 ms | ~1.6× |
+  | 16 MP | ~721 ms | ~318 ms | ~2.3× |
+  | 36 MP (extrapolated) | ~2.4 s | ~260 ms | ~9× |
+
+  Because the budget is constant while full-frame grows ~linearly, the win scales
+  with image size — collapsing Part A's superlinear blow-up to roughly constant
+  per-probe metric cost.
+
+**Conclusion:** crop-based scoring is the one shortcut that survives — it keeps the
+*real* metric at *native resolution* and only sub-samples *space*, so it tracks the
+full-frame boundary (p10, ±~1.5 pts) while making per-probe cost size-independent.
+It's a genuine speedup for large images (above ~4 MP), the exact regime where the
+full search is unaffordable. Caveats: validate the p10 threshold on a larger/owned
+corpus before fixing it; raise K or use saliency-guided tiles if targeting very low
+quality (where banding in smooth regions would need explicit sampling).
+
 ## Findings & recommendations
 
 ### 1. Ship a non-zero `autoquality_max_resolution` default
@@ -276,14 +341,35 @@ cheaper *perceptual* metric (MS-SSIM, butteraugli) — neither is in our stack t
 or per-image SSIMULACRA2 anchoring, which saves ~0 probes on the shipped narrow
 `[70,80]` bracket. Net: no change; the cost story stays as Parts A/C describe it.
 
-## The bottom line across A–D
+### 5. Crop-based scoring (#1) is the one real speedup — prototype it for large images
+
+Part E is the lever that works. Scoring the *real* SSIMULACRA2 on a *spatial
+subset* at *native resolution* tracks the full-frame boundary (p10 aggregate,
+±~1.5 pts ≈ ±2 q) — because it changes *what area* is measured, not *the metric* or
+*the resolution*, which is what sank Parts C and D. With a fixed K≈16-tile budget it
+makes per-probe cost size-independent: a loss below ~4 MP (where full-frame is cheap
+anyway) but ~1.6× at 10.7 MP, ~2.3× at 16 MP, scaling to ~9× at 36 MP — exactly the
+large-image regime where the full search is unaffordable.
+
+Recommendation: prototype crop-scoring behind the `max_resolution` threshold (#1) —
+i.e. below the cap use the full frame; above it, score K p10-tiles per probe with a
+calibrated threshold (and, for safety, one full-frame confirm on the winner). Before
+fixing the threshold and K, re-run `--part e --corpus` on a larger / production-
+representative corpus. This converts the cap from "disable autoquality on big
+images" into "run it affordably," recovering the savings on the images that matter.
+
+## The bottom line across A–E
 
 The SSIMULACRA2 quality boundary is **genuinely content-dependent and not cheaply
-predictable** — neither by reducing resolution (Part C) nor by a cheap pixel metric
-(Part D). The metric cost (~83% of wall-clock, Part A) is therefore largely
-intrinsic. The robust, shippable lever is the **resolution cap** (#1); the
-search/objective defaults are sound (#2); and the two "make it cheaper" shortcuts
-(proxy seed, cheap-metric narrowing) both founder on the same rock — a cheap or
-low-res stand-in for SSIMULACRA2 doesn't track its boundary. A real speedup needs
-either a cheaper perceptual metric in-stack or a learned per-content quality
-predictor (the endgame), both larger efforts than this benchmark.
+predictable by a *stand-in* for the metric** — neither a reduced-resolution proxy
+(Part C) nor a cheap pixel metric (Part D) tracks it; both founder on the same rock.
+But the boundary **is** recoverable by computing the *real* metric on a *spatial
+subset at native resolution* (Part E) — that tracks within ±~1.5 pts and, as a fixed
+tile budget, makes per-probe cost size-independent. So:
+
+- **Ship now:** the resolution cap (#1), objective/bracket defaults unchanged (#2).
+- **Don't ship:** the naïve proxy (#3) or PSNR narrowing (#4).
+- **Prototype next:** crop-based scoring above the cap (#5) — the genuine speedup,
+  turning the cap into "autoquality stays on, affordably" for large images.
+- **Endgame, if needed:** a cheaper perceptual metric in-stack, or a learned
+  per-content quality predictor — both larger efforts than this benchmark.

--- a/docs/autoquality_benchmark.md
+++ b/docs/autoquality_benchmark.md
@@ -1,0 +1,146 @@
+# Autoquality (ssim2) search — benchmark + findings
+
+Follow-up to #351. The `:ssim2` autoquality objective runs a binary search over
+encoder quality at the output/encode boundary
+([`ImagePipe.Output.EncodeSearch`](../lib/image_pipe/output/encode_search.ex)).
+For `:ssim2`, **every distinct iteration does a full-resolution encode + decode +
+SSIMULACRA2 metric** on the result, and the metric dominates. #351 shipped this
+correctness-verified only, with no performance data. This documents the
+benchmark tool and the numbers it produced.
+
+## Running it
+
+```shell
+mise exec -- mix autoquality.bench            # both parts, default sizes, prints tables
+mise exec -- mix autoquality.bench --part a   # cost curve only
+mise exec -- mix autoquality.bench --part b   # accuracy/behavior only
+mise exec -- mix autoquality.bench --mps 1,4  # custom Part A megapixels
+mise exec -- mix autoquality.bench --csv      # also write /tmp/autoquality_bench_part_{a,b}.csv
+```
+
+[`mix autoquality.bench`](../test/support/mix/tasks/autoquality.bench.ex) is
+gated off the default `mix test` lane: it is a `test/support` Mix task (compiled
+only under `MIX_ENV=test`, auto-selected via `mix.exs` `preferred_envs`), never a
+test the lane runs. It needs no Docker — it measures our algorithm only, over the
+committed differential sources and a synthetic zone-plate. The `ssimulacra2` Rust
+NIF builds from source on first compile (slow once).
+
+It reuses the public surface only — `ImagePipe.Output.Encoder`, `EncodeSearch`,
+`Ssim2Metric` — and reads achieved scores from the search's own
+`[:encode, :search]` `:stop` telemetry (`final_score`, the score against the
+correct pre-encode finalized reference), never an ad-hoc baseline.
+
+### What each part measures
+
+- **Part A — cost curve.** The real `:ssim2` search (target 88, bracket
+  `[40,95]`, `max_iterations 6`) on a deterministic high-frequency zone-plate
+  (chirp) generated at each target megapixel count. The injected
+  `encode_fun`/`score_fun` are wrapped to accumulate per-phase time
+  (`encode` = `Encoder.encode_to_buffer`; `decode` = `Image.from_binary`;
+  `metric` = `Ssim2Metric.score`), and the one-time reference build is timed
+  separately. Output: where the wall-clock goes as a function of pixel count.
+- **Part B — accuracy + behavior.** The production encode path
+  (`Encoder.stream_output/3`, which finalizes exactly as a real request) over the
+  committed sources at native size, for three configs each: `ssim2:88:40:95`,
+  `size`, and `max_bytes` (the latter two to `round(q90 bytes * 0.6)`). Output:
+  whether ssim2 lands at/above target, typical quality/savings/iterations, and
+  how much cheaper the metric-free objectives are.
+
+> The bracket used here (`[40,95]`, target 88) is a deliberate **worst-case**: it
+> is wide, so the binary search spends close to its full 6-iteration budget, and
+> the target is high enough that the search keeps probing. The *shipped* imgproxy
+> autoquality defaults are narrower — `min_quality 70`, `max_quality 80` (11
+> candidate qualities ⇒ ~4 probes), and `autoquality_target` is required. So
+> real-world ssim2 cost is roughly **⅔** of the per-iteration numbers below
+> (~4 metric passes instead of 6).
+
+## Results (reference machine: Apple Silicon, libvips 8.18.2)
+
+Absolute numbers are machine- and libvips-dependent; **the shape and ratios are
+the portable conclusions**. Re-run locally to calibrate a host's budget.
+
+### Part A — ssim2 search cost vs. megapixels (zone-plate, 6 iterations)
+
+| MP  | dims      | iters | total ms | ref ms | encode ms | decode ms | metric ms | /iter ms | metric % |
+|-----|-----------|-------|----------|--------|-----------|-----------|-----------|----------|----------|
+| 1   | 1000×1000 | 6     | 323      | 31     | 29        | 2         | 257       | 48       | 80%      |
+| 4   | 2000×2000 | 6     | 1179     | 118    | 92        | 2         | 967       | 177      | 82%      |
+| 9   | 3000×3000 | 6     | 2634     | 251    | 203       | 5         | 2175      | 397      | 83%      |
+| 16  | 4000×4000 | 6     | 4730     | 486    | 348       | 6         | 3890      | 707      | 82%      |
+| 25  | 5000×5000 | 6     | 8095     | 786    | 546       | 19        | 6744      | 1218     | 83%      |
+| 36  | 6000×6000 | 6     | 20405    | 1488   | 855       | 43        | 18019     | 3153     | 88%      |
+
+- **The metric is the cost.** SSIMULACRA2 scoring is ~80–88% of total wall-clock
+  at every size; encode is ~5%, decode is negligible (<1%), and the one-time
+  reference build is ~6–10%.
+- **Roughly linear in pixels through 16 MP, then superlinear.** Per-iteration
+  cost tracks pixel count closely up to ~16 MP (≈44 ms/MP for the full
+  encode+decode+metric step); 25→36 MP jumps disproportionately (8.1 s → 20.4 s),
+  consistent with memory-bandwidth/cache pressure on the larger float buffers.
+- **A full 6× pass is expensive fast.** At default `max_resolution: 0`
+  (unbounded, see below) a 16 MP request adds ~4.7 s of pure CPU, 25 MP ~8 s,
+  36 MP ~20 s — enough to blow typical HTTP timeouts and pin a scheduler.
+
+### Part B — accuracy + behavior over real sources (native size)
+
+27 committed sources, `ssim2:88:40:95` vs a fixed `q90` baseline:
+
+- **ssim2 hits its target: 26/27 sources scored ≥ 88.** The one miss is
+  `small.png` (120×90), which tops out at q95 = 87.43 — it physically cannot reach
+  88 within the bracket, so the search correctly returns the ceiling (best-effort).
+- **Iterations: 5.9 avg** (almost always the full 6 on the wide `[40,95]` bracket;
+  a couple of sources converge in 5).
+- **Savings are content-dependent and substantial on high-detail content:**
+  high-frequency photographic sources save **40–58%** vs q90 (`high_freq` 58%,
+  `marker`/`border` 40–42%) at a chosen quality of 40–74. Already-compact or
+  already-optimized sources save ~0% (the search lands at q90) or slightly
+  *negative* on tiny files (`small.png`, `cmyk.jpg` at −6%, where q95 is chosen
+  and re-encode overhead exceeds the baseline). Average across all 27: ~18%.
+- **The metric-free objectives are ~15× cheaper.** Average per-source cost:
+  **ssim2 147 ms vs size 9.8 ms vs max_bytes 9.8 ms.** `size` and `max_bytes`
+  skip the decode+metric entirely, so their cost is just the encode probes; the
+  ~15× gap *is* the decode+metric overhead and matches Part A's ~83% metric share.
+
+## Findings & recommendations
+
+### 1. Ship a non-zero `autoquality_max_resolution` default
+
+Today
+[`autoquality_max_resolution` defaults to `0`](../lib/image_pipe/parser/imgproxy.ex)
+— i.e. **unbounded**: the ssim2 search runs at any resolution. Part A shows that
+is unsafe (16 MP ≈ 4.7 s, 36 MP ≈ 20 s of CPU per request). Pick the cap from the
+host's per-request latency budget against the cost curve above, remembering the
+shipped `[70,80]` bracket runs ~4 iterations (≈⅔ of the tabulated 6-iteration
+cost):
+
+| latency budget for the search | ~MP cap (at shipped `[70,80]`, ~4 iters) |
+|-------------------------------|------------------------------------------|
+| ~0.8 s                        | ~4 MP                                     |
+| ~1.7 s                        | ~9 MP                                     |
+| ~3 s                          | ~16 MP                                     |
+
+A conservative cross-host default of **~9 MP** keeps the worst case near
+1–2 s on this machine while still covering the vast majority of real delivery
+sizes; hosts on slower hardware or with tighter budgets should lower it. The
+value should be documented as a latency knob, not left at unbounded.
+
+### 2. The shipped objective/bracket defaults are sound; no change needed
+
+ssim2 reliably lands at or above target across the source set, with sensible
+best-effort behavior at the bracket edges. The benchmark's wide `[40,95]`/target-88
+stress bracket exercised the search hard and surfaced no accuracy problem;
+nothing in the data argues for changing the shipped `target`/bracket/`max_iterations`
+defaults. (`max_iterations 6` is already generous for the `[70,80]` default
+bracket, which needs only ~4 probes; lowering it would not help the dominant
+metric cost on the wide-bracket worst case but would cap pathological brackets.)
+
+### 3. The deferred downscaled-proxy-seed optimization is worth doing
+
+A resolution cap only *disables* autoquality above the threshold (the request
+falls back to fixed quality), forfeiting the 40–58% savings exactly on the large,
+high-detail images where they matter most. Because cost is ~83% metric and scales
+with pixel count, running the **search on a downscaled proxy** to pick the quality
+and then doing a single full-res confirm encode would cut the dominant cost by the
+square of the downscale factor — turning a 20 s 36 MP search into well under a
+second while keeping most of the savings. The data supports prioritizing this over
+relying on the cap alone.

--- a/docs/autoquality_benchmark.md
+++ b/docs/autoquality_benchmark.md
@@ -16,21 +16,24 @@ mise exec -- mix autoquality.bench --part a   # cost curve only
 mise exec -- mix autoquality.bench --part b   # accuracy/behavior only
 mise exec -- mix autoquality.bench --part c   # downscaled-proxy-seed method + accuracy
 mise exec -- mix autoquality.bench --part d   # cheap full-res metric narrowing
-mise exec -- mix autoquality.bench --part e --corpus DIR  # crop-based scoring
+mise exec -- mix autoquality.corpus           # fetch the Part E corpus (one-time)
+mise exec -- mix autoquality.bench --part e --corpus DIR  # crop-based scoring, per source
 mise exec -- mix autoquality.bench --part all # A + B + C + D + E
 mise exec -- mix autoquality.bench --mps 1,4  # custom Part A megapixels
 mise exec -- mix autoquality.bench --proxy-factors 2,4 --proxy-mp 25  # Part C knobs
 mise exec -- mix autoquality.bench --csv      # also write /tmp/autoquality_bench_part_{a,b,c,e}.csv
 ```
 
-> **Part E corpus.** Part E needs a content-diverse corpus the committed sources
-> can't provide (they're synthetic/uniform). Assemble one spanning smooth /
-> heterogeneous / dark / busy / text content — the harness reports per measured
-> heterogeneity, so coverage of the *smooth+detail* (banding-prone) case is what
-> matters, not labels. The reference run used ~16 license-clean photos from Lorem
-> Picsum (varied sizes) selected by measured texture profile, plus a synthetic
-> smooth gradient (`O.grey`) and a text block (`O.text`) for the banding and
-> sharp-edge cases. Point `--corpus` at the directory.
+> **Part E corpus.** Part E needs content-diverse, license-clean images the
+> committed sources can't provide (they're synthetic/uniform). `mix
+> autoquality.corpus` fetches pinned subsets of
+> [`imazen/codec-corpus`](https://github.com/imazen/codec-corpus) — CLIC 2025
+> (photographic, train/holdout), CID22 (diverse), GB82 (hard photographic), GB82-SC
+> (screen content), QOI web screenshots — plus a fixed set of ~15 MP photos for the
+> size-dependent regime, into a shared worktree-independent cache via the GitHub
+> raw API (no git/LFS). Each `--corpus` subdirectory is a per-source group; the
+> bench reports per source then macro-averages. Pinned codec-corpus SHA
+> `bb1da43`.
 
 [`mix autoquality.bench`](../test/support/mix/tasks/autoquality.bench.ex) is
 gated off the default `mix test` lane: it is a `test/support` Mix task (compiled
@@ -218,55 +221,60 @@ SSIMULACRA2 anchoring (2 anchors + cheap interpolation + 1 confirm), which saves
 
 Score SSIMULACRA2 on native-resolution tiles of the *actual full-res encode*, not
 the whole frame. Unlike Part C's proxy this keeps native resolution, so per-pixel
-artifact statistics match — the only error is *which regions* you look at. Run over
-a curated 19-subject corpus (16 Lorem Picsum photos selected by texture profile +
-a synthetic gradient + a text block + the zone-plate), 512 px tiles, K=16
-sub-sample, reported by measured heterogeneity (HET).
+artifact statistics match — the only error is *which regions* you look at. Run
+**per content source** over the [`imazen/codec-corpus`](https://github.com/imazen/codec-corpus)
+subsets fetched by `mix autoquality.corpus` (≤24/source, macro-averaged so no one
+content type dominates), 512 px tiles, K=16 sub-sample. The honest tracking metric
+is the *offset* `tile_p10 − full_frame_score` at the boundary — a calibrated global
+threshold rides on it (the raw aggregate spread would be inflated by `full_score`'s
+integer-quality quantization):
 
-**This is the first lever that tracks.** The honest tracking metric is the *offset*
-`tile_aggregate − full_frame_score` at the boundary (a calibrated global threshold
-rides on it; the raw aggregate spread is inflated by `full_score`'s integer-quality
-quantization):
+| source | imgs | hit | q̄ | save vs q90 | **p10 offset** (median; spread) | cost full→K16 |
+|--------|------|-----|----|----|-----|-----|
+| clic (2–4 MP photos) | 24 | 24/24 | 93 | −22% | 0.29; −1.2…2.7 | 129→266 ms (loss) |
+| clic_holdout | 24 | 23/24 | 92 | −19% | −0.03; −1.1…1.8 | 125→265 ms (loss) |
+| gb82_sc (screen content) | 10 | 9/10 | 91 | −4% | −0.52; −1.2…2.1 | 124→268 ms (loss) |
+| qoi_web (huge screenshots) | 14 | 4/14 | 93 | −16% | 0.39; −0.5…2.6 | 299→267 ms (1.1×) |
+| **large (15 MP photos)** | 6 | 5/6 | 84 | **+17%** | 1.46; −0.1…3.8 | **682→270 ms (2.5×)** |
+| cid22 (512²), gb82 (576²) | 48 | 48/48 | 91 | −3…−9% | ~0 (≈1 tile — B only) | loss |
+| **macro-average** | | | | **−8%** | **+0.22** | |
 
-| aggregate | median offset | offset spread (residual) |
-|-----------|---------------|--------------------------|
-| worst-tile | −0.12 | −2.21 … 1.03 (3.24) |
-| **p10-tile** | **0.12** | **−0.87 … 1.49 (2.36)** |
-| mean-tile | 1.83 | 0.22 … 4.64 (4.42) |
+**Tracking generalizes across content types.** p10 offset median stays within ±1.5
+on photographs (CLIC), **screen content** (gb82_sc −0.52), huge web screenshots
+(qoi 0.39) and large photos (1.46); macro +0.22, residual spreads ~3–4 pts (≈ ±2–4 q)
+— versus Part C's ±18 q and Part D's hopeless spread. The screen-content
+generalization risk that motivated the diverse corpus is resolved: it tracks. A
+single threshold `≈ target + macro-offset` reproduces the full-frame decision; a
+one-pass full-frame confirm covers the residual. (`cid22`/`gb82` are ≤576 px → one
+tile, so they only exercise the B-refresh below, not crop-tracking.)
 
-**p10 holds within ±~1.5 pts** (≈ ±2 q) across content — versus Part C's ±18 q and
-Part D's hopeless spread. A single threshold `≈ target + 0.1` reproduces the
-full-frame decision. Mean is too optimistic; worst-tile is noisier.
+**Cost win is large-image-only, confirmed.** K=16 is a fixed ~265 ms budget, so it
+only beats full-frame above a **~6 MP crossover**: `large` (15 MP) wins **2.5×**,
+while CLIC at 2–4 MP and everything smaller is a *loss*. The budget is constant
+while full-frame grows ~linearly, so the win scales with size (extrapolating, ~9×
+at 36 MP) — collapsing Part A's superlinear blow-up. Sub-sampling penalty is small
+(`large`: +0.62 worst), and the worst tile sat in a smooth region in only **3/113**
+subjects (banding-in-smooth is a low-quality phenomenon, below this regime).
 
-Sub-sampling and cost:
+**B-refresh (free byproduct — and a correction).** Because the run does a full-frame
+ssim2 search per image, it doubles as Part B on real content. The result corrects
+the earlier fixture-based savings: at **target 88**, real photos land at **q91–93**,
+*above* q90 → **negative savings** vs a q90 baseline on most sources (macro −8%),
+positive only on `large` (15 MP, +17%, where camera detail needs only q84). The
+40–58 % I reported on the synthetic fixtures was an artifact of that content.
+**Caveat:** this is the benchmark's wide `[40,95]` bracket + target 88; the shipped
+`[70,80]` caps at 80, so the *defaults recommendation is unchanged* — but "target 88
+≈ q93 on photos" is real, and only a diverse corpus surfaced it. Side finding:
+`qoi_web` hit target only 4/14 — JPEG can't reach SSIM 88 on text-heavy screenshots
+(prefer WebP/PNG there).
 
-- **K=16-tile sub-sampling penalty is small:** mean +0.17 / worst +0.86 on uniform
-  images, mean +0.28 / worst +1.58 on heterogeneous ones. A sparse sample mostly
-  catches the worst region — because at the autoquality target (q≈75–90) the worst
-  tiles are *textured*, not smooth (the worst tile sat in a smooth region in only
-  **2/19** subjects; banding-in-smooth is a low-quality phenomenon, below this regime).
-- **Cost is a fixed, size-independent budget** (K=16 ≈ 260 ms here). Full tile
-  *coverage* saves nothing (same pixels as the frame), but the fixed K-tile budget
-  beats full-frame above a **~4 MP crossover**:
-
-  | size | full-frame metric | K=16 tiles | result |
-  |------|-------------------|------------|--------|
-  | ≤ 2.7 MP | 33–106 ms | ~260 ms | **loss** (use full-frame) |
-  | 10.7 MP | ~415 ms | ~263 ms | ~1.6× |
-  | 16 MP | ~721 ms | ~318 ms | ~2.3× |
-  | 36 MP (extrapolated) | ~2.4 s | ~260 ms | ~9× |
-
-  Because the budget is constant while full-frame grows ~linearly, the win scales
-  with image size — collapsing Part A's superlinear blow-up to roughly constant
-  per-probe metric cost.
-
-**Conclusion:** crop-based scoring is the one shortcut that survives — it keeps the
-*real* metric at *native resolution* and only sub-samples *space*, so it tracks the
-full-frame boundary (p10, ±~1.5 pts) while making per-probe cost size-independent.
-It's a genuine speedup for large images (above ~4 MP), the exact regime where the
-full search is unaffordable. Caveats: validate the p10 threshold on a larger/owned
-corpus before fixing it; raise K or use saliency-guided tiles if targeting very low
-quality (where banding in smooth regions would need explicit sampling).
+**Conclusion:** crop-based scoring is the one shortcut that survives, now validated
+across photographic, screen, and large content. It keeps the *real* metric at
+*native resolution* and only sub-samples *space*, so it tracks the full-frame
+boundary (p10, ±~1.5 pts) while making per-probe cost size-independent — a genuine
+speedup for large images (above ~6 MP), the regime where the full search is
+unaffordable. Caveats: calibrate the p10 threshold on `clic_holdout` (kept aside);
+raise K or use saliency-guided tiles only if targeting very low quality.
 
 ## Findings & recommendations
 
@@ -300,6 +308,16 @@ nothing in the data argues for changing the shipped `target`/bracket/`max_iterat
 defaults. (`max_iterations 6` is already generous for the `[70,80]` default
 bracket, which needs only ~4 probes; lowering it would not help the dominant
 metric cost on the wide-bracket worst case but would cap pathological brackets.)
+
+Part E's real-content B-refresh adds one nuance, not a defaults change: **target 88
+is high.** On clean photographs the search lands at q91–93 (above q90), so with a
+wide bracket the *savings vs a q90 baseline are negative* on most sources (macro
+−8 %; only 15 MP photos save, +17 %). The 40–58 % savings from the synthetic
+fixtures were content-specific. This is correct behavior (88 simply *is* a high
+perceptual bar) and the shipped `[70,80]` caps quality at 80 regardless; the
+takeaway for hosts is that the **target choice**, not the engine, sets the
+quality/size trade-off — pick it per content class (and note JPEG can't reach 88 on
+text-heavy screen content at all: `qoi_web` hit 88 on only 4/14).
 
 ### 3. The downscaled-proxy-seed optimization is harder than it looks — do not ship the naïve form
 
@@ -343,20 +361,23 @@ or per-image SSIMULACRA2 anchoring, which saves ~0 probes on the shipped narrow
 
 ### 5. Crop-based scoring (#1) is the one real speedup — prototype it for large images
 
-Part E is the lever that works. Scoring the *real* SSIMULACRA2 on a *spatial
-subset* at *native resolution* tracks the full-frame boundary (p10 aggregate,
-±~1.5 pts ≈ ±2 q) — because it changes *what area* is measured, not *the metric* or
-*the resolution*, which is what sank Parts C and D. With a fixed K≈16-tile budget it
-makes per-probe cost size-independent: a loss below ~4 MP (where full-frame is cheap
-anyway) but ~1.6× at 10.7 MP, ~2.3× at 16 MP, scaling to ~9× at 36 MP — exactly the
-large-image regime where the full search is unaffordable.
+Part E is the lever that works, now **validated per-source across the codec-corpus**
+(photographic, screen content, huge screenshots, large photos). Scoring the *real*
+SSIMULACRA2 on a *spatial subset* at *native resolution* tracks the full-frame
+boundary (p10 offset median within ±1.5 pts on every content type; macro +0.22) —
+because it changes *what area* is measured, not *the metric* or *the resolution*,
+which is what sank Parts C and D. The screen-content generalization risk is
+resolved. With a fixed K≈16-tile budget it makes per-probe cost size-independent: a
+loss below the ~6 MP crossover (where full-frame is cheap anyway) but **2.5× at
+15 MP** (the `large` source), scaling with size (~9× at 36 MP) — exactly the regime
+where the full search is unaffordable.
 
 Recommendation: prototype crop-scoring behind the `max_resolution` threshold (#1) —
-i.e. below the cap use the full frame; above it, score K p10-tiles per probe with a
-calibrated threshold (and, for safety, one full-frame confirm on the winner). Before
-fixing the threshold and K, re-run `--part e --corpus` on a larger / production-
-representative corpus. This converts the cap from "disable autoquality on big
-images" into "run it affordably," recovering the savings on the images that matter.
+below the cap use the full frame; above it, score K p10-tiles per probe with a
+threshold calibrated as `target + macro-offset`, plus one full-frame confirm on the
+winner for safety. Calibration data already exists: calibrate on `clic` and check
+on the held-out `clic_holdout`. This converts the cap from "disable autoquality on
+big images" into "run it affordably," recovering savings on the images that matter.
 
 ## The bottom line across A–E
 

--- a/docs/autoquality_benchmark.md
+++ b/docs/autoquality_benchmark.md
@@ -11,11 +11,14 @@ benchmark tool and the numbers it produced.
 ## Running it
 
 ```shell
-mise exec -- mix autoquality.bench            # both parts, default sizes, prints tables
+mise exec -- mix autoquality.bench            # parts A+B, default sizes, prints tables
 mise exec -- mix autoquality.bench --part a   # cost curve only
 mise exec -- mix autoquality.bench --part b   # accuracy/behavior only
+mise exec -- mix autoquality.bench --part c   # downscaled-proxy-seed method + accuracy
+mise exec -- mix autoquality.bench --part all # A + B + C
 mise exec -- mix autoquality.bench --mps 1,4  # custom Part A megapixels
-mise exec -- mix autoquality.bench --csv      # also write /tmp/autoquality_bench_part_{a,b}.csv
+mise exec -- mix autoquality.bench --proxy-factors 2,4 --proxy-mp 25  # Part C knobs
+mise exec -- mix autoquality.bench --csv      # also write /tmp/autoquality_bench_part_{a,b,c}.csv
 ```
 
 [`mix autoquality.bench`](../test/support/mix/tasks/autoquality.bench.ex) is
@@ -45,6 +48,17 @@ correct pre-encode finalized reference), never an ad-hoc baseline.
   `size`, and `max_bytes` (the latter two to `round(q90 bytes * 0.6)`). Output:
   whether ssim2 lands at/above target, typical quality/savings/iterations, and
   how much cheaper the metric-free objectives are.
+- **Part C — downscaled-proxy-seed method + accuracy.** For each subject and
+  downscale factor `k`: run the full-res search (ground truth `q_full`), then
+  downscale by `1/k`, run the search on the proxy (`q_proxy`), encode the
+  **full-res** image once at `q_proxy`, and score that delivered output against
+  the full-res reference. Subjects: the committed sRGB high-detail sources at
+  native size (genuine content, modest scale) plus an adversarial zone-plate at
+  16 MP (large-scale + worst-case for the metric). Output: does the proxy's
+  quality choice still hit the target at full res, how the bytes move, and the
+  measured speedup. **Caveat:** no large *real* sources exist in-repo, so
+  cross-scale generalization to 16–36 MP photos is inferred from the ≤2 MP real
+  signal; the only large subject is the adversarial synthetic.
 
 > The bracket used here (`[40,95]`, target 88) is a deliberate **worst-case**: it
 > is wide, so the binary search spends close to its full 6-iteration budget, and
@@ -101,6 +115,53 @@ the portable conclusions**. Re-run locally to calibrate a host's budget.
   skip the decode+metric entirely, so their cost is just the encode probes; the
   ~15× gap *is* the decode+metric overhead and matches Part A's ~83% metric share.
 
+### Part C — downscaled-proxy-seed method + accuracy
+
+Per source × downscale factor, full-res search vs. proxy-seed. `Δq = q_proxy −
+q_full`; `delivered` is the true full-res SSIMULACRA2 score of the full-res encode
+at `q_proxy`; `bytesΔ` is delivered bytes vs. the full-res optimum.
+
+| source        | MP   | k | q_full | q_proxy | Δq  | delivered | Δtarget | hit | bytesΔ | speedup |
+|---------------|------|---|--------|---------|-----|-----------|---------|-----|--------|---------|
+| high_freq.jpg | 1.92 | 2 | 40     | 41      | +1  | 90.03     | +2.03   | yes | +2%    | 3.1×    |
+| high_freq.jpg | 1.92 | 3 | 40     | 58      | +18 | 91.71     | +3.71   | yes | +19%   | 6.1×    |
+| high_freq.jpg | 1.92 | 4 | 40     | 75      | +35 | 93.64     | +5.64   | yes | +49%   | 9.8×    |
+| marker.png    | 1.92 | 2 | 74     | 83      | +9  | 90.26     | +2.26   | yes | +1%    | 3.5×    |
+| border.png    | 1.92 | 4 | 73     | 73      | 0   | 88.71     | +0.71   | yes | 0%     | 9.6×    |
+| placement.png | 1.92 | 2 | 90     | 90      | 0   | 88.85     | +0.85   | yes | 0%     | 3.3×    |
+| placement.png | 1.92 | 4 | 90     | 90      | 0   | 88.85     | +0.85   | yes | 0%     | 8.9×    |
+| zone-16MP     | 16.0 | 2 | 95     | 94      | −1  | 87.47     | −0.53   | **NO** | −7% | 3.6×    |
+| zone-16MP     | 16.0 | 3 | 95     | 91      | −4  | 82.85     | −5.15   | **NO** | −19% | 7.0×  |
+| zone-16MP     | 16.0 | 4 | 95     | 94      | −1  | 87.47     | −0.53   | **NO** | −7% | 9.6×    |
+
+Aggregated per factor (5 real subjects + 1 adversarial synthetic):
+
+| k | target hit @margin 0 | Δq mean / worst | margin that fixes | worst undershoot | worst byte overshoot | speedup |
+|---|----------------------|-----------------|-------------------|------------------|----------------------|---------|
+| 2 | 5/6                  | +3.2 / −1       | +1q               | −0.53            | +2%                  | ~3.4×   |
+| 3 | 5/6                  | +6.0 / −4       | +4q               | −5.15            | +19%                 | ~6.7×   |
+| 4 | 5/6                  | +9.3 / −1       | +1q               | −0.53            | +49%                 | ~9.7×   |
+
+**The proxy method works, but its error is two-directional and content-dependent
+— it is not a clean win:**
+
+- **Real high-detail content over-picks quality** (Δq ≥ 0): the downscaled proxy
+  loses the hard-to-compress detail, so the search on it reads the content as
+  *harder* and picks a higher quality. The delivered full-res image clears the
+  target (every real source hit, all k) — but the encode is **larger than the
+  optimal full-res pick**, eroding the very savings autoquality exists to capture.
+  At `k=4`, `high_freq` delivered **+49% bytes** vs. the full-res optimum (q75 vs.
+  the correct q40).
+- **The adversarial chirp under-picks** (Δq < 0): the zone-plate downscales into a
+  lower-frequency zone-plate the metric scores more easily, so `q_proxy` lands
+  below `q_full` and the delivered full-res score **undershoots** (e.g. `k=3`:
+  82.85 vs. target 88). This is the quality-risk failure mode.
+- **A single additive margin can't satisfy both directions** — the margin that
+  rescues the undershoot makes the byte overshoot worse.
+- **`k=2` is the sweet spot:** ~3.4× speedup with Δq in `[−1, +9]`, worst
+  undershoot −0.53 (a +1q margin fixes it), and ≤+2% byte overshoot. Aggressive
+  downscale (`k≥3`) trades that balance for speed.
+
 ## Findings & recommendations
 
 ### 1. Ship a non-zero `autoquality_max_resolution` default
@@ -134,13 +195,30 @@ defaults. (`max_iterations 6` is already generous for the `[70,80]` default
 bracket, which needs only ~4 probes; lowering it would not help the dominant
 metric cost on the wide-bracket worst case but would cap pathological brackets.)
 
-### 3. The deferred downscaled-proxy-seed optimization is worth doing
+### 3. The downscaled-proxy-seed optimization works, but needs the right shape
 
-A resolution cap only *disables* autoquality above the threshold (the request
-falls back to fixed quality), forfeiting the 40–58% savings exactly on the large,
-high-detail images where they matter most. Because cost is ~83% metric and scales
-with pixel count, running the **search on a downscaled proxy** to pick the quality
-and then doing a single full-res confirm encode would cut the dominant cost by the
-square of the downscale factor — turning a 20 s 36 MP search into well under a
-second while keeping most of the savings. The data supports prioritizing this over
-relying on the cap alone.
+The motivation holds: a resolution cap only *disables* autoquality above the
+threshold (the request falls back to fixed quality), forfeiting the 40–58% savings
+exactly on the large, high-detail images where they matter most. And the speedup
+is real — Part C measured ~3.4× at `k=2` up to ~9.7× at `k=4`, matching the `k²`
+expectation.
+
+But Part C also shows the naïve form — *downscale, search, deliver* — is **not** a
+clean win: the quality-transfer error is two-directional and content-dependent
+(real content over-picks → byte overshoot up to +49%; the adversarial chirp
+under-picks → quality undershoot), and a single additive margin can't fix both.
+Two shapes survive the data:
+
+- **Modest downscale (`k≈2`)** — ~3.4× faster with Δq in `[−1, +9]`, ≤+2% byte
+  overshoot, and a +1q margin covering the only undershoot. Simple; most of the
+  win with little risk.
+- **Confirm-and-adjust for aggressive downscale** — search on the proxy, then do
+  the *one* full-res confirm metric (already part of the per-request budget — it's
+  a single pass, vs. the 4–6 the full search runs) and bump quality if it missed.
+  This makes the method robust at high `k` (the only way to keep both quality and
+  savings when the bias is large).
+
+Recommendation: prototype `k≈2` first (cheapest, lowest-risk), and gate anything
+more aggressive behind a full-res confirm. Do **not** ship a fixed-margin proxy.
+Note the accuracy caveat above — the large-scale real-content signal is inferred,
+so validate on genuinely large photos before committing to a default `k`.

--- a/docs/autoquality_benchmark.md
+++ b/docs/autoquality_benchmark.md
@@ -117,50 +117,61 @@ the portable conclusions**. Re-run locally to calibrate a host's budget.
 
 ### Part C — downscaled-proxy-seed method + accuracy
 
-Per source × downscale factor, full-res search vs. proxy-seed. `Δq = q_proxy −
+Full-res search vs. proxy-seed, per subject × downscale factor. `Δq = q_proxy −
 q_full`; `delivered` is the true full-res SSIMULACRA2 score of the full-res encode
-at `q_proxy`; `bytesΔ` is delivered bytes vs. the full-res optimum.
+at `q_proxy`; `bytesΔ` is delivered bytes vs. the full-res optimum. Ground truth is
+the **full-res search**, not the absolute target (which the full search itself can
+miss at the bracket ceiling — see `aq_157`).
 
-| source        | MP   | k | q_full | q_proxy | Δq  | delivered | Δtarget | hit | bytesΔ | speedup |
-|---------------|------|---|--------|---------|-----|-----------|---------|-----|--------|---------|
-| high_freq.jpg | 1.92 | 2 | 40     | 41      | +1  | 90.03     | +2.03   | yes | +2%    | 3.1×    |
-| high_freq.jpg | 1.92 | 3 | 40     | 58      | +18 | 91.71     | +3.71   | yes | +19%   | 6.1×    |
-| high_freq.jpg | 1.92 | 4 | 40     | 75      | +35 | 93.64     | +5.64   | yes | +49%   | 9.8×    |
-| marker.png    | 1.92 | 2 | 74     | 83      | +9  | 90.26     | +2.26   | yes | +1%    | 3.5×    |
-| border.png    | 1.92 | 4 | 73     | 73      | 0   | 88.71     | +0.71   | yes | 0%     | 9.6×    |
-| placement.png | 1.92 | 2 | 90     | 90      | 0   | 88.85     | +0.85   | yes | 0%     | 3.3×    |
-| placement.png | 1.92 | 4 | 90     | 90      | 0   | 88.85     | +0.85   | yes | 0%     | 8.9×    |
-| zone-16MP     | 16.0 | 2 | 95     | 94      | −1  | 87.47     | −0.53   | **NO** | −7% | 3.6×    |
-| zone-16MP     | 16.0 | 3 | 95     | 91      | −4  | 82.85     | −5.15   | **NO** | −19% | 7.0×  |
-| zone-16MP     | 16.0 | 4 | 95     | 94      | −1  | 87.47     | −0.53   | **NO** | −7% | 9.6×    |
+**Committed sources (≤2 MP) + adversarial synthetic:**
 
-Aggregated per factor (5 real subjects + 1 adversarial synthetic):
+| source        | MP   | k | q_full | q_proxy | Δq  | delivered | hit | bytesΔ | speedup |
+|---------------|------|---|--------|---------|-----|-----------|-----|--------|---------|
+| high_freq.jpg | 1.92 | 2 | 40     | 41      | +1  | 90.03     | yes | +2%    | 3.1×    |
+| high_freq.jpg | 1.92 | 4 | 40     | 75      | +35 | 93.64     | yes | +49%   | 9.8×    |
+| marker.png    | 1.92 | 2 | 74     | 83      | +9  | 90.26     | yes | +1%    | 3.5×    |
+| placement.png | 1.92 | 4 | 90     | 90      | 0   | 88.85     | yes | 0%     | 8.9×    |
+| zone-16MP     | 16.0 | 3 | 95     | 91      | −4  | 82.85     | **NO** | −19% | 7.0× |
 
-| k | target hit @margin 0 | Δq mean / worst | margin that fixes | worst undershoot | worst byte overshoot | speedup |
-|---|----------------------|-----------------|-------------------|------------------|----------------------|---------|
-| 2 | 5/6                  | +3.2 / −1       | +1q               | −0.53            | +2%                  | ~3.4×   |
-| 3 | 5/6                  | +6.0 / −4       | +4q               | −5.15            | +19%                 | ~6.7×   |
-| 4 | 5/6                  | +9.3 / −1       | +1q               | −0.53            | +49%                 | ~9.7×   |
+**Large real photos (16–20 MP, Unsplash via Lorem Picsum, `--proxy-files`):**
 
-**The proxy method works, but its error is two-directional and content-dependent
-— it is not a clean win:**
+| source     | MP    | k | q_full | q_proxy | Δq  | full_score | delivered | vs target | bytesΔ | speedup |
+|------------|-------|---|--------|---------|-----|------------|-----------|-----------|--------|---------|
+| aq_146.jpg | 16.66 | 2 | 74     | 92      | +18 | 90.82      | 90.58     | hit       | **+56%** | 3.8×  |
+| aq_146.jpg | 16.66 | 4 | 74     | 93      | +19 | 90.82      | 90.87     | hit       | **+69%** | 14.8× |
+| aq_201.jpg | 16.66 | 2 | 93     | 95      | +2  | 88.02      | 88.32     | hit       | +14%   | 3.9×    |
+| aq_201.jpg | 16.66 | 4 | 93     | 92      | −1  | 88.02      | 87.64     | miss −0.36| −8%    | 12.7×   |
+| aq_157.jpg | 19.57 | 2 | 95     | 95      | 0   | 86.47      | 86.47     | full also misses | 0% | 4.9× |
 
-- **Real high-detail content over-picks quality** (Δq ≥ 0): the downscaled proxy
-  loses the hard-to-compress detail, so the search on it reads the content as
-  *harder* and picks a higher quality. The delivered full-res image clears the
-  target (every real source hit, all k) — but the encode is **larger than the
-  optimal full-res pick**, eroding the very savings autoquality exists to capture.
-  At `k=4`, `high_freq` delivered **+49% bytes** vs. the full-res optimum (q75 vs.
-  the correct q40).
-- **The adversarial chirp under-picks** (Δq < 0): the zone-plate downscales into a
-  lower-frequency zone-plate the metric scores more easily, so `q_proxy` lands
-  below `q_full` and the delivered full-res score **undershoots** (e.g. `k=3`:
-  82.85 vs. target 88). This is the quality-risk failure mode.
-- **A single additive margin can't satisfy both directions** — the margin that
-  rescues the undershoot makes the byte overshoot worse.
-- **`k=2` is the sweet spot:** ~3.4× speedup with Δq in `[−1, +9]`, worst
-  undershoot −0.53 (a +1q margin fixes it), and ≤+2% byte overshoot. Aggressive
-  downscale (`k≥3`) trades that balance for speed.
+Aggregated over the large-photo run (3 real + synthetic):
+
+| k | proxy-caused undershoots (of full-hit) | worst Δscore vs full | worst over-pick | speedup |
+|---|----------------------------------------|----------------------|-----------------|---------|
+| 2 | 1/3 | −1.13 | +18q / +56% bytes | ~3.9× |
+| 3 | 1/3 | −5.75 | +19q / +69% bytes | ~7.9× |
+| 4 | 2/3 | −1.13 | +19q / +69% bytes | ~12.0× |
+
+**The speedup is real (~3.9× at k=2 up to ~12× at k=4), but the large-scale test
+overturns the optimistic read from the ≤2 MP sources. The method is not a clean
+win:**
+
+- **SSIMULACRA2 is resolution-dependent — a given quality scores *lower* on a
+  downscaled image** — so the search on the proxy systematically **over-picks
+  quality** to clear the same score. Crucially, the over-pick **grows with image
+  size**: it was +1–2q on the ≤2 MP sources but **+18q on a 16 MP photo**, where
+  the proxy shipped **+56–69% more bytes** than the optimal full-res pick (`aq_146`:
+  q92 vs. the correct q74, for the same delivered ~90.6 score). This erodes — often
+  erases — the savings autoquality exists to capture, and it is the *expensive*
+  direction to undo (recovering it needs a downward full-res search).
+- **Undershoot still happens on real content** when the full score sits right on
+  the target band (`aq_201` k=4: delivered 87.64 vs. 88). The adversarial chirp
+  undershoots hard (k=3: 82.85). This direction is cheap to fix (bump q + one
+  confirm) — but the over-pick is not.
+- **A single additive margin can't help** — it only addresses undershoot, and
+  worsens the dominant over-pick.
+- **The ≤2 MP "k=2 sweet spot" does not generalize:** at 16 MP, even k=2 over-shot
+  bytes by +56%. The earlier caveat (no large real sources) was the right one to
+  flag — the cross-scale signal reverses the conclusion.
 
 ## Findings & recommendations
 
@@ -195,30 +206,31 @@ defaults. (`max_iterations 6` is already generous for the `[70,80]` default
 bracket, which needs only ~4 probes; lowering it would not help the dominant
 metric cost on the wide-bracket worst case but would cap pathological brackets.)
 
-### 3. The downscaled-proxy-seed optimization works, but needs the right shape
+### 3. The downscaled-proxy-seed optimization is harder than it looks — do not ship the naïve form
 
-The motivation holds: a resolution cap only *disables* autoquality above the
-threshold (the request falls back to fixed quality), forfeiting the 40–58% savings
-exactly on the large, high-detail images where they matter most. And the speedup
-is real — Part C measured ~3.4× at `k=2` up to ~9.7× at `k=4`, matching the `k²`
-expectation.
+The motivation still holds: a resolution cap only *disables* autoquality above the
+threshold, forfeiting savings exactly on the large images where they matter, and
+the proxy speedup is real (~3.9× at `k=2`, ~12× at `k=4`). **But the large-photo
+test (recommendation follow-up) shows the naïve *downscale → search → deliver* form
+fails on its own terms at production scale**, because SSIMULACRA2 is
+resolution-dependent: the search on the downscaled proxy systematically *over-picks*
+quality, and the over-pick grows with image size (+18q / +56–69% bytes on a 16 MP
+photo). That inflates the delivered file well beyond the optimal full-res pick —
+erasing the savings — and it is the *expensive* direction to correct (a cheap
+one-pass confirm-and-adjust only rescues the rarer undershoot, not the over-pick).
 
-But Part C also shows the naïve form — *downscale, search, deliver* — is **not** a
-clean win: the quality-transfer error is two-directional and content-dependent
-(real content over-picks → byte overshoot up to +49%; the adversarial chirp
-under-picks → quality undershoot), and a single additive margin can't fix both.
-Two shapes survive the data:
+So the earlier "ship `k≈2`" read was wrong — it was an artifact of testing only
+≤2 MP sources. Revised guidance:
 
-- **Modest downscale (`k≈2`)** — ~3.4× faster with Δq in `[−1, +9]`, ≤+2% byte
-  overshoot, and a +1q margin covering the only undershoot. Simple; most of the
-  win with little risk.
-- **Confirm-and-adjust for aggressive downscale** — search on the proxy, then do
-  the *one* full-res confirm metric (already part of the per-request budget — it's
-  a single pass, vs. the 4–6 the full search runs) and bump quality if it missed.
-  This makes the method robust at high `k` (the only way to keep both quality and
-  savings when the bias is large).
+- **Do not ship a fixed-margin / fixed-`k` naïve proxy.** It over-charges bytes on
+  real large images, defeating the point.
+- **A viable proxy needs its target calibrated across resolution** — i.e. search
+  the proxy against a *shifted* score that maps to the true full-res target for
+  that downscale factor. That calibration is the actual research problem; this
+  benchmark (`--part c --proxy-files …`) is the harness to derive and validate it.
+- **In the meantime, the resolution cap (recommendation #1) is the safe shipping
+  answer**, accepting that very large images fall back to fixed quality rather than
+  paying a 4–20 s search or shipping an over-inflated proxy result.
 
-Recommendation: prototype `k≈2` first (cheapest, lowest-risk), and gate anything
-more aggressive behind a full-res confirm. Do **not** ship a fixed-margin proxy.
-Note the accuracy caveat above — the large-scale real-content signal is inferred,
-so validate on genuinely large photos before committing to a default `k`.
+The benchmark now ships with `--proxy-files` so this can be re-run on any corpus of
+large images when the calibrated variant is prototyped.

--- a/mix.exs
+++ b/mix.exs
@@ -67,6 +67,7 @@ defmodule ImagePipe.MixProject do
         coveralls: :test,
         "coveralls.html": :test,
         "autoquality.bench": :test,
+        "autoquality.corpus": :test,
         "imgproxy.diagnose": :test,
         "imgproxy.gen_report": :test,
         "imgproxy.reauthor": :test,

--- a/mix.exs
+++ b/mix.exs
@@ -66,6 +66,7 @@ defmodule ImagePipe.MixProject do
       preferred_envs: [
         coveralls: :test,
         "coveralls.html": :test,
+        "autoquality.bench": :test,
         "imgproxy.diagnose": :test,
         "imgproxy.gen_report": :test,
         "imgproxy.reauthor": :test,

--- a/test/support/mix/tasks/autoquality.bench.ex
+++ b/test/support/mix/tasks/autoquality.bench.ex
@@ -16,9 +16,11 @@ defmodule Mix.Tasks.Autoquality.Bench do
       mise exec -- mix autoquality.bench --part a        # cost curve only
       mise exec -- mix autoquality.bench --part b        # accuracy/behavior only
       mise exec -- mix autoquality.bench --part c        # proxy-seed method + accuracy
-      mise exec -- mix autoquality.bench --part all      # A + B + C
+      mise exec -- mix autoquality.bench --part d        # cheap full-res metric narrowing
+      mise exec -- mix autoquality.bench --part all      # A + B + C + D
       mise exec -- mix autoquality.bench --mps 1,4,9     # custom Part A megapixels
       mise exec -- mix autoquality.bench --proxy-factors 2,4 --proxy-mp 25  # Part C knobs
+      mise exec -- mix autoquality.bench --part c --proxy-files a.jpg,b.jpg # large real photos
       mise exec -- mix autoquality.bench --csv           # also write CSVs under /tmp
 
   ## Part A — per-megapixel cost curve
@@ -67,6 +69,26 @@ defmodule Mix.Tasks.Autoquality.Bench do
   +56% bytes). That savings loss is the expensive direction to undo; a cheap
   confirm-and-adjust only rescues the rarer undershoot. So a naive downscale+margin
   proxy is not viable — a correct one needs its target calibrated across resolution.
+
+  ## Part D — cheap full-res metric narrowing (#6)
+
+  Tests whether a CHEAP full-res metric (PSNR variants — no XYB/multiscale SSIM
+  cost) can narrow the search so SSIMULACRA2 runs ~once instead of ~4–6×. The final
+  decision stays full-res SSIMULACRA2, so there is no resolution bias (Part C's
+  trap). Viability hinges on whether the cheap metric's value AT the SSIMULACRA2
+  boundary is stable across images: a tight spread ⇒ one global threshold narrows
+  reliably; a wide spread ⇒ content-dependent, so a global threshold mis-locates the
+  boundary. We measure that spread, then simulate the global-threshold strategy
+  (cheap bisection to a quality, one SSIMULACRA2 confirm) against the full-res
+  search as oracle. Subjects/flags as Part C.
+
+  Finding: PSNR-class metrics are NOT viable here. The cheap value at the boundary
+  spans 11–22 dB across content (high-frequency images clear the target at low PSNR;
+  clean graphics need high PSNR), so a global threshold underpicks by up to ~28q or
+  overpicks by >100% bytes. The metric is ~9–11× cheaper, but it does not track the
+  perceptual boundary. Narrowing would need a cheaper *perceptual* metric
+  (MS-SSIM/butteraugli — not in our stack) or per-image SSIMULACRA2 anchoring (which
+  saves ~0 probes on the shipped narrow [70,80] bracket).
   """
   use Mix.Task
   use Boundary, top_level?: true, check: [out: false]
@@ -140,6 +162,8 @@ defmodule Mix.Tasks.Autoquality.Bench do
       if part in ["c", "all"],
         do: run_part_c(factors, proxy_mp, proxy_files, format),
         else: nil
+
+    if part in ["d", "all"], do: run_part_d(proxy_files, proxy_mp, format)
 
     if csv? do
       if a_rows, do: write_part_a_csv(a_rows)
@@ -441,22 +465,7 @@ defmodule Mix.Tasks.Autoquality.Bench do
     IO.puts(String.duplicate("-", String.length(header)))
 
     resolved = ssim2_resolved(format)
-
-    # External files (e.g. genuinely large real photos) replace the small
-    # committed set when given, so the run can target production-scale content the
-    # repo can't carry. The adversarial synthetic always anchors the worst case.
-    real =
-      case proxy_files do
-        [] ->
-          Enum.map(@part_c_sources, fn f -> {f, base_image_at(Path.join(@sources_dir, f))} end)
-
-        paths ->
-          Enum.map(paths, fn p -> {Path.basename(p), base_image_at(p)} end)
-      end
-
-    subjects =
-      Enum.reject(real, fn {_l, img} -> is_nil(img) end) ++
-        [{"zone-#{synth_mp}MP", zone_plate_for(synth_mp)}]
+    subjects = load_subjects(proxy_files, synth_mp)
 
     subjects
     |> Enum.flat_map(fn {label, base} ->
@@ -556,6 +565,244 @@ defmodule Mix.Tasks.Autoquality.Bench do
       flat
     else
       image
+    end
+  end
+
+  # Shared by Parts C and D. External files (e.g. genuinely large real photos)
+  # replace the small committed set when given, so the run can target
+  # production-scale content the repo can't carry. The adversarial synthetic
+  # always anchors the worst case.
+  defp load_subjects(proxy_files, synth_mp) do
+    real =
+      case proxy_files do
+        [] ->
+          Enum.map(@part_c_sources, fn f -> {f, base_image_at(Path.join(@sources_dir, f))} end)
+
+        paths ->
+          Enum.map(paths, fn p -> {Path.basename(p), base_image_at(p)} end)
+      end
+
+    Enum.reject(real, fn {_l, img} -> is_nil(img) end) ++
+      [{"zone-#{synth_mp}MP", zone_plate_for(synth_mp)}]
+  end
+
+  # --- Part D: cheap full-res metric narrowing (#6) --------------------------
+
+  # Can a CHEAP full-res metric (PSNR variants — no XYB/multiscale SSIM cost)
+  # narrow the search so SSIMULACRA2 runs ~once instead of ~4-6×, landing on the
+  # quality the full-res search picks? The final decision stays full-res
+  # SSIMULACRA2, so there is no resolution bias (Part C's trap). The viability
+  # hinges on ONE thing: is the cheap metric's value AT the SSIMULACRA2 boundary
+  # stable across images? A tight spread ⇒ a single global threshold narrows
+  # reliably; a wide spread ⇒ the cheap→target mapping is content-dependent and a
+  # global threshold under/over-picks. We measure that spread, then simulate the
+  # global-threshold strategy (cheap bisection to q, then one SSIMULACRA2 confirm)
+  # against the full-res search as oracle.
+  @cheap_metrics [:psnr_rgb, :psnr_luma]
+
+  defp run_part_d(proxy_files, synth_mp, format) do
+    IO.puts("\n== Part D — cheap full-res metric narrowing (#6) ==")
+    IO.puts("oracle = full-res ssim2 search, target #{@target} [#{@min_q},#{@max_q}]  ")
+    IO.puts("cheap metrics #{inspect(@cheap_metrics)}  format #{format}\n")
+
+    resolved = ssim2_resolved(format)
+    subjects = load_subjects(proxy_files, synth_mp)
+
+    # Pass 1: oracle + the cheap value(s) at the oracle boundary (only meaningful
+    # where the oracle actually hit the target — a best-effort ceiling has no
+    # boundary, so it can't calibrate or be scored).
+    pass1 =
+      Enum.map(subjects, fn {label, base} ->
+        {:ok, _bin, om} = EncodeSearch.run(base, resolved, telemetry_opts: [])
+
+        boundary =
+          if om.score >= @target,
+            do: cheap_values(base, om.quality, format),
+            else: nil
+
+        %{
+          label: label,
+          base: base,
+          q_oracle: om.quality,
+          score_oracle: om.score,
+          oracle_probes: om.iterations,
+          bytes_oracle: om.bytes,
+          boundary: boundary
+        }
+      end)
+
+    calibrated = Enum.filter(pass1, & &1.boundary)
+
+    thresholds =
+      Map.new(@cheap_metrics, fn m -> {m, median(Enum.map(calibrated, & &1.boundary[m]))} end)
+
+    cheap_us = sample_cheap_us(pass1, format)
+    report_part_d(pass1, calibrated, thresholds, resolved, format, cheap_us)
+  end
+
+  defp report_part_d(pass1, calibrated, thresholds, resolved, format, cheap_us) do
+    Enum.each(@cheap_metrics, fn metric ->
+      threshold = thresholds[metric]
+      IO.puts("--- #{metric}: global threshold #{Float.round(threshold, 2)} ---")
+
+      vals = Enum.map(calibrated, & &1.boundary[metric])
+
+      IO.puts(
+        "  cheap@boundary spread: #{spread_note(vals)}  (n=#{length(calibrated)} subjects that hit target)"
+      )
+
+      header =
+        pad(["source", 18]) <>
+          pad(["qOracle", 8]) <>
+          pad(["qCheap", 8]) <>
+          pad(["dq", 5]) <>
+          pad(["cheap@bnd", 11]) <>
+          pad(["bytesΔ", 9]) <>
+          pad(["verdict", 10])
+
+      IO.puts(header)
+      IO.puts(String.duplicate("-", String.length(header)))
+
+      rows = Enum.map(calibrated, &part_d_row(&1, metric, threshold, resolved, format))
+      print_part_d_findings(metric, rows, pass1, cheap_us)
+    end)
+
+    report_skipped(pass1)
+  end
+
+  defp part_d_row(s, metric, threshold, resolved, format) do
+    q_cheap = bisect_cheap_q(s.base, format, metric, threshold)
+    bytes_cheap = byte_size_at(s.base, resolved, q_cheap)
+    dq = q_cheap - s.q_oracle
+    bytes_delta = pct(bytes_cheap - s.bytes_oracle, s.bytes_oracle)
+    verdict = verdict_for(dq)
+
+    IO.puts(
+      pad([s.label, 18]) <>
+        pad([s.q_oracle, 8]) <>
+        pad([q_cheap, 8]) <>
+        pad([dq, 5]) <>
+        pad([Float.round(s.boundary[metric], 2), 11]) <>
+        pad(["#{bytes_delta}%", 9]) <>
+        pad([verdict, 10])
+    )
+
+    %{
+      label: s.label,
+      metric: metric,
+      q_oracle: s.q_oracle,
+      q_cheap: q_cheap,
+      dq: dq,
+      bytes_delta: bytes_delta
+    }
+  end
+
+  defp verdict_for(dq) when dq < 0, do: "UNDERPICK"
+  defp verdict_for(dq) when dq > 0, do: "overpick"
+  defp verdict_for(_dq), do: "exact"
+
+  defp report_skipped(pass1) do
+    skipped = Enum.reject(pass1, & &1.boundary)
+
+    if skipped != [] do
+      labels =
+        Enum.map_join(
+          skipped,
+          ", ",
+          &"#{&1.label} (oracle #{fmt_score(&1.score_oracle)} < target)"
+        )
+
+      IO.puts("(excluded — full-res search itself misses target, no boundary: #{labels})")
+    end
+  end
+
+  defp print_part_d_findings(_metric, rows, pass1, {cheap_us, ssim2_us}) do
+    n = length(rows)
+    exact = Enum.count(rows, &(&1.dq == 0))
+    within1 = Enum.count(rows, &(abs(&1.dq) <= 1))
+    underpicks = Enum.filter(rows, &(&1.dq < 0))
+    worst_under = rows |> Enum.map(& &1.dq) |> Enum.min()
+    overpicks = Enum.filter(rows, &(&1.dq > 0))
+    worst_waste = overpicks |> Enum.map(& &1.bytes_delta) |> max_or_zero()
+    oracle_probes = pass1 |> Enum.map(& &1.oracle_probes) |> avg() |> Float.round(1)
+
+    IO.puts("  exact-q #{exact}/#{n}, within-1q #{within1}/#{n}")
+
+    IO.puts(
+      "  underpick (dangerous) #{length(underpicks)}/#{n} (worst #{worst_under}q)  |  " <>
+        "overpick byte waste worst +#{worst_waste}%"
+    )
+
+    IO.puts(
+      "  ssim2 probes: oracle ~#{oracle_probes} → candidate 1 confirm (+1-2 on underpick retry)  |  " <>
+        "cheap eval ~#{ms(cheap_us)}ms vs ssim2 ~#{ms(ssim2_us)}ms (#{ratio(ssim2_us, cheap_us)}× cheaper)\n"
+    )
+  end
+
+  # Cheap metric value(s) of a candidate encoded at `q` against the finalized
+  # reference. PSNR in dB (higher = better, monotone-ish in q).
+  defp cheap_values(base, q, format) do
+    {:ok, bin} = Encoder.encode_to_buffer(base, plain_resolved(format, q), q)
+    {:ok, cand} = Image.from_binary(bin)
+    Map.new(@cheap_metrics, fn m -> {m, cheap_metric(m, base, cand)} end)
+  end
+
+  defp cheap_metric(:psnr_rgb, ref, cand), do: psnr(ref, cand)
+
+  defp cheap_metric(:psnr_luma, ref, cand) do
+    {:ok, ref_l} = Operation.colourspace(ref, :VIPS_INTERPRETATION_B_W)
+    {:ok, cand_l} = Operation.colourspace(cand, :VIPS_INTERPRETATION_B_W)
+    psnr(ref_l, cand_l)
+  end
+
+  defp psnr(ref, cand) do
+    {:ok, rf} = Operation.cast(ref, :VIPS_FORMAT_FLOAT)
+    {:ok, cf} = Operation.cast(cand, :VIPS_FORMAT_FLOAT)
+    {:ok, diff} = Operation.subtract(rf, cf)
+    {:ok, sq} = Operation.multiply(diff, diff)
+    {:ok, mse} = Operation.avg(sq)
+    if mse <= 0.0, do: 99.0, else: 10 * :math.log10(255 * 255 / mse)
+  end
+
+  # Lowest q whose cheap metric clears `threshold` (monotone-increasing in q).
+  # Pure cheap probes — no SSIMULACRA2.
+  defp bisect_cheap_q(base, format, metric, threshold) do
+    do_bisect_cheap(base, format, metric, threshold, @min_q, @max_q, @max_q)
+  end
+
+  defp do_bisect_cheap(_base, _format, _metric, _threshold, lo, hi, best) when lo > hi, do: best
+
+  defp do_bisect_cheap(base, format, metric, threshold, lo, hi, best) do
+    mid = div(lo + hi, 2)
+    {:ok, bin} = Encoder.encode_to_buffer(base, plain_resolved(format, mid), mid)
+    {:ok, cand} = Image.from_binary(bin)
+
+    if cheap_metric(metric, base, cand) >= threshold,
+      do: do_bisect_cheap(base, format, metric, threshold, lo, mid - 1, mid),
+      else: do_bisect_cheap(base, format, metric, threshold, mid + 1, hi, best)
+  end
+
+  defp byte_size_at(base, resolved, q) do
+    {:ok, bin} = Encoder.encode_to_buffer(base, resolved, q)
+    byte_size(bin)
+  end
+
+  # One paired timing of a cheap eval vs a full SSIMULACRA2 eval, on the first
+  # calibrated subject, to quantify "how much cheaper".
+  defp sample_cheap_us(pass1, format) do
+    case Enum.find(pass1, & &1.boundary) do
+      nil ->
+        {1, 1}
+
+      s ->
+        {:ok, bin} =
+          Encoder.encode_to_buffer(s.base, plain_resolved(format, s.q_oracle), s.q_oracle)
+
+        {:ok, cand} = Image.from_binary(bin)
+        {cheap_us, _} = timed(fn -> cheap_metric(:psnr_rgb, s.base, cand) end)
+        {:ok, ref} = Ssim2Metric.reference(s.base)
+        {ssim2_us, _} = timed(fn -> Ssim2Metric.score(ref, cand) end)
+        {cheap_us, ssim2_us}
     end
   end
 
@@ -874,6 +1121,28 @@ defmodule Mix.Tasks.Autoquality.Bench do
 
   defp avg([]), do: 0
   defp avg(list), do: Enum.sum(list) / length(list)
+
+  defp median([]), do: 0.0
+
+  defp median(list) do
+    sorted = Enum.sort(list)
+    n = length(sorted)
+    mid = div(n, 2)
+
+    if rem(n, 2) == 1,
+      do: Enum.at(sorted, mid),
+      else: (Enum.at(sorted, mid - 1) + Enum.at(sorted, mid)) / 2
+  end
+
+  defp max_or_zero([]), do: 0
+  defp max_or_zero(list), do: Enum.max(list)
+
+  defp spread_note([]), do: "n/a"
+
+  defp spread_note(vals) do
+    "#{Float.round(Enum.min(vals), 2)}…#{Float.round(Enum.max(vals), 2)} " <>
+      "(range #{Float.round(Enum.max(vals) - Enum.min(vals), 2)})"
+  end
 
   defp fmt_score(nil), do: "-"
   defp fmt_score(score), do: Float.round(score, 2)

--- a/test/support/mix/tasks/autoquality.bench.ex
+++ b/test/support/mix/tasks/autoquality.bench.ex
@@ -17,7 +17,8 @@ defmodule Mix.Tasks.Autoquality.Bench do
       mise exec -- mix autoquality.bench --part b        # accuracy/behavior only
       mise exec -- mix autoquality.bench --part c        # proxy-seed method + accuracy
       mise exec -- mix autoquality.bench --part d        # cheap full-res metric narrowing
-      mise exec -- mix autoquality.bench --part all      # A + B + C + D
+      mise exec -- mix autoquality.bench --part e --corpus DIR  # crop-based scoring
+      mise exec -- mix autoquality.bench --part all      # A + B + C + D + E
       mise exec -- mix autoquality.bench --mps 1,4,9     # custom Part A megapixels
       mise exec -- mix autoquality.bench --proxy-factors 2,4 --proxy-mp 25  # Part C knobs
       mise exec -- mix autoquality.bench --part c --proxy-files a.jpg,b.jpg # large real photos
@@ -89,6 +90,26 @@ defmodule Mix.Tasks.Autoquality.Bench do
   perceptual boundary. Narrowing would need a cheaper *perceptual* metric
   (MS-SSIM/butteraugli — not in our stack) or per-image SSIMULACRA2 anchoring (which
   saves ~0 probes on the shipped narrow [70,80] bracket).
+
+  ## Part E — crop-based scoring vs full-frame (#1)
+
+  Scores SSIMULACRA2 on native-resolution tiles of the *actual full-res encode*
+  instead of the whole frame. Unlike Part C's proxy this keeps native resolution,
+  so per-pixel artifact statistics match — the only error is *which regions* you
+  look at. Runs on a curated `--corpus DIR` (assemble one spanning smooth /
+  heterogeneous / dark / busy / text content; the committed sources are too
+  synthetic). Reports, binned by measured heterogeneity: (1) tracking — the offset
+  `tile_aggregate − full_frame_score` at the boundary (tight ⇒ a calibrated global
+  threshold reproduces the full-frame decision); (2) sub-sampling penalty — K tiles
+  vs full coverage; (3) cost — K tiles is a fixed pixel budget regardless of size.
+
+  Finding: crop scoring is the first lever that TRACKS. The p10-tile offset holds
+  within ±~1.5 pts (median ~0) across content — vs Part C's ±18q and Part D's
+  hopeless spread — because native resolution is preserved. K=16-tile sub-sampling
+  adds only ~+0.3 (worst +1.6) pts. Full tile coverage saves nothing, but the fixed
+  K-tile budget beats full-frame above a ~4 MP crossover: ~1.6× at 10.7 MP, ~2.3× at
+  16 MP, and (budget being size-independent) growing with size. So crop scoring is a
+  viable speedup for large images — use full-frame below the crossover.
   """
   use Mix.Task
   use Boundary, top_level?: true, check: [out: false]
@@ -140,7 +161,8 @@ defmodule Mix.Tasks.Autoquality.Bench do
           format: :string,
           proxy_factors: :string,
           proxy_mp: :integer,
-          proxy_files: :string
+          proxy_files: :string,
+          corpus: :string
         ]
       )
 
@@ -151,27 +173,43 @@ defmodule Mix.Tasks.Autoquality.Bench do
     factors = parse_factors(Keyword.get(opts, :proxy_factors))
     proxy_files = parse_files(Keyword.get(opts, :proxy_files))
     proxy_mp = Keyword.get(opts, :proxy_mp, 16)
+    corpus_files = corpus_files(Keyword.get(opts, :corpus), proxy_files)
 
     {:ok, _} = Application.ensure_all_started(:image_pipe)
     warmup(format)
 
-    a_rows = if part in ["a", "both", "all"], do: run_part_a(mps, format), else: nil
-    b_rows = if part in ["b", "both", "all"], do: run_part_b(format), else: nil
+    run_ctx = %{
+      part: part,
+      mps: mps,
+      factors: factors,
+      proxy_mp: proxy_mp,
+      proxy_files: proxy_files,
+      corpus_files: corpus_files,
+      format: format
+    }
 
-    c_rows =
-      if part in ["c", "all"],
-        do: run_part_c(factors, proxy_mp, proxy_files, format),
-        else: nil
+    {a_rows, b_rows, c_rows, e_rows} = run_selected_parts(run_ctx)
+    if csv?, do: write_csvs(a_rows, b_rows, c_rows, e_rows)
+    print_findings(a_rows, b_rows, c_rows, e_rows, format)
+  end
 
-    if part in ["d", "all"], do: run_part_d(proxy_files, proxy_mp, format)
+  defp run_selected_parts(%{part: part, format: format} = ctx) do
+    a = if part in ["a", "both", "all"], do: run_part_a(ctx.mps, format)
+    b = if part in ["b", "both", "all"], do: run_part_b(format)
 
-    if csv? do
-      if a_rows, do: write_part_a_csv(a_rows)
-      if b_rows, do: write_part_b_csv(b_rows)
-      if c_rows, do: write_part_c_csv(c_rows)
-    end
+    c =
+      if part in ["c", "all"], do: run_part_c(ctx.factors, ctx.proxy_mp, ctx.proxy_files, format)
 
-    print_findings(a_rows, b_rows, c_rows, format)
+    if part in ["d", "all"], do: run_part_d(ctx.proxy_files, ctx.proxy_mp, format)
+    e = if part in ["e", "all"], do: run_part_e(ctx.corpus_files, ctx.proxy_mp, format)
+    {a, b, c, e}
+  end
+
+  defp write_csvs(a_rows, b_rows, c_rows, e_rows) do
+    if a_rows, do: write_part_a_csv(a_rows)
+    if b_rows, do: write_part_b_csv(b_rows)
+    if c_rows, do: write_part_c_csv(c_rows)
+    if e_rows, do: write_part_e_csv(e_rows)
   end
 
   # Touch every NIF/libvips path once so first-call JIT + library init does not
@@ -806,6 +844,256 @@ defmodule Mix.Tasks.Autoquality.Bench do
     end
   end
 
+  # --- Part E: crop-based scoring vs full-frame (#1) -------------------------
+
+  # Score SSIMULACRA2 on native-resolution tiles of the actual full-res encode,
+  # instead of the whole frame. Unlike the proxy (Part C) this keeps native
+  # resolution, so per-pixel artifact statistics match — the only error is *which
+  # regions* you look at. Three questions:
+  #   1. Tracking — does a tile aggregate (worst / p10 / mean) at the full-frame
+  #      boundary sit at a STABLE value across content? (a global threshold on it
+  #      would then ≈ the full-frame target). Reported as the @boundary spread.
+  #   2. Sub-sampling — full tile coverage costs ~the same as the full frame, so
+  #      the speedup needs scoring only K tiles. Does K-tile sampling still catch
+  #      the worst region, or does it miss localized banding? (penalty vs all-tile)
+  #   3. Cost — K tiles is a fixed pixel budget regardless of image size.
+  # All binned by measured heterogeneity (HET), since heterogeneous images
+  # (smooth + detail) are where crop sampling is most at risk.
+  @tile 512
+  @subsample_k 16
+
+  defp run_part_e(corpus_files, synth_mp, format) do
+    IO.puts("\n== Part E — crop-based scoring vs full-frame (#1) ==")
+    IO.puts("oracle = full-frame full-res ssim2, target #{@target} [#{@min_q},#{@max_q}]  ")
+    IO.puts("tile #{@tile}px  subsample K=#{@subsample_k}  format #{format}\n")
+
+    resolved = ssim2_resolved(format)
+    subjects = load_subjects(corpus_files, synth_mp)
+
+    header =
+      pad(["source", 16]) <>
+        pad(["MP", 6]) <>
+        pad(["HET", 6]) <>
+        pad(["tiles", 6]) <>
+        pad(["fullSc", 8]) <>
+        pad(["worst", 7]) <>
+        pad(["p10", 7]) <>
+        pad(["mean", 7]) <>
+        pad(["subWorst", 9]) <>
+        pad(["wSmooth", 8])
+
+    IO.puts(header)
+    IO.puts(String.duplicate("-", String.length(header)))
+
+    subjects
+    |> Enum.map(fn {label, base} -> bench_crop_subject(label, base, resolved, format) end)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp bench_crop_subject(label, base, resolved, format) do
+    {:ok, _bin, om} = EncodeSearch.run(base, resolved, telemetry_opts: [])
+    mp = Float.round(Image.width(base) * Image.height(base) / 1_000_000, 1)
+
+    if om.score < @target do
+      IO.puts(
+        pad([label, 16]) <>
+          pad([mp, 6]) <> "skipped (full-res misses target: #{fmt_score(om.score)})"
+      )
+
+      nil
+    else
+      crop_subject_row(label, base, mp, om, format)
+    end
+  end
+
+  defp crop_subject_row(label, base, mp, om, format) do
+    {:ok, cbin} = Encoder.encode_to_buffer(base, plain_resolved(format, om.quality), om.quality)
+    {:ok, cand} = Image.from_binary(cbin)
+
+    {:ok, fref} = Ssim2Metric.reference(base)
+    {full_us, {:ok, _}} = timed(fn -> Ssim2Metric.score(fref, cand) end)
+
+    coords = tile_coords(Image.width(base), Image.height(base), @tile)
+    tiles = Enum.map(coords, &tile_metrics(base, cand, &1))
+
+    scores = Enum.map(tiles, & &1.score)
+    texs = Enum.map(tiles, & &1.tex)
+    n = length(tiles)
+    sorted = Enum.sort(scores)
+    worst = hd(sorted)
+    p10 = percentile(sorted, 0.10)
+    mean = avg(scores)
+
+    lowtex = Enum.count(texs, &(&1 < 2.0)) / n
+    busy = Enum.count(texs, &(&1 > 6.0)) / n
+    het = Float.round(min(lowtex, busy), 2)
+
+    worst_tile = Enum.min_by(tiles, & &1.score)
+    worst_smooth? = worst_tile.tex < 2.0
+
+    sub = subsample(tiles, @subsample_k)
+    sub_sorted = sub |> Enum.map(& &1.score) |> Enum.sort()
+    sub_worst = hd(sub_sorted)
+    sub_p10 = percentile(sub_sorted, 0.10)
+
+    IO.puts(
+      pad([label, 16]) <>
+        pad([mp, 6]) <>
+        pad([het, 6]) <>
+        pad([n, 6]) <>
+        pad([fmt_score(om.score), 8]) <>
+        pad([fmt_score(worst), 7]) <>
+        pad([fmt_score(p10), 7]) <>
+        pad([fmt_score(mean), 7]) <>
+        pad([fmt_score(sub_worst), 9]) <>
+        pad([if(worst_smooth?, do: "yes", else: "no"), 8])
+    )
+
+    %{
+      label: label,
+      mp: mp,
+      het: het,
+      n_tiles: n,
+      full_score: om.score,
+      worst: worst,
+      p10: p10,
+      mean: mean,
+      sub_worst: sub_worst,
+      sub_p10: sub_p10,
+      worst_smooth?: worst_smooth?,
+      full_us: full_us,
+      per_tile_us: round(avg(Enum.map(tiles, & &1.ssim2_us)))
+    }
+  end
+
+  # Tile coordinates covering the frame with exactly tile-sized windows; the last
+  # row/col is clamped to the edge (slight overlap) so every tile is full size and
+  # safe for SSIMULACRA2's multiscale downsamples.
+  defp tile_coords(w, h, t) do
+    tw = min(t, w)
+    th = min(t, h)
+    for y <- axis_positions(h, th), x <- axis_positions(w, tw), do: {x, y, tw, th}
+  end
+
+  defp axis_positions(size, t) when size <= t, do: [0]
+
+  defp axis_positions(size, t) do
+    (Enum.take_while(Stream.iterate(0, &(&1 + t)), &(&1 + t <= size)) ++ [size - t])
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp tile_metrics(base, cand, {x, y, w, h}) do
+    {:ok, bt} = Operation.extract_area(base, x, y, w, h)
+    {:ok, ct} = Operation.extract_area(cand, x, y, w, h)
+
+    # Time only the SSIMULACRA2 work — a real crop-scoring path pays this, not the
+    # high-pass texture, which exists only for this benchmark's HET binning.
+    {ssim2_us, score} =
+      timed(fn ->
+        {:ok, ref} = Ssim2Metric.reference(bt)
+        {:ok, s} = Ssim2Metric.score(ref, ct)
+        s
+      end)
+
+    %{score: score, tex: tile_texture(bt), ssim2_us: ssim2_us}
+  end
+
+  # High-pass texture energy (gradients removed), so a smooth/gradient tile reads
+  # low even if it isn't dead flat — the banding-prone signal.
+  defp tile_texture(tile) do
+    {:ok, g} = Operation.colourspace(tile, :VIPS_INTERPRETATION_B_W)
+    {:ok, gf} = Operation.cast(g, :VIPS_FORMAT_FLOAT)
+    {:ok, blur} = Operation.gaussblur(gf, 3.0)
+    {:ok, hp} = Operation.subtract(gf, blur)
+    {:ok, sq} = Operation.multiply(hp, hp)
+    {:ok, ms} = Operation.avg(sq)
+    :math.sqrt(max(0.0, ms))
+  end
+
+  defp subsample(tiles, k) do
+    n = length(tiles)
+
+    if n <= k do
+      tiles
+    else
+      0..(k - 1)
+      |> Enum.map(&Enum.at(tiles, div(&1 * (n - 1), k - 1)))
+    end
+  end
+
+  defp percentile(sorted, p) do
+    n = length(sorted)
+    Enum.at(sorted, min(n - 1, max(0, trunc(p * (n - 1)))))
+  end
+
+  defp findings_part_e([]),
+    do: IO.puts("Part E — crop-based scoring: no subjects hit the target\n")
+
+  defp findings_part_e(rows) do
+    IO.puts("Part E — crop-based scoring vs full-frame:")
+    # 1. Tracking: the OFFSET (tile aggregate − full-frame score) at the boundary.
+    #    A tight offset spread ⇒ setting the tile threshold to `@target + median
+    #    offset` reproduces the full-frame boundary; the spread is the residual
+    #    error. (The raw aggregate spread would be inflated by full_score's own
+    #    integer-quality quantization, so we report the offset, not the raw value.)
+    IO.puts(
+      "  tracking — offset (tile aggregate − full-frame score) at the boundary; tight = tracks:"
+    )
+
+    Enum.each([{:worst, "worst-tile"}, {:p10, "p10-tile"}, {:mean, "mean-tile"}], fn {k, name} ->
+      offs = Enum.map(rows, &Float.round(Map.get(&1, k) - &1.full_score, 2))
+
+      IO.puts(
+        "    #{String.pad_trailing(name, 11)} median #{Float.round(median(offs), 2)}  spread #{spread_note(offs)}"
+      )
+    end)
+
+    # 2. Sub-sampling penalty: K tiles vs all tiles, by HET bin (heterogeneous
+    #    images are where a sparse sample misses the localized worst region).
+    IO.puts(
+      "\n  sub-sampling penalty (K=#{@subsample_k} tiles vs full coverage), by heterogeneity:"
+    )
+
+    Enum.each(
+      [{"uniform HET<0.1", &(&1.het < 0.1)}, {"hetero HET>=0.1", &(&1.het >= 0.1)}],
+      fn {name, pred} ->
+        grp = Enum.filter(rows, pred)
+
+        if grp != [] do
+          worst_gap =
+            grp |> Enum.map(&Float.round(&1.sub_worst - &1.worst, 2)) |> avg() |> Float.round(2)
+
+          worst_max = grp |> Enum.map(&Float.round(&1.sub_worst - &1.worst, 2)) |> Enum.max()
+
+          IO.puts(
+            "    #{String.pad_trailing(name, 16)} n=#{length(grp)}  sub_worst − true_worst: mean +#{worst_gap}, worst +#{worst_max}"
+          )
+        end
+      end
+    )
+
+    # 3. Banding localization + cost.
+    smooth_worst = Enum.count(rows, & &1.worst_smooth?)
+    avg_full = rows |> Enum.map(& &1.full_us) |> avg() |> ms()
+    avg_tile = rows |> Enum.map(& &1.per_tile_us) |> avg()
+    k_ms = Float.round(avg_tile * @subsample_k / 1000, 1)
+    avg_n = rows |> Enum.map(& &1.n_tiles) |> avg() |> Float.round(1)
+
+    IO.puts(
+      "\n  worst tile sits in a smooth/low-texture region: #{smooth_worst}/#{length(rows)} subjects"
+    )
+
+    IO.puts(
+      "  cost: full-frame ~#{avg_full}ms  |  full coverage ~#{avg_n} tiles (≈ no saving)  |  K=#{@subsample_k} tiles ~#{k_ms}ms (fixed, size-independent)"
+    )
+
+    IO.puts("  -> crops keep native resolution, so (unlike Part C's proxy) they TRACK")
+    IO.puts("     full-frame — p10 offset is the tightest. Full coverage saves nothing;")
+    IO.puts("     K-tile sub-sampling is a fixed budget that only wins above the tile-")
+    IO.puts("     count crossover (i.e. large images), at small sub-sampling error.\n")
+  end
+
   # --- resolved descriptors --------------------------------------------------
 
   defp ssim2_resolved(format) do
@@ -912,12 +1200,13 @@ defmodule Mix.Tasks.Autoquality.Bench do
 
   # --- findings --------------------------------------------------------------
 
-  defp print_findings(a_rows, b_rows, c_rows, format) do
+  defp print_findings(a_rows, b_rows, c_rows, e_rows, format) do
     IO.puts("\n== Findings ==\n")
 
     if a_rows, do: findings_part_a(a_rows)
     if b_rows, do: findings_part_b(b_rows)
     if c_rows, do: findings_part_c(c_rows)
+    if e_rows, do: findings_part_e(e_rows)
 
     IO.puts("\n(format: #{format}; numbers vary with CPU + libvips build — re-run locally)")
   end
@@ -1053,6 +1342,24 @@ defmodule Mix.Tasks.Autoquality.Bench do
     IO.puts("wrote #{path}")
   end
 
+  defp write_part_e_csv(rows) do
+    path = "/tmp/autoquality_bench_part_e.csv"
+
+    head =
+      "source,mp,het,n_tiles,full_score,worst,p10,mean,sub_worst,sub_p10," <>
+        "worst_smooth,full_us,per_tile_us\n"
+
+    body =
+      Enum.map_join(rows, fn r ->
+        "#{r.label},#{r.mp},#{r.het},#{r.n_tiles},#{fmt_score(r.full_score)},#{fmt_score(r.worst)}," <>
+          "#{fmt_score(r.p10)},#{fmt_score(r.mean)},#{fmt_score(r.sub_worst)},#{fmt_score(r.sub_p10)}," <>
+          "#{r.worst_smooth?},#{r.full_us},#{r.per_tile_us}\n"
+      end)
+
+    File.write!(path, head <> body)
+    IO.puts("wrote #{path}")
+  end
+
   defp write_part_c_csv(rows) do
     path = "/tmp/autoquality_bench_part_c.csv"
 
@@ -1109,6 +1416,19 @@ defmodule Mix.Tasks.Autoquality.Bench do
 
   defp parse_files(nil), do: []
   defp parse_files(str), do: str |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
+
+  # A directory of images (Part E corpus) takes precedence over --proxy-files.
+  defp corpus_files(nil, proxy_files), do: proxy_files
+
+  defp corpus_files(dir, _proxy_files) do
+    dir
+    |> Path.join("*")
+    |> Path.wildcard()
+    |> Enum.filter(&(Path.extname(&1) |> String.downcase() |> image_ext?()))
+    |> Enum.sort()
+  end
+
+  defp image_ext?(ext), do: ext in [".jpg", ".jpeg", ".png", ".webp"]
 
   defp ms(us) when is_integer(us), do: Float.round(us / 1000, 1)
   defp ms(us), do: Float.round(us / 1000, 1)

--- a/test/support/mix/tasks/autoquality.bench.ex
+++ b/test/support/mix/tasks/autoquality.bench.ex
@@ -1,0 +1,591 @@
+defmodule Mix.Tasks.Autoquality.Bench do
+  @shortdoc "Benchmark the autoquality ssim2 encode-quality search — cost curve + accuracy (no Docker)"
+  @moduledoc """
+  Produces real performance + accuracy numbers for the autoquality / max_bytes
+  encode-quality search (`ImagePipe.Output.EncodeSearch`, shipped in #351). The
+  search runs at the output/encode boundary; for the `:ssim2` objective every
+  iteration does a full-resolution **encode + decode + SSIMULACRA2 metric** on
+  the result, and the metric dominates. This task quantifies that.
+
+  Gated off the default `mix test` lane: it lives under `test/support/mix/tasks`
+  (compiled only in `MIX_ENV=test`), is a Mix task (never a test the lane runs),
+  is NIF-heavy (the `ssimulacra2` Rust NIF) and slow. Auto-selects `MIX_ENV=test`
+  via `mix.exs` `preferred_envs`.
+
+      mise exec -- mix autoquality.bench                 # both parts, default sizes
+      mise exec -- mix autoquality.bench --part a        # cost curve only
+      mise exec -- mix autoquality.bench --part b        # accuracy/behavior only
+      mise exec -- mix autoquality.bench --mps 1,4,9     # custom Part A megapixels
+      mise exec -- mix autoquality.bench --csv           # also write CSVs under /tmp
+
+  ## Part A — per-megapixel cost curve
+
+  Runs the real `:ssim2` search (target #{88}, bracket [#{40},#{95}],
+  max_iterations #{6}) on a deterministic high-frequency zone-plate at a range of
+  output sizes (default ~1, 4, 9, 16, 25, 36 MP). The zone-plate is adversarial
+  for JPEG, so the search uses its full iteration budget — worst-case cost. The
+  encode / decode / metric phases are wrapped (injected `encode_fun`/`score_fun`
+  over `Encoder.encode_to_buffer` + `Ssim2Metric`) and timed separately, so the
+  table shows where the wall-clock goes as a function of pixel count. This is the
+  data that sets a sane `autoquality_max_resolution` default.
+
+  ## Part B — accuracy + behavior over real content
+
+  Runs the production encode path (`Encoder.stream_output/3`, which finalizes the
+  image exactly as a real request would) over the committed differential sources
+  at their native sizes, for three configurations on each source:
+
+    * `ssim2:#{88}:#{40}:#{95}` — records chosen quality, the achieved
+      SSIMULACRA2 score vs the target (the search's own `final_score` telemetry,
+      not an ad-hoc baseline), bytes vs a fixed `q90` baseline (savings %), and
+      iteration count.
+    * `size` and `max_bytes` to the same byte budget — these skip the
+      decode+metric, so they are far cheaper; the table quantifies the gap.
+
+  Goal: confirm `:ssim2` lands at/above its target, and surface typical quality /
+  savings / iteration counts to validate (or adjust) the shipped defaults.
+  """
+  use Mix.Task
+  use Boundary, top_level?: true, check: [out: false]
+
+  alias ImagePipe.Output.Encoder
+  alias ImagePipe.Output.EncodeSearch
+  alias ImagePipe.Output.Resolved
+  alias ImagePipe.Output.ResolvedQualitySearch, as: RQS
+  alias ImagePipe.Output.Ssim2Metric
+  alias ImagePipe.Test.ImgproxyDifferential.SourceInventory
+  alias Vix.Vips.Operation
+
+  @sources_dir "test/support/image_pipe/test/imgproxy_differential/sources"
+  @prefix [:autoquality_bench]
+
+  # Shipped defaults under test (see ImagePipe.Output.EncodeSearch + the imgproxy
+  # autoquality parser).
+  @target 88
+  @min_q 40
+  @max_q 95
+  @max_iter 6
+
+  @default_mps [1, 4, 9, 16, 25, 36]
+  @baseline_quality 90
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _, _} =
+      OptionParser.parse(args,
+        strict: [part: :string, mps: :string, csv: :boolean, format: :string]
+      )
+
+    part = Keyword.get(opts, :part, "both")
+    csv? = Keyword.get(opts, :csv, false)
+    format = opts |> Keyword.get(:format, "jpeg") |> parse_format()
+    mps = parse_mps(Keyword.get(opts, :mps))
+
+    {:ok, _} = Application.ensure_all_started(:image_pipe)
+    warmup(format)
+
+    a_rows = if part in ["a", "both"], do: run_part_a(mps, format), else: nil
+    b_rows = if part in ["b", "both"], do: run_part_b(format), else: nil
+
+    if csv? do
+      if a_rows, do: write_part_a_csv(a_rows)
+      if b_rows, do: write_part_b_csv(b_rows)
+    end
+
+    print_findings(a_rows, b_rows, format)
+  end
+
+  # Touch every NIF/libvips path once so first-call JIT + library init does not
+  # land inside a timed measurement (the SSIMULACRA2 NIF's first call is ~10x a
+  # warm call). Discarded.
+  defp warmup(format) do
+    image = zone_plate(256, 256)
+    {:ok, ref} = Ssim2Metric.reference(image)
+    {:ok, bin} = Encoder.encode_to_buffer(image, ssim2_resolved(format), 80)
+    {:ok, candidate} = Image.from_binary(bin)
+    {:ok, _} = Ssim2Metric.score(ref, candidate)
+    :ok
+  end
+
+  # --- Part A: cost curve ---------------------------------------------------
+
+  defp run_part_a(mps, format) do
+    IO.puts("\n== Part A — ssim2 search cost vs. megapixels ==")
+    IO.puts("objective ssim2  target #{@target}  bracket [#{@min_q},#{@max_q}]  ")
+    IO.puts("max_iterations #{@max_iter}  format #{format}  source: deterministic zone-plate\n")
+
+    header =
+      pad(["MP", 6]) <>
+        pad(["dims", 12]) <>
+        pad(["iters", 6]) <>
+        pad(["total_ms", 10]) <>
+        pad(["ref_ms", 9]) <>
+        pad(["encode_ms", 11]) <>
+        pad(["decode_ms", 11]) <>
+        pad(["metric_ms", 11]) <>
+        pad(["/iter_ms", 10]) <>
+        pad(["metric%", 8])
+
+    IO.puts(header)
+    IO.puts(String.duplicate("-", String.length(header)))
+
+    resolved = ssim2_resolved(format)
+
+    rows =
+      Enum.map(mps, fn mp ->
+        {w, h} = square_dims(mp)
+        image = zone_plate(w, h)
+
+        # One-time reference build (part of the real per-request ssim2 cost).
+        {ref_us, {:ok, ref}} = timed(fn -> Ssim2Metric.reference(image) end)
+
+        acc = :atomics.new(3, signed: true)
+        encode_fun = instrumented_encode(image, resolved, acc)
+        score_fun = instrumented_score(ref, acc)
+
+        {search_us, {:ok, _binary, meta}} =
+          timed(fn ->
+            EncodeSearch.search(resolved.quality_search, nil,
+              encode_fun: encode_fun,
+              score_fun: score_fun,
+              base_quality: @max_q,
+              max_iterations: @max_iter,
+              telemetry_opts: [telemetry_prefix: @prefix]
+            )
+          end)
+
+        encode_us = :atomics.get(acc, 1)
+        decode_us = :atomics.get(acc, 2)
+        metric_us = :atomics.get(acc, 3)
+        total_us = ref_us + search_us
+        iters = meta.iterations
+        per_iter_us = if iters > 0, do: div(encode_us + decode_us + metric_us, iters), else: 0
+        metric_pct = pct(metric_us, total_us)
+
+        row = %{
+          mp: mp,
+          w: w,
+          h: h,
+          iters: iters,
+          total_us: total_us,
+          ref_us: ref_us,
+          encode_us: encode_us,
+          decode_us: decode_us,
+          metric_us: metric_us,
+          per_iter_us: per_iter_us,
+          metric_pct: metric_pct,
+          score: meta.score,
+          quality: meta.quality
+        }
+
+        IO.puts(
+          pad([mp, 6]) <>
+            pad(["#{w}x#{h}", 12]) <>
+            pad([iters, 6]) <>
+            pad([ms(total_us), 10]) <>
+            pad([ms(ref_us), 9]) <>
+            pad([ms(encode_us), 11]) <>
+            pad([ms(decode_us), 11]) <>
+            pad([ms(metric_us), 11]) <>
+            pad([ms(per_iter_us), 10]) <>
+            pad(["#{metric_pct}%", 8])
+        )
+
+        row
+      end)
+
+    rows
+  end
+
+  defp instrumented_encode(image, resolved, acc) do
+    fn quality ->
+      {us, result} = timed(fn -> Encoder.encode_to_buffer(image, resolved, quality) end)
+      :atomics.add(acc, 1, us)
+      result
+    end
+  end
+
+  # Mirrors EncodeSearch.run/3's real score closure (decode the candidate buffer,
+  # then SSIMULACRA2 against the pre-encode reference) but splits decode vs metric
+  # timing. Failures throw the same tagged tuple run/3 catches.
+  defp instrumented_score(ref, acc) do
+    fn bytes ->
+      {dec_us, decoded} = timed(fn -> Image.from_binary(bytes) end)
+      :atomics.add(acc, 2, dec_us)
+      candidate = unwrap(decoded)
+
+      {met_us, scored} = timed(fn -> Ssim2Metric.score(ref, candidate) end)
+      :atomics.add(acc, 3, met_us)
+      unwrap(scored)
+    end
+  end
+
+  defp unwrap({:ok, value}), do: value
+  defp unwrap({:error, reason}), do: throw({:image_pipe_score_error, reason})
+
+  # --- Part B: accuracy + behavior ------------------------------------------
+
+  defp run_part_b(format) do
+    IO.puts("\n== Part B — accuracy + behavior over real sources (native sizes) ==")
+    IO.puts("ssim2 target #{@target} [#{@min_q},#{@max_q}]  baseline q#{@baseline_quality}  ")
+
+    IO.puts(
+      "format #{format}  size/max_bytes budget = round(q#{@baseline_quality} bytes * 0.6)\n"
+    )
+
+    attach_telemetry()
+
+    header =
+      pad(["source", 22]) <>
+        pad(["dims", 12]) <>
+        pad(["MP", 6]) <>
+        pad(["q", 4]) <>
+        pad(["score", 8]) <>
+        pad(["hit?", 6]) <>
+        pad(["bytes", 9]) <>
+        pad(["q#{@baseline_quality}", 9]) <>
+        pad(["save%", 7]) <>
+        pad(["iters", 6]) <>
+        pad(["ssim2ms", 9]) <>
+        pad(["sizems", 8]) <>
+        pad(["mbms", 8])
+
+    IO.puts(header)
+    IO.puts(String.duplicate("-", String.length(header)))
+
+    rows =
+      SourceInventory.entries()
+      |> Enum.sort_by(&(&1.width * &1.height))
+      |> Enum.map(fn entry -> bench_source(entry, format) end)
+      |> Enum.reject(&is_nil/1)
+
+    detach_telemetry()
+    rows
+  end
+
+  defp bench_source(entry, format) do
+    path = Path.join(@sources_dir, entry.file)
+
+    case Image.open(path, access: :random) do
+      {:ok, image} ->
+        mp = Float.round(Image.width(image) * Image.height(image) / 1_000_000, 2)
+
+        # Fixed-quality baseline (no search) — finalized identically.
+        {_us, baseline_bytes} = encode_once(image, plain_resolved(format, @baseline_quality))
+        budget = round(baseline_bytes * 0.6)
+
+        ssim2 = run_config(image, ssim2_resolved(format))
+        size = run_config(image, size_resolved(format, budget))
+        mb = run_config(image, max_bytes_resolved(format, budget))
+
+        savings = pct(baseline_bytes - ssim2.bytes, baseline_bytes)
+        hit? = ssim2.score && ssim2.score >= @target
+
+        IO.puts(
+          pad([entry.file, 22]) <>
+            pad(["#{Image.width(image)}x#{Image.height(image)}", 12]) <>
+            pad([mp, 6]) <>
+            pad([ssim2.quality, 4]) <>
+            pad([fmt_score(ssim2.score), 8]) <>
+            pad([if(hit?, do: "yes", else: "NO"), 6]) <>
+            pad([ssim2.bytes, 9]) <>
+            pad([baseline_bytes, 9]) <>
+            pad(["#{savings}%", 7]) <>
+            pad([ssim2.iters, 6]) <>
+            pad([ms(ssim2.us), 9]) <>
+            pad([ms(size.us), 8]) <>
+            pad([ms(mb.us), 8])
+        )
+
+        %{
+          source: entry.file,
+          w: Image.width(image),
+          h: Image.height(image),
+          mp: mp,
+          quality: ssim2.quality,
+          score: ssim2.score,
+          hit?: hit?,
+          bytes: ssim2.bytes,
+          baseline_bytes: baseline_bytes,
+          savings: savings,
+          iters: ssim2.iters,
+          ssim2_us: ssim2.us,
+          size_us: size.us,
+          size_iters: size.iters,
+          mb_us: mb.us,
+          mb_iters: mb.iters
+        }
+
+      {:error, reason} ->
+        IO.puts(pad([entry.file, 22]) <> "skipped (open failed: #{inspect(reason)})")
+        nil
+    end
+  end
+
+  # Run one production search config and read the verdict from the search's own
+  # [:encode, :search] :stop telemetry (chosen_quality/bytes/iterations/final_score).
+  defp run_config(image, resolved) do
+    {us, _result} =
+      timed(fn ->
+        {:ok, stream, _mime} =
+          Encoder.stream_output(image, resolved, telemetry_prefix: @prefix)
+
+        Enum.each(stream, fn _ -> :ok end)
+      end)
+
+    meta = receive_search_meta()
+
+    %{
+      us: us,
+      quality: meta.chosen_quality,
+      bytes: meta.chosen_bytes,
+      iters: meta.iterations,
+      score: Map.get(meta, :final_score)
+    }
+  end
+
+  defp encode_once(image, resolved) do
+    timed(fn ->
+      {:ok, stream, _mime} = Encoder.stream_output(image, resolved, [])
+      Enum.reduce(stream, 0, fn chunk, acc -> acc + byte_size(chunk) end)
+    end)
+  end
+
+  # --- resolved descriptors --------------------------------------------------
+
+  defp ssim2_resolved(format) do
+    %Resolved{
+      base_resolved(format)
+      | quality: :default,
+        quality_search: %RQS{
+          objective: :ssim2,
+          target: @target,
+          min_quality: @min_q,
+          max_quality: @max_q,
+          allowed_error: 0,
+          max_resolution: 0
+        }
+    }
+  end
+
+  defp size_resolved(format, budget) do
+    %Resolved{
+      base_resolved(format)
+      | quality: :default,
+        quality_search: %RQS{
+          objective: :size,
+          target: budget,
+          min_quality: @min_q,
+          max_quality: @max_q,
+          allowed_error: 0,
+          max_resolution: 0
+        }
+    }
+  end
+
+  defp max_bytes_resolved(format, budget) do
+    %Resolved{base_resolved(format) | quality: :default, max_bytes: budget}
+  end
+
+  defp plain_resolved(format, quality) do
+    %Resolved{base_resolved(format) | quality: {:quality, quality}}
+  end
+
+  defp base_resolved(format) do
+    %Resolved{
+      format: format,
+      quality: :default,
+      response_headers: [],
+      strip_metadata: true,
+      keep_copyright: false,
+      color_profile: :strip
+    }
+  end
+
+  # --- telemetry capture -----------------------------------------------------
+
+  defp attach_telemetry do
+    :telemetry.attach(
+      handler_id(),
+      @prefix ++ [:encode, :search, :stop],
+      &__MODULE__.handle_search_stop/4,
+      self()
+    )
+  end
+
+  @doc false
+  def handle_search_stop(_event, _measurements, meta, target),
+    do: send(target, {:bench_search_meta, meta})
+
+  defp detach_telemetry, do: :telemetry.detach(handler_id())
+
+  defp handler_id, do: {__MODULE__, self()}
+
+  defp receive_search_meta do
+    receive do
+      {:bench_search_meta, meta} -> meta
+    after
+      0 -> raise "no [:encode, :search] :stop telemetry received — did the search run?"
+    end
+  end
+
+  # --- synthetic source ------------------------------------------------------
+
+  # Deterministic high-frequency zone-plate (chirp), scaled to a full-range 8-bit
+  # sRGB 3-band image. The frequency sweeps to Nyquist across the frame at every
+  # size, so the content is adversarial for JPEG at all resolutions — the ssim2
+  # search never reaches its target band and spends its full iteration budget,
+  # giving worst-case cost as a clean function of pixel count.
+  defp zone_plate(w, h) do
+    {:ok, z} = Operation.zone(w, h)
+    {:ok, scaled} = Operation.linear(z, [127.5], [127.5])
+    {:ok, uchar} = Operation.cast(scaled, :VIPS_FORMAT_UCHAR)
+    {:ok, rgb} = Operation.bandjoin([uchar, uchar, uchar])
+    {:ok, srgb} = Operation.copy(rgb, interpretation: :VIPS_INTERPRETATION_sRGB)
+    srgb
+  end
+
+  defp square_dims(mp) do
+    side = round(:math.sqrt(mp * 1_000_000))
+    {side, side}
+  end
+
+  # --- findings --------------------------------------------------------------
+
+  defp print_findings(a_rows, b_rows, format) do
+    IO.puts("\n== Findings ==\n")
+
+    if a_rows, do: findings_part_a(a_rows)
+    if b_rows, do: findings_part_b(b_rows)
+
+    IO.puts("\n(format: #{format}; numbers vary with CPU + libvips build — re-run locally)")
+  end
+
+  defp findings_part_a(rows) do
+    avg_metric_pct = rows |> Enum.map(& &1.metric_pct) |> avg() |> round()
+
+    over_500 = Enum.find(rows, &(&1.total_us > 500_000))
+    over_1000 = Enum.find(rows, &(&1.total_us > 1_000_000))
+    over_2000 = Enum.find(rows, &(&1.total_us > 2_000_000))
+
+    IO.puts("Part A — cost curve:")
+    IO.puts("  * metric dominates: ~#{avg_metric_pct}% of total wall-clock on average")
+    IO.puts("  * first size over 500ms total:  #{budget_note(over_500)}")
+    IO.puts("  * first size over 1000ms total: #{budget_note(over_1000)}")
+    IO.puts("  * first size over 2000ms total: #{budget_note(over_2000)}")
+    IO.puts("  -> recommended autoquality_max_resolution: pick the MP under your")
+    IO.puts("     per-request budget from the column above (full 6x pass cost).\n")
+  end
+
+  defp budget_note(nil), do: "none in tested range"
+  defp budget_note(row), do: "#{row.mp} MP (#{ms(row.total_us)} ms, #{row.iters} iters)"
+
+  defp findings_part_b(rows) do
+    scored = Enum.filter(rows, &(&1.score != nil))
+    hits = Enum.count(scored, & &1.hit?)
+    avg_q = scored |> Enum.map(& &1.quality) |> avg() |> round()
+    avg_save = scored |> Enum.map(& &1.savings) |> avg() |> round()
+    avg_iters = scored |> Enum.map(& &1.iters) |> avg() |> Float.round(1)
+    avg_ssim2_ms = scored |> Enum.map(& &1.ssim2_us) |> avg() |> ms()
+    avg_size_ms = rows |> Enum.map(& &1.size_us) |> avg() |> ms()
+    avg_mb_ms = rows |> Enum.map(& &1.mb_us) |> avg() |> ms()
+
+    speedup = ratio(avg(Enum.map(scored, & &1.ssim2_us)), avg(Enum.map(rows, & &1.size_us)))
+
+    IO.puts("Part B — accuracy + behavior:")
+    IO.puts("  * ssim2 hit target #{@target}: #{hits}/#{length(scored)} scored sources")
+
+    IO.puts(
+      "  * typical chosen quality ~#{avg_q}, avg savings vs q#{@baseline_quality} ~#{avg_save}%"
+    )
+
+    IO.puts("  * avg iterations: #{avg_iters} (cap #{@max_iter})")
+
+    IO.puts(
+      "  * avg cost: ssim2 #{avg_ssim2_ms} ms vs size #{avg_size_ms} ms vs max_bytes #{avg_mb_ms} ms"
+    )
+
+    IO.puts("  * ssim2 is ~#{speedup}x the cost of size (the decode+metric overhead)\n")
+  end
+
+  # --- CSV -------------------------------------------------------------------
+
+  defp write_part_a_csv(rows) do
+    path = "/tmp/autoquality_bench_part_a.csv"
+
+    head =
+      "mp,width,height,iters,total_us,ref_us,encode_us,decode_us,metric_us,per_iter_us,metric_pct,score,quality\n"
+
+    body =
+      Enum.map_join(rows, fn r ->
+        "#{r.mp},#{r.w},#{r.h},#{r.iters},#{r.total_us},#{r.ref_us},#{r.encode_us}," <>
+          "#{r.decode_us},#{r.metric_us},#{r.per_iter_us},#{r.metric_pct},#{fmt_score(r.score)},#{r.quality}\n"
+      end)
+
+    File.write!(path, head <> body)
+    IO.puts("\nwrote #{path}")
+  end
+
+  defp write_part_b_csv(rows) do
+    path = "/tmp/autoquality_bench_part_b.csv"
+
+    head =
+      "source,width,height,mp,quality,score,hit,bytes,baseline_bytes,savings,iters," <>
+        "ssim2_us,size_us,size_iters,mb_us,mb_iters\n"
+
+    body =
+      Enum.map_join(rows, fn r ->
+        "#{r.source},#{r.w},#{r.h},#{r.mp},#{r.quality},#{fmt_score(r.score)},#{r.hit?}," <>
+          "#{r.bytes},#{r.baseline_bytes},#{r.savings},#{r.iters},#{r.ssim2_us}," <>
+          "#{r.size_us},#{r.size_iters},#{r.mb_us},#{r.mb_iters}\n"
+      end)
+
+    File.write!(path, head <> body)
+    IO.puts("wrote #{path}")
+  end
+
+  # --- helpers ---------------------------------------------------------------
+
+  defp timed(fun) do
+    t0 = System.monotonic_time(:microsecond)
+    result = fun.()
+    {System.monotonic_time(:microsecond) - t0, result}
+  end
+
+  defp parse_format("jpeg"), do: :jpeg
+  defp parse_format("webp"), do: :webp
+  defp parse_format("avif"), do: :avif
+  defp parse_format(other), do: raise("unsupported --format #{inspect(other)} (jpeg|webp|avif)")
+
+  defp parse_mps(nil), do: @default_mps
+
+  defp parse_mps(str) do
+    str
+    |> String.split(",", trim: true)
+    |> Enum.map(&(&1 |> String.trim() |> parse_number()))
+  end
+
+  defp parse_number(s) do
+    case Integer.parse(s) do
+      {int, ""} -> int
+      _ -> s |> Float.parse() |> elem(0)
+    end
+  end
+
+  defp ms(us) when is_integer(us), do: Float.round(us / 1000, 1)
+  defp ms(us), do: Float.round(us / 1000, 1)
+
+  defp pct(_part, 0), do: 0
+  defp pct(part, whole), do: round(part / whole * 100)
+
+  defp ratio(_a, 0), do: 0.0
+  defp ratio(a, b), do: Float.round(a / b, 1)
+
+  defp avg([]), do: 0
+  defp avg(list), do: Enum.sum(list) / length(list)
+
+  defp fmt_score(nil), do: "-"
+  defp fmt_score(score), do: Float.round(score, 2)
+
+  defp pad([value, width]), do: value |> to_string() |> String.pad_trailing(width)
+end

--- a/test/support/mix/tasks/autoquality.bench.ex
+++ b/test/support/mix/tasks/autoquality.bench.ex
@@ -17,12 +17,17 @@ defmodule Mix.Tasks.Autoquality.Bench do
       mise exec -- mix autoquality.bench --part b        # accuracy/behavior only
       mise exec -- mix autoquality.bench --part c        # proxy-seed method + accuracy
       mise exec -- mix autoquality.bench --part d        # cheap full-res metric narrowing
-      mise exec -- mix autoquality.bench --part e --corpus DIR  # crop-based scoring
+      mise exec -- mix autoquality.bench --part e --corpus DIR  # crop-based scoring, per source
+      mise exec -- mix autoquality.bench --part e --corpus DIR --corpus-cap 24  # cap/source
       mise exec -- mix autoquality.bench --part all      # A + B + C + D + E
       mise exec -- mix autoquality.bench --mps 1,4,9     # custom Part A megapixels
       mise exec -- mix autoquality.bench --proxy-factors 2,4 --proxy-mp 25  # Part C knobs
       mise exec -- mix autoquality.bench --part c --proxy-files a.jpg,b.jpg # large real photos
       mise exec -- mix autoquality.bench --csv           # also write CSVs under /tmp
+
+  Fetch the corpus first with `mix autoquality.corpus`. Under `--corpus DIR`, each
+  subdirectory is a per-source group, reported separately then macro-averaged so no
+  single content type dominates.
 
   ## Part A — per-megapixel cost curve
 
@@ -162,7 +167,8 @@ defmodule Mix.Tasks.Autoquality.Bench do
           proxy_factors: :string,
           proxy_mp: :integer,
           proxy_files: :string,
-          corpus: :string
+          corpus: :string,
+          corpus_cap: :integer
         ]
       )
 
@@ -173,7 +179,6 @@ defmodule Mix.Tasks.Autoquality.Bench do
     factors = parse_factors(Keyword.get(opts, :proxy_factors))
     proxy_files = parse_files(Keyword.get(opts, :proxy_files))
     proxy_mp = Keyword.get(opts, :proxy_mp, 16)
-    corpus_files = corpus_files(Keyword.get(opts, :corpus), proxy_files)
 
     {:ok, _} = Application.ensure_all_started(:image_pipe)
     warmup(format)
@@ -184,7 +189,8 @@ defmodule Mix.Tasks.Autoquality.Bench do
       factors: factors,
       proxy_mp: proxy_mp,
       proxy_files: proxy_files,
-      corpus_files: corpus_files,
+      corpus_dir: Keyword.get(opts, :corpus),
+      corpus_cap: Keyword.get(opts, :corpus_cap, 24),
       format: format
     }
 
@@ -201,7 +207,11 @@ defmodule Mix.Tasks.Autoquality.Bench do
       if part in ["c", "all"], do: run_part_c(ctx.factors, ctx.proxy_mp, ctx.proxy_files, format)
 
     if part in ["d", "all"], do: run_part_d(ctx.proxy_files, ctx.proxy_mp, format)
-    e = if part in ["e", "all"], do: run_part_e(ctx.corpus_files, ctx.proxy_mp, format)
+
+    e =
+      if part in ["e", "all"],
+        do: run_part_e(ctx.corpus_dir, ctx.proxy_files, ctx.corpus_cap, ctx.proxy_mp, format)
+
     {a, b, c, e}
   end
 
@@ -862,108 +872,169 @@ defmodule Mix.Tasks.Autoquality.Bench do
   @tile 512
   @subsample_k 16
 
-  defp run_part_e(corpus_files, synth_mp, format) do
+  @e_exts ~w(.png .jpg .jpeg .webp)
+
+  defp run_part_e(corpus_dir, fallback_files, cap, synth_mp, format) do
     IO.puts("\n== Part E — crop-based scoring vs full-frame (#1) ==")
     IO.puts("oracle = full-frame full-res ssim2, target #{@target} [#{@min_q},#{@max_q}]  ")
-    IO.puts("tile #{@tile}px  subsample K=#{@subsample_k}  format #{format}\n")
+
+    IO.puts(
+      "tile #{@tile}px  K=#{@subsample_k}  q#{@baseline_quality} savings baseline  ≤#{cap}/source  format #{format}\n"
+    )
 
     resolved = ssim2_resolved(format)
-    subjects = load_subjects(corpus_files, synth_mp)
+    sources = discover_sources(corpus_dir, fallback_files, cap, synth_mp)
 
     header =
-      pad(["source", 16]) <>
-        pad(["MP", 6]) <>
-        pad(["HET", 6]) <>
-        pad(["tiles", 6]) <>
-        pad(["fullSc", 8]) <>
-        pad(["worst", 7]) <>
-        pad(["p10", 7]) <>
-        pad(["mean", 7]) <>
-        pad(["subWorst", 9]) <>
-        pad(["wSmooth", 8])
+      pad(["source", 14]) <>
+        pad(["imgs", 6]) <>
+        pad(["hit", 7]) <>
+        pad(["q̄", 5]) <>
+        pad(["save%", 7]) <>
+        pad(["p10off", 8]) <>
+        pad(["p10sprd", 9]) <>
+        pad(["subPen", 8]) <>
+        pad(["full ms", 9]) <>
+        pad(["k16 ms", 8])
 
     IO.puts(header)
     IO.puts(String.duplicate("-", String.length(header)))
 
-    subjects
-    |> Enum.map(fn {label, base} -> bench_crop_subject(label, base, resolved, format) end)
-    |> Enum.reject(&is_nil/1)
+    Enum.flat_map(sources, fn {sname, subjects} ->
+      rows = Enum.map(subjects, &bench_crop_subject(sname, &1, resolved, format))
+      print_source_row(sname, rows)
+      rows
+    end)
   end
 
-  defp bench_crop_subject(label, base, resolved, format) do
-    {:ok, _bin, om} = EncodeSearch.run(base, resolved, telemetry_opts: [])
-    mp = Float.round(Image.width(base) * Image.height(base) / 1_000_000, 1)
+  # One summary line per source as it finishes (per-image rows go to the CSV).
+  defp print_source_row(sname, rows) do
+    n = length(rows)
+    hits = Enum.filter(rows, & &1.hit?)
 
-    if om.score < @target do
-      IO.puts(
-        pad([label, 16]) <>
-          pad([mp, 6]) <> "skipped (full-res misses target: #{fmt_score(om.score)})"
-      )
-
-      nil
+    if hits == [] do
+      IO.puts(pad([sname, 14]) <> pad([n, 6]) <> "0/#{n} hit — no boundary")
     else
-      crop_subject_row(label, base, mp, om, format)
+      offs = Enum.map(hits, &(&1.p10 - &1.full_score))
+
+      IO.puts(
+        pad([sname, 14]) <>
+          pad([n, 6]) <>
+          pad(["#{length(hits)}/#{n}", 7]) <>
+          pad([round(avg(Enum.map(hits, & &1.quality))), 5]) <>
+          pad(["#{round(avg(Enum.map(hits, & &1.savings)))}%", 7]) <>
+          pad([Float.round(median(offs), 2), 8]) <>
+          pad([Float.round(Enum.max(offs) - Enum.min(offs), 2), 9]) <>
+          pad([Float.round(avg(Enum.map(hits, &(&1.sub_worst - &1.worst))), 2), 8]) <>
+          pad([ms(round(avg(Enum.map(hits, & &1.full_us)))), 9]) <>
+          pad([ms(round(avg(Enum.map(hits, & &1.per_tile_us)) * @subsample_k)), 8])
+      )
     end
   end
 
-  defp crop_subject_row(label, base, mp, om, format) do
-    {:ok, cbin} = Encoder.encode_to_buffer(base, plain_resolved(format, om.quality), om.quality)
+  defp bench_crop_subject(source, {label, base}, resolved, format) do
+    {:ok, _bin, om} = EncodeSearch.run(base, resolved, telemetry_opts: [])
+    mp = Float.round(Image.width(base) * Image.height(base) / 1_000_000, 1)
+
+    {:ok, b90} =
+      Encoder.encode_to_buffer(base, plain_resolved(format, @baseline_quality), @baseline_quality)
+
+    row = %{
+      source: source,
+      label: label,
+      mp: mp,
+      hit?: om.score >= @target,
+      quality: om.quality,
+      full_score: om.score,
+      bytes: om.bytes,
+      iters: om.iterations,
+      savings: pct(byte_size(b90) - om.bytes, byte_size(b90))
+    }
+
+    if om.score >= @target,
+      do: Map.merge(row, crop_metrics(base, om.quality, format)),
+      else: row
+  end
+
+  # The crop-scoring measurements for one subject (E fields only; B fields and the
+  # hit/miss decision live in bench_crop_subject).
+  defp crop_metrics(base, quality, format) do
+    {:ok, cbin} = Encoder.encode_to_buffer(base, plain_resolved(format, quality), quality)
     {:ok, cand} = Image.from_binary(cbin)
 
     {:ok, fref} = Ssim2Metric.reference(base)
     {full_us, {:ok, _}} = timed(fn -> Ssim2Metric.score(fref, cand) end)
 
-    coords = tile_coords(Image.width(base), Image.height(base), @tile)
-    tiles = Enum.map(coords, &tile_metrics(base, cand, &1))
+    tiles =
+      Image.width(base)
+      |> tile_coords(Image.height(base), @tile)
+      |> Enum.map(&tile_metrics(base, cand, &1))
 
     scores = Enum.map(tiles, & &1.score)
     texs = Enum.map(tiles, & &1.tex)
     n = length(tiles)
     sorted = Enum.sort(scores)
-    worst = hd(sorted)
-    p10 = percentile(sorted, 0.10)
-    mean = avg(scores)
 
     lowtex = Enum.count(texs, &(&1 < 2.0)) / n
     busy = Enum.count(texs, &(&1 > 6.0)) / n
-    het = Float.round(min(lowtex, busy), 2)
-
-    worst_tile = Enum.min_by(tiles, & &1.score)
-    worst_smooth? = worst_tile.tex < 2.0
-
-    sub = subsample(tiles, @subsample_k)
-    sub_sorted = sub |> Enum.map(& &1.score) |> Enum.sort()
-    sub_worst = hd(sub_sorted)
-    sub_p10 = percentile(sub_sorted, 0.10)
-
-    IO.puts(
-      pad([label, 16]) <>
-        pad([mp, 6]) <>
-        pad([het, 6]) <>
-        pad([n, 6]) <>
-        pad([fmt_score(om.score), 8]) <>
-        pad([fmt_score(worst), 7]) <>
-        pad([fmt_score(p10), 7]) <>
-        pad([fmt_score(mean), 7]) <>
-        pad([fmt_score(sub_worst), 9]) <>
-        pad([if(worst_smooth?, do: "yes", else: "no"), 8])
-    )
+    sub = subsample(tiles, @subsample_k) |> Enum.map(& &1.score) |> Enum.sort()
 
     %{
-      label: label,
-      mp: mp,
-      het: het,
+      het: Float.round(min(lowtex, busy), 2),
       n_tiles: n,
-      full_score: om.score,
-      worst: worst,
-      p10: p10,
-      mean: mean,
-      sub_worst: sub_worst,
-      sub_p10: sub_p10,
-      worst_smooth?: worst_smooth?,
+      worst: hd(sorted),
+      p10: percentile(sorted, 0.10),
+      mean: avg(scores),
+      sub_worst: hd(sub),
+      sub_p10: percentile(sub, 0.10),
+      worst_smooth?: Enum.min_by(tiles, & &1.score).tex < 2.0,
       full_us: full_us,
       per_tile_us: round(avg(Enum.map(tiles, & &1.ssim2_us)))
     }
+  end
+
+  # Sources for Part E: each subdirectory of `--corpus DIR` is a source (content
+  # type); a flat dir is one "corpus" source; no `--corpus` falls back to the
+  # committed high-detail set + a synthetic anchor. Per-source N is capped for
+  # balanced macro-averaging and bounded runtime.
+  defp discover_sources(nil, fallback_files, _cap, synth_mp) do
+    files =
+      if fallback_files == [],
+        do: Enum.map(@part_c_sources, &Path.join(@sources_dir, &1)),
+        else: fallback_files
+
+    [{"corpus", load_bases(files) ++ [{"zone-#{synth_mp}MP", zone_plate_for(synth_mp)}]}]
+  end
+
+  defp discover_sources(corpus_dir, _fallback, cap, _synth_mp) do
+    subdirs =
+      corpus_dir |> Path.join("*") |> Path.wildcard() |> Enum.filter(&File.dir?/1) |> Enum.sort()
+
+    sourced =
+      for d <- subdirs,
+          imgs = images_in(d, cap),
+          imgs != [],
+          do: {Path.basename(d), load_bases(imgs)}
+
+    case sourced do
+      [] -> [{"corpus", load_bases(images_in(corpus_dir, cap))}]
+      list -> list
+    end
+  end
+
+  defp images_in(dir, cap) do
+    dir
+    |> Path.join("*")
+    |> Path.wildcard()
+    |> Enum.filter(&(Path.extname(&1) |> String.downcase() |> Kernel.in(@e_exts)))
+    |> Enum.sort()
+    |> Enum.take(cap)
+  end
+
+  defp load_bases(files) do
+    files
+    |> Enum.map(&{Path.basename(&1), base_image_at(&1)})
+    |> Enum.reject(fn {_label, base} -> is_nil(base) end)
   end
 
   # Tile coordinates covering the frame with exactly tile-sized windows; the last
@@ -1028,70 +1099,75 @@ defmodule Mix.Tasks.Autoquality.Bench do
   end
 
   defp findings_part_e([]),
-    do: IO.puts("Part E — crop-based scoring: no subjects hit the target\n")
+    do: IO.puts("Part E — crop-based scoring: no subjects processed\n")
 
   defp findings_part_e(rows) do
-    IO.puts("Part E — crop-based scoring vs full-frame:")
-    # 1. Tracking: the OFFSET (tile aggregate − full-frame score) at the boundary.
-    #    A tight offset spread ⇒ setting the tile threshold to `@target + median
-    #    offset` reproduces the full-frame boundary; the spread is the residual
-    #    error. (The raw aggregate spread would be inflated by full_score's own
-    #    integer-quality quantization, so we report the offset, not the raw value.)
-    IO.puts(
-      "  tracking — offset (tile aggregate − full-frame score) at the boundary; tight = tracks:"
-    )
+    hits = Enum.filter(rows, & &1.hit?)
+    by_source = rows |> Enum.group_by(& &1.source) |> Enum.sort_by(&elem(&1, 0))
 
-    Enum.each([{:worst, "worst-tile"}, {:p10, "p10-tile"}, {:mean, "mean-tile"}], fn {k, name} ->
-      offs = Enum.map(rows, &Float.round(Map.get(&1, k) - &1.full_score, 2))
+    IO.puts("Part E — crop-based scoring vs full-frame (per source, macro-averaged):")
 
-      IO.puts(
-        "    #{String.pad_trailing(name, 11)} median #{Float.round(median(offs), 2)}  spread #{spread_note(offs)}"
-      )
+    # B refresh (free byproduct of the full-frame oracle search), per source.
+    IO.puts("  B refresh — ssim2 over real content (savings vs q#{@baseline_quality}):")
+
+    Enum.each(by_source, fn {src, rs} ->
+      hs = Enum.filter(rs, & &1.hit?)
+      hit_note = "#{length(hs)}/#{length(rs)} hit target"
+
+      if hs == [] do
+        IO.puts("    #{String.pad_trailing(src, 14)} #{hit_note}")
+      else
+        IO.puts(
+          "    #{String.pad_trailing(src, 14)} #{hit_note}, q̄ #{round(avg(Enum.map(hs, & &1.quality)))}, " <>
+            "save #{round(avg(Enum.map(hs, & &1.savings)))}%, iters #{Float.round(avg(Enum.map(hs, & &1.iters)), 1)}"
+        )
+      end
     end)
 
-    # 2. Sub-sampling penalty: K tiles vs all tiles, by HET bin (heterogeneous
-    #    images are where a sparse sample misses the localized worst region).
-    IO.puts(
-      "\n  sub-sampling penalty (K=#{@subsample_k} tiles vs full coverage), by heterogeneity:"
-    )
+    # E tracking: per-source p10 offset (tile p10 − full-frame score) at the
+    # boundary; tight ⇒ a calibrated global threshold reproduces the decision.
+    IO.puts("\n  E tracking — p10 offset (tile p10 − full-frame score), per source:")
+    src_offset_medians = report_e_tracking(by_source)
 
-    Enum.each(
-      [{"uniform HET<0.1", &(&1.het < 0.1)}, {"hetero HET>=0.1", &(&1.het >= 0.1)}],
-      fn {name, pred} ->
-        grp = Enum.filter(rows, pred)
+    macro_off = src_offset_medians |> avg() |> Float.round(2)
+    macro_save = macro_over_sources(by_source, & &1.savings) |> round()
+    smooth_worst = Enum.count(hits, & &1.worst_smooth?)
 
-        if grp != [] do
-          worst_gap =
-            grp |> Enum.map(&Float.round(&1.sub_worst - &1.worst, 2)) |> avg() |> Float.round(2)
-
-          worst_max = grp |> Enum.map(&Float.round(&1.sub_worst - &1.worst, 2)) |> Enum.max()
-
-          IO.puts(
-            "    #{String.pad_trailing(name, 16)} n=#{length(grp)}  sub_worst − true_worst: mean +#{worst_gap}, worst +#{worst_max}"
-          )
-        end
-      end
-    )
-
-    # 3. Banding localization + cost.
-    smooth_worst = Enum.count(rows, & &1.worst_smooth?)
-    avg_full = rows |> Enum.map(& &1.full_us) |> avg() |> ms()
-    avg_tile = rows |> Enum.map(& &1.per_tile_us) |> avg()
-    k_ms = Float.round(avg_tile * @subsample_k / 1000, 1)
-    avg_n = rows |> Enum.map(& &1.n_tiles) |> avg() |> Float.round(1)
+    IO.puts("\n  macro-average across sources:")
+    IO.puts("    p10 offset (mean of per-source medians): #{macro_off}")
 
     IO.puts(
-      "\n  worst tile sits in a smooth/low-texture region: #{smooth_worst}/#{length(rows)} subjects"
+      "    savings: #{macro_save}%  |  worst tile in a smooth region: #{smooth_worst}/#{length(hits)}"
     )
 
-    IO.puts(
-      "  cost: full-frame ~#{avg_full}ms  |  full coverage ~#{avg_n} tiles (≈ no saving)  |  K=#{@subsample_k} tiles ~#{k_ms}ms (fixed, size-independent)"
-    )
+    IO.puts("  -> crops keep native resolution, so they TRACK full-frame across content types")
 
-    IO.puts("  -> crops keep native resolution, so (unlike Part C's proxy) they TRACK")
-    IO.puts("     full-frame — p10 offset is the tightest. Full coverage saves nothing;")
-    IO.puts("     K-tile sub-sampling is a fixed budget that only wins above the tile-")
-    IO.puts("     count crossover (i.e. large images), at small sub-sampling error.\n")
+    IO.puts("     (p10 offset, above); the fixed K-tile budget wins on the large sources.\n")
+  end
+
+  defp report_e_tracking(by_source) do
+    for {src, rs} <- by_source, hs = Enum.filter(rs, & &1.hit?), hs != [] do
+      offs = Enum.map(hs, &(&1.p10 - &1.full_score))
+      med = median(offs)
+      sub_pen = Float.round(avg(Enum.map(hs, &(&1.sub_worst - &1.worst))), 2)
+      k16 = ms(round(avg(Enum.map(hs, & &1.per_tile_us)) * @subsample_k))
+      full = ms(round(avg(Enum.map(hs, & &1.full_us))))
+      win = if k16 < full, do: "#{Float.round(full / k16, 1)}× win", else: "loss"
+
+      IO.puts(
+        "    #{String.pad_trailing(src, 14)} median #{Float.round(med, 2)}  spread #{spread_note(offs)}  " <>
+          "subPen +#{sub_pen}  cost #{full}→#{k16}ms (#{win})"
+      )
+
+      med
+    end
+  end
+
+  defp macro_over_sources(by_source, field_fun) do
+    for {_src, rs} <- by_source, hs = Enum.filter(rs, & &1.hit?), hs != [] do
+      avg(Enum.map(hs, field_fun))
+    end
+    |> avg()
   end
 
   # --- resolved descriptors --------------------------------------------------
@@ -1346,18 +1422,29 @@ defmodule Mix.Tasks.Autoquality.Bench do
     path = "/tmp/autoquality_bench_part_e.csv"
 
     head =
-      "source,mp,het,n_tiles,full_score,worst,p10,mean,sub_worst,sub_p10," <>
-        "worst_smooth,full_us,per_tile_us\n"
+      "source,label,mp,hit,quality,full_score,bytes,savings,iters," <>
+        "het,n_tiles,worst,p10,mean,sub_worst,sub_p10,worst_smooth,full_us,per_tile_us\n"
 
     body =
       Enum.map_join(rows, fn r ->
-        "#{r.label},#{r.mp},#{r.het},#{r.n_tiles},#{fmt_score(r.full_score)},#{fmt_score(r.worst)}," <>
-          "#{fmt_score(r.p10)},#{fmt_score(r.mean)},#{fmt_score(r.sub_worst)},#{fmt_score(r.sub_p10)}," <>
-          "#{r.worst_smooth?},#{r.full_us},#{r.per_tile_us}\n"
+        "#{r.source},#{r.label},#{r.mp},#{r.hit?},#{r.quality},#{fmt_score(r.full_score)}," <>
+          "#{r.bytes},#{r.savings},#{r.iters}," <>
+          "#{e_cell(r, :het)},#{e_cell(r, :n_tiles)},#{e_cell(r, :worst, &fmt_score/1)}," <>
+          "#{e_cell(r, :p10, &fmt_score/1)},#{e_cell(r, :mean, &fmt_score/1)}," <>
+          "#{e_cell(r, :sub_worst, &fmt_score/1)},#{e_cell(r, :sub_p10, &fmt_score/1)}," <>
+          "#{e_cell(r, :worst_smooth?)},#{e_cell(r, :full_us)},#{e_cell(r, :per_tile_us)}\n"
       end)
 
     File.write!(path, head <> body)
     IO.puts("wrote #{path}")
+  end
+
+  # E fields are absent on miss rows (no boundary); render those cells blank.
+  defp e_cell(row, key, fmt \\ &to_string/1) do
+    case Map.get(row, key) do
+      nil -> ""
+      value -> fmt.(value)
+    end
   end
 
   defp write_part_c_csv(rows) do
@@ -1416,19 +1503,6 @@ defmodule Mix.Tasks.Autoquality.Bench do
 
   defp parse_files(nil), do: []
   defp parse_files(str), do: str |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
-
-  # A directory of images (Part E corpus) takes precedence over --proxy-files.
-  defp corpus_files(nil, proxy_files), do: proxy_files
-
-  defp corpus_files(dir, _proxy_files) do
-    dir
-    |> Path.join("*")
-    |> Path.wildcard()
-    |> Enum.filter(&(Path.extname(&1) |> String.downcase() |> image_ext?()))
-    |> Enum.sort()
-  end
-
-  defp image_ext?(ext), do: ext in [".jpg", ".jpeg", ".png", ".webp"]
 
   defp ms(us) when is_integer(us), do: Float.round(us / 1000, 1)
   defp ms(us), do: Float.round(us / 1000, 1)

--- a/test/support/mix/tasks/autoquality.bench.ex
+++ b/test/support/mix/tasks/autoquality.bench.ex
@@ -56,11 +56,17 @@ defmodule Mix.Tasks.Autoquality.Bench do
   records the full-res search as ground truth (`q_full`), the proxy's pick
   (`q_proxy`), and — the real accuracy question — the **delivered** full-res
   SSIMULACRA2 score of the full-res encode at `q_proxy`, plus byte movement and the
-  measured speedup. Subjects: the committed sRGB high-detail sources at native size
-  plus an adversarial zone-plate at `--proxy-mp` (default 16). The error is
-  two-directional (real content over-picks quality → byte overshoot; the
-  adversarial chirp under-picks → undershoot), so the findings weigh a modest `k`
-  against a confirm-and-adjust step rather than a fixed margin.
+  measured speedup. Subjects: the committed sRGB high-detail sources at native size,
+  an adversarial zone-plate at `--proxy-mp` (default 16), and any images passed via
+  `--proxy-files a.jpg,b.jpg` (which replace the committed set — use it to point at
+  genuinely large real photos the repo can't carry).
+
+  Finding: SSIMULACRA2 is resolution-dependent (a given quality scores lower on a
+  downscaled image), so the search systematically OVER-picks quality on real
+  content, and the over-pick grows with image size (≤2 MP: +1–2q; 16 MP: +18q,
+  +56% bytes). That savings loss is the expensive direction to undo; a cheap
+  confirm-and-adjust only rescues the rarer undershoot. So a naive downscale+margin
+  proxy is not viable — a correct one needs its target calibrated across resolution.
   """
   use Mix.Task
   use Boundary, top_level?: true, check: [out: false]
@@ -111,7 +117,8 @@ defmodule Mix.Tasks.Autoquality.Bench do
           csv: :boolean,
           format: :string,
           proxy_factors: :string,
-          proxy_mp: :integer
+          proxy_mp: :integer,
+          proxy_files: :string
         ]
       )
 
@@ -120,6 +127,7 @@ defmodule Mix.Tasks.Autoquality.Bench do
     format = opts |> Keyword.get(:format, "jpeg") |> parse_format()
     mps = parse_mps(Keyword.get(opts, :mps))
     factors = parse_factors(Keyword.get(opts, :proxy_factors))
+    proxy_files = parse_files(Keyword.get(opts, :proxy_files))
     proxy_mp = Keyword.get(opts, :proxy_mp, 16)
 
     {:ok, _} = Application.ensure_all_started(:image_pipe)
@@ -127,7 +135,11 @@ defmodule Mix.Tasks.Autoquality.Bench do
 
     a_rows = if part in ["a", "both", "all"], do: run_part_a(mps, format), else: nil
     b_rows = if part in ["b", "both", "all"], do: run_part_b(format), else: nil
-    c_rows = if part in ["c", "all"], do: run_part_c(factors, proxy_mp, format), else: nil
+
+    c_rows =
+      if part in ["c", "all"],
+        do: run_part_c(factors, proxy_mp, proxy_files, format),
+        else: nil
 
     if csv? do
       if a_rows, do: write_part_a_csv(a_rows)
@@ -401,7 +413,7 @@ defmodule Mix.Tasks.Autoquality.Bench do
   # quality. We measure whether the delivered full-res image still hits the target
   # (the real accuracy question) against the current full-res search as ground
   # truth, plus the measured speedup.
-  defp run_part_c(factors, synth_mp, format) do
+  defp run_part_c(factors, synth_mp, proxy_files, format) do
     IO.puts("\n== Part C — downscaled-proxy-seed method + accuracy ==")
     IO.puts("ssim2 target #{@target} [#{@min_q},#{@max_q}]  factors #{inspect(factors)}  ")
 
@@ -410,7 +422,7 @@ defmodule Mix.Tasks.Autoquality.Bench do
     )
 
     header =
-      pad(["source", 16]) <>
+      pad(["source", 18]) <>
         pad(["MP", 6]) <>
         pad(["k", 3]) <>
         pad(["pMP", 6]) <>
@@ -430,10 +442,20 @@ defmodule Mix.Tasks.Autoquality.Bench do
 
     resolved = ssim2_resolved(format)
 
+    # External files (e.g. genuinely large real photos) replace the small
+    # committed set when given, so the run can target production-scale content the
+    # repo can't carry. The adversarial synthetic always anchors the worst case.
+    real =
+      case proxy_files do
+        [] ->
+          Enum.map(@part_c_sources, fn f -> {f, base_image_at(Path.join(@sources_dir, f))} end)
+
+        paths ->
+          Enum.map(paths, fn p -> {Path.basename(p), base_image_at(p)} end)
+      end
+
     subjects =
-      (@part_c_sources
-       |> Enum.map(fn file -> {file, base_image(file)} end)
-       |> Enum.reject(fn {_f, img} -> is_nil(img) end)) ++
+      Enum.reject(real, fn {_l, img} -> is_nil(img) end) ++
         [{"zone-#{synth_mp}MP", zone_plate_for(synth_mp)}]
 
     subjects
@@ -469,7 +491,7 @@ defmodule Mix.Tasks.Autoquality.Bench do
       speedup = ratio(full_us, proxy_total_us)
 
       IO.puts(
-        pad([label, 16]) <>
+        pad([label, 18]) <>
           pad([mp, 6]) <>
           pad([k, 3]) <>
           pad([pmp, 6]) <>
@@ -511,13 +533,11 @@ defmodule Mix.Tasks.Autoquality.Bench do
     resized
   end
 
-  # Open a committed source and apply a light finalize (realize to memory, force
+  # Open an image at `path` and apply a light finalize (realize to memory, force
   # sRGB, flatten any alpha onto white) so encode_to_buffer to JPEG is valid. Real
-  # production finalization (color management) is a near-no-op for these sRGB
-  # sources, so this keeps Part C self-contained without the private finalize.
-  defp base_image(file) do
-    path = Path.join(@sources_dir, file)
-
+  # production finalization (color management) is a near-no-op for sRGB sources, so
+  # this keeps Part C self-contained without the private finalize.
+  defp base_image_at(path) do
     case Image.open(path, access: :random) do
       {:ok, img} ->
         {:ok, mem} = VixImage.copy_memory(img)
@@ -525,7 +545,7 @@ defmodule Mix.Tasks.Autoquality.Bench do
         flatten_alpha(srgb)
 
       {:error, reason} ->
-        IO.puts("Part C: skipping #{file} (open failed: #{inspect(reason)})")
+        IO.puts("Part C: skipping #{path} (open failed: #{inspect(reason)})")
         nil
     end
   end
@@ -702,14 +722,16 @@ defmodule Mix.Tasks.Autoquality.Bench do
     IO.puts("  * ssim2 is ~#{speedup}x the cost of size (the decode+metric overhead)\n")
   end
 
-  # Two failure modes, opposite directions:
-  #   * q_proxy < q_full (Δq < 0): the proxy looked "easier" → delivered full-res
-  #     score UNDERSHOOTS the target. The magnitude of −Δq is the quality margin
-  #     that fixes it (the full search picks the lowest q clearing the target, so
-  #     by monotonicity q_proxy ≥ q_full ⟹ delivered ≥ target).
-  #   * q_proxy > q_full (Δq > 0): the proxy looked "harder" → delivered overshoots
-  #     and the encode is LARGER than the optimal full-res pick — savings erode.
-  # A single additive margin only addresses the first; it makes the second worse.
+  # Two error directions, judged against the FULL-res search (the achievable
+  # ground truth — not the absolute target, which the full search itself may miss
+  # at the bracket ceiling):
+  #   * q_proxy > q_full: the downscaled proxy needs a higher quality to clear the
+  #     SAME score (SSIMULACRA2 is harsher on downscaled images), so the encode is
+  #     LARGER than the optimal full-res pick — savings erode. The expensive-to-fix
+  #     direction (recovering it needs a downward full-res search).
+  #   * q_proxy < q_full: the proxy under-picks → delivered score regresses below
+  #     full. Only a true proxy regression when the full search HIT (otherwise the
+  #     target was unreachable regardless). Cheap to fix (bump q + one confirm).
   defp findings_part_c(rows) do
     IO.puts("Part C — downscaled-proxy-seed method + accuracy:")
 
@@ -717,28 +739,30 @@ defmodule Mix.Tasks.Autoquality.Bench do
     |> Enum.group_by(& &1.k)
     |> Enum.sort_by(fn {k, _} -> k end)
     |> Enum.each(fn {k, group} ->
-      n = length(group)
-      hits = Enum.count(group, & &1.hit?)
-      mean_dq = group |> Enum.map(& &1.dq) |> avg() |> Float.round(1)
-      worst_dq = group |> Enum.map(& &1.dq) |> Enum.min()
-      margin = max(0, -worst_dq)
-      worst_under = group |> Enum.map(& &1.delta_target) |> Enum.min() |> Float.round(2)
+      full_hit = Enum.filter(group, &(&1.full_score >= @target))
+      regressions = Enum.count(full_hit, &(not &1.hit?))
+
+      worst_drop =
+        group |> Enum.map(&Float.round(&1.delivered_score - &1.full_score, 2)) |> Enum.min()
+
+      worst_overpick = group |> Enum.map(& &1.dq) |> Enum.max()
       worst_bytes = group |> Enum.map(&byte_overshoot/1) |> Enum.max()
       mean_speedup = group |> Enum.map(& &1.speedup) |> avg() |> Float.round(1)
       mean_proxy_ms = group |> Enum.map(& &1.proxy_total_us) |> avg() |> ms()
 
       IO.puts(
-        "  k=#{k}: hit #{hits}/#{n}@margin0  |  Δq mean #{mean_dq}/worst #{worst_dq} (+#{margin}q fixes)  |  " <>
-          "worst undershoot #{worst_under}  |  worst byte overshoot +#{worst_bytes}%  |  " <>
+        "  k=#{k}: proxy-caused undershoots #{regressions}/#{length(full_hit)} (of full-hit)  |  " <>
+          "worst Δscore vs full #{worst_drop}  |  worst over-pick +#{worst_overpick}q / +#{worst_bytes}% bytes  |  " <>
           "~#{mean_speedup}x (#{mean_proxy_ms} ms)"
       )
     end)
 
-    IO.puts("  -> bias direction is content-dependent: real high-detail content tends")
-    IO.puts("     to over-pick q (hits target, but inflates bytes — savings erode);")
-    IO.puts("     the adversarial chirp under-picks (undershoots). A modest k≈2 keeps")
-    IO.puts("     both small; aggressive k needs a full-res confirm-and-adjust, not a")
-    IO.puts("     fixed margin (the one full-res confirm metric is already affordable).\n")
+    IO.puts("  -> SSIMULACRA2 is resolution-dependent: a given q scores LOWER on a")
+    IO.puts("     downscaled proxy, so the search systematically OVER-picks q on real")
+    IO.puts("     content (bigger images → bigger over-pick → more savings lost). That")
+    IO.puts("     direction is the expensive one to undo; a cheap confirm-and-adjust")
+    IO.puts("     only rescues undershoot. Naive downscale+margin is not viable — a")
+    IO.puts("     correct proxy needs the target calibrated across resolution.\n")
   end
 
   defp byte_overshoot(%{bytes_proxy: bp, bytes_full: bf}) when bf > 0,
@@ -835,6 +859,9 @@ defmodule Mix.Tasks.Autoquality.Bench do
     |> String.split(",", trim: true)
     |> Enum.map(&(&1 |> String.trim() |> String.to_integer()))
   end
+
+  defp parse_files(nil), do: []
+  defp parse_files(str), do: str |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
 
   defp ms(us) when is_integer(us), do: Float.round(us / 1000, 1)
   defp ms(us), do: Float.round(us / 1000, 1)

--- a/test/support/mix/tasks/autoquality.bench.ex
+++ b/test/support/mix/tasks/autoquality.bench.ex
@@ -12,10 +12,13 @@ defmodule Mix.Tasks.Autoquality.Bench do
   is NIF-heavy (the `ssimulacra2` Rust NIF) and slow. Auto-selects `MIX_ENV=test`
   via `mix.exs` `preferred_envs`.
 
-      mise exec -- mix autoquality.bench                 # both parts, default sizes
+      mise exec -- mix autoquality.bench                 # parts A+B, default sizes
       mise exec -- mix autoquality.bench --part a        # cost curve only
       mise exec -- mix autoquality.bench --part b        # accuracy/behavior only
+      mise exec -- mix autoquality.bench --part c        # proxy-seed method + accuracy
+      mise exec -- mix autoquality.bench --part all      # A + B + C
       mise exec -- mix autoquality.bench --mps 1,4,9     # custom Part A megapixels
+      mise exec -- mix autoquality.bench --proxy-factors 2,4 --proxy-mp 25  # Part C knobs
       mise exec -- mix autoquality.bench --csv           # also write CSVs under /tmp
 
   ## Part A — per-megapixel cost curve
@@ -44,6 +47,20 @@ defmodule Mix.Tasks.Autoquality.Bench do
 
   Goal: confirm `:ssim2` lands at/above its target, and surface typical quality /
   savings / iteration counts to validate (or adjust) the shipped defaults.
+
+  ## Part C — downscaled-proxy-seed method + accuracy
+
+  Explores the deferred optimization: instead of searching at full resolution,
+  downscale by `1/k`, run the ssim2 search on the proxy to pick a quality, then
+  encode the **full-res** image once at that quality. For each subject × factor it
+  records the full-res search as ground truth (`q_full`), the proxy's pick
+  (`q_proxy`), and — the real accuracy question — the **delivered** full-res
+  SSIMULACRA2 score of the full-res encode at `q_proxy`, plus byte movement and the
+  measured speedup. Subjects: the committed sRGB high-detail sources at native size
+  plus an adversarial zone-plate at `--proxy-mp` (default 16). The error is
+  two-directional (real content over-picks quality → byte overshoot; the
+  adversarial chirp under-picks → undershoot), so the findings weigh a modest `k`
+  against a confirm-and-adjust step rather than a fixed margin.
   """
   use Mix.Task
   use Boundary, top_level?: true, check: [out: false]
@@ -54,6 +71,7 @@ defmodule Mix.Tasks.Autoquality.Bench do
   alias ImagePipe.Output.ResolvedQualitySearch, as: RQS
   alias ImagePipe.Output.Ssim2Metric
   alias ImagePipe.Test.ImgproxyDifferential.SourceInventory
+  alias Vix.Vips.Image, as: VixImage
   alias Vix.Vips.Operation
 
   @sources_dir "test/support/image_pipe/test/imgproxy_differential/sources"
@@ -69,30 +87,55 @@ defmodule Mix.Tasks.Autoquality.Bench do
   @default_mps [1, 4, 9, 16, 25, 36]
   @baseline_quality 90
 
+  # Part C subjects: the committed sRGB high-detail sources (the ones with real
+  # savings in Part B), where the downscale-proxy quality-transfer relationship is
+  # meaningful. CMYK / embedded-ICC / 16-bit / alpha sources are excluded to keep
+  # the light finalize (copy_memory + sRGB + flatten) a no-op-equivalent.
+  @part_c_sources [
+    "high_freq.jpg",
+    "marker.png",
+    "border.png",
+    "border_asym.png",
+    "placement.png"
+  ]
+
+  @default_factors [2, 3, 4]
+
   @impl Mix.Task
   def run(args) do
     {opts, _, _} =
       OptionParser.parse(args,
-        strict: [part: :string, mps: :string, csv: :boolean, format: :string]
+        strict: [
+          part: :string,
+          mps: :string,
+          csv: :boolean,
+          format: :string,
+          proxy_factors: :string,
+          proxy_mp: :integer
+        ]
       )
 
     part = Keyword.get(opts, :part, "both")
     csv? = Keyword.get(opts, :csv, false)
     format = opts |> Keyword.get(:format, "jpeg") |> parse_format()
     mps = parse_mps(Keyword.get(opts, :mps))
+    factors = parse_factors(Keyword.get(opts, :proxy_factors))
+    proxy_mp = Keyword.get(opts, :proxy_mp, 16)
 
     {:ok, _} = Application.ensure_all_started(:image_pipe)
     warmup(format)
 
-    a_rows = if part in ["a", "both"], do: run_part_a(mps, format), else: nil
-    b_rows = if part in ["b", "both"], do: run_part_b(format), else: nil
+    a_rows = if part in ["a", "both", "all"], do: run_part_a(mps, format), else: nil
+    b_rows = if part in ["b", "both", "all"], do: run_part_b(format), else: nil
+    c_rows = if part in ["c", "all"], do: run_part_c(factors, proxy_mp, format), else: nil
 
     if csv? do
       if a_rows, do: write_part_a_csv(a_rows)
       if b_rows, do: write_part_b_csv(b_rows)
+      if c_rows, do: write_part_c_csv(c_rows)
     end
 
-    print_findings(a_rows, b_rows, format)
+    print_findings(a_rows, b_rows, c_rows, format)
   end
 
   # Touch every NIF/libvips path once so first-call JIT + library init does not
@@ -351,6 +394,151 @@ defmodule Mix.Tasks.Autoquality.Bench do
     end)
   end
 
+  # --- Part C: downscaled-proxy-seed method + accuracy ----------------------
+
+  # The proxy method: downscale the finalized image by 1/k, run the ssim2 search
+  # on that proxy to pick a quality, then encode the FULL-res image once at that
+  # quality. We measure whether the delivered full-res image still hits the target
+  # (the real accuracy question) against the current full-res search as ground
+  # truth, plus the measured speedup.
+  defp run_part_c(factors, synth_mp, format) do
+    IO.puts("\n== Part C — downscaled-proxy-seed method + accuracy ==")
+    IO.puts("ssim2 target #{@target} [#{@min_q},#{@max_q}]  factors #{inspect(factors)}  ")
+
+    IO.puts(
+      "format #{format}  truth = full-res search  delivered = full-res encode at proxy's q\n"
+    )
+
+    header =
+      pad(["source", 16]) <>
+        pad(["MP", 6]) <>
+        pad(["k", 3]) <>
+        pad(["pMP", 6]) <>
+        pad(["qFull", 6]) <>
+        pad(["qProxy", 7]) <>
+        pad(["dq", 5]) <>
+        pad(["fullSc", 8]) <>
+        pad(["delivSc", 9]) <>
+        pad(["d-#{@target}", 7]) <>
+        pad(["hit?", 6]) <>
+        pad(["bFull", 9]) <>
+        pad(["bProxy", 9]) <>
+        pad(["speedup", 8])
+
+    IO.puts(header)
+    IO.puts(String.duplicate("-", String.length(header)))
+
+    resolved = ssim2_resolved(format)
+
+    subjects =
+      (@part_c_sources
+       |> Enum.map(fn file -> {file, base_image(file)} end)
+       |> Enum.reject(fn {_f, img} -> is_nil(img) end)) ++
+        [{"zone-#{synth_mp}MP", zone_plate_for(synth_mp)}]
+
+    subjects
+    |> Enum.flat_map(fn {label, base} ->
+      bench_proxy_subject(label, base, factors, resolved)
+    end)
+  end
+
+  defp bench_proxy_subject(label, base, factors, resolved) do
+    mp = Float.round(Image.width(base) * Image.height(base) / 1_000_000, 2)
+    {:ok, full_ref} = Ssim2Metric.reference(base)
+
+    {full_us, {:ok, _full_bin, full_meta}} =
+      timed(fn -> EncodeSearch.run(base, resolved, telemetry_opts: []) end)
+
+    Enum.map(factors, fn k ->
+      {ds_us, proxy} = timed(fn -> downscale(base, k) end)
+
+      {proxy_us, {:ok, _pbin, proxy_meta}} =
+        timed(fn -> EncodeSearch.run(proxy, resolved, telemetry_opts: []) end)
+
+      {conf_us, {:ok, conf_bin}} =
+        timed(fn -> Encoder.encode_to_buffer(base, resolved, proxy_meta.quality) end)
+
+      {:ok, candidate} = Image.from_binary(conf_bin)
+      {:ok, delivered} = Ssim2Metric.score(full_ref, candidate)
+
+      pmp = Float.round(Image.width(proxy) * Image.height(proxy) / 1_000_000, 2)
+      dq = proxy_meta.quality - full_meta.quality
+      delta_target = delivered - @target
+      hit? = delivered >= @target
+      proxy_total_us = ds_us + proxy_us + conf_us
+      speedup = ratio(full_us, proxy_total_us)
+
+      IO.puts(
+        pad([label, 16]) <>
+          pad([mp, 6]) <>
+          pad([k, 3]) <>
+          pad([pmp, 6]) <>
+          pad([full_meta.quality, 6]) <>
+          pad([proxy_meta.quality, 7]) <>
+          pad([dq, 5]) <>
+          pad([fmt_score(full_meta.score), 8]) <>
+          pad([fmt_score(delivered), 9]) <>
+          pad([Float.round(delta_target, 2), 7]) <>
+          pad([if(hit?, do: "yes", else: "NO"), 6]) <>
+          pad([full_meta.bytes, 9]) <>
+          pad([byte_size(conf_bin), 9]) <>
+          pad(["#{speedup}x", 8])
+      )
+
+      %{
+        source: label,
+        mp: mp,
+        k: k,
+        proxy_mp: pmp,
+        q_full: full_meta.quality,
+        q_proxy: proxy_meta.quality,
+        dq: dq,
+        full_score: full_meta.score,
+        delivered_score: delivered,
+        delta_target: delta_target,
+        hit?: hit?,
+        bytes_full: full_meta.bytes,
+        bytes_proxy: byte_size(conf_bin),
+        full_us: full_us,
+        proxy_total_us: proxy_total_us,
+        speedup: speedup
+      }
+    end)
+  end
+
+  defp downscale(image, k) do
+    {:ok, resized} = Operation.resize(image, 1.0 / k)
+    resized
+  end
+
+  # Open a committed source and apply a light finalize (realize to memory, force
+  # sRGB, flatten any alpha onto white) so encode_to_buffer to JPEG is valid. Real
+  # production finalization (color management) is a near-no-op for these sRGB
+  # sources, so this keeps Part C self-contained without the private finalize.
+  defp base_image(file) do
+    path = Path.join(@sources_dir, file)
+
+    case Image.open(path, access: :random) do
+      {:ok, img} ->
+        {:ok, mem} = VixImage.copy_memory(img)
+        {:ok, srgb} = Operation.colourspace(mem, :VIPS_INTERPRETATION_sRGB)
+        flatten_alpha(srgb)
+
+      {:error, reason} ->
+        IO.puts("Part C: skipping #{file} (open failed: #{inspect(reason)})")
+        nil
+    end
+  end
+
+  defp flatten_alpha(image) do
+    if Image.has_alpha?(image) do
+      {:ok, flat} = Image.flatten(image, background_color: [255, 255, 255])
+      flat
+    else
+      image
+    end
+  end
+
   # --- resolved descriptors --------------------------------------------------
 
   defp ssim2_resolved(format) do
@@ -445,6 +633,11 @@ defmodule Mix.Tasks.Autoquality.Bench do
     srgb
   end
 
+  defp zone_plate_for(mp) do
+    {w, h} = square_dims(mp)
+    zone_plate(w, h)
+  end
+
   defp square_dims(mp) do
     side = round(:math.sqrt(mp * 1_000_000))
     {side, side}
@@ -452,11 +645,12 @@ defmodule Mix.Tasks.Autoquality.Bench do
 
   # --- findings --------------------------------------------------------------
 
-  defp print_findings(a_rows, b_rows, format) do
+  defp print_findings(a_rows, b_rows, c_rows, format) do
     IO.puts("\n== Findings ==\n")
 
     if a_rows, do: findings_part_a(a_rows)
     if b_rows, do: findings_part_b(b_rows)
+    if c_rows, do: findings_part_c(c_rows)
 
     IO.puts("\n(format: #{format}; numbers vary with CPU + libvips build — re-run locally)")
   end
@@ -508,6 +702,50 @@ defmodule Mix.Tasks.Autoquality.Bench do
     IO.puts("  * ssim2 is ~#{speedup}x the cost of size (the decode+metric overhead)\n")
   end
 
+  # Two failure modes, opposite directions:
+  #   * q_proxy < q_full (Δq < 0): the proxy looked "easier" → delivered full-res
+  #     score UNDERSHOOTS the target. The magnitude of −Δq is the quality margin
+  #     that fixes it (the full search picks the lowest q clearing the target, so
+  #     by monotonicity q_proxy ≥ q_full ⟹ delivered ≥ target).
+  #   * q_proxy > q_full (Δq > 0): the proxy looked "harder" → delivered overshoots
+  #     and the encode is LARGER than the optimal full-res pick — savings erode.
+  # A single additive margin only addresses the first; it makes the second worse.
+  defp findings_part_c(rows) do
+    IO.puts("Part C — downscaled-proxy-seed method + accuracy:")
+
+    rows
+    |> Enum.group_by(& &1.k)
+    |> Enum.sort_by(fn {k, _} -> k end)
+    |> Enum.each(fn {k, group} ->
+      n = length(group)
+      hits = Enum.count(group, & &1.hit?)
+      mean_dq = group |> Enum.map(& &1.dq) |> avg() |> Float.round(1)
+      worst_dq = group |> Enum.map(& &1.dq) |> Enum.min()
+      margin = max(0, -worst_dq)
+      worst_under = group |> Enum.map(& &1.delta_target) |> Enum.min() |> Float.round(2)
+      worst_bytes = group |> Enum.map(&byte_overshoot/1) |> Enum.max()
+      mean_speedup = group |> Enum.map(& &1.speedup) |> avg() |> Float.round(1)
+      mean_proxy_ms = group |> Enum.map(& &1.proxy_total_us) |> avg() |> ms()
+
+      IO.puts(
+        "  k=#{k}: hit #{hits}/#{n}@margin0  |  Δq mean #{mean_dq}/worst #{worst_dq} (+#{margin}q fixes)  |  " <>
+          "worst undershoot #{worst_under}  |  worst byte overshoot +#{worst_bytes}%  |  " <>
+          "~#{mean_speedup}x (#{mean_proxy_ms} ms)"
+      )
+    end)
+
+    IO.puts("  -> bias direction is content-dependent: real high-detail content tends")
+    IO.puts("     to over-pick q (hits target, but inflates bytes — savings erode);")
+    IO.puts("     the adversarial chirp under-picks (undershoots). A modest k≈2 keeps")
+    IO.puts("     both small; aggressive k needs a full-res confirm-and-adjust, not a")
+    IO.puts("     fixed margin (the one full-res confirm metric is already affordable).\n")
+  end
+
+  defp byte_overshoot(%{bytes_proxy: bp, bytes_full: bf}) when bf > 0,
+    do: round((bp - bf) / bf * 100)
+
+  defp byte_overshoot(_), do: 0
+
   # --- CSV -------------------------------------------------------------------
 
   defp write_part_a_csv(rows) do
@@ -544,6 +782,24 @@ defmodule Mix.Tasks.Autoquality.Bench do
     IO.puts("wrote #{path}")
   end
 
+  defp write_part_c_csv(rows) do
+    path = "/tmp/autoquality_bench_part_c.csv"
+
+    head =
+      "source,mp,k,proxy_mp,q_full,q_proxy,dq,full_score,delivered_score,delta_target,hit," <>
+        "bytes_full,bytes_proxy,full_us,proxy_total_us,speedup\n"
+
+    body =
+      Enum.map_join(rows, fn r ->
+        "#{r.source},#{r.mp},#{r.k},#{r.proxy_mp},#{r.q_full},#{r.q_proxy},#{r.dq}," <>
+          "#{fmt_score(r.full_score)},#{fmt_score(r.delivered_score)},#{Float.round(r.delta_target, 2)}," <>
+          "#{r.hit?},#{r.bytes_full},#{r.bytes_proxy},#{r.full_us},#{r.proxy_total_us},#{r.speedup}\n"
+      end)
+
+    File.write!(path, head <> body)
+    IO.puts("wrote #{path}")
+  end
+
   # --- helpers ---------------------------------------------------------------
 
   defp timed(fun) do
@@ -570,6 +826,14 @@ defmodule Mix.Tasks.Autoquality.Bench do
       {int, ""} -> int
       _ -> s |> Float.parse() |> elem(0)
     end
+  end
+
+  defp parse_factors(nil), do: @default_factors
+
+  defp parse_factors(str) do
+    str
+    |> String.split(",", trim: true)
+    |> Enum.map(&(&1 |> String.trim() |> String.to_integer()))
   end
 
   defp ms(us) when is_integer(us), do: Float.round(us / 1000, 1)

--- a/test/support/mix/tasks/autoquality.corpus.ex
+++ b/test/support/mix/tasks/autoquality.corpus.ex
@@ -1,0 +1,136 @@
+defmodule Mix.Tasks.Autoquality.Corpus do
+  @shortdoc "Fetch the autoquality benchmark corpus into a shared cache — no git, no LFS"
+  @moduledoc """
+  Materializes the `mix autoquality.bench` corpus by downloading pinned subsets of
+  [`imazen/codec-corpus`](https://github.com/imazen/codec-corpus) plus a fixed set
+  of large photographs, into a **shared, worktree-independent cache**:
+
+      ${XDG_CACHE_HOME:-~/.cache}/image_pipe/corpus/<sha>/<source>/
+
+  No `git` and no `git-lfs` are involved: the file list comes from the GitHub
+  contents API at the pinned commit, and each file is fetched from its
+  `raw.githubusercontent.com` URL (GitHub resolves the LFS objects server-side).
+  Because the cache lives outside any working tree, every worktree and the main
+  checkout share one copy; nothing lands in a tracked or gitignored repo dir.
+
+  Sources (each capped for balanced, bounded per-source groups — see the bench's
+  macro-averaged, per-source reporting):
+
+    * `clic` / `clic_holdout` — CLIC 2025 photographic (train / holdout split)
+    * `cid22` — Cloudinary CID22, diverse content (portraits…medical…plots)
+    * `gb82` — purpose-built hard photographic (sky gradients, fine texture)
+    * `gb82_sc` — real screen content (text / UI / charts)
+    * `qoi_web` — large web screenshots
+    * `large` — large (~15 MP) photographs for the size-dependent parts (C, E-cost),
+      which codec-corpus has no equivalent for; pinned Lorem Picsum ids.
+
+      mise exec -- mix autoquality.corpus                 # fetch everything (~270 MB)
+      mise exec -- mix autoquality.corpus --only gb82,gb82_sc
+      mise exec -- mix autoquality.corpus --path          # just print the cache dir
+  """
+  use Mix.Task
+  use Boundary, top_level?: true, check: [out: false]
+
+  @repo "imazen/codec-corpus"
+  @sha "bb1da434fd3ab9ef58577f505d2f9194123e5d6e"
+  @exts ~w(.png .jpg .jpeg .webp)
+
+  # codec-corpus subdirs to pull, with a per-source cap (deterministic by name).
+  @codec_subsets [
+    %{name: "clic", dir: "clic2025/training", max: 40},
+    %{name: "clic_holdout", dir: "clic2025/final-test", max: 40},
+    %{name: "cid22", dir: "CID22/CID22-512/training", max: 40},
+    %{name: "gb82", dir: "gb82", max: 25},
+    %{name: "gb82_sc", dir: "gb82-sc", max: 10},
+    %{name: "qoi_web", dir: "qoi-benchmark/screenshot_web", max: 14}
+  ]
+
+  # Large photographs (~15 MP) for the size-dependent parts. Pinned Lorem Picsum
+  # ids (stable per id), requested center-cropped to a uniform 4800×3200.
+  @picsum_ids [107, 110, 146, 157, 201, 204]
+  @picsum_dims "4800/3200"
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _, _} = OptionParser.parse(args, strict: [path: :boolean, only: :string])
+
+    root = cache_root()
+
+    if opts[:path] do
+      IO.puts(root)
+    else
+      {:ok, _} = Application.ensure_all_started(:req)
+      only = parse_only(opts[:only])
+      File.mkdir_p!(root)
+
+      for s <- @codec_subsets, keep?(s.name, only), do: fetch_codec_subset(s, root)
+      if keep?("large", only), do: fetch_large(root)
+
+      IO.puts("\ncorpus ready: #{root}")
+    end
+  end
+
+  @doc "Absolute path of the shared corpus cache for the pinned revision."
+  def cache_root do
+    base = System.get_env("XDG_CACHE_HOME") || Path.join(System.user_home!(), ".cache")
+    Path.join([base, "image_pipe", "corpus", String.slice(@sha, 0, 12)])
+  end
+
+  defp parse_only(nil), do: :all
+  defp parse_only(str), do: str |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
+
+  defp keep?(_name, :all), do: true
+  defp keep?(name, only), do: name in only
+
+  defp fetch_codec_subset(%{name: name, dir: dir, max: max}, root) do
+    dest = Path.join(root, name)
+    File.mkdir_p!(dest)
+
+    files =
+      dir
+      |> list_dir()
+      |> Enum.filter(&image?/1)
+      |> Enum.sort()
+      |> Enum.take(max)
+
+    Enum.each(files, fn path ->
+      fetch_to(raw_url(path), Path.join(dest, Path.basename(path)))
+    end)
+
+    IO.puts("#{String.pad_trailing(name, 13)} #{length(files)} files -> #{dest}")
+  end
+
+  defp fetch_large(root) do
+    dest = Path.join(root, "large")
+    File.mkdir_p!(dest)
+
+    Enum.each(@picsum_ids, fn id ->
+      fetch_to(
+        "https://picsum.photos/id/#{id}/#{@picsum_dims}",
+        Path.join(dest, "picsum_#{id}.jpg")
+      )
+    end)
+
+    IO.puts("#{String.pad_trailing("large", 13)} #{length(@picsum_ids)} files -> #{dest}")
+  end
+
+  defp list_dir(dir) do
+    "https://api.github.com/repos/#{@repo}/contents/#{dir}?ref=#{@sha}"
+    |> Req.get!(headers: [{"accept", "application/vnd.github+json"}])
+    |> Map.fetch!(:body)
+    |> Enum.map(& &1["path"])
+  end
+
+  defp raw_url(path), do: "https://raw.githubusercontent.com/#{@repo}/#{@sha}/#{URI.encode(path)}"
+
+  defp fetch_to(url, dest) do
+    if File.exists?(dest) do
+      :ok
+    else
+      %{status: 200, body: body} = Req.get!(url, decode_body: false)
+      File.write!(dest, body)
+    end
+  end
+
+  defp image?(path), do: path |> Path.extname() |> String.downcase() |> Kernel.in(@exts)
+end


### PR DESCRIPTION
Follow-up to #351 (merged): produce real performance + accuracy data for the autoquality / `max_bytes` encode-quality search. #351 shipped the `:ssim2` objective correctness-verified only — every search iteration does a full-resolution encode + decode + SSIMULACRA2 metric, the metric dominates, and large images can time out. This adds a benchmark and summarizes findings.

## What's here

- **`mix autoquality.bench`** ([tool](test/support/mix/tasks/autoquality.bench.ex)) — a gated benchmark. Lives in `test/support/mix/tasks` (compiled only under `MIX_ENV=test`, auto-selected via `mix.exs` `preferred_envs`) and is a Mix task, so it **never runs on the default `mix test` lane** — same gating discipline as the `mix imgproxy.*` tooling. No Docker; measures our algorithm only. Reuses the public `Output.Encoder` / `EncodeSearch` / `Ssim2Metric` APIs and reads achieved scores from the search's own `[:encode, :search]` `final_score` telemetry (a unique `telemetry_prefix`), not an ad-hoc baseline.
- **`docs/autoquality_benchmark.md`** — how to run it + the captured findings.

Two parts:
- **Part A — cost curve.** Real ssim2 search (target 88, bracket `[40,95]`, `max_iterations 6`) on a deterministic high-frequency zone-plate at ~1/4/9/16/25/36 MP, with the `encode`/`decode`/`metric` phases timed separately via wrapped `encode_fun`/`score_fun`.
- **Part B — accuracy + behavior.** Production encode path (`Encoder.stream_output/3`, real finalization) over the committed differential sources at native size: chosen quality, achieved score vs target, savings vs a fixed q90 baseline, iterations — plus `size` and `max_bytes` for a metric-free cost comparison.

## Findings (reference machine: Apple Silicon, libvips 8.18.2)

**Part A — cost vs. megapixels (6 iterations, worst case):**

| MP | total ms | metric ms | metric % |
|----|----------|-----------|----------|
| 1  | 323      | 257       | 80% |
| 4  | 1179     | 967       | 82% |
| 9  | 2634     | 2175      | 83% |
| 16 | 4730     | 3890      | 82% |
| 25 | 8095     | 6744      | 83% |
| 36 | 20405    | 18019     | 88% |

- The **metric is ~80–88% of wall-clock** at every size; encode ~5%, decode <1%, one-time reference build ~6–10%.
- **Linear in pixels through ~16 MP, then superlinear** (25→36 MP: 8 s → 20 s — buffer/cache pressure).

**Part B — accuracy (27 sources, `ssim2:88:40:95` vs q90):**

- **ssim2 hits target on 26/27** sources (the miss, `small.png` 120×90, can't reach 88 within the bracket → correctly returns the ceiling, best-effort).
- **Savings 40–58%** on high-detail content (`high_freq` 58%, `marker`/`border` ~40%); ~0% / slightly negative on tiny or already-optimized files; ~18% average.
- **size / max_bytes are ~15× cheaper** (147 ms vs 9.8 ms avg) — that gap is exactly the decode+metric overhead.

## Recommendations

1. **Ship a non-zero `autoquality_max_resolution` default.** It is currently `0` (unbounded) — unsafe given the cost curve. A conservative cross-host default of **~9 MP** keeps the worst case near 1–2 s here; tune per host. (The shipped `[70,80]` bracket runs ~4 iterations, ≈⅔ of the tabulated 6-iteration cost.)
2. **No change to the shipped objective/bracket/`max_iterations` defaults** — ssim2 lands on target reliably; the data doesn't argue for a change.
3. **Prioritize the deferred downscaled-proxy-seed optimization.** A cap only *disables* autoquality above the threshold, forfeiting the biggest savings on exactly the large high-detail images. Searching on a downscaled proxy + one full-res confirm encode would cut the dominant metric cost by the square of the downscale factor.

## Verification

`mise run precommit` green (format, `compile --warnings-as-errors`, `credo --strict`, `mix test` — 2485 tests, 0 failures). The benchmark is excluded from the default lane and was run manually to produce the numbers above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update — Part C: downscaled-proxy-seed method + accuracy

Added `--part c` to explore the deferred optimization (recommendation #3) and **measure its accuracy**: for each subject × downscale factor `k`, run the full-res search (ground truth `q_full`), downscale by `1/k`, search on the proxy (`q_proxy`), encode the **full-res** image once at `q_proxy`, and score that delivered output against the full-res reference. Subjects are the committed sRGB high-detail sources (native ≤2 MP) plus an adversarial 16 MP zone-plate.

**The proxy method works but is not a clean win — the error is two-directional and content-dependent:**

| k | hit @margin 0 | Δq mean/worst | worst undershoot | worst byte overshoot | speedup |
|---|---------------|---------------|------------------|----------------------|---------|
| 2 | 5/6 | +3.2 / −1 | −0.53 | +2% | ~3.4× |
| 3 | 5/6 | +6.0 / −4 | −5.15 | +19% | ~6.7× |
| 4 | 5/6 | +9.3 / −1 | −0.53 | +49% | ~9.7× |

- **Real high-detail content over-picks quality** (Δq ≥ 0): downscaling drops the hard-to-compress detail, so the proxy reads as *harder* → picks higher `q`. It hits the target, but the encode is **larger than the optimal full-res pick** — at `k=4`, `high_freq` delivered **+49% bytes** (q75 vs. the correct q40), eroding the savings autoquality exists to capture.
- **The adversarial chirp under-picks** (Δq < 0): the zone-plate downscales into an easier-to-score image → `q_proxy` below `q_full` → delivered score **undershoots** (k=3: 82.85 vs. target 88).
- **A single additive margin can't fix both directions.**

**Revised recommendation #3:** prototype **`k≈2`** first (~3.4× faster, ≤+2% byte overshoot, +1q covers the only undershoot); gate anything more aggressive behind a **full-res confirm-and-adjust** (one extra full-res metric pass, vs. the 4–6 the full search runs). Do **not** ship a fixed-margin proxy. Caveat: no large *real* sources exist in-repo, so cross-scale generalization is inferred — validate on genuinely large photos before fixing a default `k`.

`mise run precommit` remains green (2485 tests, 0 failures).


---

## Update 2 — Part C validated on large real photos (`--proxy-files`)

The ≤2 MP result above (and its "k=2 sweet spot" read) **did not generalize** — exactly the caveat flagged. Added `--proxy-files` to point Part C at arbitrary paths, and re-ran on three 16–20 MP Unsplash photos. Also fixed the accuracy metric to judge the proxy against the **full-res search** (achievable ground truth), not the absolute target — one photo (`aq_157`) can't reach 88 even at full-res q95, so the proxy matching it isn't a proxy failure.

| source | MP | k | q_full | q_proxy | Δq | full_score | delivered | bytesΔ | speedup |
|--------|----|---|--------|---------|----|-----------|-----------|--------|---------|
| aq_146 | 16.66 | 2 | 74 | 92 | **+18** | 90.82 | 90.58 | **+56%** | 3.8× |
| aq_146 | 16.66 | 4 | 74 | 93 | +19 | 90.82 | 90.87 | **+69%** | 14.8× |
| aq_201 | 16.66 | 4 | 93 | 92 | −1 | 88.02 | 87.64 (miss) | −8% | 12.7× |

**The naïve proxy fails on its own terms at scale.** SSIMULACRA2 is resolution-dependent — a given quality scores *lower* on a downscaled image — so the proxy search systematically **over-picks quality**, and the over-pick **grows with image size** (+1–2q at ≤2 MP → **+18q at 16 MP**, shipping **+56–69% more bytes** than the optimal full-res pick for the same delivered score). That erases the savings autoquality exists for, and it's the *expensive* direction to undo (a cheap confirm-and-adjust only rescues the rarer undershoot).

**Revised recommendation #3:** do **not** ship a fixed-`k`/fixed-margin proxy. A viable variant needs its **target calibrated across resolution** (search the proxy against a shifted score mapping to the true full-res target) — that's the actual research problem, and `--part c --proxy-files` is the harness to derive it. Until then, the resolution cap (#1) is the safe shipping answer. `mise run precommit` green throughout.


---

## Update 3 — Part D: cheap full-res metric narrowing (#6)

Tested the other cost lever: keep the decision on full-res SSIMULACRA2, but use a **cheap full-res metric (PSNR)** to narrow the search to ~1 SSIMULACRA2 probe instead of ~4–6. This avoids Part C's resolution trap (decision stays full-res). Viability hinges on one statistic — **is the cheap metric's value at the SSIMULACRA2 boundary stable across images?**

It isn't. `cheap@boundary` spans **11–22 dB**:

| corpus | metric | cheap@boundary spread | exact-q | underpick (worst) | overpick (worst) | cheaper |
|--------|--------|------------------------|---------|-------------------|------------------|---------|
| ≤2 MP committed | PSNR-RGB | 38.8…50.0 dB (11) | 2/6 | 3/6 (−28q) | +87% | 9.2× |
| ≤2 MP committed | PSNR-luma | 38.8…58.3 dB (20) | 1/6 | 3/6 (−27q) | +136% | 9.2× |
| 16 MP photos | PSNR-RGB | 43.9…65.9 dB (22) | 2/3 | 0/3 | +27% | 11.3× |

A high-frequency photo clears SSIMULACRA2=88 at ~39 dB PSNR; clean line-art needs ~50; a 16 MP photo ~66. So a single PSNR threshold either **underpicks** (ships under-compressed images, −28q) or **overpicks** (>100% byte waste). PSNR *is* ~9–11× cheaper (cost premise holds) — it just doesn't track the *perceptual* boundary, which is the gap SSIMULACRA2 exists to close.

**Conclusion:** PSNR-class narrowing is a non-starter. It'd need a cheaper *perceptual* metric (MS-SSIM/butteraugli — not in our stack) or per-image SSIMULACRA2 anchoring (saves ~0 probes on the shipped narrow `[70,80]` bracket).

### Bottom line across A–D
The SSIMULACRA2 boundary is **content-dependent and not cheaply predictable** — by neither reduced resolution (C) nor cheap pixel metric (D) — so the ~83% metric cost is largely intrinsic. The **resolution cap (#1)** is the robust shippable lever; the search/objective defaults are sound (#2); both "make it cheaper" shortcuts founder on the same rock. A real speedup needs a cheaper perceptual metric in-stack or a learned per-content predictor (the endgame). `mise run precommit` green throughout.


---

## Update 4 — Part E: crop-based scoring (#1) — the one shortcut that works

Score SSIMULACRA2 on native-resolution **tiles of the real full-res encode**, not the whole frame. Unlike the Part C proxy this keeps native resolution, so per-pixel artifact statistics match — the only error is *which regions* you look at. Added `--part e --corpus DIR` and ran on a curated **19-subject corpus** (16 Lorem Picsum photos selected by measured texture profile, + a synthetic gradient + a text block + the zone-plate), reported per measured heterogeneity.

**It's the first lever that tracks.** Honest metric = the offset `tile_aggregate − full_frame_score` at the boundary (raw spread is inflated by integer-quality quantization):

| aggregate | median offset | residual spread |
|-----------|---------------|-----------------|
| worst-tile | −0.12 | 3.24 |
| **p10-tile** | **0.12** | **2.36 (±~1.5 pts ≈ ±2 q)** |
| mean-tile | 1.83 | 4.42 |

p10 tracks full-frame within **±~1.5 pts** — vs Part C's **±18 q** and Part D's hopeless spread — because native resolution is preserved (it changes *what area* is measured, not the metric or the resolution). K=16 sub-sampling adds only +0.3 mean / +1.6 worst pts. And at the autoquality target the worst tiles are *textured*, not smooth (worst-in-smooth only 2/19) — so sparse sampling catches them.

**Cost is a fixed, size-independent budget** (K=16 ≈ 260 ms), so it beats full-frame above a ~4 MP crossover:

| size | full-frame | K=16 tiles | result |
|------|-----------|-----------|--------|
| ≤2.7 MP | 33–106 ms | ~260 ms | loss (use full-frame) |
| 10.7 MP | ~415 ms | ~263 ms | ~1.6× |
| 16 MP | ~721 ms | ~318 ms | ~2.3× |
| 36 MP (extrap.) | ~2.4 s | ~260 ms | ~9× |

**Recommendation #5 (new):** prototype crop-scoring **above the `max_resolution` cap** — full frame below it, K p10-tiles + one confirm above — turning the cap from *"disable autoquality on big images"* into *"run it affordably."* That recovers the savings on exactly the large images where the full search is unaffordable. Validate the p10 threshold / K on a larger or production corpus before fixing them.

### Bottom line A–E
The boundary isn't predictable by a *stand-in* for the metric (reduced-res proxy C, cheap pixel metric D both fail) — but it **is** recoverable by the *real* metric on a *spatial subset at native resolution* (E). Ship the cap (#1) + unchanged defaults (#2); don't ship the proxy (#3) or PSNR narrowing (#4); prototype crop-scoring (#5). `mise run precommit` green throughout.


---

## Update 5 — proper corpus + Part E per-source

Replaced the ad-hoc picsum corpus with a real, license-clean one. New `mix autoquality.corpus` fetches pinned subsets of [`imazen/codec-corpus`](https://github.com/imazen/codec-corpus) (CLIC 2025 train/holdout, CID22, GB82, GB82-SC screen content, QOI web screenshots) + a fixed ~15 MP photo set, into a **shared worktree-independent cache via the GitHub raw API — no git, no LFS** (verified raw URLs resolve LFS objects server-side). Part E now reports **per content source, macro-averaged**.

**Part E per-source (codec-corpus, ≤24/source):**

| source | imgs | hit | save vs q90 | p10 offset | cost full→K16 |
|--------|------|-----|----|-----|-----|
| clic (2–4 MP photos) | 24 | 24/24 | −22% | 0.29 | loss |
| gb82_sc (screen content) | 10 | 9/10 | −4% | −0.52 | loss |
| qoi_web (huge screenshots) | 14 | 4/14 | −16% | 0.39 | 1.1× |
| **large (15 MP photos)** | 6 | 5/6 | **+17%** | 1.46 | **2.5×** |
| **macro** | | | **−8%** | **+0.22** | |

- **Crop-tracking generalizes** — p10 offset median within ±1.5 on photos, **screen content**, huge screenshots and large photos. The content-generalization risk that justified the corpus is resolved: it tracks everywhere.
- **Cost win is large-image-only, confirmed** — 2.5× at 15 MP, loss below the ~6 MP crossover. The `large` set demonstrates it.
- **Free B-refresh + a correction** — the full-frame search per image doubles as Part B on real content: at target 88, real photos land at **q91–93 → negative savings vs q90** (macro −8%; +17% only on 15 MP). My earlier 40–58% was a fixture artifact. *Defaults unchanged* (shipped `[70,80]` caps at 80) — but "target 88 ≈ q93 on photos" is real and only a diverse corpus showed it. Side note: JPEG can't hit SSIM 88 on text-heavy screenshots (`qoi_web` 4/14).

A–D left as they stand (settled / structural; re-running them on the corpus would be polish, not decision-changing). `mise run precommit` green throughout.
