### PR TITLE
docs(autoquality): clarify Part E scored area + correct the cap's role

### DIFF
--- a/docs/autoquality_benchmark.md
+++ b/docs/autoquality_benchmark.md
@@ -376,12 +376,22 @@ loss below the ~6 MP crossover (where full-frame is cheap anyway) but **2.5× at
 15 MP** (the `large` source), scaling with size (~9× at 36 MP) — exactly the regime
 where the full search is unaffordable.
 
-Recommendation: prototype crop-scoring behind the `max_resolution` threshold (#1) —
-below the cap use the full frame; above it, score K p10-tiles per probe with a
-threshold calibrated as `target + macro-offset`, plus one full-frame confirm on the
-winner for safety. Calibration data already exists: calibrate on `clic` and check
-on the held-out `clic_holdout`. This converts the cap from "disable autoquality on
-big images" into "run it affordably," recovering savings on the images that matter.
+Recommendation: switch the search to crop-scoring above an **internal ~6 MP
+crossover** (full frame below it, where it's cheaper) — K p10-tiles per probe
+against a threshold calibrated as `target + macro-offset`, plus one full-frame
+confirm on the winner. Calibrate on `clic`, check on the held-out `clic_holdout`.
+The crossover is **internal**, *not* the user-facing `max_resolution` cap (#1) —
+keep one knob.
+
+This also reshapes the cap's role. Crop-scoring flattens the **metric** (fixed
+~4.2 MP scored, any size) but **not** the per-probe full-res **encode** (O(pixels)×N,
+~4–5 s of encodes at 36 MP). That residual is bounded by a wall-clock **deadline**
+(#355), and decode/memory is already bounded by `max_input_pixels` at the decode
+step — so once crop-scoring + the deadline land, `max_resolution` is **redundant as a
+cost guard**. It should then *retire* to an optional **policy** knob ("don't attempt
+autoquality above X MP" → clean fixed-quality fallback), default high/off — it stays
+a must-do *interim* guard only until those land. That is what turns "autoquality off
+on big images" into "autoquality on, affordably."
 
 ## The bottom line across A–E
 
@@ -392,9 +402,12 @@ But the boundary **is** recoverable by computing the *real* metric on a *spatial
 subset at native resolution* (Part E) — that tracks within ±~1.5 pts and, as a fixed
 tile budget, makes per-probe cost size-independent. So:
 
-- **Ship now:** the resolution cap (#1), objective/bracket defaults unchanged (#2).
+- **Ship now:** the resolution cap (#1, *interim* — see below), objective/bracket
+  defaults unchanged (#2).
 - **Don't ship:** the naïve proxy (#3) or PSNR narrowing (#4).
-- **Prototype next:** crop-based scoring above the cap (#5) — the genuine speedup,
-  turning the cap into "autoquality stays on, affordably" for large images.
+- **Prototype next:** crop-based scoring above an internal ~6 MP crossover (#5) — the
+  genuine speedup, "autoquality stays on, affordably" for large images. It plus a
+  wall-clock deadline + the existing `max_input_pixels` then make the resolution cap
+  redundant as a *cost* guard, so the cap retires to an optional policy knob.
 - **Endgame, if needed:** a cheaper perceptual metric in-stack, or a learned
   per-content quality predictor — both larger efforts than this benchmark.

--- a/docs/autoquality_benchmark.md
+++ b/docs/autoquality_benchmark.md
@@ -224,8 +224,10 @@ the whole frame. Unlike Part C's proxy this keeps native resolution, so per-pixe
 artifact statistics match — the only error is *which regions* you look at. Run
 **per content source** over the [`imazen/codec-corpus`](https://github.com/imazen/codec-corpus)
 subsets fetched by `mix autoquality.corpus` (≤24/source, macro-averaged so no one
-content type dominates), 512 px tiles, K=16 sub-sample. The honest tracking metric
-is the *offset* `tile_p10 − full_frame_score` at the boundary — a calibrated global
+content type dominates), 512 px tiles, K=16 sub-sample — **so the scored sample is a
+fixed 16 × 512² ≈ 4.2 MP regardless of source resolution** (full coverage would tile
+the whole frame; sub-sampling to K=16 tiles is the cost lever). The honest tracking
+metric is the *offset* `tile_p10 − full_frame_score` at the boundary — a calibrated global
 threshold rides on it (the raw aggregate spread would be inflated by `full_score`'s
 integer-quality quantization):
 
@@ -248,11 +250,13 @@ single threshold `≈ target + macro-offset` reproduces the full-frame decision;
 one-pass full-frame confirm covers the residual. (`cid22`/`gb82` are ≤576 px → one
 tile, so they only exercise the B-refresh below, not crop-tracking.)
 
-**Cost win is large-image-only, confirmed.** K=16 is a fixed ~265 ms budget, so it
-only beats full-frame above a **~6 MP crossover**: `large` (15 MP) wins **2.5×**,
-while CLIC at 2–4 MP and everything smaller is a *loss*. The budget is constant
-while full-frame grows ~linearly, so the win scales with size (extrapolating, ~9×
-at 36 MP) — collapsing Part A's superlinear blow-up. Sub-sampling penalty is small
+**Cost win is large-image-only, confirmed.** Because K=16 always scores the same
+~4.2 MP sample (16 × 512²) no matter the source size, it's a **flat ~265 ms budget**;
+full-frame scores the whole image and grows ~linearly. So crops only beat full-frame
+above a **~6 MP crossover** (≈ where the full frame's area passes the 4.2 MP sample
+plus per-tile overhead), and the win ≈ source-MP ÷ 4.2: `large` (15 MP) wins **2.5×**,
+CLIC at 2–4 MP and smaller is a *loss*, extrapolating to ~9× at 36 MP — collapsing
+Part A's superlinear blow-up. Sub-sampling penalty is small
 (`large`: +0.62 worst), and the worst tile sat in a smooth region in only **3/113**
 subjects (banding-in-smooth is a low-quality phenomenon, below this regime).
 

--- a/test/support/mix/tasks/autoquality.bench.ex
+++ b/test/support/mix/tasks/autoquality.bench.ex
@@ -106,7 +106,8 @@ defmodule Mix.Tasks.Autoquality.Bench do
   synthetic). Reports, binned by measured heterogeneity: (1) tracking — the offset
   `tile_aggregate − full_frame_score` at the boundary (tight ⇒ a calibrated global
   threshold reproduces the full-frame decision); (2) sub-sampling penalty — K tiles
-  vs full coverage; (3) cost — K tiles is a fixed pixel budget regardless of size.
+  vs full coverage; (3) cost — K tiles is a fixed pixel budget (16 × 512² ≈ 4.2 MP
+  scored, independent of source size).
 
   Finding: crop scoring is the first lever that TRACKS. The p10-tile offset holds
   within ±~1.5 pts (median ~0) across content — vs Part C's ±18q and Part D's
@@ -879,7 +880,8 @@ defmodule Mix.Tasks.Autoquality.Bench do
     IO.puts("oracle = full-frame full-res ssim2, target #{@target} [#{@min_q},#{@max_q}]  ")
 
     IO.puts(
-      "tile #{@tile}px  K=#{@subsample_k}  q#{@baseline_quality} savings baseline  ≤#{cap}/source  format #{format}\n"
+      "tile #{@tile}px  K=#{@subsample_k} (≈#{Float.round(@subsample_k * @tile * @tile / 1_000_000, 1)} MP scored)  " <>
+        "q#{@baseline_quality} savings baseline  ≤#{cap}/source  format #{format}\n"
     )
 
     resolved = ssim2_resolved(format)


### PR DESCRIPTION
Follow-up to #352. The Part E write-up described the method as "512 px tiles, K=16 sub-sample" but never stated the number that makes the cost story legible: **the sub-sampled scored sample is a fixed 16 × 512² ≈ 4.2 MP, independent of source resolution.**

That single fact is what the cost analysis hinges on:
- it's why K=16 is a **flat ~265 ms budget** (not a function of image size),
- why the crossover is **~6 MP** (where the full frame's area passes the 4.2 MP sample + per-tile overhead),
- and why the win **≈ source-MP ÷ 4.2** (2.5× at 15 MP, ~9× at 36 MP).

Makes it explicit in three places: `docs/autoquality_benchmark.md` (setup line + cost paragraph), the `mix autoquality.bench` moduledoc, and the runtime header (now prints `K=16 (≈4.2 MP scored)`).

Docs + one runtime string only; no behavior change. `mise run precommit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Also (same Part E cost story):** corrected the cap's role in recommendations #5 and the bottom line. The full-frame↔crop switch is an **internal ~6 MP crossover**, not the user-facing `max_resolution` cap — and crop-scoring flattens the *metric* but not the per-probe full-res *encode* (O(pixels)×N), so that residual is bounded by a deadline (#355), with decode/memory already bounded by `max_input_pixels`. Net: once crop-scoring + deadline land, the cap is **redundant as a cost guard** and retires to an optional policy knob (interim must-do until then) — superseding the earlier "raise the cap" framing. Issues #353/#354 updated to match.
