### PR TITLE
feat(telemetry): autoquality probe spans + per-probe cost legs

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -293,6 +293,11 @@ result `meta`):
   absent on the full-frame path.
 - `:confirm_passes` — full-frame confirm/bump passes on the crop path (1 = confirm
   only; up to 3 with the bump cap). `0` on the full-frame path.
+- `:limiting_factor` — why a `:best_effort` result fell short, absent on a `:hit`:
+  `:ceiling`/`:floor` (the objective never cleared its band/target and pinned to
+  the bracket ceiling/floor), `:max_bytes` (the hard budget could not be met even
+  at the floor), or `:bump_exhausted` (the crop confirm undershot through every
+  bump pass).
 
 The default Logger escalates an `outcome: :best_effort` stop (and an exception) to
 `:warning`; other outcomes log at the base level. It renders the stop with the
@@ -305,20 +310,71 @@ image_pipe encode search: ok (crop hit q72 12345b score 90.42)
 
 ### Encode-quality search probe (`[:encode, :search, :probe]`)
 
-Each distinct encode the search performs emits a one-shot (non-span)
-`[:image_pipe, :encode, :search, :probe]` event with empty measurements. Re-using
-an already-memoized quality does **not** emit a probe.
+Each unit of probe work the search performs is a `[:image_pipe, :encode, :search,
+:probe]` **span**, nested under `[:encode, :search]`. A probe span is created for
+every NEW distinct encode (objective/cap search and the floor/ceiling fallbacks)
+and every NEW authoritative confirm score (the crop path's confirm/bump). Re-using
+an already-memoized quality (or confirm score) emits **nothing**. The span
+duration is the total probe time; its child legs (below) give the cost split.
 
-Metadata:
+Start metadata:
 
 - `:quality` — the probed quality.
-- `:bytes` — the encoded byte size at that quality.
-- `:index` — the distinct-encode ordinal (1-based).
-- `:score` — the SSIMULACRA2 score at that quality for an `:ssim2` search,
-  otherwise absent.
+- `:phase` — `:objective` (the objective binary search), `:cap` (the `max_bytes`
+  cap descent), `:confirm` (the first crop→full re-validation), or `:bump` (a
+  linear bump pass after a confirm undershoot).
 
-All values are product-neutral numbers (no URLs, secrets, or PII). The default
-Logger renders the probe at the base level via the generic fallback.
+Stop metadata:
+
+- `:bytes` — the encoded byte size at that quality.
+- `:index` — the distinct-encode ordinal (1-based). A confirm probe whose encode
+  was a memo hit carries the same `:index` as the objective probe that produced
+  the buffer, tying the estimate and confirm legs of one buffer together.
+- `:score` — the score this phase computed: the (offset-corrected) crop estimate
+  on an objective probe in crop mode, the authoritative full-frame score on a
+  confirm/bump probe, the whole-frame score on a full-frame objective probe;
+  absent for a `:size`/`:none` search.
+- `:scorer` — `:full` or `:crop` (the configured scorer).
+- `:tiles_scored` — tiles scored on the crop path; absent on the full-frame path.
+
+Confirm/bump probes additionally carry the crop→full residual — the real-world
+accuracy of the internal crop-correction offset, a shadow signal for any future
+per-content offset calibration:
+
+- `:crop_estimate` — the offset-corrected crop estimate for the same buffer.
+- `:full_frame_score` — the authoritative whole-frame score (equals `:score`).
+- `:passed?` — whether `:full_frame_score` cleared the confirm band.
+
+#### Per-probe cost legs
+
+Each probe span nests child spans splitting the probe's cost. These are eager
+NIF/op calls, so their durations are honest compute timing (unlike the
+libvips-lazy per-operation transform spans):
+
+- `[:encode, :search, :probe, :encode]` — the codec encode
+  (`ImagePipe.Output.Encoder.encode_to_buffer`). Method-neutral: it fires for
+  every objective (`:size`/`:ssim2`/`:none`), so it carries no metric-method
+  segment. Stop metadata: `:bytes`. Absent on a confirm probe whose encode was a
+  memo hit.
+- `[:encode, :search, :probe, :ssim2, :decode]` — the candidate decode
+  (`Image.from_binary`). Stop metadata: `:bytes` (the input buffer size).
+- `[:encode, :search, :probe, :ssim2, :metric]` — one aggregate SSIMULACRA2 score
+  (whole-frame, or K crop tiles). Stop metadata: `:score`, and `:tiles_scored` on
+  the crop-estimate path (absent on the whole-frame confirm). No per-tile span is
+  emitted — that detail lives in `mix autoquality.bench`.
+
+The scoring legs carry the metric-method segment (`:ssim2`) so a future metric
+(e.g. `dssim`) gets distinct span names a backend can group by.
+
+All values are product-neutral numbers/atoms (no URLs, secrets, or PII).
+
+**Logger vs. OTel asymmetry.** The default Logger renders the **probe span**
+(`image_pipe encode search probe: …`, base level; an exception escalates to
+`:warning`) but deliberately does **not** subscribe to the cost legs — ~15–27 leg
+lines per request would drown the human log. The legs are traced by the OTel
+exporter only (`ImagePipe.Telemetry.Trace.Capture`), where per-probe cost detail
+belongs. This is the one intentional place the Logger and the tracer cover
+different event sets.
 
 ### Delivery streaming span (`[:deliver]`)
 
@@ -654,6 +710,7 @@ defmodule MyApp.ImagePipeTelemetry do
     [:transform, :materialize],
     [:encode],
     [:encode, :search],
+    [:encode, :search, :probe],
     [:render],
     [:cache, :stage],
     [:cache, :write],

--- a/lib/image_pipe/output/encode_search.ex
+++ b/lib/image_pipe/output/encode_search.ex
@@ -54,6 +54,13 @@ defmodule ImagePipe.Output.EncodeSearch do
 
   @type outcome :: :hit | :best_effort | :skipped
 
+  # Why a `:best_effort` result fell short of the objective/budget. `nil` on a
+  # `:hit`. `:ceiling`/`:floor` — the objective never cleared its band/target and
+  # pinned to the bracket ceiling/floor; `:max_bytes` — the hard budget could not
+  # be met even at the floor; `:bump_exhausted` — the crop confirm undershot
+  # through every bump pass.
+  @type limiting_factor :: :ceiling | :floor | :max_bytes | :bump_exhausted
+
   @type meta :: %{
           quality: 1..100,
           bytes: non_neg_integer(),
@@ -62,7 +69,8 @@ defmodule ImagePipe.Output.EncodeSearch do
           score: float() | nil,
           confirm_passes: non_neg_integer(),
           scorer: :full | :crop,
-          tiles_scored: pos_integer() | nil
+          tiles_scored: pos_integer() | nil,
+          limiting_factor: limiting_factor() | nil
         }
 
   # Mutable-ish search context threaded through the loop as an immutable struct.
@@ -83,6 +91,8 @@ defmodule ImagePipe.Output.EncodeSearch do
               confirm_passes: 0,
               iterations: 0,
               max_iterations: 0,
+              phase: nil,
+              limiting_factor: nil,
               telemetry_opts: []
   end
 
@@ -121,7 +131,7 @@ defmodule ImagePipe.Output.EncodeSearch do
 
   defp do_search(quality_search, max_bytes, ctx, opts) do
     with {:ok, objective_q, objective_outcome, _objective_score, ctx} <-
-           objective_phase(quality_search, ctx, opts),
+           objective_phase(quality_search, %{ctx | phase: :objective}, opts),
          {:ok, confirmed_q, confirmed_outcome, ctx} <-
            confirm_phase(objective_q, objective_outcome, ctx),
          {:ok, final_q, final_outcome, ctx} <-
@@ -168,7 +178,8 @@ defmodule ImagePipe.Output.EncodeSearch do
       final_score: meta.score,
       scorer: meta.scorer,
       tiles_scored: meta.tiles_scored,
-      confirm_passes: meta.confirm_passes
+      confirm_passes: meta.confirm_passes,
+      limiting_factor: meta.limiting_factor
     }
   end
 
