### PR TITLE
feat(worktrees.clean): gate cleanup on per-worktree idle age

### DIFF
--- a/test/image_pipe/worktrees_clean_test.exs
+++ b/test/image_pipe/worktrees_clean_test.exs
@@ -22,6 +22,10 @@ defmodule ImagePipe.WorktreesCleanTest do
     File.write!(Path.join(path, ".keep"), "x")
   end
 
+  # These tests cover *what* gets removed and the safety boundary, independent of
+  # the age gate, so they disable it with `max_age_hours: 0` (clean anything idle
+  # ≥ 0h, i.e. every worktree). The age gate has its own `describe` block below.
+
   test "removes every regenerable dir from each worktree under both bases, leaving sources alone",
        %{root: root} do
     for base <- @bases, name <- ~w(a b) do
@@ -32,7 +36,7 @@ defmodule ImagePipe.WorktreesCleanTest do
       File.write!(Path.join(wt, "mix.exs"), "x")
     end
 
-    %{removed: removed, skipped: skipped} = Clean.clean(root)
+    %{removed: removed, skipped: skipped} = Clean.clean(root, max_age_hours: 0)
 
     assert skipped == []
     # 8 regenerable targets × 2 worktree names × 2 bases.
@@ -55,7 +59,7 @@ defmodule ImagePipe.WorktreesCleanTest do
     populate_dir(Path.join(wt, "deps"))
 
     # `.worktrees` is absent; the task must just skip it, not crash.
-    %{removed: removed} = Clean.clean(root)
+    %{removed: removed} = Clean.clean(root, max_age_hours: 0)
 
     assert removed == [Path.join(wt, "deps")]
     refute File.exists?(Path.join(wt, "deps"))
@@ -76,7 +80,7 @@ defmodule ImagePipe.WorktreesCleanTest do
     File.mkdir_p!(Path.dirname(link))
     File.ln_s!(real_wt, link)
 
-    %{removed: removed, skipped: skipped} = Clean.clean(root)
+    %{removed: removed, skipped: skipped} = Clean.clean(root, max_age_hours: 0)
 
     assert removed == []
     assert Path.join(link, "deps") in skipped
@@ -95,11 +99,72 @@ defmodule ImagePipe.WorktreesCleanTest do
     # foo/deps -> ../bar/lib: inside the git root, but escapes foo's own worktree.
     File.ln_s!("../bar/lib", Path.join(foo, "deps"))
 
-    %{removed: removed, skipped: skipped} = Clean.clean(root)
+    %{removed: removed, skipped: skipped} = Clean.clean(root, max_age_hours: 0)
 
     assert removed == []
     assert Path.join(foo, "deps") in skipped
     # The sibling worktree's sources survive.
     assert File.exists?(Path.join(bar_lib, ".keep"))
+  end
+
+  describe "age gate" do
+    # Write a source file with a controlled mtime (seconds before now). Avoids
+    # `populate_dir`, whose `.keep` would carry a fresh mtime and defeat the gate.
+    defp write_source(path, age_seconds) do
+      File.mkdir_p!(Path.dirname(path))
+      File.write!(path, "x")
+      File.touch!(path, System.os_time(:second) - age_seconds)
+    end
+
+    test "keeps regenerable dirs in a worktree edited within the window", %{root: root} do
+      wt = Path.join([root, ".claude/worktrees", "active"])
+      populate_dir(Path.join(wt, "deps"))
+      # Edited "just now" — well within the 48h window.
+      write_source(Path.join(wt, "lib/foo.ex"), 0)
+
+      %{removed: removed, fresh: fresh} = Clean.clean(root, max_age_hours: 48)
+
+      assert removed == []
+      assert wt in fresh
+      assert File.exists?(Path.join(wt, "deps"))
+    end
+
+    test "removes regenerable dirs in a worktree idle past the window", %{root: root} do
+      wt = Path.join([root, ".claude/worktrees", "stale"])
+      populate_dir(Path.join(wt, "deps"))
+      write_source(Path.join(wt, "lib/foo.ex"), 100 * 3600)
+
+      %{removed: removed, fresh: fresh} = Clean.clean(root, max_age_hours: 48)
+
+      assert removed == [Path.join(wt, "deps")]
+      assert fresh == []
+      refute File.exists?(Path.join(wt, "deps"))
+    end
+
+    test "build churn inside regenerable dirs does not count as activity", %{root: root} do
+      wt = Path.join([root, ".claude/worktrees", "built"])
+      # Source last edited days ago...
+      write_source(Path.join(wt, "lib/foo.ex"), 100 * 3600)
+      # ...but a build wrote into _build and deps moments ago (fresh mtimes).
+      populate_dir(Path.join(wt, "_build"))
+      populate_dir(Path.join(wt, "deps"))
+
+      %{removed: removed, fresh: fresh} = Clean.clean(root, max_age_hours: 48)
+
+      # The fresh build output must not keep the tree alive — only source mtime gates.
+      assert fresh == []
+      assert Path.join(wt, "deps") in removed
+      assert Path.join(wt, "_build") in removed
+    end
+
+    test "a worktree with no surviving source counts as stale", %{root: root} do
+      wt = Path.join([root, ".claude/worktrees", "onlybuild"])
+      populate_dir(Path.join(wt, "deps"))
+
+      %{removed: removed, fresh: fresh} = Clean.clean(root, max_age_hours: 48)
+
+      assert removed == [Path.join(wt, "deps")]
+      assert fresh == []
+    end
   end
 end

