### PR TITLE
perf(autoquality): skip the full-frame confirm above the crop crossover (#369)

### DIFF
--- a/docs/autoquality_benchmark.md
+++ b/docs/autoquality_benchmark.md
@@ -397,7 +397,8 @@ full-frame confirm absorbs a *systematic, content-dependent* tile→full-frame r
 touch**. Saliency-guided selection does not earn a production change, and a crop-based
 confirm cannot replace the full-frame one. The only lever left for cheapening the
 confirm on large images is per-content offset calibration (or accepting a bounded
-best-effort sub-target rate above the crossover). *Caveat:* capped single-machine run —
+best-effort sub-target rate above the crossover — the route #369 took; see Part K).
+*Caveat:* capped single-machine run —
 the portable conclusion is the **shape** (systematic ≫ sampling; selector- and
 aggregation-invariant worst-case tail), not the absolute SSIM values.
 
@@ -481,9 +482,11 @@ Reading:
 
 ### Part H — crop+confirm vs full-frame target-hit confidence
 
-Crop scoring (#354) runs above the 6 MP crossover: it estimates the full-frame score
-from K tiles, then **confirms on the full frame** (+ up to 2 bump passes). Part H asks
-how reliably that shipped path hits the target vs the full-frame search, by running
+Crop scoring (#354) ran above the 6 MP crossover by estimating the full-frame score
+from K tiles, then **confirming on the full frame** (+ up to 2 bump passes) — the path
+measured here. (#369/Part K later removed that confirm above the crossover; this part
+characterizes the crop+confirm path it replaced.) Part H asks how reliably that path
+hits the target vs the full-frame search, by running
 **both real production searches** (`EncodeSearch.run`, scorer `:full` / `:crop`) on the
 same images at the production per-format brackets + target 78. The meaningful cohort is
 the >6 MP images where crop actually engages — only `large` (~15 MP photos) and
@@ -612,6 +615,63 @@ The surprise — **tightening `allowed_error` is a far cheaper on-target lever t
 (#354) — on >6 MP content it could raise bump-exhaustion (best-effort just under target)
 slightly. And this is the hard-content corpus; the on-target lift is conservative.
 
+### Part K — dropping the full-frame confirm above the crossover (#369)
+
+Part F proved no *cheaper estimator* (tile selection, aggregation, a learned offset)
+can reproduce the full-frame confirm's verdict within the band. Part K asks the
+complementary, decisive question: **above the crossover, is the confirm worth
+running at all?** Its cost is the surviving size-dependent term — a 6–8 s full-frame
+SSIMULACRA2 on a 37 MP image, re-fired once per bump pass, the trace that motivated
+#369 (a 37.7 MP no-resize→AVIF request spent ~14 s of its 30 s budget in confirm
+metrics and 500'd). The alternative: ship the crop objective winner directly and
+absorb the crop→full residual with a single **conservative global offset** instead of
+a per-image confirm. Method (no production change in the bench): per >6 MP subject ×
+format, run the production crop+confirm path as the baseline, then sweep the
+confirm-skipped path (`EncodeSearch.search/3` with the crop `score_fun` and **no
+`confirm_fun`**) across an offset ladder, scoring each delivered pick with the
+full-frame oracle. `regress` counts images the crop+confirm baseline hit on target
+but the confirm-skipped verdict ships **below** target — the one number that decides
+whether dropping the confirm is safe.
+
+Run over the screen-content cohort (`qoi_web` + `gb82_sc` + `large`, `--corpus-cap 30`,
+Apple Silicon, libvips 8.18.2), **46 crop-regime (subject×format) cases, all three
+formats**, target 78 / band ≥77:
+
+| offset | on-target | median deliv_err | worst_under | Δbytes% | regress |
+|--------|-----------|------------------|-------------|---------|---------|
+| 0.0    | 16/46 (35%) | −1.62 | −14.13 | 0.0 | **0** |
+| 0.5    | 17/46 (37%) | −1.62 | −14.13 | 0.0 | **0** |
+| 1.0    | 17/46 (37%) | −1.62 | −14.13 | 0.0 | **0** |
+| 1.5    | 17/46 (37%) | −1.61 | −14.13 | 0.0 | **0** |
+| 2.0    | 17/46 (37%) | −1.48 | −14.13 | 0.0 | **0** |
+| **2.4 ≈ p90** | 18/46 (39%) | −1.48 | −14.13 | 0.0 | **0** |
+| 3.0    | 18/46 (39%) | −1.48 | −14.13 | 0.0 | **0** |
+
+- **Dropping the confirm regresses nothing.** 0 target-hit regressions at *every*
+  swept offset. The confirm, above the crossover, only re-confirmed images that were
+  already hits or were bracket-ceiling-bound misses it could not rescue anyway — so
+  removing it costs no accuracy on this cohort while removing **≈ 756 ms/case** of
+  full-frame metric (6–8 s on the 37 MP autopsy image), and the search becomes a flat
+  ~4.2 MP objective walk that is **bounded by construction** — it can no longer time
+  out mid-confirm.
+- **The systematic residual is the only thing the offset must cover.** even-K16 p10 −
+  full-frame: **median 0.12, p90 2.42, worst 5.84**, the tail concentrated in
+  `qoi_web` screen content (the offset-0 `worst_under −14.13` is a *different*,
+  bracket-ceiling-bound population — content that cannot reach 78 at `max_quality`
+  even with the confirm; a Part I cap lever, not a confirm-skip artifact).
+- **Operating point: `@crop_confirm_skipped_offset = 2.4` ≈ the residual p90 (2.42).**
+  It covers the over-prediction tail at **~0 % median byte cost** (the residual median
+  is ~0, so the offset only bites the minority of over-predicting screen-content
+  images). Raising it 0→3 nudges on-target only 35→39 %: the remaining misses are
+  bracket-ceiling-bound, not offset-bound, so a larger offset buys almost nothing and
+  a smaller one leaves the tail exposed. p90 is the source-agnostic choice — high
+  enough to cover the tail, low enough to stay byte-free.
+
+*Caveat:* single-machine, screen-content-weighted cohort; the portable conclusion is
+the **shape** (0 regressions; residual median ~0 with a screen-content p90 tail; misses
+ceiling-bound not offset-bound), not the absolute SSIM values — re-run `--part k` to
+re-confirm the offset on other hardware/corpora.
+
 ## Findings & recommendations
 
 ### 1. Ship a non-zero `autoquality_max_resolution` default
@@ -726,6 +786,15 @@ a must-do *interim* guard only until those land. That is what turns "autoquality
 on big images" into "autoquality on, affordably."
 
 #### Shipped calibration (#354)
+
+> **Superseded above the crossover by #369 (Part K).** This section describes the
+> crop **+ full-frame confirm/bump** path #354 shipped. #369 *removed* the confirm
+> above the crossover: production now ships the crop objective winner directly with a
+> conservative offset (`@crop_confirm_skipped_offset = 2.4`, the Part-K residual p90)
+> and **no confirm**. The `@crop_macro_offset = 0.22` calibration below and the
+> confirm/bump bullets are retained as the historical record and now live only in the
+> `mix autoquality.bench` crop+confirm baseline; the live correction lever is Part K's
+> offset.
 
 Crop-scoring shipped in #354 (`ImagePipe.Output.Ssim2Metric.CropScore` +
 `EncodeSearch`/`Encoder`), constants-only at the Part-E operating point

--- a/lib/image_pipe/output/encode_search.ex
+++ b/lib/image_pipe/output/encode_search.ex
@@ -59,6 +59,11 @@ defmodule ImagePipe.Output.EncodeSearch do
   # raising the offset 0→3 nudges on-target only ~35→39 % at ~0 % median byte cost,
   # because the remaining misses are bracket-ceiling-bound, not offset-bound. See
   # `docs/autoquality_benchmark.md` (Part K).
+  #
+  # The calibration is tied to `CropScore`'s `@subsample_k` (16 even tiles) and p10
+  # aggregation: changing the tile count or aggregator silently invalidates this
+  # offset — re-derive it with `mix autoquality.bench --part k` before shipping such
+  # a change.
   @crop_confirm_skipped_offset 2.4
 
   @type outcome :: :hit | :best_effort | :skipped

--- a/lib/image_pipe/output/encode_search.ex
+++ b/lib/image_pipe/output/encode_search.ex
@@ -41,16 +41,25 @@ defmodule ImagePipe.Output.EncodeSearch do
   @max_bytes_alone_floor 10
   @max_bytes_alone_base 90
 
-  # Crop-scoring p10→full-frame correction (offset = tile_p10 − full_frame_score).
-  # Subtracted from the tile p10 so the objective's walk-to-target band comparison
-  # reproduces the full-frame decision. Calibrated
-  # for #354 on the codec-corpus (`mix autoquality.bench --part e`): the `clic` split
-  # gives +0.29 and the held-out `clic_holdout` split −0.03 — their disagreement
-  # shows a photo-only constant would overfit, so we use the content-diverse
-  # macro-average (+0.22) across photographic/screen/large/web content. The
-  # confirm/bump phase absorbs the per-image residual (spread ~±2–4 q). See
-  # `docs/autoquality_benchmark.md` (Part E).
-  @crop_macro_offset 0.22
+  # Crop-scoring p10→full-frame correction (offset = tile_p10 − full_frame_score),
+  # subtracted from the tile p10 so the objective's walk-to-target band comparison
+  # reproduces the full-frame decision.
+  #
+  # Above the crossover the search ships the crop objective winner with NO
+  # full-frame confirm (#369), so this offset is the only correction lever left and
+  # must be conservative: set near the p90 of the systematic residual rather than
+  # the median, so it covers the over-prediction tail (concentrated in screen
+  # content) instead of leaving the tail to a confirm that no longer runs.
+  #
+  # 2.4 ≈ the p90 of the (even-K16 p10 − full-frame) residual measured on
+  # `mix autoquality.bench --part k` over a 46-case >6 MP cohort (median 0.12,
+  # p90 2.42, worst 5.84 in `qoi_web` screen content). Dropping the confirm cost
+  # 0 target-hit regressions vs the crop+confirm baseline at every swept offset
+  # 0→3; the residual median is ~0, so biasing to the p90 barely moves bytes —
+  # raising the offset 0→3 nudges on-target only ~35→39 % at ~0 % median byte cost,
+  # because the remaining misses are bracket-ceiling-bound, not offset-bound. See
+  # `docs/autoquality_benchmark.md` (Part K).
+  @crop_confirm_skipped_offset 2.4
 
   @type outcome :: :hit | :best_effort | :skipped
 
@@ -200,13 +209,7 @@ defmodule ImagePipe.Output.EncodeSearch do
     telemetry_opts = Keyword.get(opts, :telemetry_opts, [])
     encode_fun = fn quality -> encode_leg(finalized_image, resolved, quality, telemetry_opts) end
     scorer = Keyword.get(opts, :scorer, :full)
-
-    # The confirm/bump phase does up to @default_max_bump_passes + 1 MANDATORY
-    # encodes (1 confirm + the bump steps). Give crop mode that much headroom over
-    # the objective-search cap so confirm/bump never starve the objective search or
-    # the max_bytes cap-descent of their probe budget.
-    max_iterations =
-      Keyword.get(opts, :max_iterations, @default_max_iterations) + bump_headroom(scorer)
+    max_iterations = Keyword.get(opts, :max_iterations, @default_max_iterations)
 
     with {:ok, search_opts} <- score_opts(finalized_image, resolved, scorer, telemetry_opts) do
       base_quality = base_quality(resolved)
@@ -333,13 +336,15 @@ defmodule ImagePipe.Output.EncodeSearch do
 
   # --- confirm phase (objective-neutral re-validation) ----------------------
 
-  # No confirm closure: the objective's verdict stands (full-frame ssim2, :size,
-  # :none paths are byte-identical to before this feature).
+  # No confirm closure: the objective's verdict stands. Every production path takes
+  # this clause — full-frame ssim2, :size, :none, and (since #369) crop scoring,
+  # which ships its objective winner directly using the conservative offset.
   defp confirm_phase(objective_q, objective_outcome, %Ctx{confirm_fun: nil} = ctx),
     do: {:ok, objective_q, objective_outcome, ctx}
 
-  # The objective ran on an ESTIMATE; re-validate the winner against the
-  # authoritative measure and linear-bump on undershoot (cap @max_bump_passes).
+  # A `confirm_fun` was supplied (the `mix autoquality.bench` crop+confirm
+  # baseline): the objective ran on an ESTIMATE, so re-validate the winner against
+  # the authoritative measure and linear-bump on undershoot (cap @max_bump_passes).
   defp confirm_phase(objective_q, _objective_outcome, ctx) do
     with {:ok, ctx} <- confirm_score(objective_q, :confirm, ctx) do
       if Map.fetch!(ctx.confirm_memo, objective_q) >= ctx.confirm_band do
@@ -614,11 +619,12 @@ defmodule ImagePipe.Output.EncodeSearch do
     }
   end
 
-  # Stop metadata for a confirm/bump probe. `:score` is the authoritative
-  # full-frame score; `:crop_estimate` (the offset-corrected estimate) and
-  # `:full_frame_score` + `:passed?` expose the @crop_macro_offset residual — the
-  # real-world accuracy of the crop→full correction (shadow signal for a future
-  # per-content offset calibration).
+  # Stop metadata for a confirm/bump probe. Production crop scoring no longer wires
+  # a confirm (#369); this remains for `search/3` callers that pass a `confirm_fun`
+  # (the `mix autoquality.bench` crop+confirm baseline). `:score` is the
+  # authoritative full-frame score; `:crop_estimate` (the offset-corrected estimate)
+  # and `:full_frame_score` + `:passed?` expose the crop→full residual — the
+  # real-world accuracy of the correction.
   defp confirm_probe_meta(q, ctx) do
     full = Map.fetch!(ctx.confirm_memo, q)
 
@@ -707,13 +713,10 @@ defmodule ImagePipe.Output.EncodeSearch do
 
   # --- run/3 helpers --------------------------------------------------------
 
-  defp bump_headroom(:crop), do: @default_max_bump_passes + 1
-  defp bump_headroom(:full), do: 0
-
-  # Build the objective score_fun (+ confirm closures for crop mode) for the
-  # resolved objective and the chosen scorer. Returns extra search/3 opts. The
-  # score closures emit the `:decode`/`:metric` cost legs; the core only sees an
-  # opaque float-returning closure, never the decode/metric structure.
+  # Build the objective score_fun (crop estimate or full-frame) for the resolved
+  # objective and the chosen scorer. Returns extra search/3 opts. The score
+  # closures emit the `:decode`/`:metric` cost legs; the core only sees an opaque
+  # float-returning closure, never the decode/metric structure.
   defp score_opts(_image, %Resolved{quality_search: :none}, _scorer, _telemetry_opts),
     do: {:ok, []}
 
@@ -730,27 +733,18 @@ defmodule ImagePipe.Output.EncodeSearch do
     end
   end
 
-  # Crop mode: crop score_fun (estimate) + full-frame confirm closure + the
-  # deterministic tile count for telemetry.
-  defp score_opts(image, %Resolved{quality_search: %RQS{objective: :ssim2} = rqs}, :crop, t) do
-    case Ssim2Metric.reference(image) do
-      {:ok, ref} ->
-        tiles = CropScore.tile_count(Image.width(image), Image.height(image))
-        confirm = fn bytes -> full_frame_score(ref, bytes, nil, t) end
-        crop = fn bytes -> crop_estimate(image, bytes, tiles, t) end
-
-        {:ok,
-         [
-           score_fun: crop,
-           confirm_fun: confirm,
-           confirm_band: rqs.target - rqs.allowed_error,
-           confirm_max_quality: rqs.max_quality,
-           scorer_tiles: tiles
-         ]}
-
-      {:error, reason} ->
-        {:error, {:encode, reason}}
-    end
+  # Crop mode (above the crossover): crop score_fun (estimate) only — no full-frame
+  # confirm/bump (#369). The conservative `@crop_confirm_skipped_offset` baked into
+  # the estimate replaces the confirm as the crop→full correction; the objective
+  # walk's verdict ships as-is, bounding the large-image search to a flat ~4.2 MP
+  # metric sample. No whole-frame reference is built — `crop_estimate` references
+  # per-tile via `CropScore.p10/2`, so the O(pixels) full-frame reference (the very
+  # cost this path avoids) never runs; a per-tile reference failure surfaces through
+  # the score closure's throw.
+  defp score_opts(image, %Resolved{quality_search: %RQS{objective: :ssim2}}, :crop, t) do
+    tiles = CropScore.tile_count(Image.width(image), Image.height(image))
+    crop = fn bytes -> crop_estimate(image, bytes, tiles, t) end
+    {:ok, [score_fun: crop, scorer_tiles: tiles]}
   end
 
   # The score_fun contract is float-returning, but Image.from_binary and
@@ -772,15 +766,15 @@ defmodule ImagePipe.Output.EncodeSearch do
     end)
   end
 
-  # Decode the candidate once; crop-score its tiles vs the base; subtract the macro
-  # offset so the objective's walk-to-target band comparison reproduces the
-  # full-frame decision.
+  # Decode the candidate once; crop-score its tiles vs the base; subtract the
+  # conservative confirm-skipped offset so the objective's walk-to-target band
+  # comparison reproduces the full-frame decision without a full-frame confirm.
   defp crop_estimate(base, bytes, tiles, telemetry_opts) do
     candidate = decode_leg(bytes, telemetry_opts)
 
     metric_leg(telemetry_opts, tiles, fn ->
       case CropScore.p10(base, candidate) do
-        {:ok, p10} -> p10 - @crop_macro_offset
+        {:ok, p10} -> p10 - @crop_confirm_skipped_offset
         {:error, reason} -> throw({:image_pipe_score_error, reason})
       end
     end)

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -18,6 +18,7 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
   alias ImgproxyWireConformanceTest.OriginImage
   alias ImgproxyWireConformanceTest.OriginShouldNotFetch
   alias Vix.Vips.Image, as: VipsImage
+  alias Vix.Vips.Operation
 
   @source_url_encryption_key "000102030405060708090a0b0c0d0e0f"
   @source_url_encryption_iv <<16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31>>
@@ -56,6 +57,31 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
         |> Image.Draw.rect!(0, 0, 40, 40, color: :red)
         |> Image.set_orientation!(6)
         |> Image.write!(:memory, suffix: ".jpg")
+
+      conn
+      |> Plug.Conn.put_resp_content_type("image/jpeg")
+      |> Plug.Conn.send_resp(200, body)
+    end
+  end
+
+  # A >6 MP source so the autoquality `:ssim2` search crosses the crop crossover
+  # (`CropScore.crossover_megapixels/0`) and runs in crop-scoring mode. A
+  # high-frequency zone plate gives the search real detail to score (a flat image
+  # would clear the band at the floor in one probe). 2800² ≈ 7.84 MP. Served as
+  # JPEG so the body stays under the default 10 MB source `max_body_bytes` (an
+  # incompressible zone-plate PNG exceeds it); the decoded source is still 7.84 MP.
+  defmodule LargeSsim2OriginImage do
+    @moduledoc false
+
+    def call(conn, _opts) do
+      side = 2800
+      {:ok, z} = Operation.zone(side, side)
+      {:ok, scaled} = Operation.linear(z, [127.5], [127.5])
+      {:ok, uchar} = Operation.cast(scaled, :VIPS_FORMAT_UCHAR)
+      {:ok, gray} = Operation.copy(uchar, interpretation: :VIPS_INTERPRETATION_B_W)
+      {:ok, rgb} = Operation.bandjoin([gray, gray, gray])
+      {:ok, srgb} = Operation.copy(rgb, interpretation: :VIPS_INTERPRETATION_sRGB)
+      body = Image.write!(srgb, :memory, suffix: ".jpg")
 
       conn
       |> Plug.Conn.put_resp_content_type("image/jpeg")
@@ -648,6 +674,49 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
         {RootHTTPAdapter, root_url: "http://origin.test", req_options: [plug: Hdr16OriginImage]}
     ]
   ]