@@ -186,7 +197,8 @@ defmodule ImagePipe.Output.EncodeSearch do
   @spec run(Vix.Vips.Image.t(), Resolved.t(), keyword()) ::
           {:ok, binary(), meta()} | {:error, term()}
   def run(finalized_image, %Resolved{} = resolved, opts) do
-    encode_fun = fn quality -> Encoder.encode_to_buffer(finalized_image, resolved, quality) end
+    telemetry_opts = Keyword.get(opts, :telemetry_opts, [])
+    encode_fun = fn quality -> encode_leg(finalized_image, resolved, quality, telemetry_opts) end
     scorer = Keyword.get(opts, :scorer, :full)
 
     # The confirm/bump phase does up to @default_max_bump_passes + 1 MANDATORY
@@ -196,7 +208,7 @@ defmodule ImagePipe.Output.EncodeSearch do
     max_iterations =
       Keyword.get(opts, :max_iterations, @default_max_iterations) + bump_headroom(scorer)
 
-    with {:ok, search_opts} <- score_opts(finalized_image, resolved, scorer) do
+    with {:ok, search_opts} <- score_opts(finalized_image, resolved, scorer, telemetry_opts) do
       base_quality = base_quality(resolved)
 
       try do
@@ -208,7 +220,7 @@ defmodule ImagePipe.Output.EncodeSearch do
             base_quality: base_quality,
             max_iterations: max_iterations,
             scorer: scorer,
-            telemetry_opts: Keyword.get(opts, :telemetry_opts, [])
+            telemetry_opts: telemetry_opts
           ] ++ search_opts
         )
       catch
@@ -246,6 +258,7 @@ defmodule ImagePipe.Output.EncodeSearch do
       {best, outcome, ctx} ->
         # None fit → floor (min_quality), best-effort.
         chosen = best || rqs.min_quality
+        ctx = set_factor(ctx, if(best, do: nil, else: :floor))
         with {:ok, ctx} <- ensure_probed(chosen, ctx), do: {:ok, chosen, outcome, nil, ctx}
     end
   end
@@ -262,6 +275,7 @@ defmodule ImagePipe.Output.EncodeSearch do
       {best, outcome, ctx} ->
         # None clear → ceiling (max_quality), best-effort.
         chosen = best || rqs.max_quality
+        ctx = set_factor(ctx, if(best, do: nil, else: :ceiling))
 
         with {:ok, ctx} <- ensure_probed(chosen, ctx) do
           {:ok, chosen, outcome, Map.get(ctx.score_memo, chosen), ctx}
@@ -277,6 +291,7 @@ defmodule ImagePipe.Output.EncodeSearch do
 
   defp cap_phase(quality_search, max_bytes, objective_q, objective_outcome, ctx) do
     floor = cap_floor(quality_search)
+    ctx = %{ctx | phase: :cap}
 
     with {:ok, ctx} <- ensure_probed(objective_q, ctx) do
       upper_bytes = byte_size(Map.fetch!(ctx.encode_memo, objective_q))
@@ -306,11 +321,13 @@ defmodule ImagePipe.Output.EncodeSearch do
         err
 
       {nil, _outcome, ctx} ->
+        ctx = set_factor(ctx, :max_bytes)
+
         with {:ok, ctx} <- ensure_probed(floor, ctx),
              do: {:ok, floor, :best_effort, ctx}
 
       {best, outcome, ctx} ->
-        {:ok, best, outcome, ctx}
+        {:ok, best, outcome, set_factor(ctx, nil)}
     end
   end
 
@@ -327,9 +344,9 @@ defmodule ImagePipe.Output.EncodeSearch do
   # The objective ran on an ESTIMATE; re-validate the winner against the
   # authoritative measure and linear-bump on undershoot (cap @max_bump_passes).
   defp confirm_phase(objective_q, _objective_outcome, ctx) do
-    with {:ok, ctx} <- confirm_score(objective_q, ctx) do
+    with {:ok, ctx} <- confirm_score(objective_q, :confirm, ctx) do
       if Map.fetch!(ctx.confirm_memo, objective_q) >= ctx.confirm_band do
-        {:ok, objective_q, :hit, ctx}
+        {:ok, objective_q, :hit, set_factor(ctx, nil)}
       else
         bump(objective_q, ctx)
       end
@@ -346,37 +363,56 @@ defmodule ImagePipe.Output.EncodeSearch do
   end
 
   defp do_bump(try_q, last_q, best_q, ctx) when try_q > last_q,
-    do: {:ok, best_q, :best_effort, ctx}
+    do: {:ok, best_q, :best_effort, set_factor(ctx, :bump_exhausted)}
 
   defp do_bump(try_q, last_q, _best_q, ctx) do
-    case confirm_score(try_q, ctx) do
+    case confirm_score(try_q, :bump, ctx) do
       {:error, _} = err ->
         err
 
       {:ok, ctx} ->
         if Map.fetch!(ctx.confirm_memo, try_q) >= ctx.confirm_band,
-          do: {:ok, try_q, :hit, ctx},
+          do: {:ok, try_q, :hit, set_factor(ctx, nil)},
           else: do_bump(try_q + 1, last_q, try_q, ctx)
     end
   end
 
