### PR TITLE
feat(telemetry): carry the per-result verdict on OTel span attributes

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -742,6 +742,11 @@ A host implements `ImagePipe.Telemetry.Trace.Exporter`:
   (allowlist only — source URLs, request paths, signatures, and tokens are never
   copied in). Exporters that fan out to third parties remain responsible for
   their own egress policy.
+- Attributes carry **both the start metadata and the allowlisted stop
+  metadata** — the per-result verdict (e.g. the encode-search `chosen_quality` /
+  `final_score` / `scorer`, the HTTP `status`, the classified `error` tag, the
+  decoded shape). Stop keys win on collision. Exporters need not read the
+  telemetry events separately to recover the outcome.
 - The allowlist covers **attributes only**. A span's `status_message` and the
   `reason` on a folded `exception` event carry the raw exception reason
   (`inspect/1`, standard tracing behavior) and are **not** allowlist-filtered,

--- a/lib/image_pipe/telemetry/trace/capture.ex
+++ b/lib/image_pipe/telemetry/trace/capture.ex
@@ -79,7 +79,36 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
     :max_bytes,
     :quality,
     :bytes,
-    :score
+    :score,
+    # Stop-metadata verdicts (the per-result facts an observer reads off a
+    # finished span). All product-neutral; sourced from request inputs or
+    # runtime image inspection, never from secret-bearing strings.
+    :status,
+    :error,
+    :reason,
+    :output_format,
+    :content_type,
+    :stream_phase,
+    # encode-search outcome
+    :chosen_quality,
+    :chosen_bytes,
+    :final_score,
+    :scorer,
+    :outcome,
+    :iterations,
+    :tiles_scored,
+    :confirm_passes,
+    # fetch/decode shape
+    :load_option,
+    :loaded_dims,
+    :original_dims,
+    :achieved_shrink,
+    :detected_source_format,
+    :source_format_resolution,
+    # cache admission / warm-start
+    :victim_count,
+    :own_state_loaded,
+    :peer_state_files
   ]
 
   @spec attach(map()) :: :ok
@@ -188,7 +217,10 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
         :ok
 
       span ->
-        span |> finalize(measurements, status_from(meta)) |> export(exporter)
+        span
+        |> merge_attrs(meta)
+        |> finalize(measurements, status_from(meta))
+        |> export(exporter)
     end
   end
 
@@ -263,6 +295,15 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
   end
 
   defp exception_message(meta), do: inspect(meta[:reason])
+
+  # Span attributes are seeded from start metadata (on_start) and then enriched
+  # with the stop metadata's allowlisted keys here — the per-result verdict
+  # (chosen quality/score, HTTP status, error tag, decoded shape, …) that the
+  # Logger and metrics handlers already see. Stop keys win on collision (the
+  # start value was a placeholder for the same fact).
+  defp merge_attrs(%Span{attributes: attrs} = span, meta) do
+    %{span | attributes: Map.merge(attrs, safe_attrs(meta))}
+  end
 
   defp safe_attrs(meta) do
     Map.take(meta, @safe_keys)

--- a/test/image_pipe/telemetry/trace/capture_test.exs
+++ b/test/image_pipe/telemetry/trace/capture_test.exs
@@ -109,6 +109,57 @@ defmodule ImagePipe.Telemetry.Trace.CaptureTest do
     assert_receive {:span, %Span{name: "image_pipe.render"} = span}
     assert span.status == :ok
     assert span.attributes[:renderer] == ImagePipe.Telemetry.Trace.CaptureTest