+
+  test "autoquality :ssim2 on a >6 MP source ships the crop verdict with no full-frame confirm (#369)" do
+    # Above the crop crossover the search must ship the crop objective winner with
+    # NO full-frame confirm/bump — the O(pixels) cost that risked the request
+    # deadline. Capture the encode-search verdict through a real Plug request.
+    telemetry_prefix = [:"ip_aq_crop_wire_#{System.unique_integer([:positive])}"]
+    search_stop = telemetry_prefix ++ [:encode, :search, :stop]
+    test_pid = self()
+    handler_id = "aq-crop-wire-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach(
+      handler_id,
+      search_stop,
+      fn _event, _measurements, meta, _config -> send(test_pid, {:search_stop, meta}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    opts = [
+      parser: ImagePipe.Parser.Imgproxy,
+      sources: [
+        path:
+          {RootHTTPAdapter,
+           root_url: "http://origin.test", req_options: [plug: LargeSsim2OriginImage]}
+      ],
+      imgproxy: [autoquality_method: :ssim2, autoquality_target: 70],
+      telemetry_prefix: telemetry_prefix
+    ]
+
+    # No resize: the full >6 MP frame is finalized, so the ladder selects crop mode.
+    conn = call_imgproxy("/_/f:jpeg/plain/images/large.jpg", opts)
+
+    assert conn.status == 200
+    assert content_type(conn) == ["image/jpeg"]
+    # A valid, decodable result — the search did not time out or error mid-confirm.
+    assert {2800, 2800} = dimensions(conn)
+
+    assert_receive {:search_stop, meta}
+    assert meta.scorer == :crop
+    assert meta.confirm_passes == 0
+    assert meta.result == :ok
+  end
 
   test "equivalent imgproxy option order shares filesystem cache through real Plug requests" do
     {opts, cache_root} = cached_opts()

--- a/test/image_pipe/output/encode_search_telemetry_test.exs
+++ b/test/image_pipe/output/encode_search_telemetry_test.exs
@@ -128,7 +128,7 @@ defmodule ImagePipe.Output.EncodeSearchTelemetryTest do
       assert probe.scorer == :crop
       assert probe.tiles_scored == 12
       # estimate (q+26) and authoritative full-frame (q+25) differ by exactly 1.0:
-      # the @crop_macro_offset residual, surfaced for shadow calibration.
+      # the crop→full residual, surfaced for shadow calibration.
       assert_in_delta probe.full_frame_score - probe.crop_estimate, -1.0, 0.001
       assert probe.score == probe.full_frame_score
       assert is_boolean(probe.passed?)

--- a/test/image_pipe/output/encoder_crop_scoring_test.exs
+++ b/test/image_pipe/output/encoder_crop_scoring_test.exs
@@ -57,7 +57,7 @@ defmodule ImagePipe.Output.EncoderCropScoringTest do
     }
   end
 
