### PR TITLE
feat(telemetry): tag the delivered probe in the encode-search trace (#372)

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -376,6 +376,32 @@ exporter only (`ImagePipe.Telemetry.Trace.Capture`), where per-probe cost detail
 belongs. This is the one intentional place the Logger and the tracer cover
 different event sets.
 
+#### Delivered-probe marker (`[:encode, :search, :probe, :chosen]`)
+
+The delivered bytes are the **winning probe's** encode — produced during the
+search and reused via memoization, with no separate post-search re-encode. Because
+probe spans close before the search resolves its final quality, the winner cannot
+be tagged on its own (already-closed) span. Instead a single **one-shot** event,
+`[:image_pipe, :encode, :search, :probe, :chosen]`, is emitted once when the search
+resolves, naming the delivered probe so it is directly filterable. In a trace it
+folds as an annotation onto the enclosing `[:encode, :search]` span.
+
+Metadata (a subset of the winning probe's, plus the encode phase):
+
+- `:quality` — the delivered quality (equals the search's `:chosen_quality`).
+- `:bytes` — the delivered byte size (equals `:chosen_bytes`).
+- `:phase` — the phase that actually **encoded** the delivered bytes: `:objective`
+  or `:cap`, or `:bump` when the winner was first encoded during a confirm bump.
+  (A confirm only re-scores already-encoded bytes, so it never names the winner.)
+- `:index` — the distinct-encode ordinal of that encode.
+- `:score` — the delivered quality's score; absent for a `:size`/`:none` search.
+- `:scorer` — `:full` or `:crop`.
+- `:tiles_scored` — tiles scored on the crop path; absent on the full-frame path.
+
+Both surfaces subscribe to it: the default Logger renders one line
+(`image_pipe encode search chosen: q64 12345b (objective score 90.42)`, base
+level), and the OTel exporter folds it onto the search span.
+
 ### Delivery streaming span (`[:deliver]`)
 
 The `[:image_pipe, :deliver]` span wraps streaming the already-produced encoded

--- a/lib/image_pipe/output/encode_search.ex
+++ b/lib/image_pipe/output/encode_search.ex
@@ -102,6 +102,7 @@ defmodule ImagePipe.Output.EncodeSearch do
               encode_memo: %{},
               score_memo: %{},
               confirm_memo: %{},
+              probe_log: %{},
               confirm_passes: 0,
               iterations: 0,
               max_iterations: 0,
@@ -403,7 +404,7 @@ defmodule ImagePipe.Output.EncodeSearch do
       [:encode, :search, :probe],
       %{quality: q, phase: phase},
       fn ->
-        case ensure_encoded_raw(q, ctx) do
+        case ensure_encoded_raw(q, phase, ctx) do
           {:ok, ctx} ->
             score = ctx.confirm_fun.(Map.fetch!(ctx.encode_memo, q))
 
@@ -572,7 +573,7 @@ defmodule ImagePipe.Output.EncodeSearch do
       [:encode, :search, :probe],
       %{quality: q, phase: ctx.phase},
       fn ->
-        case do_encode(q, ctx) do
+        case do_encode(q, ctx.phase, ctx) do
           {:ok, ctx} -> {{:ok, ctx}, objective_probe_meta(q, ctx)}
           {:error, reason} = err -> {err, %{result: :processing_error, error: reason}}
         end
@@ -582,14 +583,19 @@ defmodule ImagePipe.Output.EncodeSearch do
 
   # Raw encode + memoize + estimate-score, WITHOUT a probe span: the caller owns
   # the span (encode_probe for objective/cap, confirm_probe for confirm/bump), so
-  # a bump that encodes a never-seen q emits a single probe, not two.
-  defp do_encode(q, ctx) do
+  # a bump that encodes a never-seen q emits a single probe, not two. `phase` is
+  # the enclosing probe span's phase, logged per distinct encode so the delivered
+  # quality can later name the phase that actually produced its bytes.
+  defp do_encode(q, phase, ctx) do
     case ctx.encode_fun.(q) do
       {:ok, binary} ->
+        iterations = ctx.iterations + 1
+
         ctx = %{
           ctx
           | encode_memo: Map.put(ctx.encode_memo, q, binary),
-            iterations: ctx.iterations + 1
+            iterations: iterations,
+            probe_log: Map.put(ctx.probe_log, q, %{phase: phase, index: iterations})
         }
 
         {:ok, maybe_score(q, binary, ctx)}
@@ -599,8 +605,8 @@ defmodule ImagePipe.Output.EncodeSearch do
     end
   end
 
-  defp ensure_encoded_raw(q, ctx) do
-    if Map.has_key?(ctx.encode_memo, q), do: {:ok, ctx}, else: do_encode(q, ctx)
+  defp ensure_encoded_raw(q, phase, ctx) do
+    if Map.has_key?(ctx.encode_memo, q), do: {:ok, ctx}, else: do_encode(q, phase, ctx)
   end
 
   defp maybe_score(_q, _binary, %Ctx{score_fun: nil} = ctx), do: ctx
@@ -657,6 +663,8 @@ defmodule ImagePipe.Output.EncodeSearch do
     binary = Map.fetch!(ctx.encode_memo, final_q)
     ctx = ensure_winner_scored(final_q, binary, ctx)
 
+    emit_chosen(final_q, binary, ctx)
+
     meta = %{
       quality: final_q,
       bytes: byte_size(binary),
@@ -670,6 +678,35 @@ defmodule ImagePipe.Output.EncodeSearch do
     }
 
     {:ok, binary, meta}
+  end
+
+  # One-shot marker naming the delivered probe. The winning quality's encode IS the
+  # bytes we ship — produced during the search and reused via memoization, with no
+  # post-search re-encode — so there is no span of its own to tag as the winner.
+  # Probe spans also close before the winner is known, so this is emitted once at
+  # resolution rather than as an attribute on the (already-closed) probe span; it
+  # folds onto the enclosing `[:encode, :search]` span. `:phase` names the phase
+  # that actually encoded the delivered bytes (objective/cap, or bump when the
+  # winner was first encoded during the confirm bump). All product-neutral; nils
+  # (`:score`/`:tiles_scored` on the :size/:none/full-frame paths) are stripped by
+  # the telemetry layer, matching the probe-span metadata.
+  defp emit_chosen(final_q, binary, ctx) do
+    probe = Map.get(ctx.probe_log, final_q, %{})
+
+    Telemetry.execute(
+      ctx.telemetry_opts,
+      [:encode, :search, :probe, :chosen],
+      %{},
+      %{
+        quality: final_q,
+        bytes: byte_size(binary),
+        phase: probe[:phase],
+        index: probe[:index],
+        score: result_score(final_q, ctx),
+        scorer: ctx.scorer,
+        tiles_scored: ctx.scorer_tiles
+      }
+    )
   end
 
   # The limiting factor is meaningful only for a degraded result; a `:hit` (or

--- a/lib/image_pipe/request/source_session/producer.ex
+++ b/lib/image_pipe/request/source_session/producer.ex
@@ -166,11 +166,15 @@ defmodule ImagePipe.Request.SourceSession.Producer do
   end
 
   # Honest forced-encode span. `Encoder.stream_output/3` builds the lazy encoder
-  # pipeline; `first_chunk/1` pulls the first chunk, forcing libvips to actually
-  # encode — the heaviest stage of most requests. Both run here, in the producer
-  # process, so the span measures real compute (unlike per-op transform spans,
-  # which time construction). Parents to the request root (sibling of the
-  # delivery-backstop materialize) via the adopted remote-parent frame.
+  # pipeline; on the lazy (non-search) path `first_chunk/1` pulls the first chunk,
+  # forcing libvips to actually encode — the heaviest stage of most requests. On
+  # the `:ssim2` quality-search path the encode already happened eagerly inside the
+  # search (the delivered bytes are the winning probe's encode), so here
+  # `first_chunk/1` only pulls a pre-encoded buffer and this span's duration is
+  # dominated by that earlier search, not by work done under it. Both run here, in
+  # the producer process, so the span measures real compute (unlike per-op
+  # transform spans, which time construction). Parents to the request root (sibling
+  # of the delivery-backstop materialize) via the adopted remote-parent frame.
   defp encode_first_chunk(image, %Resolved{} = resolved_output, opts) do
     Telemetry.span(
       Telemetry.telemetry_opts(opts),

--- a/lib/image_pipe/telemetry/logger.ex
+++ b/lib/image_pipe/telemetry/logger.ex
@@ -34,6 +34,11 @@ defmodule ImagePipe.Telemetry.Logger do
     http_cache: []
   }
 
+  # request one-shot events (already terminal; not spans)
+  @request_oneshot [
+    [:encode, :search, :probe, :chosen]
+  ]
+
   # cache one-shot events (already terminal; not spans)
   @cache_oneshot [
     [:cache, :eviction, :stop],
@@ -94,6 +99,7 @@ defmodule ImagePipe.Telemetry.Logger do
       |> Enum.flat_map(&Map.get(@group_span_events, &1, []))
       |> Enum.flat_map(fn e -> [e ++ [:stop], e ++ [:exception]] end)
 
+    request_oneshots = if :request in groups, do: @request_oneshot, else: []
     cache_oneshots = if :cache in groups, do: @cache_oneshot, else: []
     transform_oneshots = if :transform in groups, do: @transform_oneshot, else: []
     output_oneshots = if :output in groups, do: @output_oneshot, else: []
@@ -101,6 +107,7 @@ defmodule ImagePipe.Telemetry.Logger do
 
     Enum.map(
       spans ++
+        request_oneshots ++
         cache_oneshots ++
         transform_oneshots ++ output_oneshots ++ http_cache_oneshots,
       fn e -> prefix ++ e end
@@ -245,6 +252,16 @@ defmodule ImagePipe.Telemetry.Logger do
 
     "image_pipe output clamp: #{sw}x#{sh} -> #{w}x#{h} for #{meta[:format]} " <>
       "(caps w:#{cap(mw)} h:#{cap(mh)} px:#{cap(mp)})"
+  end
+
+  # The delivered-probe marker. BEFORE the probe-span clause below: its event name
+  # nests under [:encode, :search, :probe], so the span clause would otherwise
+  # match and render it as a probe stop (missing the phase/winner framing).
+  defp message([:encode, :search, :probe, :chosen | _], _m, meta) do
+    score = if meta[:score], do: " score #{round2(meta[:score])}", else: ""
+
+    "image_pipe encode search chosen: q#{meta[:quality]} #{meta[:bytes]}b " <>
+      "(#{meta[:phase]}#{score})"
   end
 
   # Specific clause BEFORE the search clause below: a probe stop would otherwise

--- a/lib/image_pipe/telemetry/trace/capture.ex
+++ b/lib/image_pipe/telemetry/trace/capture.ex
@@ -38,6 +38,10 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
 
   # One-shot (terminal) events — folded as annotations onto the current span.
   @oneshot_stages [
+    # Delivered-probe marker: folds onto the enclosing [:encode, :search] span,
+    # naming the winning quality/phase that produced the shipped bytes. All keys
+    # (quality, bytes, phase, index, score, scorer, tiles_scored) are in @safe_keys.
+    [:encode, :search, :probe, :chosen],
     [:cache, :stage],
     [:cache, :eviction, :stop],
     [:cache, :flush, :stop],

--- a/test/image_pipe/output/encode_search_telemetry_test.exs
+++ b/test/image_pipe/output/encode_search_telemetry_test.exs
@@ -10,6 +10,7 @@ defmodule ImagePipe.Output.EncodeSearchTelemetryTest do
   @prefix [:ip_es_test]
   @stop @prefix ++ [:encode, :search, :stop]
   @probe @prefix ++ [:encode, :search, :probe, :stop]
+  @chosen @prefix ++ [:encode, :search, :probe, :chosen]
 
   setup do
     handler_id = "encode-search-telemetry-#{System.unique_integer([:positive])}"
@@ -17,7 +18,7 @@ defmodule ImagePipe.Output.EncodeSearchTelemetryTest do
 
     :telemetry.attach_many(
       handler_id,
-      [@stop, @probe],
+      [@stop, @probe, @chosen],
       fn event, measurements, metadata, _config ->
         send(test_pid, {:telemetry, event, measurements, metadata})
       end,
@@ -87,6 +88,19 @@ defmodule ImagePipe.Output.EncodeSearchTelemetryTest do
 
     # the distinct-encode index is the running ordinal
     assert Enum.sort(Enum.map(probes, & &1.index)) == Enum.to_list(1..length(probes))
+
+    # exactly one chosen marker fires, naming the delivered probe: same quality as
+    # the search verdict, the objective phase that encoded it, and the shipped bytes.
+    assert_receive {:telemetry, @chosen, _m, chosen}
+    assert chosen.quality == chosen_q
+    assert chosen.bytes == chosen_q * 100
+    assert chosen.phase == :objective
+    assert chosen.score == score_value
+    assert chosen.scorer == :full
+    assert is_integer(chosen.index)
+    # full-frame mode: nil tiles_scored is stripped by the telemetry layer.
+    refute Map.has_key?(chosen, :tiles_scored)
+    refute_received {:telemetry, @chosen, _m2, _meta2}
   end
 
   test "confirm/bump probes carry the phase + the crop→full residual fields" do
@@ -138,6 +152,16 @@ defmodule ImagePipe.Output.EncodeSearchTelemetryTest do
     [confirm64, bump65] = confirm_probes
     assert confirm64.quality == 64 and confirm64.passed? == false
     assert bump65.quality == 65 and bump65.passed? == true
+
+    # the delivered q65 was first encoded during the objective walk (probed as an
+    # overshoot); the bump only re-scored those already-memoized bytes. So the
+    # chosen marker names :objective — the phase that produced the shipped bytes,
+    # not the phase that re-validated them.
+    assert_receive {:telemetry, @chosen, _m, chosen}
+    assert chosen.quality == 65
+    assert chosen.phase == :objective
+    assert chosen.scorer == :crop
+    assert chosen.tiles_scored == 12
   end
 
   test "search stop names the limiting factor on a ceiling best-effort" do
@@ -184,6 +208,13 @@ defmodule ImagePipe.Output.EncodeSearchTelemetryTest do
 
     assert_receive {:telemetry, @stop, _m, stop_meta}
     assert stop_meta.limiting_factor == :max_bytes
+
+    # the floor (q10) was encoded under the cap phase, so the chosen marker names
+    # :cap. :none objective carries no score → nil is stripped from the marker.
+    assert_receive {:telemetry, @chosen, _m, chosen}
+    assert chosen.quality == 10
+    assert chosen.phase == :cap
+    refute Map.has_key?(chosen, :score)
   end
 
   defp collect_probes(probes \\ [], durations \\ []) do

--- a/test/image_pipe/telemetry/logger_test.exs
+++ b/test/image_pipe/telemetry/logger_test.exs
@@ -154,6 +154,22 @@ defmodule ImagePipe.Telemetry.LoggerTest do
     assert log =~ "encode search probe: ok (confirm q65 6500b score 90.42)"
   end
 
+  test "renders the delivered-probe chosen marker with quality, bytes, phase, score" do
+    Telemetry.attach_default_logger(level: :info)
+
+    log =
+      capture_log(fn ->
+        :telemetry.execute(
+          [:image_pipe, :encode, :search, :probe, :chosen],
+          %{},
+          %{quality: 64, bytes: 12_345, phase: :objective, index: 3, score: 90.42}
+        )
+      end)
+
+    refute log =~ "[warning]"
+    assert log =~ "encode search chosen: q64 12345b (objective score 90.42)"
+  end
+
   test "escalates an encode-search probe exception to warning" do
     Telemetry.attach_default_logger(level: :info)
 

--- a/test/image_pipe/telemetry/trace/capture_test.exs
+++ b/test/image_pipe/telemetry/trace/capture_test.exs
@@ -111,6 +111,33 @@ defmodule ImagePipe.Telemetry.Trace.CaptureTest do
     assert probe.attributes[:passed?] == true
   end
 
+  test "folds the delivered-probe chosen marker onto the enclosing search span" do
+    Telemetry.span([], [:encode, :search], %{objective: :ssim2}, fn ->
+      Telemetry.execute(
+        [],
+        [:encode, :search, :probe, :chosen],
+        %{},
+        %{quality: 64, bytes: 12_345, phase: :objective, index: 3, score: 90.42, scorer: :full}
+      )
+
+      {:ok, %{result: :ok}}
+    end)
+
+    assert_receive {:span, %Span{name: "image_pipe.encode.search"} = search}
+
+    # the marker is a one-shot annotation on the search span, not a child span.
+    refute_received {:span, %Span{name: "image_pipe.encode.search.probe.chosen"}}
+
+    chosen = Enum.find(search.events, &(&1.name == "image_pipe.encode.search.probe.chosen"))
+    assert chosen
+    assert chosen.attributes[:quality] == 64
+    assert chosen.attributes[:bytes] == 12_345
+    assert chosen.attributes[:phase] == :objective
+    assert chosen.attributes[:index] == 3
+    assert chosen.attributes[:score] == 90.42
+    assert chosen.attributes[:scorer] == :full
+  end
+
   test "nests the probe cost legs (encode/decode/metric) under the probe span" do
     Telemetry.span([], [:encode, :search, :probe], %{quality: 62, phase: :objective}, fn ->
       Telemetry.span([], [:encode, :search, :probe, :encode], %{quality: 62}, fn ->


### PR DESCRIPTION
## Problem

In the `:ssim2`/`:size` quality search (`ImagePipe.Output.EncodeSearch`), the shipped bytes are the **winning probe's** encode — produced during the search and reused via memoization, with no separate post-search re-encode (correct and intentional). But every `encode.search.probe` looks identical in a trace, so you can't tell which probe produced the delivered image without manually joining the search span's `chosen_quality` to the probe whose `quality` matches. On a large image where each probe is a multi-second full-frame encode, "which encode did we actually ship?" is exactly the first question you ask when debugging latency — and the trace didn't answer it directly.

A span's stop metadata is fixed the moment the probe closes — *during* the search, before the winner is known — so the winning probe's own (already-closed) span can't be retroactively tagged.

## Change

Emit a **one-shot** `[:encode, :search, :probe, :chosen]` event once when the search resolves, naming the delivered probe so it's directly filterable.

- `EncodeSearch` — a `probe_log` memo on `Ctx` records each distinct encode's phase/index; `build_result` emits the marker carrying `quality`, `bytes`, `score`, `scorer`, `tiles_scored` (a subset of the winning probe's), plus `:phase` and `:index`. `:phase` names the phase that actually **encoded** the shipped bytes (`:objective`/`:cap`, or `:bump` when first encoded during a bump) — genuinely new info beyond `chosen_quality`, since a confirm only re-scores already-encoded bytes.
- **Logger** — new `@request_oneshot` subscription + a render clause ordered before the probe-span clause: `image_pipe encode search chosen: q64 12345b (objective score 90.42)`.
- **OTel `Capture`** — added to `@oneshot_stages` (all keys already in `@safe_keys`); folds as an annotation onto the enclosing `[:encode, :search]` span.
- Clarified the producer's `encode_first_chunk` comment (the lazy path forces the encode; the search path pulls a pre-encoded buffer) and documented the marker in `docs/telemetry.md`.

## Tests (written first)

Chosen-marker assertions in `encode_search_telemetry_test.exs` covering the `:objective` and `:cap` phases and single-emission; a Logger render test; a Capture annotation-fold test. Full gate green (`format`/`compile --warnings-as-errors`/`credo --strict`/`test`).

## Acceptance

- [x] The delivered probe carries a `chosen` marker; non-winning probes do not.
- [x] Logger + OTel Capture both surface it; test coverage added.
- [x] `encode_first_chunk` comment clarified re: lazy vs search path.

Fixes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)