-  # Ensure q is encoded, then authoritatively score it once (memoized), counting
-  # the pass. Encode is forced even past the iteration cap: the confirm MUST run.
-  defp confirm_score(q, ctx) do
-    with {:ok, ctx} <- ensure_probed(q, ctx) do
-      if Map.has_key?(ctx.confirm_memo, q) do
-        {:ok, ctx}
-      else
-        score = ctx.confirm_fun.(Map.fetch!(ctx.encode_memo, q))
-
-        {:ok,
-         %{
-           ctx
-           | confirm_memo: Map.put(ctx.confirm_memo, q, score),
-             confirm_passes: ctx.confirm_passes + 1
-         }}
-      end
+  # Authoritatively score q once (memoized), counting the pass, under a confirm
+  # probe span tagged with `phase` (:confirm | :bump). A confirm_memo hit emits
+  # nothing. The probe span owns the encode/score legs: the encode is forced even
+  # past the iteration cap (the confirm MUST run) and emits its `:encode` leg only
+  # when q was not already encoded.
+  defp confirm_score(q, phase, ctx) do
+    if Map.has_key?(ctx.confirm_memo, q) do
+      {:ok, ctx}
+    else
+      confirm_probe(q, phase, ctx)
     end
+  end
+
+  defp confirm_probe(q, phase, ctx) do
+    Telemetry.span(
+      ctx.telemetry_opts,
+      [:encode, :search, :probe],
+      %{quality: q, phase: phase},
+      fn ->
+        case ensure_encoded_raw(q, ctx) do
+          {:ok, ctx} ->
+            score = ctx.confirm_fun.(Map.fetch!(ctx.encode_memo, q))
+
+            ctx = %{
+              ctx
+              | confirm_memo: Map.put(ctx.confirm_memo, q, score),
+                confirm_passes: ctx.confirm_passes + 1
+            }
+
+            {{:ok, ctx}, confirm_probe_meta(q, ctx)}
+
+          {:error, reason} = err ->
+            {err, %{result: :processing_error, error: reason}}
+        end
+      end
+    )
   end
 
   # --- binary search primitives ---------------------------------------------
@@ -461,7 +497,9 @@ defmodule ImagePipe.Output.EncodeSearch do
   end
 
   # Ensure q is encoded (and scored when a score_fun is present), memoized.
-  # Returns {:ok, byte_size, score | nil, ctx} | :capped | {:error, _}.
+  # Returns {:ok, byte_size, score | nil, ctx} | :capped | {:error, _}. A NEW
+  # distinct encode runs under an objective/cap probe span (memo hits and the cap
+  # never reach it).
   defp materialize(q, ctx) do
     cond do
       Map.has_key?(ctx.encode_memo, q) ->
@@ -472,17 +510,9 @@ defmodule ImagePipe.Output.EncodeSearch do
         :capped
 
       true ->
-        case ctx.encode_fun.(q) do
-          {:ok, binary} ->
-            ctx = %{
-              ctx
-              | encode_memo: Map.put(ctx.encode_memo, q, binary),
-                iterations: ctx.iterations + 1
-            }
-
-            ctx = maybe_score(q, binary, ctx)
-            emit_probe(q, binary, ctx)
-            {:ok, byte_size(binary), Map.get(ctx.score_memo, q), ctx}
+        case encode_probe(q, ctx) do
+          {:ok, ctx} ->
+            {:ok, byte_size(Map.fetch!(ctx.encode_memo, q)), Map.get(ctx.score_memo, q), ctx}
 
           {:error, _} = err ->
             err
@@ -490,22 +520,56 @@ defmodule ImagePipe.Output.EncodeSearch do
     end
   end
 
-  # One probe event per NEW distinct encode (memo hits never reach here).
-  # `:index` is the distinct-encode ordinal (`iterations` after the increment);
-  # `:score` is the scored value when an ssim2 score_fun ran, else nil. All
-  # product-neutral numbers.
-  defp emit_probe(q, binary, %Ctx{telemetry_opts: telemetry_opts} = ctx) do
-    Telemetry.execute(
-      telemetry_opts,
+  # Encode a specific quality (e.g. the chosen boundary) without requiring the
+  # predicate, so its buffer/score is in the memo for the final result. Respects
+  # the cap only when a NEW encode is needed; if capped and already absent, we
+  # force the encode anyway because the result MUST carry a real buffer. A NEW
+  # encode runs under an objective/cap probe span (a memo hit emits nothing).
+  defp ensure_probed(q, ctx) do
+    if Map.has_key?(ctx.encode_memo, q), do: {:ok, ctx}, else: encode_probe(q, ctx)
+  end
+
+  # Encode (+ estimate-score) a NEW distinct q under a `[:encode, :search, :probe]`
+  # span tagged with the current phase (:objective | :cap). `:index` is the
+  # distinct-encode ordinal (`iterations` after the increment); `:score` is the
+  # estimate when a score_fun ran, else nil. All product-neutral numbers. The
+  # encode/decode/metric cost legs are emitted by the injected closures and nest
+  # under this span.
+  defp encode_probe(q, ctx) do
+    Telemetry.span(
+      ctx.telemetry_opts,
       [:encode, :search, :probe],
-      %{},
-      %{
-        quality: q,
-        bytes: byte_size(binary),
-        index: ctx.iterations,
-        score: Map.get(ctx.score_memo, q)
-      }
+      %{quality: q, phase: ctx.phase},
+      fn ->
+        case do_encode(q, ctx) do
+          {:ok, ctx} -> {{:ok, ctx}, objective_probe_meta(q, ctx)}
+          {:error, reason} = err -> {err, %{result: :processing_error, error: reason}}
+        end
+      end
     )
+  end
+
+  # Raw encode + memoize + estimate-score, WITHOUT a probe span: the caller owns
+  # the span (encode_probe for objective/cap, confirm_probe for confirm/bump), so
+  # a bump that encodes a never-seen q emits a single probe, not two.
+  defp do_encode(q, ctx) do
+    case ctx.encode_fun.(q) do
+      {:ok, binary} ->
+        ctx = %{
+          ctx
+          | encode_memo: Map.put(ctx.encode_memo, q, binary),
+            iterations: ctx.iterations + 1
+        }
+
+        {:ok, maybe_score(q, binary, ctx)}
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  defp ensure_encoded_raw(q, ctx) do
+    if Map.has_key?(ctx.encode_memo, q), do: {:ok, ctx}, else: do_encode(q, ctx)
   end
 
   defp maybe_score(_q, _binary, %Ctx{score_fun: nil} = ctx), do: ctx
@@ -514,30 +578,39 @@ defmodule ImagePipe.Output.EncodeSearch do
     %{ctx | score_memo: Map.put(ctx.score_memo, q, score_fun.(binary))}
   end
 
-  # Encode a specific quality (e.g. the chosen boundary) without requiring the
-  # predicate, so its buffer/score is in the memo for the final result. Respects
-  # the cap only when a NEW encode is needed; if capped and already absent, we
-  # force the encode anyway because the result MUST carry a real buffer.
-  defp ensure_probed(q, ctx) do
-    case Map.has_key?(ctx.encode_memo, q) do
-      true ->
-        {:ok, ctx}
+  defp set_factor(ctx, factor), do: %{ctx | limiting_factor: factor}
 
-      false ->
-        case ctx.encode_fun.(q) do
-          {:ok, binary} ->
-            ctx = %{
-              ctx
-              | encode_memo: Map.put(ctx.encode_memo, q, binary),
-                iterations: ctx.iterations + 1
-            }
+  # Stop metadata for an objective/cap probe: the encode + (estimate) score it just
+  # produced. `:tiles_scored`/nil `:score` are stripped by the telemetry layer, so
+  # the full-frame and :size/:none paths carry only the fields they populate.
+  defp objective_probe_meta(q, ctx) do
+    %{
+      bytes: byte_size(Map.fetch!(ctx.encode_memo, q)),
+      index: ctx.iterations,
+      score: Map.get(ctx.score_memo, q),
+      scorer: ctx.scorer,
+      tiles_scored: ctx.scorer_tiles
+    }
+  end
 
-            {:ok, maybe_score(q, binary, ctx)}
+  # Stop metadata for a confirm/bump probe. `:score` is the authoritative
+  # full-frame score; `:crop_estimate` (the offset-corrected estimate) and
+  # `:full_frame_score` + `:passed?` expose the @crop_macro_offset residual — the
+  # real-world accuracy of the crop→full correction (shadow signal for a future
+  # per-content offset calibration).
+  defp confirm_probe_meta(q, ctx) do
+    full = Map.fetch!(ctx.confirm_memo, q)
 
-          {:error, _} = err ->
-            err
-        end
-    end
+    %{
+      bytes: byte_size(Map.fetch!(ctx.encode_memo, q)),
+      index: ctx.iterations,
+      score: full,
+      scorer: ctx.scorer,
+      tiles_scored: ctx.scorer_tiles,
+      crop_estimate: Map.get(ctx.score_memo, q),
+      full_frame_score: full,
+      passed?: full >= ctx.confirm_band
+    }
   end
 
   defp outcome_for(nil), do: :best_effort
@@ -563,11 +636,17 @@ defmodule ImagePipe.Output.EncodeSearch do
       score: result_score(final_q, ctx),
       confirm_passes: ctx.confirm_passes,
       scorer: ctx.scorer,
-      tiles_scored: ctx.scorer_tiles
+      tiles_scored: ctx.scorer_tiles,
+      limiting_factor: limiting_factor_for(final_outcome, ctx)
     }
 
     {:ok, binary, meta}
   end