-  test "stream_output crop-scores a >6 MP output (ladder picks :crop)" do
+  test "stream_output crop-scores a >6 MP output with no full-frame confirm (ladder picks :crop)" do
     attach_stop()
 
     {:ok, [_bin], _mime} =
@@ -66,6 +66,9 @@ defmodule ImagePipe.Output.EncoderCropScoringTest do
     assert_receive {:stop, meta}
     assert meta.scorer == :crop
     assert meta.tiles_scored == 16
+    # Above the crossover the search ships the crop objective winner with no
+    # full-frame confirm/bump — the O(pixels) cost the crop path exists to avoid.
+    assert meta.confirm_passes == 0
   end
 
   test "stream_output full-frame-scores a <6 MP output (ladder picks :full)" do
@@ -88,10 +91,13 @@ defmodule ImagePipe.Output.EncoderCropScoringTest do
     {:ok, _crop_bin, crop} = EncodeSearch.run(image, resolved, scorer: :crop)
 
     assert crop.scorer == :crop
-    assert crop.confirm_passes >= 1
-    # Part E residual is ±2-4 q; 3 is the robust bound. Re-confirm after the bench
-    # sets the calibrated @crop_macro_offset; tighten to <= 2 only if it supports it.
-    assert abs(crop.quality - full.quality) <= 3
+    # No full-frame confirm above the crossover: the crop objective winner ships as-is.
+    assert crop.confirm_passes == 0
+    # The conservative offset biases the estimate down, so the crop walk can land a
+    # step or two higher than the full-frame pick; 4 is the robust bound.
+    assert abs(crop.quality - full.quality) <= 4
+    # meta.score is the offset-corrected crop estimate the walk converged to; by
+    # construction it sits at/above the band floor.
     assert crop.score >= resolved.quality_search.target - resolved.quality_search.allowed_error
   end
 