--- a/test/support/mix/tasks/worktrees.clean.ex
+++ b/test/support/mix/tasks/worktrees.clean.ex
@@ -1,5 +1,5 @@
 defmodule Mix.Tasks.Worktrees.Clean do
-  @shortdoc "Remove regenerable dirs (deps, _build, fiddle deps/build/node_modules, .dexter, .expert) from every worktree"
+  @shortdoc "Remove regenerable dirs (deps, _build, fiddle deps/build/node_modules, .dexter, .expert) from idle worktrees"
 
   @moduledoc """
   Reclaims disk by deleting the regenerable build/dependency directories from
@@ -12,10 +12,22 @@ defmodule Mix.Tasks.Worktrees.Clean do
   worktree you invoke it from.
 
       mise exec -- mix worktrees.clean
+      mise exec -- mix worktrees.clean --hours 12
 
   Lives under `test/support/mix/tasks` (compiled only in `MIX_ENV=test`, never
   shipped in the `lib` package) and auto-selects `MIX_ENV=test` via `mix.exs`
   `preferred_envs`, like the other repo-internal tasks.
+
+  ## Age gate
+
+  A worktree is cleaned only when it has been idle longer than `--hours` (default
+  48). "Idle" is measured from the newest mtime of its **source** files — the
+  walk skips the regenerable directories themselves and `.git`, so an abandoned
+  tree that was merely recompiled (which rewrites `_build`/`deps`) still counts as
+  idle and gets reclaimed. A worktree edited within the window is left fully
+  intact and reported as active. The gate is per-worktree: a tree is either fresh
+  (all targets kept) or stale (all targets eligible, subject to the safety check
+  below).
 
   ## Safety
 
@@ -39,12 +51,30 @@ defmodule Mix.Tasks.Worktrees.Clean do
     .dexter .expert
   )
 
+  @default_max_age_hours 48
+
+  # Subtrees ignored when measuring a worktree's "last edited" time: the
+  # regenerable targets (rewritten by builds, not by you) and git's own metadata.
+  @ignored_for_age @regenerable ++ [".git"]
+
   @impl Mix.Task
-  def run(_args) do
-    %{root: root, removed: removed, skipped: skipped} = clean(git_root())
+  def run(args) do
+    {opts, _rest} = OptionParser.parse!(args, strict: [hours: :integer])
+    max_age_hours = Keyword.get(opts, :hours, @default_max_age_hours)
+
+    unless max_age_hours > 0 do
+      Mix.raise("--hours must be a positive integer, got: #{max_age_hours}")
+    end
+
+    %{root: root, removed: removed, skipped: skipped, fresh: fresh} =
+      clean(git_root(), max_age_hours: max_age_hours)
 
     for path <- skipped do
       Mix.shell().error("skip (outside git root): #{path}")
+    end
+
+    for worktree <- fresh do
+      Mix.shell().info("skip (active < #{max_age_hours}h): #{Path.relative_to(worktree, root)}")
     end
 
     for path <- removed do
@@ -56,18 +86,29 @@ defmodule Mix.Tasks.Worktrees.Clean do
 
   @doc """
   Removes the regenerable directories under `root`'s worktree bases and returns