+
+  # The limiting factor is meaningful only for a degraded result; a `:hit` (or
+  # `:skipped`) carries none, regardless of any factor a superseded phase staged.
+  defp limiting_factor_for(:best_effort, ctx), do: ctx.limiting_factor
+  defp limiting_factor_for(_outcome, _ctx), do: nil
 
   # meta.score must reflect the DELIVERED quality, never a different one. The cap
   # phase (byte-only predicate) can relocate the winner to a quality the objective
@@ -584,7 +663,7 @@ defmodule ImagePipe.Output.EncodeSearch do
   # estimate fallback.
   defp ensure_winner_scored(final_q, _binary, %Ctx{confirm_fun: fun} = ctx)
        when not is_nil(fun) do
-    {:ok, ctx} = confirm_score(final_q, ctx)
+    {:ok, ctx} = confirm_score(final_q, :confirm, ctx)
     ctx
   end
 
@@ -614,29 +693,33 @@ defmodule ImagePipe.Output.EncodeSearch do
   defp bump_headroom(:full), do: 0
 
   # Build the objective score_fun (+ confirm closures for crop mode) for the
-  # resolved objective and the chosen scorer. Returns extra search/3 opts.
-  defp score_opts(_image, %Resolved{quality_search: :none}, _scorer), do: {:ok, []}
+  # resolved objective and the chosen scorer. Returns extra search/3 opts. The
+  # score closures emit the `:decode`/`:metric` cost legs; the core only sees an
+  # opaque float-returning closure, never the decode/metric structure.
+  defp score_opts(_image, %Resolved{quality_search: :none}, _scorer, _telemetry_opts),
+    do: {:ok, []}
 
-  defp score_opts(_image, %Resolved{quality_search: %RQS{objective: :size}}, _scorer),
+  defp score_opts(_image, %Resolved{quality_search: %RQS{objective: :size}}, _scorer, _t),
     do: {:ok, []}
 
   # Full-frame mode: one whole-frame reference; candidate scored whole. (No `= rqs`
   # binding — the bracket/target is consumed by the search, not here — so there is
   # no unused-variable warning under --warnings-as-errors.)
-  defp score_opts(image, %Resolved{quality_search: %RQS{objective: :ssim2}}, :full) do
+  defp score_opts(image, %Resolved{quality_search: %RQS{objective: :ssim2}}, :full, t) do
     case Ssim2Metric.reference(image) do
-      {:ok, ref} -> {:ok, [score_fun: fn bytes -> full_frame_score(ref, bytes) end]}
+      {:ok, ref} -> {:ok, [score_fun: fn bytes -> full_frame_score(ref, bytes, nil, t) end]}
       {:error, reason} -> {:error, {:encode, reason}}
     end
   end
 
   # Crop mode: crop score_fun (estimate) + full-frame confirm closure + the
   # deterministic tile count for telemetry.
-  defp score_opts(image, %Resolved{quality_search: %RQS{objective: :ssim2} = rqs}, :crop) do
+  defp score_opts(image, %Resolved{quality_search: %RQS{objective: :ssim2} = rqs}, :crop, t) do
     case Ssim2Metric.reference(image) do
       {:ok, ref} ->
-        confirm = fn bytes -> full_frame_score(ref, bytes) end
-        crop = fn bytes -> crop_estimate(image, bytes) end
+        tiles = CropScore.tile_count(Image.width(image), Image.height(image))
+        confirm = fn bytes -> full_frame_score(ref, bytes, nil, t) end
+        crop = fn bytes -> crop_estimate(image, bytes, tiles, t) end
 
         {:ok,
          [
@@ -644,7 +727,7 @@ defmodule ImagePipe.Output.EncodeSearch do
            confirm_fun: confirm,
            confirm_band: rqs.target - rqs.allowed_error,
            confirm_max_quality: rqs.max_quality,
-           scorer_tiles: CropScore.tile_count(Image.width(image), Image.height(image))
+           scorer_tiles: tiles
          ]}
 
       {:error, reason} ->
@@ -655,27 +738,85 @@ defmodule ImagePipe.Output.EncodeSearch do
   # The score_fun contract is float-returning, but Image.from_binary and
   # Ssim2Metric.score can fail. We surface such failures by throwing a tagged
   # tuple that run/3 catches around the search/3 call, mapping it to
-  # {:error, {:encode, reason}}.
+  # {:error, {:encode, reason}}. A throw propagates through the leg span (→
+  # `:exception`) and the enclosing probe span before reaching the catch.
 