@@ -130,10 +136,12 @@ defmodule ImagePipe.Output.EncoderCropScoringTest do
     legs = drain_legs()
     by_stage = Enum.group_by(legs, &elem(&1, 0), &elem(&1, 1))
 
-    # probe spans tag their phase; crop mode runs the objective then confirm/bump.
+    # probe spans tag their phase; above the crossover crop mode runs the objective
+    # walk only — no confirm/bump phase fires.
     probe_phases = by_stage |> Map.fetch!([:encode, :search, :probe]) |> Enum.map(& &1.phase)
     assert :objective in probe_phases
-    assert :confirm in probe_phases
+    refute :confirm in probe_phases
+    refute :bump in probe_phases
 
     # every objective/cap probe encodes -> an encode leg with the produced byte size.
     encode_legs = Map.fetch!(by_stage, [:encode, :search, :probe, :encode])
@@ -145,10 +153,9 @@ defmodule ImagePipe.Output.EncoderCropScoringTest do
     metric_legs = Map.fetch!(by_stage, [:encode, :search, :probe, :ssim2, :metric])
     assert metric_legs != []
     assert Enum.all?(metric_legs, &is_float(&1.score))
-    # objective probes crop-score K tiles (tiles_scored: 16); confirm probes run
-    # the whole-frame measure, so their metric leg carries no tile count.
-    assert Enum.any?(metric_legs, &(Map.get(&1, :tiles_scored) == 16))
-    assert Enum.all?(metric_legs, &(Map.get(&1, :tiles_scored) in [nil, 16]))
+    # Every probe crop-scores K tiles (tiles_scored: 16); there is no whole-frame
+    # confirm leg above the crossover.
+    assert Enum.all?(metric_legs, &(Map.get(&1, :tiles_scored) == 16))
   end
 
   defp drain_legs(acc \\ []) do