-  `%{root:, removed:, skipped:}` with the paths it deleted and the paths it
-  refused to delete (because they canonicalize outside `root`).
+  `%{root:, removed:, skipped:, fresh:}`: the paths it deleted, the paths it
+  refused to delete (because they canonicalize outside `root`), and the worktrees
+  it left intact because they were edited within `max_age_hours` (default
+  `#{@default_max_age_hours}`) — only worktrees that actually held a regenerable
+  dir are reported as `fresh`.
   """
-  def clean(root) do
+  def clean(root, opts \\ []) do
     root = Path.expand(root)
+    max_age_hours = Keyword.get(opts, :max_age_hours, @default_max_age_hours)
+    cutoff = System.os_time(:second) - max_age_hours * 3600
 
-    candidates =
+    worktrees =
       for base <- @bases,
           base_dir = Path.join(root, base),
           File.dir?(base_dir),
           worktree <- Path.wildcard(Path.join(base_dir, "*")),
           File.dir?(worktree),
+          do: worktree
+
+    {stale, fresh} = Enum.split_with(worktrees, &stale?(&1, cutoff))
+
+    candidates =
+      for worktree <- stale,
           target <- @regenerable,
           File.exists?(Path.join(worktree, target)),
           do: {worktree, target}
@@ -77,7 +118,49 @@ defmodule Mix.Tasks.Worktrees.Clean do
     to_abs = fn {worktree, target} -> Path.join(worktree, target) end
     removed = Enum.map(safe, to_abs)
     Enum.each(removed, &File.rm_rf!/1)
-    %{root: root, removed: removed, skipped: Enum.map(skipped, to_abs)}
+
+    %{
+      root: root,
+      removed: removed,
+      skipped: Enum.map(skipped, to_abs),
+      fresh: Enum.filter(fresh, &has_regenerable?/1)
+    }
+  end
+
+  defp has_regenerable?(worktree),
+    do: Enum.any?(@regenerable, &File.exists?(Path.join(worktree, &1)))
+
+  # Stale once the worktree's newest source mtime predates `cutoff`. A tree with
+  # no surviving source (mtime 0) is always stale.
+  defp stale?(worktree, cutoff), do: newest_source_mtime(worktree) <= cutoff
+
+  defp newest_source_mtime(worktree) do
+    ignored = MapSet.new(@ignored_for_age, &Path.join(worktree, &1))
+    max_mtime(worktree, ignored, 0)
+  end
+
+  # Walks `path` with `File.lstat` (never following symlinks, so it can't loop or
+  # escape), pruning `ignored` subtrees, and returns the largest file/symlink
+  # mtime seen. Directory mtimes are not counted — only the files themselves —
+  # because a build creating/removing `deps`/`_build` bumps the containing dir's
+  # mtime even though no source changed.
+  defp max_mtime(path, ignored, acc) do
+    if MapSet.member?(ignored, path) do
+      acc
+    else
+      case File.lstat(path, time: :posix) do
+        {:ok, %File.Stat{type: :directory}} ->
+          path
+          |> File.ls!()
+          |> Enum.reduce(acc, &max_mtime(Path.join(path, &1), ignored, &2))
+
+        {:ok, %File.Stat{mtime: mtime}} ->
+          max(acc, mtime)
+
+        {:error, _} ->
+          acc
+      end
+    end
   end
 
   # Safe to delete only if `target` resolves inside its `worktree` (a symlinked


### PR DESCRIPTION
Extends the `worktrees.clean` mix task with an age gate so it only reclaims worktrees that have actually gone idle, leaving trees you're actively working in untouched.

## What changed

`test/support/mix/tasks/worktrees.clean.ex`:

- **`--hours` flag, default 48.** `mix worktrees.clean` keeps the prior behavior at a 48h threshold; `mix worktrees.clean --hours 12` tightens it. `run/1` validates the flag is a positive integer; `clean/2` accepts `max_age_hours:`.
- **Activity signal = newest source-file mtime.** `newest_source_mtime/1` walks the worktree with `File.lstat` (never follows symlinks → no loops or escape) and prunes the regenerable dirs **and `.git`**. Only file/symlink mtimes count, never directory mtimes — so a build creating/removing `deps`/`_build` (which bumps the parent dir's mtime) doesn't masquerade as activity.
- **New `fresh` key** in the `clean/2` return (`%{root:, removed:, skipped:, fresh:}`), listing worktrees skipped for being active — filtered to only those that held a regenerable dir. `run/1` prints `skip (active < Nh): <worktree>`.
- Updated `@moduledoc`/`@shortdoc` with an "Age gate" section.

The gate is per-worktree: a tree is either fresh (all targets kept) or stale (all targets eligible, still subject to the existing symlink safety check).

## Tests

`test/image_pipe/worktrees_clean_test.exs`:

- The four existing removal/safety tests now pass `max_age_hours: 0` (gate disabled) since they cover *what* gets removed, not staleness.
- New `describe "age gate"` block: kept-when-fresh, removed-when-idle, **build-churn-doesn't-count** (the crux of the chosen signal), and no-source-counts-as-stale.

## Verification

`mise run precommit` green: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, and the full `mix test` suite (1 doctest, 81 properties, 2557 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)