-  # Decode the candidate once and score the whole frame against the reference.
-  defp full_frame_score(ref, bytes) do
-    with {:ok, candidate} <- Image.from_binary(bytes),
-         {:ok, score} <- Ssim2Metric.score(ref, candidate) do
-      score
-    else
-      {:error, reason} -> throw({:image_pipe_score_error, reason})
-    end
+  # Decode the candidate once and score the whole frame against the reference,
+  # each as a cost leg nested under the active probe span.
+  defp full_frame_score(ref, bytes, tiles, telemetry_opts) do
+    candidate = decode_leg(bytes, telemetry_opts)
+
+    metric_leg(telemetry_opts, tiles, fn ->
+      case Ssim2Metric.score(ref, candidate) do
+        {:ok, score} -> score
+        {:error, reason} -> throw({:image_pipe_score_error, reason})
+      end
+    end)
   end
 
   # Decode the candidate once; crop-score its tiles vs the base; subtract the macro
   # offset so the unchanged objective predicate reproduces the full-frame decision.
-  defp crop_estimate(base, bytes) do
-    with {:ok, candidate} <- Image.from_binary(bytes),
-         {:ok, p10} <- CropScore.p10(base, candidate) do
-      p10 - @crop_macro_offset
-    else
-      {:error, reason} -> throw({:image_pipe_score_error, reason})
-    end
+  defp crop_estimate(base, bytes, tiles, telemetry_opts) do
+    candidate = decode_leg(bytes, telemetry_opts)
+
+    metric_leg(telemetry_opts, tiles, fn ->
+      case CropScore.p10(base, candidate) do
+        {:ok, p10} -> p10 - @crop_macro_offset
+        {:error, reason} -> throw({:image_pipe_score_error, reason})
+      end
+    end)
+  end
+
+  # --- cost legs (emitted from run/3's closures; the pure core never sees them) -
+
+  # The codec encode, as a leg nested under the active probe span. Method-neutral:
+  # it fires for every objective (:size/:ssim2/:none), so unlike the scoring legs
+  # it carries no metric-method name segment.
+  defp encode_leg(image, resolved, quality, telemetry_opts) do
+    Telemetry.span(
+      telemetry_opts,
+      [:encode, :search, :probe, :encode],
+      %{quality: quality},
+      fn ->
+        case Encoder.encode_to_buffer(image, resolved, quality) do
+          {:ok, binary} = ok -> {ok, %{result: :ok, bytes: byte_size(binary)}}
+          {:error, reason} = err -> {err, %{result: :processing_error, error: reason}}
+        end
+      end
+    )
+  end
+
+  # Candidate decode, as an ssim2-namespaced leg. The metric method qualifies the
+  # scoring legs (`:ssim2`) so a future metric (e.g. dssim) gets distinct span
+  # names a backend can group by; a decode failure throws and surfaces as the
+  # leg's `:exception`.
+  defp decode_leg(bytes, telemetry_opts) do
+    Telemetry.span(
+      telemetry_opts,
+      [:encode, :search, :probe, :ssim2, :decode],
+      %{bytes: byte_size(bytes)},
+      fn ->
+        case Image.from_binary(bytes) do
+          {:ok, candidate} -> {candidate, %{result: :ok}}
+          {:error, reason} -> throw({:image_pipe_score_error, reason})
+        end
+      end
+    )
+  end
+
+  # One aggregate SSIMULACRA2 metric leg per probe (the crop path scores K tiles
+  # internally; `:tiles_scored` records how many, but no per-tile span is emitted —
+  # that detail lives in `mix autoquality.bench`).
+  defp metric_leg(telemetry_opts, tiles, fun) do
+    Telemetry.span(
+      telemetry_opts,
+      [:encode, :search, :probe, :ssim2, :metric],
+      %{tiles_scored: tiles},
+      fn ->
+        score = fun.()
+        {score, %{result: :ok, score: score}}
+      end
+    )
   end
 
   defp base_quality(%Resolved{quality: {:quality, v}}), do: v