@@ -159,7 +166,7 @@ defmodule ImagePipe.Output.EncoderCropScoringTest do
     end
   end
 
-  test "max_bytes binds the crop-path delivered q (cap runs after confirm/bump)" do
+  test "max_bytes binds the crop-path delivered q (cap descends from the crop pick)" do
     image = zone_plate(7)
     resolved = ssim2_resolved()
 
@@ -169,8 +176,8 @@ defmodule ImagePipe.Output.EncoderCropScoringTest do
 
     {:ok, capped_bin, capped} = EncodeSearch.run(image, capped_resolved, scorer: :crop)
 
-    # A budget below the crop pick forces cap_phase (which runs AFTER confirm/bump) to
-    # descend: lower-or-equal quality and never more bytes than the uncapped pick.
+    # A budget below the crop pick forces cap_phase to descend: lower-or-equal
+    # quality and never more bytes than the uncapped pick.
     assert capped.quality <= no_cap.quality
     assert byte_size(capped_bin) <= byte_size(no_cap_bin)
   end

--- a/test/image_pipe/output/encoder_crop_scoring_test.exs
+++ b/test/image_pipe/output/encoder_crop_scoring_test.exs
@@ -94,7 +94,8 @@ defmodule ImagePipe.Output.EncoderCropScoringTest do
     # No full-frame confirm above the crossover: the crop objective winner ships as-is.
     assert crop.confirm_passes == 0
     # The conservative offset biases the estimate down, so the crop walk can land a
