### PR TITLE
chore: port worktrees:clean from a mise task to a mix task

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -60,6 +60,13 @@ run = [
   "pnpm -C fiddle/assets run build",
 ]
 
+# Thin alias so the task shows up in `mise tasks`; the implementation (and its
+# symlink-safety logic) lives in the `mix worktrees.clean` task, which selects
+# MIX_ENV=test itself via mix.exs `preferred_envs`.
+[tasks."worktrees:clean"]
+description = "Remove regenerable dirs (deps, _build, fiddle deps/_build/node_modules, .dexter, .expert) from every worktree (→ mix worktrees.clean)"
+run = "mix worktrees.clean"
+
 [tasks.server]
 description = "Run the ImagePipe Fiddle dev server (Phoenix + Vite)"
 dir = "fiddle"

--- a/mise.toml
+++ b/mise.toml
@@ -60,43 +60,6 @@ run = [
   "pnpm -C fiddle/assets run build",
 ]
 
-[tasks."worktrees:clean"]
-description = "Remove regenerable dirs (deps, _build, fiddle deps/_build/node_modules, .dexter, .expert) from every worktree under .worktrees and .claude/worktrees"
-run = """
-set -eu
-root=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")
-[ -n "$root" ] && [ -d "$root" ] || { echo "could not resolve git root" >&2; exit 1; }
-root=$(CDPATH= cd -- "$root" && pwd -P)
-
-# Canonical absolute path of an existing file/dir (resolves symlinks).
-resolve() {
-  d=$(CDPATH= cd -- "$(dirname -- "$1")" && pwd -P) || return 1
-  case "$d" in */) printf '%s%s\\n' "$d" "$(basename -- "$1")" ;;
-                *) printf '%s/%s\\n' "$d" "$(basename -- "$1")" ;; esac
-}
-
-removed=0
-for base in "$root/.worktrees" "$root/.claude/worktrees"; do
-  [ -d "$base" ] || continue
-  for wt in "$base"/*/; do
-    [ -d "$wt" ] || continue
-    for target in deps _build fiddle/deps fiddle/_build fiddle/node_modules fiddle/assets/node_modules .dexter .expert; do
-      path="$wt$target"
-      [ -e "$path" ] || continue
-      real=$(resolve "$path") || { echo "skip (unresolvable): $path" >&2; continue; }
-      case "$real" in
-        "$root"/*) ;;
-        *) echo "skip (outside git root): $real" >&2; continue ;;
-      esac
-      echo "rm -rf ${real#"$root/"}"
-      rm -rf "$real"
-      removed=$((removed + 1))
-    done
-  done
-done
-echo "Cleaned $removed director(ies)."
-"""
-
 [tasks.server]
 description = "Run the ImagePipe Fiddle dev server (Phoenix + Vite)"
 dir = "fiddle"

--- a/mix.exs
+++ b/mix.exs
@@ -75,7 +75,8 @@ defmodule ImagePipe.MixProject do
         "twicpics.gen_fixtures": :test,
         "twicpics.diagnose": :test,
         "twicpics.gen_report": :test,
-        "twicpics.reauthor": :test
+        "twicpics.reauthor": :test,
+        "worktrees.clean": :test
       ]
     ]
   end