+    assert span.attributes[:content_type] == "application/json"
+  end
+
+  test "merges allowlisted stop-metadata attributes onto the span, preserving start attrs" do
+    Telemetry.span(
+      [],
+      [:encode, :search],
+      %{objective: :ssim2, max_bytes: 200_000},
+      fn ->
+        {:ok,
+         %{
+           result: :ok,
+           chosen_quality: 62,
+           chosen_bytes: 12_345,
+           final_score: 90.42,
+           scorer: :crop,
+           outcome: :hit
+         }}
+      end
+    )
+
+    assert_receive {:span, %Span{name: "image_pipe.encode.search"} = span}
+    # start attributes preserved
+    assert span.attributes[:objective] == :ssim2
+    assert span.attributes[:max_bytes] == 200_000
+    # stop attributes (the per-result verdict) now captured
+    assert span.attributes[:chosen_quality] == 62
+    assert span.attributes[:chosen_bytes] == 12_345
+    assert span.attributes[:final_score] == 90.42
+    assert span.attributes[:scorer] == :crop
+    assert span.attributes[:outcome] == :hit
+  end
+
+  test "captures HTTP status and the classified error tag from stop metadata" do
+    Telemetry.span([], [:request], %{}, fn ->
+      {:ok, %{result: :source_error, status: 422, error: :body_too_large}}
+    end)
+
+    assert_receive {:span, %Span{name: "image_pipe.request"} = span}
+    assert span.status == :error
+    assert span.attributes[:status] == 422
+    assert span.attributes[:error] == :body_too_large
+  end
+
+  test "drops non-allowlisted stop-metadata keys" do
+    Telemetry.span([], [:request], %{}, fn ->
+      {:ok, %{result: :ok, source_url: "https://secret.example/signed?sig=abc"}}
+    end)
+
+    assert_receive {:span, %Span{name: "image_pipe.request"} = span}
+    refute Map.has_key?(span.attributes, :source_url)
   end
 
   test "captures the input color management span" do


### PR DESCRIPTION
## Summary

Span attributes were seeded from **start metadata only**: `Capture.on_start` ran `safe_attrs/1`, but `on_stop` set just duration + status and dropped all stop metadata. So every span's per-result verdict — the facts the default Logger and metrics handlers already receive on the merged `:stop` event — was invisible to the OTel trace exporter. This was noted in passing in #361 ("span attributes still come from start metadata only").

The gap is architectural, not encode-search-specific. This closes it for all spans.

## What changed

- `on_stop` now merges the **allowlisted** stop metadata into the span's attributes (stop keys win on collision) — a small `merge_attrs/2` helper in `Capture`.
- `@safe_keys` extended with the product-neutral verdict keys, grouped by source span.

### Now surfaced on spans

- `status` (HTTP code) + `error` (classified tag) — every request stage; the two biggest wins
- encode-search verdict — `chosen_quality`, `chosen_bytes`, `final_score`, `scorer`, `outcome`, `iterations`, `tiles_scored`, `confirm_passes`
- fetch/decode shape — `load_option`, `loaded_dims`, `original_dims`, `achieved_shrink`, `detected_source_format`, `source_format_resolution`
- `output_format` / `content_type` / `stream_phase`, plus cache `victim_count` / `own_state_loaded` / `peer_state_files`
- `regions` and `cache` were *already* allowlisted, so the detector region count and cache hit/miss outcome now surface for free via the merge

## Safety

The allowlist still gates egress. Every key added was already emitted as telemetry metadata and already fans out to all attached handlers, so this only brings ImagePipe's own trace exporter to parity — it can't widen the public surface. Each new key's emission sites were audited; all values are tags/ints/atoms/dims, none secret-bearing. `source_url` and friends stay excluded (pinned by a test). Exception spans are unchanged — a raised fun produces no stop metadata.

## Tests / docs

- TDD: 4 new assertions in `capture_test.exs` (stop-attr merge, start-attr preservation, HTTP status + error tag, non-allowlisted key drop), watched fail then green.
- Synced the exporter-contract note in `docs/telemetry.md` per the telemetry guidelines. The default Logger needed no change — it already receives stop metadata.
- Full `mise run precommit` green: format, compile (warnings-as-errors), credo --strict, 2523 tests + 81 properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)