--- a/lib/image_pipe/telemetry/logger.ex
+++ b/lib/image_pipe/telemetry/logger.ex
@@ -10,7 +10,15 @@ defmodule ImagePipe.Telemetry.Logger do
 
   # group => span event suffixes (each gets :stop + :exception)
   @group_span_events %{
-    request: [[:request], [:send], [:encode], [:encode, :search], [:deliver], [:render]],
+    request: [
+      [:request],
+      [:send],
+      [:encode],
+      [:encode, :search],
+      [:encode, :search, :probe],
+      [:deliver],
+      [:render]
+    ],
     parse: [[:parse]],
     source: [[:source, :resolve], [:source, :fetch], [:source, :fetch_decode]],
     transform: [
@@ -43,11 +51,6 @@ defmodule ImagePipe.Telemetry.Logger do
   # output one-shot events (already terminal; not spans)
   @output_oneshot [
     [:output, :clamp]
-  ]
-
-  # request one-shot events (already terminal; not spans)
-  @request_oneshot [
-    [:encode, :search, :probe]
   ]
 
   # generated CDN HTTP-cache one-shot events (already terminal; not spans)
@@ -94,13 +97,12 @@ defmodule ImagePipe.Telemetry.Logger do
     cache_oneshots = if :cache in groups, do: @cache_oneshot, else: []
     transform_oneshots = if :transform in groups, do: @transform_oneshot, else: []
     output_oneshots = if :output in groups, do: @output_oneshot, else: []
-    request_oneshots = if :request in groups, do: @request_oneshot, else: []
     http_cache_oneshots = if :http_cache in groups, do: @http_cache_oneshot, else: []
 
     Enum.map(
       spans ++
         cache_oneshots ++
-        transform_oneshots ++ output_oneshots ++ request_oneshots ++ http_cache_oneshots,
+        transform_oneshots ++ output_oneshots ++ http_cache_oneshots,
       fn e -> prefix ++ e end
     )
   end
@@ -243,6 +245,15 @@ defmodule ImagePipe.Telemetry.Logger do
 
     "image_pipe output clamp: #{sw}x#{sh} -> #{w}x#{h} for #{meta[:format]} " <>
       "(caps w:#{cap(mw)} h:#{cap(mh)} px:#{cap(mp)})"
+  end
+
+  # Specific clause BEFORE the search clause below: a probe stop would otherwise
+  # match [:encode, :search | _] and render with the search verdict's keys (nil).
+  defp message([:encode, :search, :probe | _], _m, meta) do
+    score = if meta[:score], do: " score #{round2(meta[:score])}", else: ""
+
+    "image_pipe encode search probe: #{outcome(meta)} " <>
+      "(#{meta[:phase]} q#{meta[:quality]} #{meta[:bytes]}b#{score})"
   end
 
   defp message([:encode, :search | _], _m, meta) do

--- a/lib/image_pipe/telemetry/trace/capture.ex
+++ b/lib/image_pipe/telemetry/trace/capture.ex
@@ -11,6 +11,13 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
     [:send],
     [:encode],
     [:encode, :search],
+    [:encode, :search, :probe],
+    # Per-probe cost legs (eager NIF/op calls → honest durations). The encode leg
+    # is method-neutral (fires for every objective); the scoring legs carry the
+    # metric-method segment (:ssim2) so a future metric gets distinct span names.
+    [:encode, :search, :probe, :encode],
+    [:encode, :search, :probe, :ssim2, :decode],
+    [:encode, :search, :probe, :ssim2, :metric],
     [:render],
     [:deliver],
     [:source, :resolve],
@@ -31,7 +38,6 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
 
   # One-shot (terminal) events — folded as annotations onto the current span.
   @oneshot_stages [
-    [:encode, :search, :probe],
     [:cache, :stage],
     [:cache, :eviction, :stop],
     [:cache, :flush, :stop],
@@ -98,6 +104,13 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
     :iterations,
     :tiles_scored,
     :confirm_passes,
+    # per-probe span attributes: phase, the search-level limiting factor, and the
+    # crop→full confirm residual (all product-neutral numbers/atoms)
+    :phase,
+    :limiting_factor,
+    :crop_estimate,
+    :full_frame_score,
+    :passed?,
     # fetch/decode shape
     :load_option,
     :loaded_dims,

--- a/test/image_pipe/output/encode_search_telemetry_test.exs
+++ b/test/image_pipe/output/encode_search_telemetry_test.exs
@@ -9,7 +9,7 @@ defmodule ImagePipe.Output.EncodeSearchTelemetryTest do
   # default-prefixed emissions and leak them into this async test's mailbox.
   @prefix [:ip_es_test]
   @stop @prefix ++ [:encode, :search, :stop]
-  @probe @prefix ++ [:encode, :search, :probe]
+  @probe @prefix ++ [:encode, :search, :probe, :stop]
 
   setup do
     handler_id = "encode-search-telemetry-#{System.unique_integer([:positive])}"
@@ -28,7 +28,7 @@ defmodule ImagePipe.Output.EncodeSearchTelemetryTest do
     :ok
   end
 
-  test "emits a search stop span and one probe per distinct quality" do
+  test "emits a search stop span and one objective probe span per distinct quality" do
     rs = %RQS{
       objective: :ssim2,
       target: 90.0,
@@ -62,33 +62,136 @@ defmodule ImagePipe.Output.EncodeSearchTelemetryTest do
     assert is_integer(stop_meta.iterations)
     assert stop_meta.scorer == :full
     assert stop_meta.confirm_passes == 0
-    # nil metadata is stripped by the telemetry layer, so the full-frame path
-    # emits no tiles_scored key (it's a crop-only measurement).
+    # :hit carries no limiting factor; nil metadata is stripped by the layer.
+    refute Map.has_key?(stop_meta, :limiting_factor)
+    # nil metadata is stripped, so the full-frame path emits no tiles_scored key.
     refute Map.has_key?(stop_meta, :tiles_scored)
 
-    probes = collect_probes()
+    {probes, durations} = collect_probes()
     assert probes != []
+    # every probe is a span: its stop measurement carries a real duration.
+    assert Enum.all?(durations, &is_integer/1)
 
-    # one probe per distinct probed quality, carrying product-neutral numbers
+    # full-frame mode: every probe is an objective encode, carrying the phase.
     qualities = Enum.map(probes, & &1.quality)
     assert qualities == Enum.uniq(qualities)
 
     for probe <- probes do
+      assert probe.phase == :objective
       assert is_integer(probe.quality)
       assert probe.bytes == probe.quality * 100
       assert is_integer(probe.index)
       assert is_float(probe.score)
+      assert probe.scorer == :full
     end
 
     # the distinct-encode index is the running ordinal
     assert Enum.sort(Enum.map(probes, & &1.index)) == Enum.to_list(1..length(probes))
   end
 
-  defp collect_probes(acc \\ []) do
+  test "confirm/bump probes carry the phase + the crop→full residual fields" do
+    rs = %RQS{
+      objective: :ssim2,
+      target: 90.0,
+      min_quality: 10,
+      max_quality: 80,
+      allowed_error: 0.0
+    }
+
+    enc = fn q -> {:ok, :binary.copy(<<0>>, q * 100)} end
+    # estimate over-reports by +1: objective picks q64 (est 90), true at 64 is 89
+    # (undershoot), true at 65 is 90 (clears) -> one confirm + one bump.
+    estimate = fn bin -> byte_size(bin) / 100 + 26.0 end
+    confirm = fn bin -> byte_size(bin) / 100 + 25.0 end
+
+    telemetry_opts = Telemetry.telemetry_opts(telemetry_prefix: @prefix)
+
+    assert {:ok, _bin, %{quality: 65, outcome: :hit, scorer: :crop, tiles_scored: 12}} =
+             EncodeSearch.search(rs, nil,
+               encode_fun: enc,
+               score_fun: estimate,
+               confirm_fun: confirm,
+               confirm_band: 90.0,
+               confirm_max_quality: 80,
+               max_bump_passes: 2,
+               scorer: :crop,
+               scorer_tiles: 12,
+               telemetry_opts: telemetry_opts
+             )
+
+    {probes, _durations} = collect_probes()
+
+    confirm_probes = Enum.filter(probes, &(&1.phase in [:confirm, :bump]))
+    assert Enum.map(confirm_probes, & &1.phase) == [:confirm, :bump]
+
+    for probe <- confirm_probes do
+      assert probe.scorer == :crop
+      assert probe.tiles_scored == 12
+      # estimate (q+26) and authoritative full-frame (q+25) differ by exactly 1.0:
+      # the @crop_macro_offset residual, surfaced for shadow calibration.
+      assert_in_delta probe.full_frame_score - probe.crop_estimate, -1.0, 0.001
+      assert probe.score == probe.full_frame_score
+      assert is_boolean(probe.passed?)
+    end
+
+    # confirm@64 undershoots (q64 -> 89 < 90); bump@65 clears (q65 -> 90).
+    [confirm64, bump65] = confirm_probes
+    assert confirm64.quality == 64 and confirm64.passed? == false
+    assert bump65.quality == 65 and bump65.passed? == true
+  end
+
+  test "search stop names the limiting factor on a ceiling best-effort" do
+    rs = %RQS{
+      objective: :ssim2,
+      target: 90.0,
+      min_quality: 10,
+      max_quality: 80,
+      allowed_error: 0.0
+    }
+
+    enc = fn q -> {:ok, :binary.copy(<<0>>, q * 100)} end
+    # score never reaches the band in [10, 80] -> pin to the ceiling (max_quality).
+    score = fn _bin -> 50.0 end
+
+    telemetry_opts = Telemetry.telemetry_opts(telemetry_prefix: @prefix)
+
+    assert {:ok, _bin, %{outcome: :best_effort, limiting_factor: :ceiling}} =
+             EncodeSearch.search(rs, nil,
+               encode_fun: enc,
+               score_fun: score,
+               max_iterations: 8,
+               telemetry_opts: telemetry_opts
+             )
+
+    assert_receive {:telemetry, @stop, _m, stop_meta}
+    assert stop_meta.outcome == :best_effort
+    assert stop_meta.limiting_factor == :ceiling
+  end
+
+  test "search stop names :max_bytes when the budget cannot be met even at the floor" do
+    enc = fn q -> {:ok, :binary.copy(<<0>>, q * 100)} end
+
+    telemetry_opts = Telemetry.telemetry_opts(telemetry_prefix: @prefix)
+
+    # max_bytes-alone: floor is q10 -> 1000 bytes, over the 500-byte budget.
+    assert {:ok, _bin, %{outcome: :best_effort, limiting_factor: :max_bytes}} =
+             EncodeSearch.search(:none, 500,
+               encode_fun: enc,
+               base_quality: 90,
+               max_iterations: 8,
+               telemetry_opts: telemetry_opts
+             )
+
+    assert_receive {:telemetry, @stop, _m, stop_meta}
+    assert stop_meta.limiting_factor == :max_bytes
+  end
+
+  defp collect_probes(probes \\ [], durations \\ []) do
     receive do
-      {:telemetry, @probe, _measurements, metadata} -> collect_probes([metadata | acc])
+      {:telemetry, @probe, measurements, metadata} ->
+        collect_probes([metadata | probes], [measurements[:duration] | durations])
     after
-      0 -> Enum.reverse(acc)
+      0 -> {Enum.reverse(probes), Enum.reverse(durations)}
     end
   end
 end

--- a/test/image_pipe/output/encoder_crop_scoring_test.exs
+++ b/test/image_pipe/output/encoder_crop_scoring_test.exs
@@ -95,6 +95,70 @@ defmodule ImagePipe.Output.EncoderCropScoringTest do
     assert crop.score >= resolved.quality_search.target - resolved.quality_search.allowed_error
   end
 
+  test "run/3 emits the probe spans and their encode/decode/metric cost legs (crop mode)" do
+    prefix = [:"ip_crop_legs_#{System.unique_integer([:positive])}"]
+    test_pid = self()
+    handler_id = "crop-legs-#{System.unique_integer([:positive])}"
+
+    events =
+      for stage <- [
+            [:encode, :search, :probe],
+            [:encode, :search, :probe, :encode],
+            [:encode, :search, :probe, :ssim2, :decode],
+            [:encode, :search, :probe, :ssim2, :metric]
+          ],
+          do: prefix ++ stage ++ [:stop]
+
+    :telemetry.attach_many(
+      handler_id,
+      events,
+      fn event, _measurements, metadata, _config ->
+        stage = event |> Enum.drop(length(prefix)) |> Enum.drop(-1)
+        send(test_pid, {:leg, stage, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    {:ok, _bin, _meta} =
+      EncodeSearch.run(zone_plate(7), ssim2_resolved(),
+        scorer: :crop,
+        telemetry_opts: ImagePipe.Telemetry.telemetry_opts(telemetry_prefix: prefix)
+      )
+
+    legs = drain_legs()
+    by_stage = Enum.group_by(legs, &elem(&1, 0), &elem(&1, 1))
+
+    # probe spans tag their phase; crop mode runs the objective then confirm/bump.
+    probe_phases = by_stage |> Map.fetch!([:encode, :search, :probe]) |> Enum.map(& &1.phase)
+    assert :objective in probe_phases
+    assert :confirm in probe_phases
+
+    # every objective/cap probe encodes -> an encode leg with the produced byte size.
+    encode_legs = Map.fetch!(by_stage, [:encode, :search, :probe, :encode])
+    assert encode_legs != []
+    assert Enum.all?(encode_legs, &(&1.result == :ok and is_integer(&1.bytes)))
+
+    # ssim2 scoring legs: a decode and an aggregate metric per probe.
+    assert Map.fetch!(by_stage, [:encode, :search, :probe, :ssim2, :decode]) != []
+    metric_legs = Map.fetch!(by_stage, [:encode, :search, :probe, :ssim2, :metric])
+    assert metric_legs != []
+    assert Enum.all?(metric_legs, &is_float(&1.score))
+    # objective probes crop-score K tiles (tiles_scored: 16); confirm probes run
+    # the whole-frame measure, so their metric leg carries no tile count.
+    assert Enum.any?(metric_legs, &(Map.get(&1, :tiles_scored) == 16))
+    assert Enum.all?(metric_legs, &(Map.get(&1, :tiles_scored) in [nil, 16]))
+  end
+
+  defp drain_legs(acc \\ []) do
+    receive do
+      {:leg, _stage, _meta} = msg -> drain_legs([msg | acc])
+    after
+      0 -> Enum.reverse(acc) |> Enum.map(fn {:leg, stage, meta} -> {stage, meta} end)
+    end
+  end
+
   test "max_bytes binds the crop-path delivered q (cap runs after confirm/bump)" do
     image = zone_plate(7)
     resolved = ssim2_resolved()

--- a/test/image_pipe/telemetry/logger_test.exs
+++ b/test/image_pipe/telemetry/logger_test.exs
@@ -138,6 +138,38 @@ defmodule ImagePipe.Telemetry.LoggerTest do
     assert log =~ "encode search: ok (best_effort q10 99999b)"
   end
 
+  test "renders an encode-search probe span stop with its phase, quality, bytes, score" do
+    Telemetry.attach_default_logger(level: :info)
+
+    log =
+      capture_log(fn ->
+        :telemetry.execute(
+          [:image_pipe, :encode, :search, :probe, :stop],
+          %{duration: System.convert_time_unit(1, :millisecond, :native)},
+          %{result: :ok, phase: :confirm, quality: 65, bytes: 6500, score: 90.42}
+        )
+      end)
+
+    refute log =~ "[warning]"
+    assert log =~ "encode search probe: ok (confirm q65 6500b score 90.42)"
+  end
+
+  test "escalates an encode-search probe exception to warning" do
+    Telemetry.attach_default_logger(level: :info)
+
+    log =
+      capture_log(fn ->
+        :telemetry.execute(
+          [:image_pipe, :encode, :search, :probe, :exception],
+          %{duration: 1000},
+          %{kind: :error, reason: :badimage, phase: :objective, quality: 50}
+        )
+      end)
+
+    assert log =~ "[warning]"
+    assert log =~ "encode search probe: exception"
+  end
+
   test "renders the deliver span and does not escalate a client disconnect" do
     Telemetry.attach_default_logger(level: :info)
 

--- a/test/image_pipe/telemetry/trace/capture_test.exs
+++ b/test/image_pipe/telemetry/trace/capture_test.exs
@@ -80,25 +80,65 @@ defmodule ImagePipe.Telemetry.Trace.CaptureTest do
     assert span.attributes[:target] == 90.0
   end
 
-  test "folds the encode-search probe one-shot onto the current span with its numbers" do
+  test "captures the encode-search probe as a span nested under the search, with its phase/numbers" do
     Telemetry.span([], [:encode, :search], %{objective: :ssim2}, fn ->
-      Telemetry.execute(
+      Telemetry.span(
         [],
         [:encode, :search, :probe],
-        %{},
-        %{quality: 62, bytes: 12_345, index: 1, score: 90.42}
+        %{quality: 62, phase: :confirm},
+        fn ->
+          {:ok, %{bytes: 12_345, index: 1, score: 90.42, full_frame_score: 90.42, passed?: true}}
+        end
       )
 
       {:ok, %{result: :ok}}
     end)
 
-    assert_receive {:span, %Span{name: "image_pipe.encode.search"} = span}
-    probe = Enum.find(span.events, &(&1.name == "image_pipe.encode.search.probe"))
-    assert probe
+    assert_receive {:span, %Span{name: "image_pipe.encode.search.probe"} = probe}
+    assert_receive {:span, %Span{name: "image_pipe.encode.search"} = search}
+
+    # the probe is a real child span of the search span, not a folded annotation
+    assert probe.parent_span_id == search.span_id
+    assert probe.trace_id == search.trace_id
+    assert is_integer(probe.duration_native)
+
+    assert probe.attributes[:phase] == :confirm
     assert probe.attributes[:quality] == 62
     assert probe.attributes[:bytes] == 12_345
     assert probe.attributes[:index] == 1
     assert probe.attributes[:score] == 90.42
+    assert probe.attributes[:full_frame_score] == 90.42
+    assert probe.attributes[:passed?] == true
+  end
+
+  test "nests the probe cost legs (encode/decode/metric) under the probe span" do
+    Telemetry.span([], [:encode, :search, :probe], %{quality: 62, phase: :objective}, fn ->
+      Telemetry.span([], [:encode, :search, :probe, :encode], %{quality: 62}, fn ->
+        {:ok, %{result: :ok, bytes: 12_345}}
+      end)
+
+      Telemetry.span([], [:encode, :search, :probe, :ssim2, :decode], %{bytes: 12_345}, fn ->
+        {:ok, %{result: :ok}}
+      end)
+
+      Telemetry.span([], [:encode, :search, :probe, :ssim2, :metric], %{tiles_scored: 12}, fn ->
+        {90.42, %{result: :ok, score: 90.42}}
+      end)
+
+      {:ok, %{bytes: 12_345}}
+    end)
+
+    assert_receive {:span, %Span{name: "image_pipe.encode.search.probe.encode"} = enc}
+    assert_receive {:span, %Span{name: "image_pipe.encode.search.probe.ssim2.decode"} = dec}
+    assert_receive {:span, %Span{name: "image_pipe.encode.search.probe.ssim2.metric"} = met}
+    assert_receive {:span, %Span{name: "image_pipe.encode.search.probe"} = probe}
+
+    for leg <- [enc, dec, met] do
+      assert leg.parent_span_id == probe.span_id
+      assert leg.trace_id == probe.trace_id
+    end
+
+    assert met.attributes[:tiles_scored] == 12
   end
 
   test "captures the render span with its renderer attribute" do


### PR DESCRIPTION
Makes every step of the autoquality encode-quality search observable, and promotes `[:encode, :search, :probe]` from a one-shot to a span whose children are the per-probe cost legs.

## Why

Today `[:encode, :search, :probe]` fired only on a new distinct encode inside the objective/cap search, so:
- the **confirm/bump** phase was invisible (it runs through `confirm_score`, which emitted nothing),
- there was **no `phase` label** (objective vs cap-descent probes were indistinguishable),
- the per-probe **cost split** (encode vs decode vs metric) was an opaque blob,
- the confirm computed `crop_estimate` / `full_frame_score` / `passed?` and **threw them away**, and
- a `:best_effort` outcome **didn't say why** it fell short.

## What

**Probe span (core-owned, product-neutral).** `[:encode, :search, :probe]` is now a span, created per NEW distinct encode **and** per NEW authoritative confirm score (memo hits emit nothing). Each is tagged `phase` (`:objective` | `:cap` | `:confirm` | `:bump`), unifying confirm/bump as probe spans. Stop metadata keeps `quality, bytes, index, score` (+ `scorer`/`tiles_scored` in crop mode); the span duration is the total probe time.

**Cost legs (child spans, emitted from `run/3`'s closures).** `[…, :probe, :encode]` (method-neutral codec encode), and for ssim2 `[…, :probe, :ssim2, :decode]` + `[…, :probe, :ssim2, :metric]`. Eager NIF/op calls → honest durations. The scoring legs carry the metric-method segment (`:ssim2`) so a future metric (e.g. `dssim`) gets distinct, group-by-able span names. The pure core never learns decode/metric structure — it only wraps its opaque closure calls in the parent probe span; nesting relies on telemetry→OTel context propagation (Capture's process `Stack`).

**Confirm/bump residual.** Confirm/bump probes also carry `crop_estimate`, `full_frame_score`, `passed?` — the `@crop_macro_offset` residual (the real-world accuracy of the crop→full correction; a shadow signal for future per-content offset calibration).

**`limiting_factor`** on `…search.stop`: `:ceiling` | `:floor` | `:max_bytes` | `:bump_exhausted`, emitted only on `:best_effort`.

## Telemetry discipline

- **Logger**: probe moved from the one-shot list to the request span group, with a dedicated `message/3` clause (before the search clause) that still surfaces the outcome; the now-empty `@request_oneshot` removed.
- **Capture/OTel**: probe promoted to `@span_stages`, the three leg stages registered, and `:phase` / `:limiting_factor` / `:crop_estimate` / `:full_frame_score` / `:passed?` added to `@safe_keys`.
- **Deliberate asymmetry**: the cost legs are traced by OTel only, not the default Logger (~15–27 leg lines/request would drown the human log). This is the one intentional place the two surfaces cover different event sets — documented in `docs/telemetry.md`.
- Metadata stays product-neutral (qualities/bytes/scores/durations — no URLs or secrets).

## Granularity

Stops at encode/decode/metric per probe (~15–27 spans/request). No per-tile span — in crop mode one aggregate `:metric` leg per probe carries `tiles_scored`; per-tile detail stays in `mix autoquality.bench`. Note the confirm probe's metric leg has **no** `tiles_scored` (the confirm runs the whole-frame measure, not tiles).

## Tests

Work was test-first. Search **behavior is unchanged** (the existing `encode_search_test`/property suite is the regression guard).
- Core telemetry test rewritten for the span contract: phase, confirm-residual fields, `limiting_factor` (`:ceiling`, `:max_bytes`).
- New `run/3` end-to-end test proves the legs actually fire nested with real scores/byte sizes/`tiles_scored`.
- Capture test: probe captured as a nested child span + leg parentage.
- Logger test: probe span line + exception escalation.
- Full gate green: `mix format`, `compile --warnings-as-errors`, `credo --strict`, `mix test` (2538 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)