--- a/test/image_pipe/worktrees_clean_test.exs
+++ b/test/image_pipe/worktrees_clean_test.exs
@@ -1,0 +1,105 @@
+defmodule ImagePipe.WorktreesCleanTest do
+  use ExUnit.Case, async: true
+
+  alias Mix.Tasks.Worktrees.Clean
+
+  @bases [".worktrees", ".claude/worktrees"]
+  @regenerable ~w(
+    deps _build
+    fiddle/deps fiddle/_build fiddle/node_modules fiddle/assets/node_modules
+    .dexter .expert
+  )
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "wtclean_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(root)
+    on_exit(fn -> File.rm_rf!(root) end)
+    {:ok, root: root}
+  end
+
+  defp populate_dir(path) do
+    File.mkdir_p!(path)
+    File.write!(Path.join(path, ".keep"), "x")
+  end
+
+  test "removes every regenerable dir from each worktree under both bases, leaving sources alone",
+       %{root: root} do
+    for base <- @bases, name <- ~w(a b) do
+      wt = Path.join([root, base, name])
+      for target <- @regenerable, do: populate_dir(Path.join(wt, target))
+      # Source files that must survive.
+      populate_dir(Path.join(wt, "lib"))
+      File.write!(Path.join(wt, "mix.exs"), "x")
+    end
+
+    %{removed: removed, skipped: skipped} = Clean.clean(root)
+
+    assert skipped == []
+    # 8 regenerable targets × 2 worktree names × 2 bases.
+    assert length(removed) == 32
+
+    for base <- @bases, name <- ~w(a b) do
+      wt = Path.join([root, base, name])
+      for target <- @regenerable, do: refute(File.exists?(Path.join(wt, target)))
+      # The fiddle dir itself stays — only its regenerable children are removed.
+      assert File.dir?(Path.join(wt, "fiddle"))
+      assert File.dir?(Path.join(wt, "fiddle/assets"))
+      # Sources untouched.
+      assert File.dir?(Path.join(wt, "lib"))
+      assert File.exists?(Path.join(wt, "mix.exs"))
+    end
+  end
+
+  test "ignores a base directory that does not exist", %{root: root} do
+    wt = Path.join([root, ".claude/worktrees", "only"])
+    populate_dir(Path.join(wt, "deps"))
+
+    # `.worktrees` is absent; the task must just skip it, not crash.
+    %{removed: removed} = Clean.clean(root)
+
+    assert removed == [Path.join(wt, "deps")]
+    refute File.exists?(Path.join(wt, "deps"))
+  end
+
+  test "does not delete content reached through a worktree symlink that escapes the root",
+       %{root: root} do
+    # An intermediate symlink: <root>/.claude/worktrees/escape -> <outside>/realwt,
+    # whose `deps` lives entirely outside the git root.
+    outside =
+      Path.join(System.tmp_dir!(), "wtclean_outside_#{System.unique_integer([:positive])}")
+
+    on_exit(fn -> File.rm_rf!(outside) end)
+    real_wt = Path.join(outside, "realwt")
+    populate_dir(Path.join(real_wt, "deps"))
+
+    link = Path.join([root, ".claude/worktrees", "escape"])
+    File.mkdir_p!(Path.dirname(link))
+    File.ln_s!(real_wt, link)
+
+    %{removed: removed, skipped: skipped} = Clean.clean(root)
+
+    assert removed == []
+    assert Path.join(link, "deps") in skipped
+    # The real content outside the root is untouched.
+    assert File.exists?(Path.join([real_wt, "deps", ".keep"]))
+  end
+
+  test "does not delete a sibling worktree's sources via a target symlink that stays inside the root",
+       %{root: root} do
+    base = ".claude/worktrees"
+    bar_lib = Path.join([root, base, "bar", "lib"])
+    populate_dir(bar_lib)
+
+    foo = Path.join([root, base, "foo"])
+    File.mkdir_p!(foo)
+    # foo/deps -> ../bar/lib: inside the git root, but escapes foo's own worktree.
+    File.ln_s!("../bar/lib", Path.join(foo, "deps"))
+
+    %{removed: removed, skipped: skipped} = Clean.clean(root)
+
+    assert removed == []
+    assert Path.join(foo, "deps") in skipped
+    # The sibling worktree's sources survive.
+    assert File.exists?(Path.join(bar_lib, ".keep"))
+  end
+end