-    # step or two higher than the full-frame pick; 4 is the robust bound.
+    # step or two higher than the full-frame pick; 4 is the robust bound. This bound
+    # tracks @crop_confirm_skipped_offset — retune it together with the offset.
     assert abs(crop.quality - full.quality) <= 4
     # meta.score is the offset-corrected crop estimate the walk converged to; by
     # construction it sits at/above the band floor.


### PR DESCRIPTION
## Problem

Above the crop crossover (`CropScore.crossover_megapixels/0`, 6 MP) the `:ssim2` search shipped the crop objective winner **then ran a full-frame SSIMULACRA2 confirm + bump loop** on it — an O(pixels) metric (6–8 s on a 37 MP image, re-fired once per bump pass) that could blow the request deadline and 500 mid-metric. The motivating trace: a 5011×7516 (37.7 MP) no-resize→AVIF request spent ~14 s of its 30 s budget in full-frame confirm metrics and timed out.

This is the **deterministic, source-agnostic** alternative to the #355 runtime deadline: instead of reacting to wall-clock (which would make the same cache key resolve to different bytes), remove the unbounded cost so the large-image search is **bounded by construction**.

## Change

Above the crossover the search now **ships the crop objective winner with no confirm/bump**. `EncodeSearch.score_opts` (crop clause) stops wiring `confirm_fun`/`confirm_band`/`confirm_max_quality`, routing crop mode through the existing `confirm_fun: nil` passthrough. The crop→full correction becomes a single conservative global offset `@crop_confirm_skipped_offset = 2.4` (replacing the median-calibrated `@crop_macro_offset 0.22`), subtracted from the tile p10. The now-pointless top-level full-frame `Ssim2Metric.reference` build and the crop bump headroom in `run/3` are dropped. The crop path is now a flat ~4.2 MP objective walk that can no longer time out mid-confirm.

