### PR TITLE
fix(fiddle): sane ssim2 autoquality target default

### DIFF
--- a/fiddle/assets/ImgproxyControls.svelte
+++ b/fiddle/assets/ImgproxyControls.svelte
@@ -1097,7 +1097,7 @@
   {#if fiddleState.autoqualityMethod === "size"}
     <RangeNumber
       label="Target (bytes)"
-      bind:value={fiddleState.autoqualityTarget}
+      bind:value={fiddleState.autoqualitySizeTarget}
       min={controlLimits.autoquality.sizeTarget.min}
       max={controlLimits.autoquality.sizeTarget.max}
       step={controlLimits.autoquality.sizeTarget.step}
@@ -1121,7 +1121,7 @@
   {#if fiddleState.autoqualityMethod === "ssim2"}
     <RangeNumber
       label="Target (SSIMULACRA2)"
-      bind:value={fiddleState.autoqualityTarget}
+      bind:value={fiddleState.autoqualitySsim2Target}
       min={controlLimits.autoquality.ssim2Target.min}
       max={controlLimits.autoquality.ssim2Target.max}
       step={controlLimits.autoquality.ssim2Target.step}

--- a/fiddle/assets/fiddle-url-state.ts
+++ b/fiddle/assets/fiddle-url-state.ts
@@ -1134,7 +1134,7 @@ function parseAutoquality(currentState: FiddleState, args: string[]): FiddleStat
     return {
       ...currentState,
       autoqualityMethod: "size",
-      autoqualityTarget: parsePositiveInteger(target) ?? currentState.autoqualityTarget,
+      autoqualitySizeTarget: parsePositiveInteger(target) ?? currentState.autoqualitySizeTarget,
       autoqualityMinQuality: parseQualityValue(min) ?? currentState.autoqualityMinQuality,
       autoqualityMaxQuality: parseQualityValue(max) ?? currentState.autoqualityMaxQuality,
     };
@@ -1146,7 +1146,7 @@ function parseAutoquality(currentState: FiddleState, args: string[]): FiddleStat
     return {
       ...currentState,
       autoqualityMethod: "ssim2",
-      autoqualityTarget: parsedTarget ?? currentState.autoqualityTarget,
+      autoqualitySsim2Target: parsedTarget ?? currentState.autoqualitySsim2Target,
       autoqualityMinQuality: parseQualityValue(min) ?? currentState.autoqualityMinQuality,
       autoqualityMaxQuality: parseQualityValue(max) ?? currentState.autoqualityMaxQuality,
       autoqualityAllowedError:

--- a/fiddle/assets/processing-path.test.ts
+++ b/fiddle/assets/processing-path.test.ts
@@ -1142,11 +1142,26 @@ describe("processing path generation", () => {
     expect(optionSegments(state)).toEqual(["rs:fill:640:360:0", "g:ce", "q:85"]);
   });
 
+  it("defaults each autoquality target within its own valid range", () => {
+    expect(defaultFiddleState.autoqualitySizeTarget).toBeGreaterThanOrEqual(
+      controlLimits.autoquality.sizeTarget.min,
+    );
+    expect(defaultFiddleState.autoqualitySizeTarget).toBeLessThanOrEqual(
+      controlLimits.autoquality.sizeTarget.max,
+    );
+    expect(defaultFiddleState.autoqualitySsim2Target).toBeGreaterThanOrEqual(
+      controlLimits.autoquality.ssim2Target.min,
+    );
+    expect(defaultFiddleState.autoqualitySsim2Target).toBeLessThanOrEqual(
+      controlLimits.autoquality.ssim2Target.max,
+    );
+  });
+
   it("serializes size autoquality as target:min:max", () => {
     const state = {
       ...activeFiddleState,
       autoqualityMethod: "size" as const,
-      autoqualityTarget: 40000,
+      autoqualitySizeTarget: 40000,
       autoqualityMinQuality: 60,
       autoqualityMaxQuality: 90,
     };
@@ -1163,7 +1178,7 @@ describe("processing path generation", () => {
     const state = {
       ...activeFiddleState,
       autoqualityMethod: "ssim2" as const,
-      autoqualityTarget: 80,
+      autoqualitySsim2Target: 80,
       autoqualityMinQuality: 50,
       autoqualityMaxQuality: 95,
       autoqualityAllowedError: 1.5,
@@ -1388,7 +1403,7 @@ describe("fiddle URL state", () => {
 
     expect(parsed).toMatchObject({
       autoqualityMethod: "size",
-      autoqualityTarget: 40000,
+      autoqualitySizeTarget: 40000,
       autoqualityMinQuality: 60,
       autoqualityMaxQuality: 90,
     });
@@ -1403,7 +1418,7 @@ describe("fiddle URL state", () => {
 
     expect(parsed).toMatchObject({
       autoqualityMethod: "ssim2",
-      autoqualityTarget: 80,
+      autoqualitySsim2Target: 80,
       autoqualityMinQuality: 50,
       autoqualityMaxQuality: 95,
       autoqualityAllowedError: 1.5,
@@ -1419,7 +1434,7 @@ describe("fiddle URL state", () => {
 
     expect(parsed).toMatchObject({
       autoqualityMethod: "size",
-      autoqualityTarget: 40000,
+      autoqualitySizeTarget: 40000,
     });
   });
 

--- a/fiddle/assets/processing-path.ts
+++ b/fiddle/assets/processing-path.ts
@@ -206,7 +206,8 @@ export type FiddleState = {
   qualityEnabled: boolean;
   quality: number;
   autoqualityMethod: AutoqualityMethod;
-  autoqualityTarget: number;
+  autoqualitySizeTarget: number;
+  autoqualitySsim2Target: number;
   autoqualityMinQuality: number;
   autoqualityMaxQuality: number;
   autoqualityAllowedError: number;
@@ -433,7 +434,8 @@ export const defaultFiddleState: FiddleState = {
   qualityEnabled: false,
   quality: 85,
   autoqualityMethod: "none",
-  autoqualityTarget: 50000,
+  autoqualitySizeTarget: 50000,
+  autoqualitySsim2Target: 90,
   autoqualityMinQuality: 70,
   autoqualityMaxQuality: 90,
   autoqualityAllowedError: 1,
@@ -648,7 +650,7 @@ export function autoqualityOptionSegment(currentState: FiddleState): string | nu
     return [
       "autoquality",
       "size",
-      currentState.autoqualityTarget,
+      currentState.autoqualitySizeTarget,
       currentState.autoqualityMinQuality,
       currentState.autoqualityMaxQuality,
     ].join(":");
@@ -658,7 +660,7 @@ export function autoqualityOptionSegment(currentState: FiddleState): string | nu
     return [
       "autoquality",
       "ssim2",
-      currentState.autoqualityTarget,
+      currentState.autoqualitySsim2Target,
       currentState.autoqualityMinQuality,
       currentState.autoqualityMaxQuality,
       currentState.autoqualityAllowedError,


### PR DESCRIPTION
## Problem

In the fiddle's imgproxy controls, enabling **ssim2** autoquality started with an invalid value. A single `autoqualityTarget` state field was shared between two semantically different quantities:

- `size` method — target in **bytes** (default `50000`, range 1–5,000,000)
- `ssim2` method — target is a **SSIMULACRA2 score** (range 0–100)

So switching the method to `ssim2` left the slider holding `50000`, far outside its 0–100 range.

## Fix

Split the field into two, each with its own valid default:

- `autoqualitySizeTarget` → `50000` (bytes)
- `autoqualitySsim2Target` → `90` (a sensible high-quality SSIMULACRA2 score; 80–90 is what the conformance tests use)

Each method now starts in range, and switching between methods no longer clobbers the other's target.

## Changes (fiddle demo app only)

- `processing-path.ts` — `FiddleState` type, `defaultFiddleState`, and the `size`/`ssim2` serialization in `autoqualityOptionSegment`
- `fiddle-url-state.ts` — `parseAutoquality` writes the method-specific field
- `ImgproxyControls.svelte` — the two `Target` sliders bind to their respective fields
- `processing-path.test.ts` — updated pinned serialization/round-trip tests + a new test asserting each default sits within its own control range

No effect on ImagePipe's observable imgproxy behavior, so no conformance-doc update needed.

## Verification

- `pnpm test` → 255 passed
- `pnpm run check` (tsgo + svelte-check) → 0 errors
- `pnpm run lint` (oxlint) → 0 warnings/errors
- `pnpm run format` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)