--- a/test/support/mix/tasks/worktrees.clean.ex
+++ b/test/support/mix/tasks/worktrees.clean.ex
@@ -1,0 +1,100 @@
+defmodule Mix.Tasks.Worktrees.Clean do
+  @shortdoc "Remove regenerable dirs (deps, _build, fiddle deps/build/node_modules, .dexter, .expert) from every worktree"
+
+  @moduledoc """
+  Reclaims disk by deleting the regenerable build/dependency directories from
+  every git worktree under `.worktrees` and `.claude/worktrees` (the native and
+  harness worktree roots). Everything removed is rebuildable with `mise run setup`
+  / a fresh `mix deps.get`.
+
+  Run it from anywhere inside the repo; it resolves the shared git common dir, so
+  it always cleans the worktrees of the *main* checkout regardless of which
+  worktree you invoke it from.
+
+      mise exec -- mix worktrees.clean
+
+  Lives under `test/support/mix/tasks` (compiled only in `MIX_ENV=test`, never
+  shipped in the `lib` package) and auto-selects `MIX_ENV=test` via `mix.exs`
+  `preferred_envs`, like the other repo-internal tasks.
+
+  ## Safety
+
+  A target is removed only when `Path.safe_relative/2` accepts it on two counts,
+  after resolving every path segment's symlinks: the target stays inside *its
+  worktree* (so a symlinked target can't redirect the delete elsewhere — not even
+  to a sibling worktree's sources inside the same git root), and the worktree
+  itself stays inside the git root (so an escaping worktree-dir symlink is
+  refused). Anything that fails either check is skipped and reported, never
+  deleted. This is the Mix equivalent of the former `worktrees:clean` mise task.
+  """
+
+  use Mix.Task
+  use Boundary, top_level?: true, deps: []
+
+  @bases [".worktrees", ".claude/worktrees"]
+
+  @regenerable ~w(
+    deps _build
+    fiddle/deps fiddle/_build fiddle/node_modules fiddle/assets/node_modules
+    .dexter .expert
+  )
+
+  @impl Mix.Task
+  def run(_args) do
+    %{root: root, removed: removed, skipped: skipped} = clean(git_root())
+
+    for path <- skipped do
+      Mix.shell().error("skip (outside git root): #{path}")
+    end
+
+    for path <- removed do
+      Mix.shell().info("rm -rf #{Path.relative_to(path, root)}")
+    end
+
+    Mix.shell().info("Cleaned #{length(removed)} director(ies).")
+  end
+
+  @doc """
+  Removes the regenerable directories under `root`'s worktree bases and returns
+  `%{root:, removed:, skipped:}` with the paths it deleted and the paths it
+  refused to delete (because they canonicalize outside `root`).
+  """
+  def clean(root) do
+    root = Path.expand(root)
+
+    candidates =
+      for base <- @bases,
+          base_dir = Path.join(root, base),
+          File.dir?(base_dir),
+          worktree <- Path.wildcard(Path.join(base_dir, "*")),
+          File.dir?(worktree),
+          target <- @regenerable,
+          File.exists?(Path.join(worktree, target)),
+          do: {worktree, target}
+
+    {safe, skipped} = Enum.split_with(candidates, &removable?(root, &1))
+
+    to_abs = fn {worktree, target} -> Path.join(worktree, target) end
+    removed = Enum.map(safe, to_abs)
+    Enum.each(removed, &File.rm_rf!/1)
+    %{root: root, removed: removed, skipped: Enum.map(skipped, to_abs)}
+  end
+
+  # Safe to delete only if `target` resolves inside its `worktree` (a symlinked
+  # target can't redirect the delete out of the worktree we're cleaning) and the
+  # worktree resolves inside the git root (an escaping worktree-dir symlink is
+  # refused). `Path.safe_relative/2` resolves each segment's symlinks for us.
+  defp removable?(root, {worktree, target}) do
+    match?({:ok, _}, Path.safe_relative(Path.relative_to(worktree, root), root)) and
+      match?({:ok, _}, Path.safe_relative(target, worktree))
+  end
+
+  defp git_root do
+    case System.cmd("git", ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+           stderr_to_stdout: true
+         ) do
+      {out, 0} -> out |> String.trim() |> Path.dirname()
+      {out, _} -> Mix.raise("could not resolve git root: #{String.trim(out)}")
+    end
+  end
+end


### PR DESCRIPTION
Replaces the `worktrees:clean` mise task (a ~35-line shell blob in `mise.toml`) with a Mix task, `mix worktrees.clean`, and keeps `mise run worktrees:clean` as a thin alias.

## What & why

`worktrees:clean` reclaims disk by deleting regenerable build/dependency dirs from every git worktree. Porting it to Elixir removes the hand-maintained shell from `mise.toml` and makes the safety logic testable.

- **Location:** `test/support/mix/tasks/worktrees.clean.ex` — compiled only in `MIX_ENV=test`, never shipped in the `lib` Hex package, exactly like the other repo-internal tasks (`imgproxy.*`, `autoquality.*`).
- **Invocation:** `mise exec -- mix worktrees.clean`, or `mise run worktrees:clean`. The Mix name uses `.` namespacing; `mix.exs` `preferred_envs` auto-selects `MIX_ENV=test`.
- **mise alias:** a thin `worktrees:clean` task (`run = "mix worktrees.clean"`, no `depends`) so it still shows up in `mise tasks` as a single discovery surface. The implementation and its safety logic live only in the Mix task.

## Behavior

Unchanged from the old task: resolves the shared git common dir (so it always cleans the *main* checkout's worktrees regardless of which worktree you run it from), walks `.worktrees/*` and `.claude/worktrees/*`, and removes `deps`, `_build`, `fiddle/{deps,_build,node_modules}`, `fiddle/assets/node_modules`, `.dexter`, `.expert`.

## Safety (tightened over the shell version)

A target is deleted only when `Path.safe_relative/2` accepts it on two counts, after resolving every path segment's symlinks:

1. the **target** stays inside *its worktree* — a symlinked target can't redirect the delete elsewhere, **not even to a sibling worktree's sources inside the same git root** (which the old git-root-only boundary would have allowed); and
2. the **worktree** itself stays inside the git root — refusing an escaping worktree-dir symlink.

Anything failing either check is skipped and reported, never deleted.

## Tests

`test/image_pipe/worktrees_clean_test.exs` (4 cases): full sweep across both bases leaving sources alone, missing-base tolerance, escaping-worktree symlink, and target-symlink redirect to a sibling worktree.

Full `mise run precommit` gate green (format, compile `--warnings-as-errors`, credo `--strict`, 2553 tests).