The pure core `search/3` **keeps** `confirm_fun` support — the `mix autoquality.bench` crop+confirm baseline still uses it. Telemetry needs no code change: event names are unchanged (Logger/OTel Capture stay in sync); the path naturally emits `confirm_passes: 0`, no `:confirm`/`:bump` probe phases, `scorer: :crop`.

## Gating — Part K re-run (screen-content cohort)

`mix autoquality.bench --part k` over `qoi_web` + `gb82_sc` + `large`, **46 crop-regime (subject×format) cases**:

- **0 target-hit regressions at every swept offset (0→3)** — dropping the confirm never turned a baseline crop+confirm hit into a miss.
- Systematic residual (even-K16 p10 − full): **median 0.12, p90 2.42, worst 5.84**, the tail concentrated in `qoi_web` screen content (phoboslab).
- Confirm cost removed ≈ **756 ms/case**. Offset **2.4 ≈ p90 (2.42)** at ~0 % median byte cost; raising 0→3 nudges on-target only 35→39 % (the misses are bracket-ceiling-bound, a Part I lever, not offset-bound).

## Verification

- Full precommit green: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict` (no issues), **2547 tests, 0 failures**.
- New request-boundary wire test: a >6 MP `:ssim2` request ships the crop verdict (`confirm_passes == 0`, `scorer: :crop`) with a decodable result through `ImagePipe.call/2`.
- `docs/autoquality_benchmark.md`: new **Part K** section + operating point; #354 "Shipped calibration" and Part H marked superseded above the crossover.

No imgproxy compat impact — the autoquality `:ssim2` search is ImagePipe-native, not an imgproxy-parity behavior.

Fixes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Benchmark study published demonstrating that full-frame confirmation can be safely eliminated in crop-scoring mode with zero quality regressions across tested scenarios.

* **Tests**
  * Added conformance tests validating crop-scoring behavior on large images; updated existing test expectations to reflect the optimized processing flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->