### PR TITLE
bench(autoquality): screenshot-capture cohort + Part L cross-format AVIF finding (#359)

### DIFF
--- a/docs/autoquality_benchmark.md
+++ b/docs/autoquality_benchmark.md
@@ -744,6 +744,70 @@ floor), K is a pure cost lever above it, and the protectable residual stays well
 2.4 at tile ≥ 512 — not the absolute knee. Re-run `--part l` (and `--part k --k <K>`) to
 re-confirm on other hardware/corpora.
 
+### Part L follow-up — enriched screen-content cohort, and the AVIF residual (#359)
+
+The thin-cohort caveat above turned out to matter. The original Part L cohort had only
+**16** crop-regime images (6 photos + 10 screenshots), so "K=8/512 is a safe cost knee"
+and "16/512 is adequately offset" rested on a screen-content sample of ten. To test that,
+`mix autoquality.corpus.capture` was added to grow the >6 MP **screen-content** half:
+`web_sc` (21 text/docs/UI/table pages, full-page captured then top-cropped to ≤30 MP and
+≤16383 px so they stay WebP/AVIF-encodable) and `grafana_sc` (5 chart composites — Grafana
+dashboards are fixed-viewport SPAs, so captured at 2× density and stitched ×3 to ~22 MP).
+No off-the-shelf dataset fit: UI-screenshot datasets are overwhelmingly viewport-sized
+(WebUI-COCO-868 measured at a uniform 1920×1080 ≈ 2 MP, below the crossover).
+
+Re-running Part L over the enriched cohort (Apple Silicon, libvips 8.18.2) revealed the
+decisive thing the thin cohort hid: **the confirm-skipped residual is format-dependent,
+and AVIF on dense text is a binding worst case.** Run per format group (`p90hit*` =
+worst-source p90 over baseline-hit cases = the offset that combo needs):
+
+**jpeg + webp (77 cases, baseline on-target 10/77):**
+
+| K/tile | resid med | p90hit\* | regress | binds |
+|--------|-----------|----------|---------|-------|
+| 8/512  | −0.42 | 0.40 | 0/77 | large |
+| **16/512** | **0.63** | **1.07** | **0/77** | **large (shipped)** |
+| 16/768 | 0.08 | 2.09 | 0/77 | web_sc |
+
+**AVIF (38 cases, baseline on-target 29/38):**
+
+| K/tile | resid med | p90hit\* | regress | binds |
+|--------|-----------|----------|---------|-------|
+| 8/512  | 1.64 | 4.97 | 1/38 | web_sc |
+| **16/512** | **2.28** | **6.07** | **0/38** | **web_sc (shipped)** |
+| 16/768 | 1.10 | 5.53 | 1/38 | web_sc |
+
+- **jpeg+webp confirms the prior conclusion** — `web_sc` (large text) tracks fine; the
+  shipped 16/512 p90hit is 1.07 (binds on `large`), within the 2.4 offset, and K=8/512 is
+  still a clean cost knee. The alarming `web_sc` p90hit ≈ 6 seen in an earlier jpeg-only
+  pass was an **artifact** of capping by *scaling* (which left 1:19 aspect ratios) — it
+  collapsed once the cap was switched to *top-crop* (realistic aspect, native resolution).
+- **AVIF overturns it.** On dense text (`web_sc`), the crop estimate overshoots the
+  full-frame score by **~6** (p90hit 6.07 at the shipped 16/512), and **no swept combo
+  covers its worst source within the 2.4 offset.** AVIF binds on `web_sc` for every combo.
+  This is the opposite of the *target-setting* axis (where WebP binds): for the
+  *confirm-skip residual*, **AVIF + dense text is the worst case.**
+
+**Consequences for autoquality (production, post-#369):** above the crossover the search
+ships the crop verdict with offset `@crop_confirm_skipped_offset` ≈ 2.4 and no full-frame
+confirm. For **large AVIF renders of screen/text content**, the crop estimate overshoots
+by ~6, so the search stops ~3.7 ssim2 **below** target (p90) — silent under-quality, not
+an error (the confirm that would have caught it is the thing #369 removed for cost). So:
+
+- The **K=8/512 cost-knee retune is off the table** — it widens the AVIF-text gap, not a
+  free win.
+- The **single global offset (2.4) is under-calibrated for AVIF dense-text** — it was
+  calibrated on a photo-heavy cohort. A flat raise to ~6 would over-inflate every large
+  AVIF photo (which needs ~1) to fix a content slice, so the better shape is a
+  **`{format, content-class}` → offset** policy (AVIF×screen gets the big offset; AVIF×photo
+  and webp/jpeg stay lean), driven by a cheap content classifier — feasibility to be
+  probed on this cohort (Part M).
+
+*Caveat:* one machine/libvips build; the AVIF `web_sc` sample is ~13–18 images. The
+direction is consistent across all 9 combos, but confirm the ~6 magnitude on a larger
+AVIF-text sample before it drives a production constant. `mix autoquality.corpus.capture`
+materializes the cohort; re-run `--part l` per format to reproduce.
+
 ## Findings & recommendations
 
 ### 1. Ship a non-zero `autoquality_max_resolution` default

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,14 @@ erlang = "29"
 elixir = "1.20.0-otp-29"
 node = "latest"
 rust = "1.91"
+python = "3.14.6"
+uv = "0.11.23"
+"pipx:shot-scraper" = "1.9.1"
+
+[settings]
+# python-build-standalone defaults to a freethreaded build for 3.14, whose layout
+# trips mise ("missing a `lib` directory"); the standard build installs cleanly.
+python.precompiled_flavor = "install_only"
 
 [tasks.setup]
 description = "Install library and fiddle dependencies"

--- a/mix.exs
+++ b/mix.exs
@@ -68,6 +68,7 @@ defmodule ImagePipe.MixProject do
         "coveralls.html": :test,
         "autoquality.bench": :test,
         "autoquality.corpus": :test,
+        "autoquality.corpus.capture": :test,
         "imgproxy.diagnose": :test,
         "imgproxy.gen_report": :test,
         "imgproxy.reauthor": :test,

--- a/test/image_pipe/autoquality/corpus_capture_test.exs
+++ b/test/image_pipe/autoquality/corpus_capture_test.exs
@@ -1,0 +1,110 @@
+defmodule Mix.Tasks.Autoquality.Corpus.CaptureTest do
+  @moduledoc """
+  Unit tests for the benchmark-only screenshot-capture task (`mix
+  autoquality.corpus.capture`). The task's value is reproducible, incrementally
+  expandable acquisition of the >6 MP screen-content cohort, so the two contracts
+  that make that work are pinned here: the committed `{name, url}` list maps each
+  URL to a **stable, unique, filesystem-safe** filename, and `pending/2` selects
+  **only the URLs whose file is missing** (so re-runs fill gaps and never re-capture
+  — which keeps already-materialized pixels sticky). The actual `shot-scraper`
+  shell-out is environmental and not exercised here.
+  """
+  use ExUnit.Case, async: true
+
+  alias Mix.Tasks.Autoquality.Corpus.Capture
+
+  describe "sources/0 — the committed recipe, grouped by source" do
+    test "names each source with a filesystem-safe stem, shot-scraper args, and entries" do
+      sources = Capture.sources()
+      assert length(sources) >= 2
+
+      for {source, extra_args, entries} <- sources do
+        assert is_binary(source) and source != ""
+        refute source =~ ~r/[\/\\.\s]/, "unsafe source dir: #{inspect(source)}"
+        assert is_list(extra_args) and Enum.all?(extra_args, &is_binary/1)
+        assert entries != []
+      end
+    end
+  end
+
+  describe "screenshot_urls/0 — the flattened recipe" do
+    test "carries enough entries to thicken the cohort, each a {name, url} pair" do
+      urls = Capture.screenshot_urls()
+      assert length(urls) >= 20
+
+      for entry <- urls do
+        assert {name, url} = entry
+        assert is_binary(name) and name != ""
+        assert is_binary(url)
+        assert String.starts_with?(url, "https://")
+      end
+    end
+
+    test "names are unique — no two URLs collide on a filename" do
+      names = Capture.screenshot_urls() |> Enum.map(&elem(&1, 0))
+      assert names == Enum.uniq(names)
+    end
+
+    test "names are filesystem-safe stems (no separators, dots, or whitespace)" do
+      for {name, _url} <- Capture.screenshot_urls() do
+        refute name =~ ~r/[\/\\.\s]/, "unsafe filename stem: #{inspect(name)}"
+      end
+    end
+  end
+
+  describe "target_path/2 — stable URL→filename mapping" do
+    test "is a pure function of the dir and committed name" do
+      assert Capture.target_path("/corpus/web_sc", "hn") == "/corpus/web_sc/hn.png"
+    end
+  end
+
+  describe "pending/2 — the incremental capture contract" do
+    setup do
+      dir = Path.join(System.tmp_dir!(), "capture_test_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(dir)
+      on_exit(fn -> File.rm_rf!(dir) end)
+      {:ok, dir: dir}
+    end
+
+    test "returns every entry when the dir is empty", %{dir: dir} do
+      urls = [{"a", "https://a"}, {"b", "https://b"}]
+      assert Capture.pending(urls, dir) == urls
+    end
+
+    test "skips entries whose .png already exists, keeps the rest", %{dir: dir} do
+      urls = [{"a", "https://a"}, {"b", "https://b"}, {"c", "https://c"}]
+      File.write!(Capture.target_path(dir, "b"), "existing")
+
+      assert Capture.pending(urls, dir) == [{"a", "https://a"}, {"c", "https://c"}]
+    end
+
+    test "returns [] once every entry is materialized", %{dir: dir} do
+      urls = [{"a", "https://a"}, {"b", "https://b"}]
+      for {name, _} <- urls, do: File.write!(Capture.target_path(dir, name), "x")
+
+      assert Capture.pending(urls, dir) == []
+    end
+  end
+
+  describe "cap_crop/3 — top-crop to the MP + encoder-dimension budget" do
+    test "keeps an image already within budget untouched" do
+      assert Capture.cap_crop(2560, 2400, 30) == :keep
+    end
+
+    test "crops a tall image to the MP budget, preserving full width" do
+      # 2560×40452 ≈ 103.6 MP; cap at 30 MP.
+      assert {:crop, keep_h} = Capture.cap_crop(2560, 40_452, 30)
+      assert keep_h == div(30_000_000, 2560)
+      assert 2560 * keep_h <= 30_000_000
+      assert keep_h <= 16_383
+    end
+
+    test "caps height at the 16383 px encoder limit even when MP budget allows taller" do
+      assert {:crop, 16_383} = Capture.cap_crop(1000, 50_000, 100)
+    end
+
+    test "treats the exact budget as within the cap" do
+      assert Capture.cap_crop(6000, 5000, 30) == :keep
+    end
+  end
+end

--- a/test/support/mix/tasks/autoquality.corpus.capture.ex
+++ b/test/support/mix/tasks/autoquality.corpus.capture.ex
@@ -1,0 +1,358 @@
+defmodule Mix.Tasks.Autoquality.Corpus.Capture do
+  @shortdoc "Capture large full-page web screenshots for the >6 MP screen-content cohort"
+  @moduledoc """
+  Materializes the **screen-content half of the `mix autoquality.bench` >6 MP
+  cohort** by capturing full-page screenshots of a committed list of public pages
+  into the shared corpus cache, one subdir per source:
+
+      ${XDG_CACHE_HOME:-~/.cache}/image_pipe/corpus/<sha>/<source>/<name>.png
+
+  This is the deliberate complement to the off-the-shelf datasets: large
+  *screen content* (text / UI / charts / tables) above the 6 MP crop crossover is
+  where the crop-scoring residual tail lives (Part K), and no convenient permissive
+  dataset ships it — UI-screenshot datasets are overwhelmingly viewport-sized
+  (1920×1080 ≈ 2 MP), below the crossover. Capturing full-page at a wide viewport
+  (`--width #{2560}`, no fixed height) puts every reasonably tall page over 6 MP,
+  guaranteeing the spec (>6 MP, PNG, stable filenames) that real datasets don't.
+
+  Two sources, captured as separate bench sources so the per-source residual
+  separates the two screen-content tails:
+
+    * `web_sc` — text / docs / UI pages (Wikipedia articles & tables, MDN, language
+      docs, news, package docs).
+    * `grafana_sc` — Grafana Play dashboards: dense charts, heatmaps, flame graphs,
+      time series, candlesticks, BI tables. The hardest tracking content — fine lines,
+      gradients, and small labels diverge most from the whole frame. A dashboard is a
+      fixed-viewport SPA (~1.8 MP full-page), so these capture at 2× density and are
+      vertically stitched in threes (~22 MP) to land deep enough in the crop regime to
+      exercise the residual (see `@stitch`).
+
+  ## Prerequisites
+
+  [`shot-scraper`](https://shot-scraper.datasette.io/) (a headless Chromium wrapper)
+  is a mise-managed tool (`pipx:shot-scraper` in `mise.toml`), so `mise install`
+  provides it. Its browser is a one-time separate download:
+
+      mise install                       # installs shot-scraper (+ python/uv)
+      mise exec -- shot-scraper install  # one-time; downloads headless Chromium
+
+  ## Reproducibility & expansion
+
+  The committed `@sources` list of `{source, [{name, url}]}` is the recipe: `name` is
+  a stable, hand-pinned filename stem, so the URL→file mapping never drifts. Capture
+  is **incremental** — a page is captured only if its `<name>.png` is missing, so
+  re-runs fill gaps and never re-fetch. That makes already-materialized pixels
+  *sticky*: live-site drift (Grafana panels render live data) only affects newly
+  added or explicitly refreshed URLs, not every run.
+
+    * **Expand** — append `{stem, url}` entries and re-run; only the new ones capture.
+    * **Refresh one** — delete its `<name>.png` (or pass `--force` to recapture all).
+
+  Captured bytes live in the shared cache, never in a tracked repo dir — same posture
+  as `mix autoquality.corpus`. The pages carry their origin sites' copyright; this is
+  a local benchmark cache, not redistribution.
+
+  Grafana panels load asynchronously, so the default wait is generous
+  (`--wait #{4000}` ms); raise it for the heavy BI dashboards if panels capture blank.
+
+  Full-page captures of long pages can be enormous (a long wiki article is ~100 MP)
+  and pathologically tall, exceeding both ImagePipe's #{40} MP decode limit and the
+  16383 px WebP/AVIF encoder dimension limit (which would drop those formats — the
+  binding ssim2 formats — from the cohort). Each capture is **cropped from the top**
+  in place to at most `--max-mp #{30}` MP and ≤ 16383 px tall, preserving native
+  resolution and a realistic screenshot aspect rather than squashing the whole page.
+  The cap pass is idempotent and runs over every cached file, so it also normalizes
+  pages captured before the cap existed.
+
+      mise exec -- mix autoquality.corpus.capture            # capture the missing pages
+      mise exec -- mix autoquality.corpus.capture --force    # recapture everything
+      mise exec -- mix autoquality.corpus.capture --width 2880 --wait 6000 --max-mp 25
+      mise exec -- mix autoquality.corpus.capture --path     # just print the cache dir
+  """
+  use Mix.Task
+  use Boundary, top_level?: true, check: [out: false]
+
+  alias Mix.Tasks.Autoquality.Corpus
+  alias Vix.Vips.Operation
+
+  @default_width 2560
+  @default_wait_ms 4000
+  @default_max_megapixels 30
+  @crossover_megapixels 6
+  # WebP's hard max dimension (AVIF in this libvips build too); a taller capture would
+  # silently drop from the WebP/AVIF cohort, leaving only jpeg.
+  @max_dimension 16_383
+
+  # Sources to vertically stitch into composites of N captures (source => N). A single
+  # Grafana dashboard at 2× density is only ~7.4 MP — over the crossover, but crop
+  # scoring covers ~57% of it, so its confirm-skipped residual is ~0 (uninformative).
+  # Stacking 3 dashboards (~22 MP) drops coverage to ~19%, the regime where the
+  # residual the bench measures actually appears. The raw single captures stay in a
+  # hidden staging dir so capture stays incremental and the bench scans only composites.
+  @stitch %{"grafana_sc" => 3}
+
+  # Committed recipe: {source_dir, extra_shot_scraper_args, [{stable_stem, url}]}.
+  # `stem` pins the filename so the URL→file mapping never drifts; append to expand,
+  # never rename an existing stem (it would orphan the cached file). Curated toward
+  # tall, dense pages — the residual-tail stressors. `grafana_sc` adds `--retina`: a
+  # Grafana dashboard is a fixed-viewport SPA (full-page is only ~2560×720 ≈ 1.8 MP,
+  # below the crossover), so 2× device density (≈7.4 MP) lifts it into the crop cohort
+  # while preserving the real layout.
+  @sources [
+    {"web_sc", [],
+     [
+       {"wikipedia_ww2", "https://en.wikipedia.org/wiki/World_War_II"},
+       {"wikipedia_gdp", "https://en.wikipedia.org/wiki/List_of_countries_by_GDP_(nominal)"},
+       {"wikipedia_filesystems", "https://en.wikipedia.org/wiki/Comparison_of_file_systems"},
+       {"wikipedia_unicode", "https://en.wikipedia.org/wiki/List_of_Unicode_characters"},
+       {"mdn_css", "https://developer.mozilla.org/en-US/docs/Web/CSS"},
+       {"mdn_js_array",
+        "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array"},
+       {"mdn_http_headers", "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers"},
+       {"pydocs_stdtypes", "https://docs.python.org/3/library/stdtypes.html"},
+       {"pydocs_functions", "https://docs.python.org/3/library/functions.html"},
+       {"postgres_string_funcs", "https://www.postgresql.org/docs/current/functions-string.html"},
+       {"rust_book_ownership", "https://doc.rust-lang.org/book/ch04-01-what-is-ownership.html"},
+       {"elixir_kernel", "https://hexdocs.pm/elixir/Kernel.html"},
+       {"sqlite_lang", "https://www.sqlite.org/lang_select.html"},
+       {"w3_css22_visudet", "https://www.w3.org/TR/CSS22/visudet.html"},
+       {"hn", "https://news.ycombinator.com/"},
+       {"hackernews_item", "https://news.ycombinator.com/item?id=1"},
+       {"github_linux", "https://github.com/torvalds/linux"},
+       {"stackoverflow_yield",
+        "https://stackoverflow.com/questions/231767/what-does-the-yield-keyword-do-in-python"},
+       {"arxiv_attention", "https://arxiv.org/abs/1706.03762"},
+       {"caniuse_grid", "https://caniuse.com/grid"},
+       {"stripe_pricing", "https://stripe.com/pricing"},
+       {"tailwind_flex", "https://tailwindcss.com/docs/flex"},
+       {"csstricks_flexbox", "https://css-tricks.com/snippets/css/a-guide-to-flexbox/"},
+       {"kernel_org", "https://www.kernel.org/"},
+       {"bbc_news", "https://www.bbc.com/news"},
+       {"reddit_programming", "https://www.reddit.com/r/programming/"},
+       {"mozilla_security", "https://infosec.mozilla.org/guidelines/web_security"}
+     ]},
+    {"grafana_sc", ["--retina"],
+     [
+       {"grafana_bar_gauges",
+        "https://play.grafana.org/d/KIhkVD6Gk/bar-gauges?orgId=1&from=now-6h&to=now&timezone=browser"},
+       {"grafana_flame_graphs",
+        "https://play.grafana.org/d/cdl34qv4zzg8wa/flame-graphs?orgId=1&from=now-6h&to=now&timezone=browser"},
+       {"grafana_heatmaps",
+        "https://play.grafana.org/d/heatmap-calculate-log/grafana-heatmaps?orgId=1&from=now-6h&to=now&timezone=utc"},
+       {"grafana_histogram",
+        "https://play.grafana.org/d/histogram_tests/histogram-examples?orgId=1&from=now-6h&to=now&timezone=utc"},
+       {"grafana_logs",
+        "https://play.grafana.org/d/6NmftOxZz/logs-panel?orgId=1&from=now-6h&to=now&timezone=browser"},
+       {"grafana_time_series",
+        "https://play.grafana.org/d/000000016/time-series-graphs?orgId=1&from=now-1h&to=now&timezone=browser"},
+       {"grafana_state_timeline",
+        "https://play.grafana.org/d/qD-rVv6Mz/state-timeline-and-status-history?orgId=1&from=now-6h&to=now&timezone=browser"},
+       {"grafana_stats",
+        "https://play.grafana.org/d/Zb3f4veGk/stats?orgId=1&from=now-6h&to=now&timezone=utc"},
+       {"grafana_candlestick",
+        "https://play.grafana.org/d/candlestick/candlestick?orgId=1&from=2021-07-13T22:13:30.740Z&to=2021-07-13T22:46:18.921Z&timezone=utc"},
+       {"grafana_weblogs",
+        "https://play.grafana.org/d/play-elastic-web-logs/elasticsearch-83a-web-logs?orgId=1&from=1998-04-30T20:00:18.000Z&to=1998-04-30T20:10:33.000Z&timezone=utc"},
+       {"grafana_gapminder",
+        "https://play.grafana.org/d/play-bigquery-2/gapminder-ish-hans-rosling?orgId=1&from=now-20y&to=now&timezone=browser&var-country_name=Japan"},
+       {"grafana_revops_sql",
+        "https://play.grafana.org/d/territory-navigator-sql-only-version/grafanacon2026-revops3a-sql-only?orgId=1&from=2026-02-01T00:00:00.000Z&to=2026-04-30T23:59:59.000Z&timezone=utc"},
+       {"grafana_revops_semantic",
+        "https://play.grafana.org/d/territory-navigator/grafanacon2026-revops3a-semantic-layer?orgId=1&from=2026-02-01T00:00:00.000Z&to=2026-04-30T23:59:59.000Z&timezone=utc&var-Filters="},
+       {"grafana_product_usecase",
+        "https://play.grafana.org/d/chmktv7/grafanacon2026-product-use-case?orgId=1&from=now%2Fd-90d&to=now%2Fd-1d&timezone=utc&var-cohort=$__all"},
+       {"grafana_citibike",
+        "https://play.grafana.org/d/play-bigquery-1/citibike-example3a-overview?orgId=1&from=2017-04-01T00:00:00.000Z&to=2018-05-31T23:59:59.000Z&timezone=utc"}
+     ]}
+  ]
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _, _} =
+      OptionParser.parse(args,
+        strict: [
+          path: :boolean,
+          force: :boolean,
+          width: :integer,
+          wait: :integer,
+          max_mp: :integer
+        ]
+      )
+
+    if opts[:path] do
+      IO.puts(Corpus.cache_root())
+    else
+      Application.ensure_all_started(:image)
+      bin = require_shot_scraper!()
+      width = opts[:width] || @default_width
+      wait = opts[:wait] || @default_wait_ms
+      max_mp = opts[:max_mp] || @default_max_megapixels
+
+      failures = Enum.flat_map(@sources, &capture_source(&1, bin, width, wait, opts[:force]))
+      Enum.each(@sources, &stitch_source/1)
+      inventory = Enum.flat_map(@sources, &cap_and_inventory(&1, max_mp))
+      report(inventory, failures, max_mp)
+    end
+  end
+
+  @doc "The committed `{source, [{name, url}]}` capture recipe, grouped by source."
+  def sources, do: @sources
+
+  @doc "The flattened committed `{name, url}` entries across all sources."
+  def screenshot_urls, do: Enum.flat_map(@sources, fn {_source, _args, entries} -> entries end)
+
+  @doc "Absolute dir the bench scans for a source (composites, for stitched sources)."
+  def dest_dir(source), do: Path.join(Corpus.cache_root(), source)
+
+  # Where raw single captures land. For stitched sources this is a hidden staging dir
+  # (leading dot → skipped by the bench's `Path.wildcard("*")` source scan) so raw
+  # captures stay incremental without polluting the cohort; others capture in place.
+  defp capture_dir(source) do
+    if Map.has_key?(@stitch, source),
+      do: Path.join(Corpus.cache_root(), ".#{source}_raw"),
+      else: dest_dir(source)
+  end
+
+  @doc "Stable path for a committed filename stem under `dir`."
+  def target_path(dir, name), do: Path.join(dir, "#{name}.png")
+
+  @doc """
+  The entries from `urls` whose target file is missing under `dir` — the URLs a run
+  would (re)capture. Already-materialized pages are skipped, so re-runs fill gaps.
+  """
+  def pending(urls, dir),
+    do: Enum.reject(urls, fn {name, _url} -> File.exists?(target_path(dir, name)) end)
+
+  @doc """
+  How to bring a `w`×`h` image within budget by top-cropping: `:keep` if already
+  within both the `max_megapixels` and the #{@max_dimension} px encoder limit, else
+  `{:crop, keep_height}` — the (full-width) height to retain. Width is assumed within
+  the encoder limit (capture widths are ≤ 2× `@default_width`).
+  """
+  def cap_crop(w, h, max_megapixels) do
+    keep_h = Enum.min([h, div(max_megapixels * 1_000_000, w), @max_dimension])
+    if keep_h >= h, do: :keep, else: {:crop, keep_h}
+  end
+
+  defp require_shot_scraper! do
+    System.find_executable("shot-scraper") ||
+      Mix.raise(
+        "shot-scraper not found on PATH. It is a mise-managed tool:\n" <>
+          "    mise install                       # installs shot-scraper\n" <>
+          "    mise exec -- shot-scraper install  # one-time; downloads headless Chromium"
+      )
+  end
+
+  defp capture_source({source, extra_args, entries}, bin, width, wait, force?) do
+    dir = capture_dir(source)
+    File.mkdir_p!(dir)
+    todo = if force?, do: entries, else: pending(entries, dir)
+
+    IO.puts(
+      "[#{source}] capturing #{length(todo)}/#{length(entries)} pages " <>
+        "(#{length(entries) - length(todo)} already cached) -> #{dir}"
+    )
+
+    todo
+    |> Enum.map(&capture_one(bin, source, &1, dir, width, wait, extra_args))
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp capture_one(bin, source, {name, url}, dir, width, wait, extra_args) do
+    dest = target_path(dir, name)
+
+    args =
+      [url, "-o", dest, "--width", to_string(width), "--wait", to_string(wait), "--silent"] ++
+        extra_args
+
+    case System.cmd(bin, args, stderr_to_stdout: true) do
+      {_out, 0} ->
+        nil
+
+      {out, status} ->
+        File.rm(dest)
+        {source, name, "exit #{status}: #{String.slice(out, 0, 200)}"}
+    end
+  end
+
+  # Idempotent: downscale any cached file over the cap in place, and inventory the
+  # final megapixels of every file in the source dir.
+  defp cap_and_inventory({source, _extra_args, _entries}, max_mp) do
+    dir = dest_dir(source)
+
+    dir
+    |> Path.join("*.png")
+    |> Path.wildcard()
+    |> Enum.sort()
+    |> Enum.map(fn path -> {source, Path.basename(path, ".png"), cap_file(path, max_mp)} end)
+  end
+
+  # Rebuild a stitched source's composites from its (same-width) raw captures:
+  # vertically concatenate every N into `stitch_NN.png`. Idempotent — old composites
+  # are cleared and regenerated deterministically from the sorted raw set each run.
+  defp stitch_source({source, _extra_args, _entries}) do
+    case Map.get(@stitch, source) do
+      nil ->
+        :ok
+
+      group_size ->
+        dest = dest_dir(source)
+        File.mkdir_p!(dest)
+        dest |> Path.join("*.png") |> Path.wildcard() |> Enum.each(&File.rm!/1)
+
+        capture_dir(source)
+        |> Path.join("*.png")
+        |> Path.wildcard()
+        |> Enum.sort()
+        |> Enum.chunk_every(group_size)
+        |> Enum.with_index(1)
+        |> Enum.each(fn {paths, i} ->
+          out = Path.join(dest, "stitch_#{String.pad_leading(to_string(i), 2, "0")}.png")
+          stitch_group(paths, out)
+        end)
+    end
+  end
+
+  defp stitch_group(paths, out) do
+    images = Enum.map(paths, &Image.open!/1)
+    {:ok, joined} = Operation.arrayjoin(images, across: 1)
+    Image.write!(joined, out)
+  end
+
+  defp cap_file(path, max_mp) do
+    img = Image.open!(path, access: :sequential)
+    w = Image.width(img)
+    h = Image.height(img)
+
+    case cap_crop(w, h, max_mp) do
+      :keep ->
+        w * h / 1_000_000
+
+      {:crop, keep_h} ->
+        tmp = path <> ".tmp.png"
+        img |> Image.crop!(0, 0, w, keep_h) |> Image.write!(tmp)
+        File.rename!(tmp, path)
+        w * keep_h / 1_000_000
+    end
+  end
+
+  defp report(inventory, failures, max_mp) do
+    {big, small} = Enum.split_with(inventory, fn {_s, _n, mp} -> mp > @crossover_megapixels end)
+
+    for {source, name, mp} <- Enum.sort(inventory) do
+      tag = if mp > @crossover_megapixels, do: "✓", else: "below"
+      IO.puts("  #{String.pad_trailing("#{source}/#{name}", 36)} #{format_mp(mp)} MP  #{tag}")
+    end
+
+    for {source, name, msg} <- failures do
+      IO.puts("  #{String.pad_trailing("#{source}/#{name}", 36)} FAILED — #{msg}")
+    end
+
+    IO.puts(
+      "\n#{length(big)} in the crop cohort (>#{@crossover_megapixels} MP, capped at " <>
+        "#{max_mp} MP), #{length(small)} below the crossover, #{length(failures)} failed."
+    )
+  end
+
+  defp format_mp(mp), do: :erlang.float_to_binary(mp, decimals: 1) |> String.pad_leading(5)
+end


### PR DESCRIPTION
## What

Adds `mix autoquality.corpus.capture` — a benchmark-only task that captures large (>6 MP) screenshot/screen-content images into the autoquality corpus cache — and records the cross-format Part L re-run it enabled.

## Why

#359 asked whether the crop-scoring operating point (K=16/512, confirm-skipped above the ~6 MP crossover per #369) is the right one. The original Part L cohort had only **16** crop-regime images (10 screenshots) — too thin to trust. No off-the-shelf dataset fit: UI-screenshot datasets are overwhelmingly viewport-sized (WebUI-COCO-868 measured at a uniform 1920×1080 ≈ 2 MP, below the crossover), so this captures real large screen content.

## Capture tooling

- Two bench sources: **`web_sc`** (text/docs/UI/table pages) and **`grafana_sc`** (Grafana Play chart dashboards).
- Committed `{source, args, {name, url}}` recipe with **stable filename stems** + **skip-if-exists**, so capture is incremental and the URL→file mapping never drifts.
- **Top-crop cap** to ≤ `--max-mp` (30) and ≤ 16383 px, keeping captures under the 40 MP decode limit and the WebP/AVIF dimension limit at native resolution + realistic aspect.
- Grafana dashboards are fixed-viewport SPAs (~1.8 MP), so they capture at 2× density and vertically **stitch ×3** (~22 MP) to land in the crop regime.
- `shot-scraper` is now a **mise-managed tool** (`pipx:shot-scraper`, plus python/uv); `python.precompiled_flavor = "install_only"` forces the standard 3.14 build over the freethreaded default that fails `mise install`.

## Finding

Re-running Part L on the enriched cohort reveals the confirm-skipped residual is **format-dependent**:

- **jpeg+webp** — `web_sc` tracks fine; shipped K=16/512 within the 2.4 offset; K=8/512 still a clean cost knee (confirms the prior thin-cohort conclusion). The earlier alarming ~6 `web_sc` residual was an aspect-ratio artifact of scale-capping, gone once the cap became a top-crop.
- **AVIF** — on dense text the crop estimate overshoots full-frame by **~6** (p90hit 6.07 at shipped 16/512); **no swept combo covers its worst source within the 2.4 offset**. AVIF + dense text is the binding worst case (opposite of the WebP-binds target axis).

**Consequence:** above the crossover, large AVIF screen/text renders ship ~3.7 ssim2 **under target** (silent, post-#369 confirm-skip). The K=8 cost-knee retune is off the table, and the single global `@crop_confirm_skipped_offset` is under-calibrated for AVIF dense-text. Better shape: a `{format, content-class} => offset` policy via a cheap content classifier — follow-up work.

## Scope

Benchmark tooling (`test/support` mix task) + docs only — **no library/production code touched**. This adds the cohort tooling and records the finding that reframes #359; the offset/classifier fix is follow-up, so #359 stays open. Refs #359.

## Testing

- `mise run precommit` green: format, `compile --warnings-as-errors`, `credo --strict`, `mix test` (2559 tests + 81 properties + 1 doctest, 0 failures).
- Pure logic (recipe invariants, incremental `pending/2`, the crop cap) unit-tested in `test/image_pipe/autoquality/corpus_capture_test.exs`; the capture/stitch backend is environmental.
- Full cohort captured and Part L run per format on Apple Silicon / libvips 8.18.2; documented numbers match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)