### PR TITLE
autoquality: ship the {format, content-class} → offset policy (#380)

### DIFF
--- a/docs/superpowers/plans/2026-06-23-autoquality-content-class-offset.md
+++ b/docs/superpowers/plans/2026-06-23-autoquality-content-class-offset.md
@@ -4,7 +4,7 @@
 
 **Goal:** Replace the single global confirm-skipped offset (`@crop_confirm_skipped_offset = 2.4`) with a `{format, content-class} → offset` policy keyed on a cheap libvips content classifier, so large AVIF dense-graphic renders stop shipping silently under-quality above the 6 MP crop crossover.
 
-**Architecture:** A new `ImagePipe.Output.ContentClassifier` classifies the finalized image (`:photo` / `:graphic`) lazily, only inside the `:ssim2`+>6 MP crop-scoring path where the offset is consumed. The declarative `{format, class} → offset` table lives on `Plan.Output` (defaulted, a future parser seam like `flatten_background`), is resolved per negotiated format into `ResolvedQualitySearch`, and is applied as a per-class offset in `EncodeSearch.crop_estimate`. A `[:encode, :search, :classify]` telemetry span surfaces the class + applied offset.
+**Architecture:** A new `ImagePipe.Output.ContentClassifier` classifies the finalized image (`:photo` / `:graphic`) lazily, only inside the `:ssim2`+>6 MP crop-scoring path where the offset is consumed. The declarative `{format, class} → offset` table lives on `Plan.Output` (defaulted, a future parser seam like `flatten_background`), is resolved per negotiated format into `ResolvedQualitySearch`, and is applied as a per-class offset in `EncodeSearch.crop_estimate`. A `[:encode, :classify]` telemetry span surfaces the class + applied offset.
 
 **Tech Stack:** Elixir, libvips via `Vix.Vips.Operation` / `Image`, `:telemetry`, ExUnit, the `mix autoquality.bench` test-support task.
 
@@ -28,7 +28,9 @@
 - **Modify** `test/image_pipe/output/encoder_crop_scoring_test.exs` — adapt to the offset-as-parameter shape.
 - **Modify** `test/image_pipe/imgproxy_wire_conformance_test.exs` — the request-boundary acceptance test + a `:graphic` large-AVIF origin.
 
-**Note on `lib/image_pipe/cache/key.ex`:** `output_plan_data/2` enumerates cache-key fields explicitly. **Do NOT add `quality_search_offsets` to it** — the policy is a constant default (never request-varying), so it stays out of the key and ETag (spec §2). No change to `key.ex` is required.
+**Note on `lib/image_pipe/cache/key.ex`:** `output_plan_data/2` enumerates cache-key fields explicitly (no whole-struct serialization, no `KeyData` protocol impl for `%Output{}`). **Do NOT add `quality_search_offsets` to it** — the policy is a constant default (never request-varying), so it stays out of the key and ETag (spec §2; the ETag path `http_cache.ex` → `Key.plan_material/2` shares `output_plan_data/2`). No change to `key.ex` is required, and a cache-key test would be a no-op pin.
+
+**Note on the `Output` boundary:** **no `output.ex` `exports:`/`deps:` change is needed.** `ContentClassifier` is an unexported sibling consumed only by `EncodeSearch` (also intra-`Output`, unexported — like `Ssim2Metric`/`CropScore`); Boundary requires `exports:` only for cross-boundary refs. `Vix`/`Image` are external libraries, not boundaries, so the existing `deps: [Format, Plan, Telemetry]` already covers the classifier. Task 8 Step 2 asserts this.
 
 ---
 
@@ -72,7 +74,9 @@ mise exec -- mix autoquality.bench --part m --downsample 512 --corpus "$(mise ex
 ```
 Expected (≈18 min): the `(a) class separation` table prints `θ` for `palette_ent` and `nat_var`; the new `PRODUCTION rule (palette_ent ∧ nat_var)` line prints `screen→photo 0`; the `(b)` residual section prints `screen avif … p90_hit ≈ 6`. 
 
-**Record** in this task's commit message: `θ_palette = <value>`, `θ_nat = <value>` (the printed Youden θ for each), `avif_graphic_offset = <round(p90_hit)>` (≈ 6.0). Confirm the production-rule line shows **0** screen→photo. If it shows 1, raise whichever θ is closer to its overlap until it reads 0, and record the raised value.
+**Record** in this task's commit message: `θ_palette = <value>`, `θ_nat = <value>` (the printed Youden θ for each), `avif_graphic_offset = <round(p90_hit)>` (≈ 6.0). Confirm the production-rule line shows **0** screen→photo.
+
+If it shows 1, raise whichever θ is closer to its overlap and **re-run the bench** so the `PRODUCTION rule` line is re-printed for the *adjusted* pair — the frozen constants are the hand-adjusted ones, so the 0-screen→photo evidence must be for those exact values, not the original Youden pair. Repeat until the re-printed line reads 0, and paste that final line into the commit body. The thresholds hardcoded in Task 2 must be exactly the values whose `PRODUCTION rule` line you pasted.
 
 - [ ] **Step 4: Commit (bench change only)**
 
@@ -105,8 +109,9 @@ defmodule ImagePipe.Output.ContentClassifierTest do
   alias ImagePipe.Output.ContentClassifier
   alias Vix.Vips.Operation
 
-  # A smooth continuous-tone gradient: high palette entropy + high mid-band
-  # variation → :photo.
+  # A smooth high-frequency continuous-tone field (zone plate): many luminance
+  # values (high palette entropy) + abundant mid-band gradient (high nat_var) →
+  # :photo. (Used elsewhere in the suite as the continuous-tone surrogate.)
   defp photo_image do
     {:ok, ramp} = Operation.zone(512, 512)
     {:ok, scaled} = Operation.linear(ramp, [127.5], [127.5])
@@ -117,31 +122,29 @@ defmodule ImagePipe.Output.ContentClassifierTest do
     srgb
   end
 
-  # A hard-edged two-tone grid (text/line-art surrogate): two luminance values
-  # (low palette entropy) + hard edges, near-zero mid-band (low nat_var) → :graphic.
+  # A hard-edged two-tone field (line-art surrogate): a white canvas overlaid with
+  # a fine black line grid → two luminance values (low palette entropy) + all-hard
+  # edges (near-zero mid-band) → :graphic. Built with Image.Draw, not Operation.grid.
   defp graphic_image do
-    {:ok, board} = Operation.grid(black_white_tile(), 64, 8, 8)
-    {:ok, srgb} = Operation.copy(board, interpretation: :VIPS_INTERPRETATION_sRGB)
-    srgb
+    side = 512
+    base = Image.new!(side, side, color: :white)
+
+    drawn =
+      Enum.reduce(0..(side - 1)//8, base, fn x, acc ->
+        acc
+        |> Image.Draw.rect!(x, 0, 1, side, color: :black)
+        |> Image.Draw.rect!(0, x, side, 1, color: :black)
+      end)
+
+    Image.to_colorspace!(drawn, :srgb)
   end
 
-  defp black_white_tile do
-    {:ok, white} = Operation.black(8, 8)
-    {:ok, white} = Operation.linear(white, [1.0], [255.0])
-    {:ok, black} = Operation.black(8, 8)
-    {:ok, row} = Operation.join(white, black, :VIPS_DIRECTION_HORIZONTAL)
-    {:ok, row2} = Operation.join(black, white, :VIPS_DIRECTION_HORIZONTAL)
-    {:ok, tile} = Operation.join(row, row2, :VIPS_DIRECTION_VERTICAL)
-    {:ok, rgb} = Operation.bandjoin([tile, tile, tile])
-    rgb
-  end
-
-  test "classifies a continuous-tone gradient as :photo" do
+  test "classifies a continuous-tone field as :photo" do
     assert {:photo, %{palette_ent: pe, nat_var: nv}} = ContentClassifier.classify(photo_image())
     assert is_float(pe) and is_float(nv)
   end
 
-  test "classifies a hard-edged two-tone grid as :graphic" do
+  test "classifies a hard-edged two-tone field as :graphic" do
     assert {:graphic, _features} = ContentClassifier.classify(graphic_image())
   end
 
@@ -459,7 +462,7 @@ In `lib/image_pipe/output/resolved_quality_search.ex`, extend the struct + type:
         }
 ```
 
-Update the `@moduledoc` to note `quality_search_offsets` is the per-class confirm-skipped crop offset for the negotiated format, consumed by `EncodeSearch`.
+Update the `@moduledoc` to note `quality_search_offsets` is the per-class confirm-skipped crop offset for the negotiated format, consumed by `EncodeSearch`. Note the default `%{}` is the resolved shape only for `:size`/`:none` (which never crop-score); the `:ssim2` resolver always populates both `:photo` and `:graphic` keys, so the `:crop` path's `Map.fetch!` trusts a fully-populated map.
 
 - [ ] **Step 4: Carry the field through the policy struct**
 
@@ -536,14 +539,24 @@ git commit -m "feat(autoquality): resolve quality_search_offsets per negotiated 
 
 The pure `search/3` core is unchanged — the offset is baked into the crop closure by `run/3`, exactly like the reference build. The classify telemetry span is added here in Task 6; this task does the offset plumbing first and keeps tests green.
 
-- [ ] **Step 1: Update the production crop-scoring test for the per-class offset**
+- [ ] **Step 1: Preserve the existing crop test by neutralizing the offset**
 
-Read `test/image_pipe/output/encoder_crop_scoring_test.exs` first. It currently asserts behavior tied to the global `2.4`. Adapt the assertion(s) that depend on the offset to go through the resolved `quality_search_offsets`: build the `%Resolved{}` with `quality_search_offsets: %{photo: 2.4, graphic: 6.0}` and assert the chosen `meta.score` reflects the **classified** offset (a `:graphic` finalized image subtracts 6.0, a `:photo` subtracts 2.4). If the existing test used a content-neutral synthetic, split it into a `:graphic` case (two-tone grid, expects the 6.0 subtraction) and keep a `:photo` case (gradient, 2.4). Preserve the existing decode/score structure; only the offset source changes.
+Read `test/image_pipe/output/encoder_crop_scoring_test.exs` first. Its full-vs-crop test asserts `abs(crop.quality - full.quality) <= 4` (~line 99) and the by-construction `crop.score >= band` (~line 102) under the *old* fixed 2.4. This task is a pure refactor (global constant → per-class map lookup) that must keep that test green; the *new* per-class behavior is proven in Task 6 via telemetry. Preserve the existing test's intent by adding a content-neutral offset map to its `%RQS{}` literal (~line 49), so classification cannot change its result:
 
-- [ ] **Step 2: Run to verify it fails**
+```elixir
+        quality_search: %RQS{
+          objective: :ssim2,
+          # ... existing fields (target/min/max/allowed_error/max_resolution) ...
+          quality_search_offsets: %{photo: 2.4, graphic: 2.4}
+        }
+```
+
+Both classes subtract 2.4 (the prior global value), so the `<=4` bound and the by-construction assertion hold regardless of how the test image classifies. Do **not** widen the bound; do **not** use this test to prove the new offset.
+
+- [ ] **Step 2: Run to verify the refactor target is reachable**
 
 Run: `mise exec -- mix test test/image_pipe/output/encoder_crop_scoring_test.exs`
-Expected: FAIL — `crop_estimate/5` arity / offset wiring not present yet.
+Expected: with Task 4 done, the `%RQS{quality_search_offsets: …}` literal compiles; the test currently **passes** (the live `:crop` path still subtracts the hardcoded 2.4, matching the neutral map). This step has no fail-first — it is a behavior-preserving refactor; the new behavior's fail-first lives in Task 6. Proceed to wire the offset so the constant is gone.
 
 - [ ] **Step 3: Remove the constant; thread the per-class offset**
 
@@ -557,6 +570,11 @@ Replace the `:crop` clause of `score_opts/4`:
   defp score_opts(image, %Resolved{quality_search: %RQS{objective: :ssim2} = rqs}, :crop, t) do
     tiles = CropScore.tile_count(Image.width(image), Image.height(image))
     {class, _features} = ContentClassifier.classify(image)
+    # `Output.Policy.resolve_search/2` always stamps both :photo and :graphic keys
+    # for an :ssim2 search (the only objective that reaches the :crop path), so
+    # `fetch!` trusts the in-repo producer — a missing key is a resolver bug, not a
+    # runtime input. (The `RQS` default `%{}` only occurs for :size/:none, which
+    # never crop-score.)
     offset = Map.fetch!(rqs.quality_search_offsets, class)
     crop = fn bytes -> crop_estimate(image, bytes, tiles, offset, t) end
     {:ok, [score_fun: crop, scorer_tiles: tiles]}
@@ -607,41 +625,99 @@ git commit -m "feat(autoquality): apply per-class crop offset, drop global const
 - Modify: `docs/telemetry.md`
 - Test: `test/image_pipe/output/encode_search_telemetry_test.exs`
 
-- [ ] **Step 1: Write the failing telemetry test**
+- [ ] **Step 1: Write the failing per-class telemetry test**
 
-Add to `test/image_pipe/output/encode_search_telemetry_test.exs` a test that runs `EncodeSearch.run/3` on a >6 MP finalized image with an `:ssim2` resolved search (mirror the file's existing crop-path telemetry setup) and a **unique `telemetry_prefix`**, attaches to `prefix ++ [:encode, :search, :classify, :stop]`, and asserts the metadata:
+This is the **fail-first proof of the new behavior**: the right offset is selected per content class. It's deterministic (depends only on classification, which is robust to the exact thresholds) and fails before Step 3 (no span emitted, offset still hardcoded). Add to `test/image_pipe/output/encode_search_telemetry_test.exs` (mirror the file's existing crop-path `%Resolved{}`/`telemetry_prefix` setup; the helper builds a >6 MP image and an `:ssim2` resolved search):
 
 ```elixir
-  test "emits a classify span with the content class and applied offset" do
-    prefix = [:ip_classify_test]
+  # >6 MP hard-edged two-tone field (dense-graphic surrogate): a white canvas with
+  # a fine grid of black lines → two luminance values (low palette entropy) +
+  # all-hard edges (low mid-band) → classifies :graphic. Built with Image.Draw (no
+  # Operation.grid). >6 MP so the crop scorer fires.
+  defp large_graphic_image do
+    side = 2800
+    base = Image.new!(side, side, color: :white)
+
+    drawn =
+      Enum.reduce(0..(side - 1)//16, base, fn x, acc ->
+        acc
+        |> Image.Draw.rect!(x, 0, 1, side, color: :black)
+        |> Image.Draw.rect!(0, x, side, 1, color: :black)
+      end)
+
+    Image.to_colorspace!(drawn, :srgb)
+  end
+
+  # A smooth continuous-tone field → high palette entropy + mid-band variation →
+  # classifies :photo. A zone plate (used elsewhere in the suite) works.
+  defp large_photo_image do
+    side = 2800
+    {:ok, z} = Vix.Vips.Operation.zone(side, side)
+    {:ok, scaled} = Vix.Vips.Operation.linear(z, [127.5], [127.5])
+    {:ok, uchar} = Vix.Vips.Operation.cast(scaled, :VIPS_FORMAT_UCHAR)
+    {:ok, gray} = Vix.Vips.Operation.copy(uchar, interpretation: :VIPS_INTERPRETATION_B_W)
+    {:ok, rgb} = Vix.Vips.Operation.bandjoin([gray, gray, gray])
+    {:ok, srgb} = Vix.Vips.Operation.copy(rgb, interpretation: :VIPS_INTERPRETATION_sRGB)
+    srgb
+  end
+
+  defp resolved_ssim2_avif do
+    %ImagePipe.Output.Resolved{
+      format: :avif,
+      quality: :default,
+      response_headers: [],
+      strip_metadata: true,
+      keep_copyright: true,
+      color_profile: :strip,
+      quality_search: %ImagePipe.Output.ResolvedQualitySearch{
+        objective: :ssim2,
+        target: 88,
+        min_quality: 40,
+        max_quality: 95,
+        allowed_error: 1.0,
+        max_resolution: 0,
+        quality_search_offsets: %{photo: 2.4, graphic: 6.0}
+      }
+    }
+  end
+
+  defp attach_classify(prefix) do
     handler = {__MODULE__, make_ref()}
-
-    :telemetry.attach(
-      handler,
-      prefix ++ [:encode, :search, :classify, :stop],
-      fn _event, _measure, meta, pid -> send(pid, {:classify, meta}) end,
-      self()
-    )
-
+    :telemetry.attach(handler, prefix ++ [:encode, :classify, :stop],
+      fn _e, _m, meta, pid -> send(pid, {:classify, meta}) end, self())
     on_exit(fn -> :telemetry.detach(handler) end)
+  end
 
-    # ... build a >6 MP :graphic finalized image + %Resolved{quality_search:
-    # %RQS{objective: :ssim2, quality_search_offsets: %{photo: 2.4, graphic: 6.0}, ...}}
-    # following this file's existing crop-path helpers, then:
-    EncodeSearch.run(finalized, resolved, telemetry_opts: [prefix: prefix])
+  test "classify span selects the avif×graphic offset (6.0) for graphic content" do
+    prefix = [:ip_classify_graphic_test]
+    attach_classify(prefix)
+
+    EncodeSearch.run(large_graphic_image(), resolved_ssim2_avif(), telemetry_opts: [prefix: prefix])
 
     assert_receive {:classify, meta}
-    assert meta.content_class in [:photo, :graphic]
-    assert is_number(meta.applied_offset)
-    assert is_float(meta.palette_ent)
-    assert is_float(meta.nat_var)
+    assert meta.content_class == :graphic
+    assert meta.applied_offset == 6.0
+    assert is_float(meta.palette_ent) and is_float(meta.nat_var)
+  end
+
+  test "classify span keeps the lean offset (2.4) for photo content" do
+    prefix = [:ip_classify_photo_test]
+    attach_classify(prefix)
+
+    EncodeSearch.run(large_photo_image(), resolved_ssim2_avif(), telemetry_opts: [prefix: prefix])
+
+    assert_receive {:classify, meta}
+    assert meta.content_class == :photo
+    assert meta.applied_offset == 2.4
   end
 ```
+
+> Confirm the two fixtures classify as intended during implementation (the tests assert it). If `large_graphic_image/0` reads `:photo` or vice-versa, adjust the fixture (line density/contrast) — the synthetic must be unambiguous. Confirm `Image.Draw.rect!`/`Image.to_colorspace!` against the installed `image` lib API.
 
 - [ ] **Step 2: Run to verify it fails**
 
 Run: `mise exec -- mix test test/image_pipe/output/encode_search_telemetry_test.exs`
-Expected: FAIL — no `[:encode, :search, :classify]` event emitted.
+Expected: FAIL — no `[:encode, :classify]` event emitted yet (the `assert_receive` times out).
 
 - [ ] **Step 3: Emit the span from `score_opts(:crop)`**
 
@@ -652,7 +728,7 @@ In `lib/image_pipe/output/encode_search.ex`, wrap the classification in a span:
     tiles = CropScore.tile_count(Image.width(image), Image.height(image))
 
     {class, offset} =
-      Telemetry.span(t, [:encode, :search, :classify], %{}, fn ->
+      Telemetry.span(t, [:encode, :classify], %{}, fn ->
         {class, features} = ContentClassifier.classify(image)
         offset = Map.fetch!(rqs.quality_search_offsets, class)
 
@@ -675,22 +751,24 @@ In `lib/image_pipe/output/encode_search.ex`, wrap the classification in a span:
 
 - [ ] **Step 4: Subscribe + render in the Logger**
 
-In `lib/image_pipe/telemetry/logger.ex`, add `[:encode, :search, :classify]` to the `request` list in `@group_span_events` (after `[:encode, :search, :probe]`):
+In `lib/image_pipe/telemetry/logger.ex`, add `[:encode, :classify]` to the `request` list in `@group_span_events` (after `[:encode, :search, :probe]`):
 
 ```elixir
       [:encode, :search, :probe],
-      [:encode, :search, :classify],
+      [:encode, :classify],
 ```
 
 Add a `message/3` clause (before the generic fallback) that surfaces class + offset and still carries the outcome:
 
 ```elixir
-  defp message([:encode, :search, :classify, :stop], _measurements, meta) do
-    "encode.search.classify #{meta.content_class} offset=#{meta.applied_offset} #{outcome(meta)}"
+  defp message([:encode, :classify, :stop], _measurements, meta) do
+    "encode.classify #{meta.content_class} offset=#{meta.applied_offset} #{outcome(meta)}"
   end
 ```
 
 (Match the exact `message/3` signature/`outcome/1` helper used by the file's other clauses.)
+
+**Level note:** the classify stop meta carries `result: :ok` and **no `:outcome` key**, so it logs at the base level (`:info`). Do not add an `:outcome` key — `level_for([:encode, :search | _])` escalates on `outcome: :best_effort`, but `[:encode, :classify]` does not match that clause anyway (it is `[:encode, :classify | _]`), so the classify span stays at base level regardless. Keep it that way.
 
 - [ ] **Step 5: Trace + allowlist in Capture**
 
@@ -698,7 +776,7 @@ In `lib/image_pipe/telemetry/trace/capture.ex`, add the stage to `@span_stages` 
 
 ```elixir
     [:encode, :search],
-    [:encode, :search, :classify],
+    [:encode, :classify],
 ```
 
 Add the new metadata keys to `@safe_keys` (next to `:scorer`, `:tiles_scored`):
@@ -712,11 +790,11 @@ Add the new metadata keys to `@safe_keys` (next to `:scorer`, `:tiles_scored`):
 
 - [ ] **Step 6: Add a Logger coverage assertion**
 
-In `test/image_pipe/telemetry/logger_test.exs`, add an assertion that the classify line renders the class + offset (follow the file's existing capture-log pattern).
+In `test/image_pipe/telemetry/logger_test.exs`, add an assertion that the classify line renders the class + offset (follow the file's existing capture-log pattern), and that it logs at `:info` (not `:warning`) — pinning the base-level behavior from Step 4's level note.
 
 - [ ] **Step 7: Update `docs/telemetry.md`**
 
-Document `[:encode, :search, :classify]` (start/stop/exception) on both the Logger and OTel surfaces, listing the metadata keys `content_class`, `applied_offset`, `palette_ent`, `nat_var`, and noting all are product-neutral/non-sensitive.
+Document `[:encode, :classify]` (start/stop; the `:exception` leg is structurally unreachable — the classifier is total and never raises) on both the Logger and OTel surfaces, listing the metadata keys `content_class`, `applied_offset`, `palette_ent`, `nat_var`, and noting all are product-neutral/non-sensitive.
 
 - [ ] **Step 8: Run the telemetry + logger + capture tests**
 
@@ -732,37 +810,39 @@ git commit -m "feat(autoquality): classify telemetry span on Logger + OTel surfa
 
 ---
 
-## Task 7: Request-boundary acceptance test
+## Task 7: Request-boundary contract test
 
 **Files:**
-- Modify: `test/image_pipe/imgproxy_wire_conformance_test.exs` (add a `:graphic` large-AVIF origin near `LargeSsim2OriginImage` ~line 73; add the acceptance test near the #369 crop-verdict test ~line 678)
+- Modify: `test/image_pipe/imgproxy_wire_conformance_test.exs` (add a `:graphic` large origin near `LargeSsim2OriginImage` ~line 73; add the tests near the #369 crop-verdict test ~line 678)
 
-This is the primary acceptance criterion: a large AVIF dense-graphic render above the crossover hits the target band (no silent under-quality) and isn't misclassified as photo.
+**What this proves (and what it deliberately does NOT).** This test proves the user-visible *contract*: a large graphic AVIF goes through `ImagePipe.call/2` end-to-end, classifies `:graphic`, and the `{avif, :graphic}` offset (6.0) is selected and applied on the crop path — while a continuous-tone AVIF keeps the lean 2.4. It does **NOT** assert "achieves target band": on the crop path `final_score` is the *offset-corrected estimate*, which the objective walk lands in-band **by construction at any offset** (see `encoder_crop_scoring_test.exs:100-102`), so such an assertion is vacuous — it passes identically at 2.4 and 6.0. The empirical claim that 6.0 is the *right magnitude* for real dense text is owned by `mix autoquality.bench --part m` (Task 1), not reproducible on the network-free default lane. The wire test's job (per the repo's "representative public contracts, not exhaustive" test guideline) is the plumbing + per-class selection, end-to-end.
 
 - [ ] **Step 1: Add a deterministic large `:graphic` origin**
 
-After `LargeSsim2OriginImage`, add an origin that serves a >6 MP hard-edged two-tone grid (a text/line-art surrogate the classifier reads as `:graphic`), as JPEG to stay under `max_body_bytes`:
+After `LargeSsim2OriginImage`, add an origin serving a >6 MP white field overlaid with a fine grid of black lines (a dense line-art surrogate the classifier reads as `:graphic`), as JPEG to stay under `max_body_bytes`. Built with `Image.Draw` (the file already uses `Image.Draw.rect!`), **not** `Operation.grid` (which tiles a tall input into a grid layout — it does not replicate a small tile):
 
 ```elixir
-  # A >6 MP hard-edged two-tone grid: a dense-text / line-art surrogate the
-  # content classifier reads as :graphic (low palette entropy, near-zero mid-band
-  # gradient). Above the crop crossover this is the cell whose crop estimate
-  # overshoots full-frame, so the {avif, :graphic} offset must rescue it. 2800² ≈
-  # 7.84 MP. Served JPEG to stay under the default 10 MB source max_body_bytes.
+  # A >6 MP white field overlaid with a fine black line grid: a dense line-art /
+  # text surrogate the classifier reads as :graphic (two luminance values → low
+  # palette entropy; all-hard edges → low mid-band gradient). Above the crossover
+  # this is the cell whose crop estimate overshoots full-frame, so {avif,:graphic}
+  # draws the big offset. 2800² ≈ 7.84 MP. Served JPEG to stay under the default
+  # 10 MB source max_body_bytes.
   defmodule LargeGraphicOriginImage do
     @moduledoc false
 
     def call(conn, _opts) do
       side = 2800
-      {:ok, tile} = Operation.black(8, 8)
-      {:ok, white} = Operation.linear(tile, [1.0], [255.0])
-      {:ok, grid} = Operation.grid(white, 8, side, side)
-      # Lay a fine black grid of lines over the field to maximise hard edges.
-      {:ok, lined} = Operation.cast(grid, :VIPS_FORMAT_UCHAR)
-      {:ok, gray} = Operation.copy(lined, interpretation: :VIPS_INTERPRETATION_B_W)
-      {:ok, rgb} = Operation.bandjoin([gray, gray, gray])
-      {:ok, srgb} = Operation.copy(rgb, interpretation: :VIPS_INTERPRETATION_sRGB)
-      body = Image.write!(srgb, :memory, suffix: ".jpg")
+      base = Image.new!(side, side, color: :white)
+
+      drawn =
+        Enum.reduce(0..(side - 1)//16, base, fn x, acc ->
+          acc
+          |> Image.Draw.rect!(x, 0, 1, side, color: :black)
+          |> Image.Draw.rect!(0, x, side, 1, color: :black)
+        end)
+
+      body = drawn |> Image.to_colorspace!(:srgb) |> Image.write!(:memory, suffix: ".jpg")
 
       conn
       |> Plug.Conn.put_resp_content_type("image/jpeg")
@@ -771,46 +851,53 @@ After `LargeSsim2OriginImage`, add an origin that serves a >6 MP hard-edged two-
   end
 ```
 
-> Adjust the generator if needed so the served content (a) decodes ≥ 6 MP and (b) classifies `:graphic` — verify with a quick `ContentClassifier.classify/1` in IEx on the generated image during implementation. The exact drawing ops matter less than the property (two-tone, hard-edged, low mid-band).
+> The served content must (a) decode ≥ 6 MP and (b) classify `:graphic`. The Step 2 test asserts (b) directly (telemetry `content_class: :graphic`), so a miss fails loudly — but verify with `ContentClassifier.classify/1` in IEx during implementation and raise the line density/contrast if it reads `:photo`. Confirm `Image.Draw.rect!`/`Image.to_colorspace!` against the installed `image` lib API.
 
-- [ ] **Step 2: Write the acceptance test**
+- [ ] **Step 2: Write the contract test (graphic → 6.0)**
 
-Mirror the existing #369 test (request an explicit AVIF autoquality `:ssim2` render with **no resize** so the full >6 MP frame is finalized and the crop scorer fires), but against `LargeGraphicOriginImage`, and assert the achieved score reaches the target band. Capture the search `:stop` telemetry (with a unique `telemetry_prefix`) and assert `scorer: :crop`, `content_class: :graphic` on the classify span, and `applied_offset` equals the avif×graphic offset (6.0). Assert the delivered AVIF decodes and the search `final_score` is `>= target - allowed_error` (i.e. it did **not** stop ~3.7 below target as it would with the lean 2.4 offset).
+Mirror the existing #369 crop-verdict test for request construction (explicit AVIF, autoquality `:ssim2`, **no resize** so the full >6 MP frame is finalized and the crop scorer fires), against `LargeGraphicOriginImage`. Use a unique `telemetry_prefix`; attach to `prefix ++ [:encode, :classify, :stop]` and `prefix ++ [:encode, :search, :stop]`. Read `target`/`allowed_error` from the request the test itself built (they are **not** in the search `:stop` meta — that meta carries `chosen_quality`, `scorer`, `final_score`, etc., per `search_stop_meta/2`).
 
 ```elixir
-  test "large AVIF :graphic render above the crossover hits the target band (#380)" do
-    prefix = [:ip_aq_offset_test]
-    # attach to prefix ++ [:encode, :search, :stop] and
-    # prefix ++ [:encode, :search, :classify, :stop]; forward meta to self()
-    # ... build the imgproxy AVIF autoquality request (ssim2 target/bracket),
-    # no resize, against LargeGraphicOriginImage; make the request via ImagePipe.call/2.
+  test "large graphic AVIF above the crossover selects the {avif, graphic} offset (#380)" do
+    prefix = [:ip_aq_graphic_offset]
+    attach_meta(prefix ++ [:encode, :classify, :stop], :classify)
+    attach_meta(prefix ++ [:encode, :search, :stop], :search)
+
+    conn = call_imgproxy(LargeGraphicOriginImage, "<avif autoquality ssim2 path, no resize>",
+                          telemetry_prefix: prefix)
 
     assert conn.status == 200
     assert get_resp_header(conn, "content-type") == ["image/avif"]
 
-    assert_receive {:classify_stop, %{content_class: :graphic, applied_offset: 6.0}}
-    assert_receive {:search_stop, %{scorer: :crop, final_score: score, target: target, allowed_error: ae}}
-    assert score >= target - ae
+    # Classification + per-class offset selection, end-to-end:
+    assert_receive {:classify, %{content_class: :graphic, applied_offset: 6.0}}
+    # Crop path was taken (the regime the offset governs):
+    assert_receive {:search, %{scorer: :crop}}
   end
 ```
 
-- [ ] **Step 3: Run the acceptance test**
+(`attach_meta/2` and `call_imgproxy/3` stand for the file's existing telemetry-attach and request helpers — reuse them, do not invent new ones; read the file first.)
 
-Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs -k "graphic render above"`
-Expected: PASS. If `content_class` comes back `:photo`, fix the generator (Step 1) until the served content is unambiguously graphic.
+- [ ] **Step 3: Add the no-inflation companion (photo → 2.4)**
 
-- [ ] **Step 4: Add the no-inflation guard (avif×photo / jpeg)**
+Either extend the existing #369 zone-plate test (continuous-tone → `:photo`) or add a sibling against `LargeSsim2OriginImage`, asserting the lean offset is retained for the covered cells:
 
-Add a companion test (or extend the existing #369 zone-plate test, which is continuous-tone → `:photo`) asserting the AVIF `:photo` / JPEG path still subtracts the lean `2.4` (telemetry `applied_offset == 2.4`) — i.e. no byte inflation vs today for the covered cells.
+```elixir
+    assert_receive {:classify, %{content_class: :photo, applied_offset: 2.4}}
+```
+
+This is the "no byte inflation vs today" guard: avif×photo (and jpeg/webp) keep the prior 2.4.
+
+- [ ] **Step 4: Run the wire tests**
 
 Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs`
-Expected: PASS.
+Expected: PASS. If `content_class` comes back `:photo` for the graphic origin (or vice-versa), fix the origin generator (Step 1) until classification is unambiguous.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add test/image_pipe/imgproxy_wire_conformance_test.exs
-git commit -m "test(autoquality): request-boundary acceptance for {format,class} offset (#380)"
+git commit -m "test(autoquality): request-boundary contract for {format,class} offset (#380)"
 ```
 
 ---
@@ -829,17 +916,21 @@ Expected: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `m
 Run: `mise exec -- mix test test/image_pipe/architecture_boundary_test.exs`
 Expected: PASS — `ContentClassifier` sits inside `Output.*`; no request/source/response code names it. (No boundary edits expected.)
 
-- [ ] **Step 3: Re-confirm the cohort safety property (optional, environmental)**
+- [ ] **Step 3: Re-confirm the frozen-constant safety property (environmental)**
 
-If the thresholds were adjusted in Task 1 Step 3, re-run `mise exec -- mix autoquality.bench --part m --downsample 512 --corpus "$(mise exec -- mix autoquality.corpus --path)"` and confirm the `PRODUCTION rule` line still reads `screen→photo 0`.
+Confirm the thresholds hardcoded in `ContentClassifier` (Task 2) are exactly the pair whose `PRODUCTION rule` line read `screen→photo 0` in Task 1's commit body (re-validated there after any hand-adjustment). If they differ, re-run `mise exec -- mix autoquality.bench --part m --downsample 512 --corpus "$(mise exec -- mix autoquality.corpus --path)"` for the hardcoded pair and confirm `screen→photo 0` before shipping.
 
 - [ ] **Step 4: Final review prep**
 
 Confirm the spec's acceptance criteria are all covered:
-- Large AVIF dense-graphic hits target band → Task 7.
-- avif×photo / jpeg / webp no byte inflation → Task 7 Step 4 (lean 2.4 retained).
-- Request-boundary test decodes output, confirms no misclassification → Task 7.
-- Telemetry surfaces class + offset → Task 6.
+- No silent under-quality for large AVIF graphic → proven across layers: the per-class
+  6.0 offset is selected/applied end-to-end (T6 telemetry + T7 wire contract), the offset
+  bites in the correcting direction (search monotonicity, documented), and 6.0 is the
+  right magnitude on real dense text (bench, T1). The lane does **not** assert "hits
+  target" off the by-construction estimate (would be vacuous).
+- avif×photo / jpeg / webp no byte inflation → T7 Step 3 (`applied_offset: 2.4` retained).
+- Request-boundary test through `ImagePipe.call/2`, classification confirmed → T7.
+- Telemetry surfaces class + offset on both surfaces → T6.
 
 ---
 
@@ -847,5 +938,5 @@ Confirm the spec's acceptance criteria are all covered:
 
 - **Spec coverage:** ContentClassifier (T2 ↔ spec §1), Plan.Output table (T3 ↔ §2), resolution (T4 ↔ §3), EncodeSearch consumption + constant removal (T5 ↔ §4), telemetry both surfaces (T6 ↔ §5), tests incl. acceptance (T2/T4/T6/T7 ↔ §"Testing"), empirical constants (T1 ↔ §"Empirical constants"). WebP cap (#381) correctly excluded.
 - **Cache key:** explicitly NOT touched (constant policy, out of key/ETag) — documented in File Structure.
-- **Naming consistency:** `quality_search_offsets` (field, all three layers), `offset_for/3`, `default_quality_search_offsets/0`, `:photo`/`:graphic`, `crop_estimate/5`, span `[:encode, :search, :classify]`, meta keys `content_class`/`applied_offset`/`palette_ent`/`nat_var` — used identically across tasks.
+- **Naming consistency:** `quality_search_offsets` (field, all three layers), `offset_for/3`, `default_quality_search_offsets/0`, `:photo`/`:graphic`, `crop_estimate/5`, span `[:encode, :classify]`, meta keys `content_class`/`applied_offset`/`palette_ent`/`nat_var` — used identically across tasks.
 - **Empirical placeholders:** the three constants (`@palette_photo_threshold`, `@nat_var_photo_threshold`, avif×graphic offset) are bench-derived in T1; example values (`0.62`/`0.22`/`6.0`) are flagged as substitutable, not invented design gaps.

--- a/docs/superpowers/plans/2026-06-23-autoquality-content-class-offset.md
+++ b/docs/superpowers/plans/2026-06-23-autoquality-content-class-offset.md
@@ -37,25 +37,32 @@
 ## Task 1: Pin the empirical constants via the bench
 
 **Files:**
-- Modify: `test/support/mix/tasks/autoquality.bench.ex` (around the Part M separation report, `m_report_separation/1` near line 3800)
+- Modify: `test/support/mix/tasks/autoquality.bench.ex` (the Part M separation report, `m_report_separation/2`)
 
 This task produces three frozen numbers consumed by Tasks 2 and 3:
-1. `θ_palette` — `palette_ent` photo-side Youden threshold
-2. `θ_nat` — `nat_var` photo-side Youden threshold
+1. `θ_palette` — `palette_ent` photo-side threshold
+2. `θ_nat` — `nat_var` photo-side threshold
 3. the `{:avif, :graphic}` offset (round the avif×screen residual p90 ≈ 6.07)
 
-The bench already reports per-feature θ (the `θ` column) and the 4-/5-feature AND-rules, but **not** the exact shipped 2-feature rule. Add that report so the run confirms `palette_ent ∧ nat_var` makes **0 screen→photo** errors at those θ.
+> **As-built note.** During implementation this evolved past the first sketch below.
+> The bench's per-feature Youden θ leaked **1** screen→photo for the 2-feature
+> `palette_ent ∧ nat_var` rule (a photo-embedding `qoi_web` screenshot), so the
+> shipped thresholds are pinned **above** the Youden split (0.82 / 0.27) by
+> analysing the feature CSV for the 0-error / max-margin pair. The bench's
+> `m_production_rule_report/2` therefore evaluates the rule at
+> `ContentClassifier.photo_thresholds/0` (the single source of truth, no duplicate)
+> rather than the per-feature Youden θ, and only prints the ✓/✗ verdict at
+> `--downsample 512` (the calibration regime). Steps 1–4 below describe the original
+> sketch; follow the as-built note where they differ.
 
 - [ ] **Step 1: Add the production-rule report**
 
-In `m_report_separation/1`, immediately after the existing `strong-features AND-rule` block (the `case strong do … end`), add:
-
-```elixir
-    production = Enum.filter(stats, &(&1.name in ["palette_ent", "nat_var"]))
-    m_rule_report("PRODUCTION rule (palette_ent ∧ nat_var)", rows, production)
-```
-
-This reuses `m_rule_report/3` (prints photo→photo recall, photo→screen, and the safety-critical screen→photo count) over just the two shipped features, each at its own Youden θ from the printed stats table.
+In `m_report_separation/2`, after the existing `strong-features AND-rule` block, call a
+`m_production_rule_report(rows, downsample)` that evaluates the shipped 2-feature rule
+at `ContentClassifier.photo_thresholds/0` and prints the photo recall + the
+safety-critical **screen→photo** count (must be 0 at downsample 512). Thread `downsample`
+from `run_part_m` into `m_report_separation/2` so the report can gate its certifying
+verdict on `== 512`.
 
 - [ ] **Step 2: Set up the corpus (network; one-time)**
 

--- a/docs/superpowers/plans/2026-06-23-autoquality-content-class-offset.md
+++ b/docs/superpowers/plans/2026-06-23-autoquality-content-class-offset.md
@@ -1,0 +1,851 @@
+# Autoquality `{format, content-class} → offset` Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the single global confirm-skipped offset (`@crop_confirm_skipped_offset = 2.4`) with a `{format, content-class} → offset` policy keyed on a cheap libvips content classifier, so large AVIF dense-graphic renders stop shipping silently under-quality above the 6 MP crop crossover.
+
+**Architecture:** A new `ImagePipe.Output.ContentClassifier` classifies the finalized image (`:photo` / `:graphic`) lazily, only inside the `:ssim2`+>6 MP crop-scoring path where the offset is consumed. The declarative `{format, class} → offset` table lives on `Plan.Output` (defaulted, a future parser seam like `flatten_background`), is resolved per negotiated format into `ResolvedQualitySearch`, and is applied as a per-class offset in `EncodeSearch.crop_estimate`. A `[:encode, :search, :classify]` telemetry span surfaces the class + applied offset.
+
+**Tech Stack:** Elixir, libvips via `Vix.Vips.Operation` / `Image`, `:telemetry`, ExUnit, the `mix autoquality.bench` test-support task.
+
+**Spec:** `docs/superpowers/specs/2026-06-23-autoquality-content-class-offset-design.md`
+
+---
+
+## File Structure
+
+- **Create** `lib/image_pipe/output/content_classifier.ex` — the classifier (downsample → features → `:photo`/`:graphic`, safe fallback). One responsibility: turn a finalized image into a content class.
+- **Create** `test/image_pipe/output/content_classifier_test.exs` — classifier unit tests.
+- **Modify** `lib/image_pipe/plan/output.ex` — add the `quality_search_offsets` field + default policy helper.
+- **Modify** `lib/image_pipe/output/resolved_quality_search.ex` — add the resolved per-class `quality_search_offsets` field.
+- **Modify** `lib/image_pipe/output/policy.ex` — carry the field through the policy struct; collapse the table per-format in `resolve_search`.
+- **Modify** `lib/image_pipe/output/encode_search.ex` — remove the constant; classify + look up offset in the `:crop` `score_opts` clause; parametrize `crop_estimate`; emit the classify span.
+- **Modify** `lib/image_pipe/telemetry/logger.ex` — subscribe + render the classify span.
+- **Modify** `lib/image_pipe/telemetry/trace/capture.ex` — trace the classify span; allowlist its metadata keys.
+- **Modify** `docs/telemetry.md` — document the new span on both surfaces.
+- **Modify** `test/support/mix/tasks/autoquality.bench.ex` — report the exact shipped 2-feature rule (to pin/validate the constants).
+- **Modify** `test/image_pipe/output_policy_test.exs` — resolution test for the table collapse.
+- **Modify** `test/image_pipe/output/encoder_crop_scoring_test.exs` — adapt to the offset-as-parameter shape.
+- **Modify** `test/image_pipe/imgproxy_wire_conformance_test.exs` — the request-boundary acceptance test + a `:graphic` large-AVIF origin.
+
+**Note on `lib/image_pipe/cache/key.ex`:** `output_plan_data/2` enumerates cache-key fields explicitly. **Do NOT add `quality_search_offsets` to it** — the policy is a constant default (never request-varying), so it stays out of the key and ETag (spec §2). No change to `key.ex` is required.
+
+---
+
+## Task 1: Pin the empirical constants via the bench
+
+**Files:**
+- Modify: `test/support/mix/tasks/autoquality.bench.ex` (around the Part M separation report, `m_report_separation/1` near line 3800)
+
+This task produces three frozen numbers consumed by Tasks 2 and 3:
+1. `θ_palette` — `palette_ent` photo-side Youden threshold
+2. `θ_nat` — `nat_var` photo-side Youden threshold
+3. the `{:avif, :graphic}` offset (round the avif×screen residual p90 ≈ 6.07)
+
+The bench already reports per-feature θ (the `θ` column) and the 4-/5-feature AND-rules, but **not** the exact shipped 2-feature rule. Add that report so the run confirms `palette_ent ∧ nat_var` makes **0 screen→photo** errors at those θ.
+
+- [ ] **Step 1: Add the production-rule report**
+
+In `m_report_separation/1`, immediately after the existing `strong-features AND-rule` block (the `case strong do … end`), add:
+
+```elixir
+    production = Enum.filter(stats, &(&1.name in ["palette_ent", "nat_var"]))
+    m_rule_report("PRODUCTION rule (palette_ent ∧ nat_var)", rows, production)
+```
+
+This reuses `m_rule_report/3` (prints photo→photo recall, photo→screen, and the safety-critical screen→photo count) over just the two shipped features, each at its own Youden θ from the printed stats table.
+
+- [ ] **Step 2: Set up the corpus (network; one-time)**
+
+Run:
+```bash
+mise exec -- mix autoquality.corpus
+mise exec -- mix autoquality.corpus.capture
+```
+Expected: both complete; `mix autoquality.corpus --path` prints a populated corpus dir.
+
+- [ ] **Step 3: Run Part M and capture the numbers**
+
+Run:
+```bash
+mise exec -- mix autoquality.bench --part m --downsample 512 --corpus "$(mise exec -- mix autoquality.corpus --path)"
+```
+Expected (≈18 min): the `(a) class separation` table prints `θ` for `palette_ent` and `nat_var`; the new `PRODUCTION rule (palette_ent ∧ nat_var)` line prints `screen→photo 0`; the `(b)` residual section prints `screen avif … p90_hit ≈ 6`. 
+
+**Record** in this task's commit message: `θ_palette = <value>`, `θ_nat = <value>` (the printed Youden θ for each), `avif_graphic_offset = <round(p90_hit)>` (≈ 6.0). Confirm the production-rule line shows **0** screen→photo. If it shows 1, raise whichever θ is closer to its overlap until it reads 0, and record the raised value.
+
+- [ ] **Step 4: Commit (bench change only)**
+
+```bash
+git add test/support/mix/tasks/autoquality.bench.ex
+git commit -m "bench(autoquality): report the shipped palette_ent ∧ nat_var rule (#380)
+
+Pinned constants from this run (downsample 512):
+θ_palette=<value> θ_nat=<value> avif×graphic offset=<value>; screen→photo=0"
+```
+
+> These three values are referenced below as `@palette_photo_threshold`, `@nat_var_photo_threshold`, and the `{:avif, :graphic} => <offset>` table entry. Substitute the recorded numbers wherever the plan shows them; the example values below (`0.62`, `0.22`, `6.0`) are placeholders for the bench-pinned ones.
+
+---
+
+## Task 2: `ContentClassifier` module
+
+**Files:**
+- Create: `lib/image_pipe/output/content_classifier.ex`
+- Test: `test/image_pipe/output/content_classifier_test.exs`
+
+The classifier downsamples to 512 px long-edge, grayscales, computes `palette_ent` (luminance-hist entropy ÷ 8) and `nat_var` (mid-band gradient fraction), and applies the AND-rule with the safe `:graphic` fallback. Ported from the bench `m_features/2` (constants `@m_flat_thresh 8.0`, `@m_hard_thresh 64.0`, Sobel kernels `@m_k0`/`@m_k90`). Only `palette_ent` + `nat_var` are needed (the dropped features `axis_align`/`hard_edge` and kernels `k45`/`k135` are not ported).
+
+- [ ] **Step 1: Write the failing test**
+
+```elixir
+defmodule ImagePipe.Output.ContentClassifierTest do
+  use ExUnit.Case, async: true
+
+  alias ImagePipe.Output.ContentClassifier
+  alias Vix.Vips.Operation
+
+  # A smooth continuous-tone gradient: high palette entropy + high mid-band
+  # variation → :photo.
+  defp photo_image do
+    {:ok, ramp} = Operation.zone(512, 512)
+    {:ok, scaled} = Operation.linear(ramp, [127.5], [127.5])
+    {:ok, uchar} = Operation.cast(scaled, :VIPS_FORMAT_UCHAR)
+    {:ok, gray} = Operation.copy(uchar, interpretation: :VIPS_INTERPRETATION_B_W)
+    {:ok, rgb} = Operation.bandjoin([gray, gray, gray])
+    {:ok, srgb} = Operation.copy(rgb, interpretation: :VIPS_INTERPRETATION_sRGB)
+    srgb
+  end
+
+  # A hard-edged two-tone grid (text/line-art surrogate): two luminance values
+  # (low palette entropy) + hard edges, near-zero mid-band (low nat_var) → :graphic.
+  defp graphic_image do
+    {:ok, board} = Operation.grid(black_white_tile(), 64, 8, 8)
+    {:ok, srgb} = Operation.copy(board, interpretation: :VIPS_INTERPRETATION_sRGB)
+    srgb
+  end
+
+  defp black_white_tile do
+    {:ok, white} = Operation.black(8, 8)
+    {:ok, white} = Operation.linear(white, [1.0], [255.0])
+    {:ok, black} = Operation.black(8, 8)
+    {:ok, row} = Operation.join(white, black, :VIPS_DIRECTION_HORIZONTAL)
+    {:ok, row2} = Operation.join(black, white, :VIPS_DIRECTION_HORIZONTAL)
+    {:ok, tile} = Operation.join(row, row2, :VIPS_DIRECTION_VERTICAL)
+    {:ok, rgb} = Operation.bandjoin([tile, tile, tile])
+    rgb
+  end
+
+  test "classifies a continuous-tone gradient as :photo" do
+    assert {:photo, %{palette_ent: pe, nat_var: nv}} = ContentClassifier.classify(photo_image())
+    assert is_float(pe) and is_float(nv)
+  end
+
+  test "classifies a hard-edged two-tone grid as :graphic" do
+    assert {:graphic, _features} = ContentClassifier.classify(graphic_image())
+  end
+
+  test "falls back to :graphic on a degenerate 1x1 input (no raise)" do
+    {:ok, tiny} = Operation.black(1, 1)
+    {:ok, srgb} = Operation.copy(tiny, interpretation: :VIPS_INTERPRETATION_sRGB)
+    assert {:graphic, _features} = ContentClassifier.classify(srgb)
+  end
+end
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/output/content_classifier_test.exs`
+Expected: FAIL — `ImagePipe.Output.ContentClassifier` is undefined.
+
+- [ ] **Step 3: Implement the classifier**
+
+```elixir
+defmodule ImagePipe.Output.ContentClassifier do
+  @moduledoc """
+  Cheap content classifier for the autoquality crop-offset policy.
+
+  Returns `:photo` (continuous-tone photographic content) or `:graphic`
+  (discrete-tone synthetic content: screenshots, UI, text, charts, line art).
+  Derived entirely from runtime image inspection on a 512 px downsample, like
+  EXIF auto-orient and input color management — not a `Plan.Operation`.
+
+  `:graphic` is the **safe fallback**: misclassification is asymmetric (a photo
+  read as graphic only inflates a file slightly; a graphic read as photo ships
+  visible text/edge damage at the lean offset), so any internal libvips error
+  returns `:graphic` rather than failing the request. The graphic→photo error is
+  the one that must stay at zero (validated on the labeled cohort by
+  `mix autoquality.bench --part m`).
+  """
+
+  alias Vix.Vips.Image, as: VixImage
+  alias Vix.Vips.Operation
+
+  @type class :: :photo | :graphic
+  @type features :: %{palette_ent: float(), nat_var: float()}
+
+  # 512 px long-edge downsample: separation is near-invariant 256→1024 px
+  # (palette_ent is a histogram measure) and screen→photo stays 0 at every size,
+  # so 512 buys ~all the accuracy at ~60% the cost (bench Part M).
+  @downsample 512
+
+  # Gradient-magnitude thresholds (bench Part M): below @flat = flat fill, above
+  # @hard = hard edge; nat_var is the mid-band fraction between them.
+  @flat_thresh 8.0
+  @hard_thresh 64.0
+
+  # Sobel kernels (horizontal / vertical).
+  @k0 [[1.0, 0.0, -1.0], [2.0, 0.0, -2.0], [1.0, 0.0, -1.0]]
+  @k90 [[1.0, 2.0, 1.0], [0.0, 0.0, 0.0], [-1.0, -2.0, -1.0]]
+
+  # Photo-side Youden thresholds, pinned by `mix autoquality.bench --part m`
+  # (Task 1). Photos read HIGH on both features (cohort medians palette_ent
+  # 0.909/0.393, nat_var 0.411/0.110); :photo requires BOTH to clear their
+  # threshold, else the safe :graphic fallback.
+  @palette_photo_threshold 0.62
+  @nat_var_photo_threshold 0.22
+
+  @doc """
+  Classify a finalized image. Never raises; any libvips failure → `:graphic`.
+  """
+  @spec classify(VixImage.t()) :: {class(), features()}
+  def classify(%VixImage{} = image) do
+    case features(image) do
+      {:ok, %{palette_ent: pe, nat_var: nv} = feats} ->
+        class =
+          if pe >= @palette_photo_threshold and nv >= @nat_var_photo_threshold,
+            do: :photo,
+            else: :graphic
+
+        {class, feats}
+
+      :error ->
+        {:graphic, %{palette_ent: 0.0, nat_var: 0.0}}
+    end
+  end
+
+  defp features(image) do
+    with {:ok, feats} <- extract(image) do
+      {:ok, feats}
+    end
+  rescue
+    _ -> :error
+  catch
+    _, _ -> :error
+  end
+
+  defp extract(image) do
+    scale = min(1.0, @downsample / max(VixImage.width(image), VixImage.height(image)))
+
+    with {:ok, small} <- Operation.resize(image, scale),
+         {:ok, g8lazy} <- Operation.colourspace(small, :VIPS_INTERPRETATION_B_W),
+         # Pull the downsample+grayscale into RAM once so the convolutions and the
+         # histogram read the ~256 KB buffer instead of re-evaluating the resize.
+         {:ok, g8} <- VixImage.copy_memory(g8lazy),
+         {:ok, gf} <- Operation.cast(g8, :VIPS_FORMAT_FLOAT),
+         {:ok, c0} <- conv(gf, @k0),
+         {:ok, c90} <- conv(gf, @k90),
+         {:ok, mag} <- gradient_magnitude(c0, c90),
+         {:ok, flat} <- frac(mag, :VIPS_OPERATION_RELATIONAL_LESS, @flat_thresh),
+         {:ok, hard} <- frac(mag, :VIPS_OPERATION_RELATIONAL_MORE, @hard_thresh),
+         {:ok, hist} <- Operation.hist_find(g8),
+         {:ok, ent} <- Operation.hist_entropy(hist) do
+      {:ok, %{palette_ent: ent / 8.0, nat_var: max(0.0, 1.0 - flat - hard)}}
+    end
+  end
+
+  defp conv(gf, kernel) do
+    with {:ok, mask} <- VixImage.new_from_list(kernel), do: Operation.conv(gf, mask)
+  end
+
+  defp gradient_magnitude(c0, c90) do
+    with {:ok, sq0} <- Operation.multiply(c0, c0),
+         {:ok, sq90} <- Operation.multiply(c90, c90),
+         {:ok, sumsq} <- Operation.add(sq0, sq90) do
+      Operation.math2_const(sumsq, :VIPS_OPERATION_MATH2_POW, [0.5])
+    end
+  end
+
+  # Fraction of pixels passing a relational test on the gradient magnitude. The
+  # boolean image is 255 where true, so avg / 255 is the fraction.
+  defp frac(mag, op, threshold) do
+    with {:ok, bool} <- Operation.relational_const(mag, op, [threshold]),
+         {:ok, avg} <- Operation.avg(bool) do
+      {:ok, avg / 255.0}
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mise exec -- mix test test/image_pipe/output/content_classifier_test.exs`
+Expected: PASS (3 tests). If `:photo`/`:graphic` mismatch, the example fixtures are robust to any sane θ — recheck the pinned thresholds from Task 1.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/output/content_classifier.ex test/image_pipe/output/content_classifier_test.exs
+git commit -m "feat(autoquality): add ContentClassifier (:photo/:graphic) (#380)"
+```
+
+---
+
+## Task 3: `Plan.Output.quality_search_offsets` field + default
+
+**Files:**
+- Modify: `lib/image_pipe/plan/output.ex`
+- Test: `test/image_pipe/plan/output_test.exs` (create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+Create/extend `test/image_pipe/plan/output_test.exs`:
+
+```elixir
+defmodule ImagePipe.Plan.OutputTest do
+  use ExUnit.Case, async: true
+  alias ImagePipe.Plan.Output
+
+  test "default quality_search_offsets carries the 2.4 default and the avif×graphic override" do
+    %Output{quality_search_offsets: offsets} = %Output{mode: :automatic}
+    assert offsets.default == 2.4
+    assert Map.fetch!(offsets.overrides, {:avif, :graphic}) == 6.0
+  end
+
+  test "offset_for/3 falls back to the default for unlisted cells" do
+    offsets = Output.default_quality_search_offsets()
+    assert Output.offset_for(offsets, :avif, :graphic) == 6.0
+    assert Output.offset_for(offsets, :avif, :photo) == 2.4
+    assert Output.offset_for(offsets, :jpeg, :graphic) == 2.4
+    assert Output.offset_for(offsets, :webp, :photo) == 2.4
+  end
+end
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/plan/output_test.exs`
+Expected: FAIL — `quality_search_offsets`/`default_quality_search_offsets`/`offset_for` undefined.
+
+- [ ] **Step 3: Implement the field, default, and lookup**
+
+In `lib/image_pipe/plan/output.ex`, add to the `defstruct` (after `max_bytes: nil`):
+
+```elixir
+            max_bytes: nil,
+            quality_search_offsets: %{default: 2.4, overrides: %{{:avif, :graphic} => 6.0}}
+```
+
+Add to the `@type t` map (after `max_bytes:`):
+
+```elixir
+          max_bytes: nil | pos_integer(),
+          quality_search_offsets: quality_search_offsets()
+```
+
+Add the type + helpers (the `@moduledoc` should gain a sentence noting `quality_search_offsets` is the confirm-skipped crop-estimate correction per `{format, content-class}`, a defaulted seam no parser overrides today — like `flatten_background`):
+
+```elixir
+  @type content_class :: :photo | :graphic
+  @type quality_search_offsets :: %{
+          default: number(),
+          overrides: %{optional({format(), content_class()}) => number()}
+        }
+
+  @doc "The built-in confirm-skipped crop-offset policy (bench Part M / #380)."
+  @spec default_quality_search_offsets() :: quality_search_offsets()
+  def default_quality_search_offsets,
+    do: %{default: 2.4, overrides: %{{:avif, :graphic} => 6.0}}
+
+  @doc "Resolve the offset for a `{format, content_class}` cell, defaulting per policy."
+  @spec offset_for(quality_search_offsets(), format(), content_class()) :: number()
+  def offset_for(%{overrides: overrides, default: default}, format, class),
+    do: Map.get(overrides, {format, class}, default)
+```
+
+> Substitute the Task 1 bench-pinned offset for `6.0` if it rounded differently.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mise exec -- mix test test/image_pipe/plan/output_test.exs`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/plan/output.ex test/image_pipe/plan/output_test.exs
+git commit -m "feat(autoquality): add Plan.Output.quality_search_offsets policy (#380)"
+```
+
+---
+
+## Task 4: Resolve the table per format into `ResolvedQualitySearch`
+
+**Files:**
+- Modify: `lib/image_pipe/output/resolved_quality_search.ex`
+- Modify: `lib/image_pipe/output/policy.ex` (struct fields + `from_output_plan/3` both clauses + `resolve_search/2`, near lines 24, 60, 76, 177)
+- Test: `test/image_pipe/output_policy_test.exs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test/image_pipe/output_policy_test.exs` (follow the file's existing setup for building a `%Output.Policy{}` / `Plan.Output` + calling `resolve/2`; mirror an existing `quality_search` resolution test):
+
+```elixir
+  test "resolves quality_search_offsets to the per-class map for the negotiated format" do
+    output = %ImagePipe.Plan.Output{
+      mode: {:explicit, :avif},
+      quality_search: %ImagePipe.Plan.Output.QualitySearch{
+        objective: :ssim2,
+        target: 78,
+        min_quality: 70,
+        max_quality: 80,
+        allowed_error: 1.0,
+        max_resolution: 0,
+        format_min: %{},
+        format_max: %{}
+      }
+    }
+
+    policy = ImagePipe.Output.Policy.from_output_plan(%Plug.Conn{}, output, [])
+    {:ok, resolved} = ImagePipe.Output.Policy.resolve(policy, :avif)
+
+    # avif → graphic draws the big offset; photo keeps the lean default.
+    assert resolved.quality_search.quality_search_offsets == %{photo: 2.4, graphic: 6.0}
+  end
+
+  test "a non-avif format keeps the lean default for both classes" do
+    output = %ImagePipe.Plan.Output{
+      mode: {:explicit, :jpeg},
+      quality_search: %ImagePipe.Plan.Output.QualitySearch{
+        objective: :ssim2,
+        target: 78,
+        min_quality: 70,
+        max_quality: 80,
+        allowed_error: 1.0,
+        max_resolution: 0,
+        format_min: %{},
+        format_max: %{}
+      }
+    }
+
+    policy = ImagePipe.Output.Policy.from_output_plan(%Plug.Conn{}, output, [])
+    {:ok, resolved} = ImagePipe.Output.Policy.resolve(policy, :jpeg)
+    assert resolved.quality_search.quality_search_offsets == %{photo: 2.4, graphic: 2.4}
+  end
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/output_policy_test.exs`
+Expected: FAIL — `quality_search_offsets` not a key of `ResolvedQualitySearch`.
+
+- [ ] **Step 3: Add the resolved field**
+
+In `lib/image_pipe/output/resolved_quality_search.ex`, extend the struct + type:
+
+```elixir
+  @enforce_keys [:objective, :target, :min_quality, :max_quality]
+  defstruct @enforce_keys ++ [allowed_error: 0, max_resolution: 0, quality_search_offsets: %{}]
+
+  @type content_class :: :photo | :graphic
+  @type t :: %__MODULE__{
+          objective: :size | :ssim2,
+          target: number(),
+          min_quality: 1..100,
+          max_quality: 1..100,
+          allowed_error: number(),
+          max_resolution: non_neg_integer(),
+          quality_search_offsets: %{optional(content_class()) => number()}
+        }
+```
+
+Update the `@moduledoc` to note `quality_search_offsets` is the per-class confirm-skipped crop offset for the negotiated format, consumed by `EncodeSearch`.
+
+- [ ] **Step 4: Carry the field through the policy struct**
+
+In `lib/image_pipe/output/policy.ex`:
+
+In the `defstruct` defaults (line ~24/25), add `quality_search_offsets` defaulting to the Plan.Output default:
+
+```elixir
+  defstruct @enforce_keys ++
+              [
+                flatten_background: Color.white(),
+                quality_search: :none,
+                max_bytes: nil,
+                quality_search_offsets: Output.default_quality_search_offsets()
+              ]
+```
+
+Add to the `@type t` map: `quality_search_offsets: Output.quality_search_offsets()`.
+
+In **both** `from_output_plan/3` clauses, add to the struct literal (next to `quality_search: output.quality_search`):
+
+```elixir
+      quality_search: output.quality_search,
+      quality_search_offsets: output.quality_search_offsets,
+```
+
+- [ ] **Step 5: Collapse the table in `resolve_search/2`**
+
+Replace the `%Output.QualitySearch{}` clause of `resolve_search/2` so it takes the whole policy and stamps the per-class map for the format:
+
+```elixir
+  defp resolve_search(%__MODULE__{quality_search: :none}, _format), do: :none
+
+  defp resolve_search(
+         %__MODULE__{quality_search: %Output.QualitySearch{} = search} = policy,
+         format
+       ) do
+    %ResolvedQualitySearch{
+      objective: search.objective,
+      target: search.target,
+      min_quality: Map.get(search.format_min, format, search.min_quality),
+      max_quality: Map.get(search.format_max, format, search.max_quality),
+      allowed_error: search.allowed_error,
+      max_resolution: search.max_resolution,
+      quality_search_offsets: %{
+        photo: Output.offset_for(policy.quality_search_offsets, format, :photo),
+        graphic: Output.offset_for(policy.quality_search_offsets, format, :graphic)
+      }
+    }
+  end
+```
+
+(The call site `resolve_search(policy, format)` already passes the whole policy — confirm line ~170 reads `quality_search: resolve_search(policy, format)`.)
+
+- [ ] **Step 6: Run to verify it passes**
+
+Run: `mise exec -- mix test test/image_pipe/output_policy_test.exs`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/image_pipe/output/resolved_quality_search.ex lib/image_pipe/output/policy.ex test/image_pipe/output_policy_test.exs
+git commit -m "feat(autoquality): resolve quality_search_offsets per negotiated format (#380)"
+```
+
+---
+
+## Task 5: Apply the per-class offset in `EncodeSearch` (remove the constant)
+
+**Files:**
+- Modify: `lib/image_pipe/output/encode_search.ex` (the `@crop_confirm_skipped_offset` constant ~line 44-67; the `:crop` `score_opts/4` clause ~line 786-790; `crop_estimate/4` ~line 814-823)
+- Modify: `test/image_pipe/output/encoder_crop_scoring_test.exs`
+
+The pure `search/3` core is unchanged — the offset is baked into the crop closure by `run/3`, exactly like the reference build. The classify telemetry span is added here in Task 6; this task does the offset plumbing first and keeps tests green.
+
+- [ ] **Step 1: Update the production crop-scoring test for the per-class offset**
+
+Read `test/image_pipe/output/encoder_crop_scoring_test.exs` first. It currently asserts behavior tied to the global `2.4`. Adapt the assertion(s) that depend on the offset to go through the resolved `quality_search_offsets`: build the `%Resolved{}` with `quality_search_offsets: %{photo: 2.4, graphic: 6.0}` and assert the chosen `meta.score` reflects the **classified** offset (a `:graphic` finalized image subtracts 6.0, a `:photo` subtracts 2.4). If the existing test used a content-neutral synthetic, split it into a `:graphic` case (two-tone grid, expects the 6.0 subtraction) and keep a `:photo` case (gradient, 2.4). Preserve the existing decode/score structure; only the offset source changes.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/output/encoder_crop_scoring_test.exs`
+Expected: FAIL — `crop_estimate/5` arity / offset wiring not present yet.
+
+- [ ] **Step 3: Remove the constant; thread the per-class offset**
+
+In `lib/image_pipe/output/encode_search.ex`:
+
+Delete the `@crop_confirm_skipped_offset 2.4` attribute and its long explanatory comment block (lines ~44-67). Its 2.4 now lives as the `Plan.Output` policy default.
+
+Replace the `:crop` clause of `score_opts/4`:
+
+```elixir
+  defp score_opts(image, %Resolved{quality_search: %RQS{objective: :ssim2} = rqs}, :crop, t) do
+    tiles = CropScore.tile_count(Image.width(image), Image.height(image))
+    {class, _features} = ContentClassifier.classify(image)
+    offset = Map.fetch!(rqs.quality_search_offsets, class)
+    crop = fn bytes -> crop_estimate(image, bytes, tiles, offset, t) end
+    {:ok, [score_fun: crop, scorer_tiles: tiles]}
+  end
+```
+
+Update `crop_estimate/4` → `crop_estimate/5` to take the offset:
+
+```elixir
+  defp crop_estimate(base, bytes, tiles, offset, telemetry_opts) do
+    candidate = decode_leg(bytes, telemetry_opts)
+
+    metric_leg(telemetry_opts, tiles, fn ->
+      case CropScore.p10(base, candidate) do
+        {:ok, p10} -> p10 - offset
+        {:error, reason} -> throw({:image_pipe_score_error, reason})
+      end
+    end)
+  end
+```
+
+Add the alias near the top (with the other `alias ImagePipe.Output.*`):
+
+```elixir
+  alias ImagePipe.Output.ContentClassifier
+```
+
+- [ ] **Step 4: Run the focused tests**
+
+Run: `mise exec -- mix test test/image_pipe/output/encoder_crop_scoring_test.exs test/image_pipe/output/encode_search_test.exs`
+Expected: PASS. (`encode_search_test.exs` drives the pure `search/3` with injected closures and the `confirm_fun` baseline — unaffected by the offset change.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/image_pipe/output/encode_search.ex test/image_pipe/output/encoder_crop_scoring_test.exs
+git commit -m "feat(autoquality): apply per-class crop offset, drop global constant (#380)"
+```
+
+---
+
+## Task 6: Classify telemetry span + Logger + Capture + docs
+
+**Files:**
+- Modify: `lib/image_pipe/output/encode_search.ex` (wrap the classify in a span in the `:crop` `score_opts` clause)
+- Modify: `lib/image_pipe/telemetry/logger.ex` (`@group_span_events` line ~17-18; add a `message/3` clause)
+- Modify: `lib/image_pipe/telemetry/trace/capture.ex` (`@span_stages` line ~13-14; `@safe_keys` line ~65)
+- Modify: `docs/telemetry.md`
+- Test: `test/image_pipe/output/encode_search_telemetry_test.exs`
+
+- [ ] **Step 1: Write the failing telemetry test**
+
+Add to `test/image_pipe/output/encode_search_telemetry_test.exs` a test that runs `EncodeSearch.run/3` on a >6 MP finalized image with an `:ssim2` resolved search (mirror the file's existing crop-path telemetry setup) and a **unique `telemetry_prefix`**, attaches to `prefix ++ [:encode, :search, :classify, :stop]`, and asserts the metadata:
+
+```elixir
+  test "emits a classify span with the content class and applied offset" do
+    prefix = [:ip_classify_test]
+    handler = {__MODULE__, make_ref()}
+
+    :telemetry.attach(
+      handler,
+      prefix ++ [:encode, :search, :classify, :stop],
+      fn _event, _measure, meta, pid -> send(pid, {:classify, meta}) end,
+      self()
+    )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+
+    # ... build a >6 MP :graphic finalized image + %Resolved{quality_search:
+    # %RQS{objective: :ssim2, quality_search_offsets: %{photo: 2.4, graphic: 6.0}, ...}}
+    # following this file's existing crop-path helpers, then:
+    EncodeSearch.run(finalized, resolved, telemetry_opts: [prefix: prefix])
+
+    assert_receive {:classify, meta}
+    assert meta.content_class in [:photo, :graphic]
+    assert is_number(meta.applied_offset)
+    assert is_float(meta.palette_ent)
+    assert is_float(meta.nat_var)
+  end
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mise exec -- mix test test/image_pipe/output/encode_search_telemetry_test.exs`
+Expected: FAIL — no `[:encode, :search, :classify]` event emitted.
+
+- [ ] **Step 3: Emit the span from `score_opts(:crop)`**
+
+In `lib/image_pipe/output/encode_search.ex`, wrap the classification in a span:
+
+```elixir
+  defp score_opts(image, %Resolved{quality_search: %RQS{objective: :ssim2} = rqs}, :crop, t) do
+    tiles = CropScore.tile_count(Image.width(image), Image.height(image))
+
+    {class, offset} =
+      Telemetry.span(t, [:encode, :search, :classify], %{}, fn ->
+        {class, features} = ContentClassifier.classify(image)
+        offset = Map.fetch!(rqs.quality_search_offsets, class)
+
+        {{class, offset},
+         %{
+           result: :ok,
+           content_class: class,
+           applied_offset: offset,
+           palette_ent: features.palette_ent,
+           nat_var: features.nat_var
+         }}
+      end)
+
+    crop = fn bytes -> crop_estimate(image, bytes, tiles, offset, t) end
+    {:ok, [score_fun: crop, scorer_tiles: tiles]}
+  end
+```
+
+(Confirm `Telemetry.span/4` arity against the existing calls in this file, e.g. `encode_leg/4`.)
+
+- [ ] **Step 4: Subscribe + render in the Logger**
+
+In `lib/image_pipe/telemetry/logger.ex`, add `[:encode, :search, :classify]` to the `request` list in `@group_span_events` (after `[:encode, :search, :probe]`):
+
+```elixir
+      [:encode, :search, :probe],
+      [:encode, :search, :classify],
+```
+
+Add a `message/3` clause (before the generic fallback) that surfaces class + offset and still carries the outcome:
+
+```elixir
+  defp message([:encode, :search, :classify, :stop], _measurements, meta) do
+    "encode.search.classify #{meta.content_class} offset=#{meta.applied_offset} #{outcome(meta)}"
+  end
+```
+
+(Match the exact `message/3` signature/`outcome/1` helper used by the file's other clauses.)
+
+- [ ] **Step 5: Trace + allowlist in Capture**
+
+In `lib/image_pipe/telemetry/trace/capture.ex`, add the stage to `@span_stages` (after `[:encode, :search]`):
+
+```elixir
+    [:encode, :search],
+    [:encode, :search, :classify],
+```
+
+Add the new metadata keys to `@safe_keys` (next to `:scorer`, `:tiles_scored`):
+
+```elixir
+    :content_class,
+    :applied_offset,
+    :palette_ent,
+    :nat_var,
+```
+
+- [ ] **Step 6: Add a Logger coverage assertion**
+
+In `test/image_pipe/telemetry/logger_test.exs`, add an assertion that the classify line renders the class + offset (follow the file's existing capture-log pattern).
+
+- [ ] **Step 7: Update `docs/telemetry.md`**
+
+Document `[:encode, :search, :classify]` (start/stop/exception) on both the Logger and OTel surfaces, listing the metadata keys `content_class`, `applied_offset`, `palette_ent`, `nat_var`, and noting all are product-neutral/non-sensitive.
+
+- [ ] **Step 8: Run the telemetry + logger + capture tests**
+
+Run: `mise exec -- mix test test/image_pipe/output/encode_search_telemetry_test.exs test/image_pipe/telemetry/logger_test.exs test/image_pipe/telemetry/trace/capture_test.exs`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add lib/image_pipe/output/encode_search.ex lib/image_pipe/telemetry/logger.ex lib/image_pipe/telemetry/trace/capture.ex docs/telemetry.md test/image_pipe/output/encode_search_telemetry_test.exs test/image_pipe/telemetry/logger_test.exs
+git commit -m "feat(autoquality): classify telemetry span on Logger + OTel surfaces (#380)"
+```
+
+---
+
+## Task 7: Request-boundary acceptance test
+
+**Files:**
+- Modify: `test/image_pipe/imgproxy_wire_conformance_test.exs` (add a `:graphic` large-AVIF origin near `LargeSsim2OriginImage` ~line 73; add the acceptance test near the #369 crop-verdict test ~line 678)
+
+This is the primary acceptance criterion: a large AVIF dense-graphic render above the crossover hits the target band (no silent under-quality) and isn't misclassified as photo.
+
+- [ ] **Step 1: Add a deterministic large `:graphic` origin**
+
+After `LargeSsim2OriginImage`, add an origin that serves a >6 MP hard-edged two-tone grid (a text/line-art surrogate the classifier reads as `:graphic`), as JPEG to stay under `max_body_bytes`:
+
+```elixir
+  # A >6 MP hard-edged two-tone grid: a dense-text / line-art surrogate the
+  # content classifier reads as :graphic (low palette entropy, near-zero mid-band
+  # gradient). Above the crop crossover this is the cell whose crop estimate
+  # overshoots full-frame, so the {avif, :graphic} offset must rescue it. 2800² ≈
+  # 7.84 MP. Served JPEG to stay under the default 10 MB source max_body_bytes.
+  defmodule LargeGraphicOriginImage do
+    @moduledoc false
+
+    def call(conn, _opts) do
+      side = 2800
+      {:ok, tile} = Operation.black(8, 8)
+      {:ok, white} = Operation.linear(tile, [1.0], [255.0])
+      {:ok, grid} = Operation.grid(white, 8, side, side)
+      # Lay a fine black grid of lines over the field to maximise hard edges.
+      {:ok, lined} = Operation.cast(grid, :VIPS_FORMAT_UCHAR)
+      {:ok, gray} = Operation.copy(lined, interpretation: :VIPS_INTERPRETATION_B_W)
+      {:ok, rgb} = Operation.bandjoin([gray, gray, gray])
+      {:ok, srgb} = Operation.copy(rgb, interpretation: :VIPS_INTERPRETATION_sRGB)
+      body = Image.write!(srgb, :memory, suffix: ".jpg")
+
+      conn
+      |> Plug.Conn.put_resp_content_type("image/jpeg")
+      |> Plug.Conn.send_resp(200, body)
+    end
+  end
+```
+
+> Adjust the generator if needed so the served content (a) decodes ≥ 6 MP and (b) classifies `:graphic` — verify with a quick `ContentClassifier.classify/1` in IEx on the generated image during implementation. The exact drawing ops matter less than the property (two-tone, hard-edged, low mid-band).
+
+- [ ] **Step 2: Write the acceptance test**
+
+Mirror the existing #369 test (request an explicit AVIF autoquality `:ssim2` render with **no resize** so the full >6 MP frame is finalized and the crop scorer fires), but against `LargeGraphicOriginImage`, and assert the achieved score reaches the target band. Capture the search `:stop` telemetry (with a unique `telemetry_prefix`) and assert `scorer: :crop`, `content_class: :graphic` on the classify span, and `applied_offset` equals the avif×graphic offset (6.0). Assert the delivered AVIF decodes and the search `final_score` is `>= target - allowed_error` (i.e. it did **not** stop ~3.7 below target as it would with the lean 2.4 offset).
+
+```elixir
+  test "large AVIF :graphic render above the crossover hits the target band (#380)" do
+    prefix = [:ip_aq_offset_test]
+    # attach to prefix ++ [:encode, :search, :stop] and
+    # prefix ++ [:encode, :search, :classify, :stop]; forward meta to self()
+    # ... build the imgproxy AVIF autoquality request (ssim2 target/bracket),
+    # no resize, against LargeGraphicOriginImage; make the request via ImagePipe.call/2.
+
+    assert conn.status == 200
+    assert get_resp_header(conn, "content-type") == ["image/avif"]
+
+    assert_receive {:classify_stop, %{content_class: :graphic, applied_offset: 6.0}}
+    assert_receive {:search_stop, %{scorer: :crop, final_score: score, target: target, allowed_error: ae}}
+    assert score >= target - ae
+  end
+```
+
+- [ ] **Step 3: Run the acceptance test**
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs -k "graphic render above"`
+Expected: PASS. If `content_class` comes back `:photo`, fix the generator (Step 1) until the served content is unambiguously graphic.
+
+- [ ] **Step 4: Add the no-inflation guard (avif×photo / jpeg)**
+
+Add a companion test (or extend the existing #369 zone-plate test, which is continuous-tone → `:photo`) asserting the AVIF `:photo` / JPEG path still subtracts the lean `2.4` (telemetry `applied_offset == 2.4`) — i.e. no byte inflation vs today for the covered cells.
+
+Run: `mise exec -- mix test test/image_pipe/imgproxy_wire_conformance_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/image_pipe/imgproxy_wire_conformance_test.exs
+git commit -m "test(autoquality): request-boundary acceptance for {format,class} offset (#380)"
+```
+
+---
+
+## Task 8: Full gate + bench re-validation
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the precommit gate**
+
+Run: `mise run precommit`
+Expected: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict`, and `mix test` all pass.
+
+- [ ] **Step 2: Architecture boundary check**
+
+Run: `mise exec -- mix test test/image_pipe/architecture_boundary_test.exs`
+Expected: PASS — `ContentClassifier` sits inside `Output.*`; no request/source/response code names it. (No boundary edits expected.)
+
+- [ ] **Step 3: Re-confirm the cohort safety property (optional, environmental)**
+
+If the thresholds were adjusted in Task 1 Step 3, re-run `mise exec -- mix autoquality.bench --part m --downsample 512 --corpus "$(mise exec -- mix autoquality.corpus --path)"` and confirm the `PRODUCTION rule` line still reads `screen→photo 0`.
+
+- [ ] **Step 4: Final review prep**
+
+Confirm the spec's acceptance criteria are all covered:
+- Large AVIF dense-graphic hits target band → Task 7.
+- avif×photo / jpeg / webp no byte inflation → Task 7 Step 4 (lean 2.4 retained).
+- Request-boundary test decodes output, confirms no misclassification → Task 7.
+- Telemetry surfaces class + offset → Task 6.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** ContentClassifier (T2 ↔ spec §1), Plan.Output table (T3 ↔ §2), resolution (T4 ↔ §3), EncodeSearch consumption + constant removal (T5 ↔ §4), telemetry both surfaces (T6 ↔ §5), tests incl. acceptance (T2/T4/T6/T7 ↔ §"Testing"), empirical constants (T1 ↔ §"Empirical constants"). WebP cap (#381) correctly excluded.
+- **Cache key:** explicitly NOT touched (constant policy, out of key/ETag) — documented in File Structure.
+- **Naming consistency:** `quality_search_offsets` (field, all three layers), `offset_for/3`, `default_quality_search_offsets/0`, `:photo`/`:graphic`, `crop_estimate/5`, span `[:encode, :search, :classify]`, meta keys `content_class`/`applied_offset`/`palette_ent`/`nat_var` — used identically across tasks.
+- **Empirical placeholders:** the three constants (`@palette_photo_threshold`, `@nat_var_photo_threshold`, avif×graphic offset) are bench-derived in T1; example values (`0.62`/`0.22`/`6.0`) are flagged as substitutable, not invented design gaps.

--- a/docs/superpowers/specs/2026-06-23-autoquality-content-class-offset-design.md
+++ b/docs/superpowers/specs/2026-06-23-autoquality-content-class-offset-design.md
@@ -113,9 +113,14 @@ The finalized image is already materialized in RAM before encode
 
 ### 5. Telemetry
 
-- New span `[:encode, :search, :classify]` emitted from the `:crop` setup in `run/3`,
-  stop metadata: `content_class`, `applied_offset`, `palette_ent`, `nat_var` — all
-  product-neutral, non-sensitive (per the telemetry guidelines, fine to emit).
+- New span `[:encode, :classify]` emitted from the `:crop` setup in `run/3`, stop
+  metadata: `content_class`, `applied_offset`, `palette_ent`, `nat_var` — all
+  product-neutral, non-sensitive (per the telemetry guidelines, fine to emit). Named
+  `[:encode, :classify]` (not `…:search:classify`) because `score_opts` runs **before**
+  `search/3` opens the `[:encode, :search]` span — classification is a sibling of the
+  search under the `[:encode]` span, so the name reflects its true trace position.
+  Start/stop only in practice (the classifier is total — it never raises — so the span's
+  `:exception` leg is structurally unreachable).
 - Wire **both** subscription surfaces in the same change:
   - Logger: add to `@group_span_events`, add a `message/3` clause that surfaces the class
     + offset (and still surfaces `:result`), add a `logger_test.exs` assertion.
@@ -132,7 +137,7 @@ request → transform → materialize_for_delivery (image in RAM)
       → score_opts(:crop):
           {class, features} = ContentClassifier.classify(finalized)
           offset = quality_search_offsets[class]  # default 2.4, avif×graphic → 6.0
-          emit [:encode, :search, :classify]
+          emit [:encode, :classify]               # sibling of [:encode, :search] under [:encode]
           crop_fun = fn bytes -> crop_estimate(finalized, bytes, tiles, offset, t) end
       → search/3 (pure core, offset already baked into the closure)
 ```
@@ -154,21 +159,40 @@ must.
 
 ## Testing
 
-- **`ContentClassifier` unit test:** a graphic fixture → `:graphic`, a photo fixture →
-  `:photo`, a degenerate/tiny input → `:graphic` fallback (no raise). Uses committed
-  sources where possible.
-- **Request-boundary test (primary acceptance):** a large AVIF dense-text render above
-  the crossover hits the target band (no silent under-quality) and is **not**
-  misclassified as photo; decode the response body and assert the achieved score / band.
-  An `avif × :photo` (and a `jpeg`) case shows **no byte inflation** vs today.
-- **Resolution test:** `Output.Policy` collapses the `Plan.Output.quality_search_offsets`
-  table to the per-class `ResolvedQualitySearch.quality_search_offsets` for the negotiated
-  format.
-- **Telemetry test:** with a private `telemetry_prefix`, assert the
-  `[:encode, :search, :classify]` span fires with `content_class` + `applied_offset`.
-- **Encode-search behavior:** the existing crop-scoring tests update for the
-  offset-as-parameter signature; the pure `search/3` confirm-baseline tests are
-  unaffected.
+The acceptance work splits along what each layer can honestly prove:
+
+- The **bench (Part M)** owns the empirical claim that `6.0` is the right magnitude for
+  `avif × graphic` on *real dense-text* content. The default test lane has no network and
+  no committed dense-text source, so a lane test cannot reproduce that magnitude.
+- The **lane tests** prove the user-visible *contract*: the `{format, class}` offset is
+  plumbed end-to-end, classification works on real-ish content, and a larger offset
+  materially raises the chosen quality (the correcting direction). They must **not**
+  assert "hits target" off the offset-corrected estimate — the objective walk lands that
+  estimate in-band *by construction* at any offset, so such an assertion is vacuous.
+
+Tests:
+
+- **`ContentClassifier` unit test:** a continuous-tone fixture → `:photo`, a hard-edged
+  two-tone fixture → `:graphic`, a degenerate 1×1 input → `:graphic` fallback (no raise).
+  Fixtures built so the verdict is robust to the exact pinned thresholds.
+- **Offset-bites differential (focused, deterministic — the core proof):** drive
+  `EncodeSearch.run/3` on one large `:graphic` finalized image with
+  `quality_search_offsets` `%{graphic: 2.4}` vs `%{graphic: 6.0}`; assert the chosen
+  quality at 6.0 is `>=` (and, on content with real overshoot, `>`) the quality at 2.4.
+  This proves the offset bites in the under-quality-correcting direction without
+  depending on reproducing the real-world overshoot magnitude.
+- **Request-boundary contract test:** a large hard-edged AVIF render above the crossover,
+  through `ImagePipe.call/2`, returns `200`/`image/avif`, and telemetry shows
+  `content_class: :graphic`, `applied_offset: 6.0`, `scorer: :crop`. Classification is
+  self-checking (if the synthetic classified `:photo`, the test fails loudly). A
+  continuous-tone (`:photo`) AVIF / JPEG companion asserts `applied_offset: 2.4` — the
+  lean offset is retained for the covered cells (no byte inflation vs today).
+- **Resolution test:** `Output.Policy` collapses `Plan.Output.quality_search_offsets` to
+  the per-class `ResolvedQualitySearch.quality_search_offsets` for the negotiated format.
+- **Telemetry test:** with a private `telemetry_prefix`, assert the `[:encode, :classify]`
+  span fires with `content_class` + `applied_offset` + features, at the base log level.
+- **Encode-search behavior:** the existing crop-scoring test keeps its photo (2.4) case
+  and `<=4` full-vs-crop bound; the pure `search/3` confirm-baseline tests are unaffected.
 
 ## Out of scope (YAGNI)
 

--- a/docs/superpowers/specs/2026-06-23-autoquality-content-class-offset-design.md
+++ b/docs/superpowers/specs/2026-06-23-autoquality-content-class-offset-design.md
@@ -1,0 +1,191 @@
+# Autoquality `{format, content-class} → offset` policy
+
+**Issue:** [#380](https://github.com/hlindset/image_pipe/issues/380)
+**Date:** 2026-06-23
+**Status:** design approved, pending spec review
+
+## Problem
+
+Above the 6 MP crop crossover (#369), the confirm-skipped `:ssim2` search ships the
+crop verdict minus a single global offset, `@crop_confirm_skipped_offset` ≈ 2.4. That
+offset was calibrated on photo-heavy content. For **large AVIF renders of dense screen
+text** the crop estimate overshoots full-frame by ~6, so the search stops ~3.7 ssim2
+**below** target — silent under-quality, because the full-frame confirm that would have
+caught it is exactly what #369 removed for cost. A flat raise of the global offset to
+~6 would over-inflate every AVIF photo to rescue one content slice.
+
+Part M (#379, `docs/autoquality_benchmark.md` → Part M) proved a cheap libvips
+classifier separates photographic from graphic content (`palette_ent` AUC 0.959 +
+`nat_var` AUC 0.940, **zero** screen→photo errors on the 189-image cohort), and that the
+residual the offset corrects is carried **only** by AVIF × graphic content (p90 6.07);
+every other `{format, class}` cell's proper offset is already at or below today's 2.4.
+
+This change replaces the single global offset with a `{format, content-class} → offset`
+policy keyed on that classifier.
+
+## Content classes
+
+Two classes, named for the compression-relevant property they capture (tone
+continuity), not a content guess:
+
+- **`:photo`** — continuous-tone photographic content (gradients, sensor noise, soft
+  edges).
+- **`:graphic`** — discrete-tone synthetic content: screenshots, UI, text, charts,
+  diagrams, line art. **This is the safe fallback.**
+
+Misclassification is asymmetric: a photo read as graphic only inflates a file slightly;
+a graphic read as photo gets the lean offset and ships visible text/edge damage. So the
+classifier falls back to `:graphic`, and the **graphic→photo** error is the one that
+must stay at zero.
+
+(The Part M bench keeps its own corpus labels `:photo` / `:screen_or_other` — it is a
+separate `test/support` measurement tool with its own labeled corpus and is **not**
+renamed by this change.)
+
+## Architecture decision: lazy at the crop boundary
+
+The issue frames the class as self-managing `Transform.State` input conditioning (like
+EXIF auto-orient). We instead classify **lazily, inside the encode path, only when the
+`:ssim2` + >6 MP crop scorer is selected** — the single place the offset is consumed.
+
+Rationale: the class is read in exactly one place (`crop_estimate`, on the finalized
+image, only on the crop path), which is a tiny fraction of requests. Running the ~12 ms
+classifier eagerly during transform would tax every thumbnail and every non-autoquality
+request for a value almost none of them use. Lazy-at-boundary still honors "derived from
+runtime image inspection, not a `Plan.Operation`," and the declarative table still lives
+on `Plan.Output`. It avoids all `Transform.State` / metadata-carry plumbing and the
+materialization-gate proof a transform-stage operation would require.
+
+The finalized image is already materialized in RAM before encode
+(`materialize_for_delivery`), so the classifier reads the in-RAM buffer — no re-decode.
+
+## Components
+
+### 1. `ImagePipe.Output.ContentClassifier` (new)
+
+- **Boundary:** `Output.*` (consumed at the output/encode boundary).
+- **Public:** `classify(finalized_image) :: {class, features}` where
+  `class :: :photo | :graphic` and `features :: %{palette_ent: float, nat_var: float}`.
+- **Features** (ported from the bench `m_features/2`): a **512 px** long-edge downsample
+  → grayscale → Sobel gradient magnitude → `palette_ent` (luminance-histogram entropy ÷
+  8) + `nat_var` (mid-band gradient fraction). 512 px is near-invariant with 1024 for
+  separation at ~60 % the cost (Part M).
+- **AND-rule:** `:photo` iff `palette_ent ≥ θ_palette` **and** `nat_var ≥ θ_nat`; else
+  `:graphic`. Photos read high on both (cohort medians 0.909/0.411 vs 0.393/0.110).
+- **Fail-safe:** any internal libvips error → `{:graphic, features_or_zeroes}`. The
+  classifier never errors the request; the fallback *is* the safe class.
+- **Thresholds** `θ_palette`, `θ_nat` are frozen module constants, derived from the
+  bench re-run (Youden θ, validated at 0 graphic→photo on the cohort). Pinned values
+  filled in during implementation (see "Empirical constants").
+
+### 2. `ImagePipe.Plan.Output` — the declarative table (parser seam)
+
+- New field `quality_search_offsets`, a defaulted policy struct/map:
+  `%{default: 2.4, overrides: %{{:avif, :graphic} => 6.0}}` (offset values pinned by the
+  bench). Named for what it belongs to — the autoquality quality-search — so it reads as
+  an autoquality knob on `Plan.Output`, not image-crop geometry (the "crop" in the
+  internal crop-scorer is misleading at this layer). Mirrors `flatten_background`: a
+  built-in default that is the declarative seam a future dialect/host could override;
+  **no parser overrides it today.**
+- **Cache key / ETag:** the policy is a constant default (never request-varying), so it
+  stays **out of** both the cache key and the ETag — identical to today's module
+  constant `2.4`. The runtime-derived class is not a request input either (same request →
+  same source → same finalized pixels → deterministically same class), so it is also not
+  a key input.
+
+### 3. `ImagePipe.Output.Policy.resolve` → `ResolvedQualitySearch`
+
+- For the negotiated format, collapse the table into a per-class map
+  `%{photo: offset, graphic: offset}` and stash it on a new `ResolvedQualitySearch`
+  field (`quality_search_offsets`). Built **only** for `:ssim2` (crop scoring is
+  `:ssim2`-only; `:size`/`:none` never see it).
+
+### 4. `ImagePipe.Output.EncodeSearch` — consume lazily
+
+- Remove the `@crop_confirm_skipped_offset` module constant (its 2.4 now lives as the
+  policy `default`).
+- The `:crop` clause of `score_opts/4` (the only path that fires): classify the
+  finalized image once, look up `offset = quality_search_offsets[class]`, emit the
+  classify telemetry span, and close the offset into the crop closure —
+  `crop_estimate(base, bytes, tiles, offset, t)`.
+- `:full`, `:size`, and `:none` clauses unchanged. The pure `search/3` core never sees
+  the class — same pattern as the one-time reference build.
+
+### 5. Telemetry
+
+- New span `[:encode, :search, :classify]` emitted from the `:crop` setup in `run/3`,
+  stop metadata: `content_class`, `applied_offset`, `palette_ent`, `nat_var` — all
+  product-neutral, non-sensitive (per the telemetry guidelines, fine to emit).
+- Wire **both** subscription surfaces in the same change:
+  - Logger: add to `@group_span_events`, add a `message/3` clause that surfaces the class
+    + offset (and still surfaces `:result`), add a `logger_test.exs` assertion.
+  - OTel Capture: add the stage to `@span_stages`, add the new metadata keys to
+    `@safe_keys`, add a capture test.
+  - Update `docs/telemetry.md` for both surfaces.
+
+## Data flow
+
+```
+request → transform → materialize_for_delivery (image in RAM)
+  → Encoder.stream_output → search_output (megapixels > crossover, :ssim2)
+    → EncodeSearch.run(finalized, %Resolved{quality_search: %RQS{quality_search_offsets}})
+      → score_opts(:crop):
+          {class, features} = ContentClassifier.classify(finalized)
+          offset = quality_search_offsets[class]  # default 2.4, avif×graphic → 6.0
+          emit [:encode, :search, :classify]
+          crop_fun = fn bytes -> crop_estimate(finalized, bytes, tiles, offset, t) end
+      → search/3 (pure core, offset already baked into the closure)
+```
+
+## Empirical constants (derived during implementation)
+
+The feature is only as good as three frozen numbers. Implementation re-runs
+`mix autoquality.corpus` + `…capture` + `mix autoquality.bench --part m` on this machine
+to derive and freeze:
+
+1. `θ_palette` — `palette_ent` photo-side threshold (Youden split, AND-rule).
+2. `θ_nat` — `nat_var` photo-side threshold.
+3. `{:avif, :graphic}` offset — confirm/round the p90 6.07 (~6).
+
+Acceptance for the constants: **0 graphic→photo misclassifications** on the labeled
+cohort at the chosen thresholds; the avif×graphic offset covers the `web_sc` dense-text
+worst case (~7) without over-covering charts more than the 2-class split inherently
+must.
+
+## Testing
+
+- **`ContentClassifier` unit test:** a graphic fixture → `:graphic`, a photo fixture →
+  `:photo`, a degenerate/tiny input → `:graphic` fallback (no raise). Uses committed
+  sources where possible.
+- **Request-boundary test (primary acceptance):** a large AVIF dense-text render above
+  the crossover hits the target band (no silent under-quality) and is **not**
+  misclassified as photo; decode the response body and assert the achieved score / band.
+  An `avif × :photo` (and a `jpeg`) case shows **no byte inflation** vs today.
+- **Resolution test:** `Output.Policy` collapses the `Plan.Output.quality_search_offsets`
+  table to the per-class `ResolvedQualitySearch.quality_search_offsets` for the negotiated
+  format.
+- **Telemetry test:** with a private `telemetry_prefix`, assert the
+  `[:encode, :search, :classify]` span fires with `content_class` + `applied_offset`.
+- **Encode-search behavior:** the existing crop-scoring tests update for the
+  offset-as-parameter signature; the pure `search/3` confirm-baseline tests are
+  unaffected.
+
+## Out of scope (YAGNI)
+
+- No `Transform.State` / metadata-carry plumbing (lazy-at-boundary chosen).
+- No 3-class (text vs chart) refinement; no continuous/sliding offset — Part M ruled
+  both out (best feature↔residual r² ≈ 0.17; free tile-dispersion ≤ 7 %).
+- No parser config surface for the table — the default policy suffices; it is a future
+  declarative seam, like `flatten_background`.
+- The Part M bench and its corpus labels are unchanged.
+- The `max_quality` **cap** lever for ceiling-bound cells (`webp × *`, `jpeg × screen`,
+  which an offset cannot rescue) is out of scope — tracked separately in
+  [#381](https://github.com/hlindset/image_pipe/issues/381). The offset and the cap are
+  orthogonal levers.
+
+## Compatibility
+
+No compatibility-target impact: this is native `:ssim2` autoquality, which imgproxy does
+not implement (its `size`/`dssim`/`ml` search is Pro/closed-source). No
+`docs/imgproxy_support_matrix.md` change. The plan-review compatibility reviewer is
+therefore optional for this change.

--- a/docs/superpowers/specs/2026-06-23-autoquality-content-class-offset-design.md
+++ b/docs/superpowers/specs/2026-06-23-autoquality-content-class-offset-design.md
@@ -157,6 +157,18 @@ cohort at the chosen thresholds; the avif×graphic offset covers the `web_sc` de
 worst case (~7) without over-covering charts more than the 2-class split inherently
 must.
 
+**Pinned (bench run 2026-06-23, downsample 512, 133 photo / 56 screen):**
+
+- `palette_ent ≥ 0.82` ∧ `nat_var ≥ 0.27` → `:photo`, else `:graphic`. Set **above** the
+  per-feature Youden split (0.70 / 0.27), which leaked **1** screen→photo (a
+  photo-embedding `qoi_web` web screenshot). The frozen pair gives **0** screen→photo
+  with a 0.048 margin to the nearest screen and **71 %** photo recall (94/133) — better
+  than the 4-feature rule's 62 % at 0 errors.
+- `{:avif, :graphic}` offset **6.0** — the avif×screen residual p90 is 5.44 overall and
+  **6.07** for `web_sc` (the binding dense-text worst case); `grafana_sc` charts 0.46,
+  `qoi_web` 1.82. The bench `PRODUCTION rule` line (evaluated at the frozen thresholds,
+  not Youden) is the reproducible safety evidence.
+
 ## Testing
 
 The acceptance work splits along what each layer can honestly prove:

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -324,6 +324,8 @@ emits start/stop only (the classifier is total — it never raises — so no
 Stop metadata (all product-neutral — a class atom, a constant offset, two image
 statistics; nothing sensitive):
 
+- `:result` — `:ok` (the classifier is total, so this is always `:ok`; it gives the
+  Logger/exporters the standard outcome key).
 - `:content_class` — `:photo` or `:graphic` (the safe fallback).
 - `:applied_offset` — the offset subtracted from the crop estimate for this
   `{format, content-class}` cell.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -64,6 +64,7 @@ streaming spans.
 [:image_pipe, :transform, :materialize, ...]
 [:image_pipe, :encode, ...]
 [:image_pipe, :encode, :search, ...]
+[:image_pipe, :encode, :classify, ...]
 [:image_pipe, :cache, :write, ...]
 [:image_pipe, :render, ...]
 [:image_pipe, :send, ...]
@@ -307,6 +308,36 @@ scorer token (`full`/`crop`):
 image_pipe encode search: ok (full hit q62 12345b score 90.42)
 image_pipe encode search: ok (crop hit q72 12345b score 90.42)
 ```
+
+### Content-class classify span (`[:encode, :classify]`)
+
+On the crop-scoring path (an `:ssim2` search above the internal ~6 MP crossover),
+ImagePipe classifies the finalized image as `:photo` (continuous-tone) or
+`:graphic` (discrete-tone: screenshots, text, charts, line art) to select the
+per-`{format, content-class}` confirm-skipped crop offset (#380). The
+classification is wrapped in a `[:image_pipe, :encode, :classify]` span. It is
+emitted from the search setup, **before** the `[:encode, :search]` span opens, so
+it is a sibling of the search under `[:encode]` — not nested under it. The span
+emits start/stop only (the classifier is total — it never raises — so no
+`:exception` leg fires).
+
+Stop metadata (all product-neutral — a class atom, a constant offset, two image
+statistics; nothing sensitive):
+
+- `:content_class` — `:photo` or `:graphic` (the safe fallback).
+- `:applied_offset` — the offset subtracted from the crop estimate for this
+  `{format, content-class}` cell.
+- `:palette_ent` — the luminance-histogram entropy feature (÷ 8).
+- `:nat_var` — the mid-band gradient-fraction feature.
+
+The default Logger renders the stop at the base level (it never escalates):
+
+```text
+image_pipe encode classify: ok (graphic offset 6.0)
+```
+
+The OTel exporter captures it as `image_pipe.encode.classify` with the four
+attributes above on the span.
 
 ### Encode-quality search probe (`[:encode, :search, :probe]`)
 

--- a/lib/image_pipe/output/content_classifier.ex
+++ b/lib/image_pipe/output/content_classifier.ex
@@ -50,7 +50,8 @@ defmodule ImagePipe.Output.ContentClassifier do
   @nat_var_photo_threshold 0.27
 
   @doc """
-  Classify a finalized image. Never raises; any libvips failure → `:graphic`.
+  Classify a finalized image. Never raises; any libvips failure — a raised
+  exception OR an `{:error, _}` return from any op — falls back to `:graphic`.
   """
   @spec classify(VixImage.t()) :: {class(), features()}
   def classify(%VixImage{} = image) do
@@ -63,10 +64,19 @@ defmodule ImagePipe.Output.ContentClassifier do
 
         {class, feats}
 
-      :error ->
+      # `:error` (a caught raise) or any `{:error, _}` an op returned through the
+      # else-less `with` — both fall back to the safe class. Keep this total: the
+      # safety design depends on classify/1 never raising.
+      _ ->
         {:graphic, %{palette_ent: 0.0, nat_var: 0.0}}
     end
   end
+
+  @doc false
+  # The frozen photo-side thresholds, exposed so `mix autoquality.bench --part m`
+  # certifies the exact pair that ships (no hand-synced duplicate).
+  @spec photo_thresholds() :: {float(), float()}
+  def photo_thresholds, do: {@palette_photo_threshold, @nat_var_photo_threshold}
 
   defp features(image) do
     extract(image)

--- a/lib/image_pipe/output/content_classifier.ex
+++ b/lib/image_pipe/output/content_classifier.ex
@@ -35,12 +35,19 @@ defmodule ImagePipe.Output.ContentClassifier do
   @k0 [[1.0, 0.0, -1.0], [2.0, 0.0, -2.0], [1.0, 0.0, -1.0]]
   @k90 [[1.0, 2.0, 1.0], [0.0, 0.0, 0.0], [-1.0, -2.0, -1.0]]
 
-  # Photo-side Youden thresholds, pinned by `mix autoquality.bench --part m`.
-  # Photos read HIGH on both features (cohort medians palette_ent 0.909/0.393,
-  # nat_var 0.411/0.110); :photo requires BOTH to clear their threshold, else the
-  # safe :graphic fallback.
-  @palette_photo_threshold 0.62
-  @nat_var_photo_threshold 0.22
+  # Photo-side thresholds pinned by `mix autoquality.bench --part m` (downsample 512,
+  # 133 photo / 56 screen cohort). Photos read HIGH on both features (cohort medians
+  # palette_ent 0.91/0.44, nat_var 0.40/0.17); :photo requires BOTH to clear their
+  # threshold, else the safe :graphic fallback.
+  #
+  # Set ABOVE the per-feature Youden split (palette 0.70 / nat 0.27): the Youden pair
+  # leaks 1 screen→photo on this cohort (a photo-embedding `qoi_web` web screenshot).
+  # 0.82 / 0.27 makes screen→photo = 0 with a 0.048 margin to the nearest screen and
+  # 71 % photo recall — the asymmetric cost (a misread screenshot ships visible text
+  # damage; a misread photo only inflates its file slightly) buys safety with recall.
+  # Re-derive with `mix autoquality.bench --part m` (the PRODUCTION rule line).
+  @palette_photo_threshold 0.82
+  @nat_var_photo_threshold 0.27
 
   @doc """
   Classify a finalized image. Never raises; any libvips failure → `:graphic`.

--- a/lib/image_pipe/output/content_classifier.ex
+++ b/lib/image_pipe/output/content_classifier.ex
@@ -1,0 +1,112 @@
+defmodule ImagePipe.Output.ContentClassifier do
+  @moduledoc """
+  Cheap content classifier for the autoquality crop-offset policy.
+
+  Returns `:photo` (continuous-tone photographic content) or `:graphic`
+  (discrete-tone synthetic content: screenshots, UI, text, charts, line art).
+  Derived entirely from runtime image inspection on a 512 px downsample, like
+  EXIF auto-orient and input color management — not a `Plan.Operation`.
+
+  `:graphic` is the **safe fallback**: misclassification is asymmetric (a photo
+  read as graphic only inflates a file slightly; a graphic read as photo ships
+  visible text/edge damage at the lean offset), so any internal libvips error
+  returns `:graphic` rather than failing the request. The graphic→photo error is
+  the one that must stay at zero (validated on the labeled cohort by
+  `mix autoquality.bench --part m`).
+  """
+
+  alias Vix.Vips.Image, as: VixImage
+  alias Vix.Vips.Operation
+
+  @type class :: :photo | :graphic
+  @type features :: %{palette_ent: float(), nat_var: float()}
+
+  # 512 px long-edge downsample: separation is near-invariant 256→1024 px
+  # (palette_ent is a histogram measure) and screen→photo stays 0 at every size,
+  # so 512 buys ~all the accuracy at ~60% the cost (bench Part M).
+  @downsample 512
+
+  # Gradient-magnitude thresholds (bench Part M): below @flat = flat fill, above
+  # @hard = hard edge; nat_var is the mid-band fraction between them.
+  @flat_thresh 8.0
+  @hard_thresh 64.0
+
+  # Sobel kernels (horizontal / vertical).
+  @k0 [[1.0, 0.0, -1.0], [2.0, 0.0, -2.0], [1.0, 0.0, -1.0]]
+  @k90 [[1.0, 2.0, 1.0], [0.0, 0.0, 0.0], [-1.0, -2.0, -1.0]]
+
+  # Photo-side Youden thresholds, pinned by `mix autoquality.bench --part m`.
+  # Photos read HIGH on both features (cohort medians palette_ent 0.909/0.393,
+  # nat_var 0.411/0.110); :photo requires BOTH to clear their threshold, else the
+  # safe :graphic fallback.
+  @palette_photo_threshold 0.62
+  @nat_var_photo_threshold 0.22
+
+  @doc """
+  Classify a finalized image. Never raises; any libvips failure → `:graphic`.
+  """
+  @spec classify(VixImage.t()) :: {class(), features()}
+  def classify(%VixImage{} = image) do
+    case features(image) do
+      {:ok, %{palette_ent: pe, nat_var: nv} = feats} ->
+        class =
+          if pe >= @palette_photo_threshold and nv >= @nat_var_photo_threshold,
+            do: :photo,
+            else: :graphic
+
+        {class, feats}
+
+      :error ->
+        {:graphic, %{palette_ent: 0.0, nat_var: 0.0}}
+    end
+  end
+
+  defp features(image) do
+    extract(image)
+  rescue
+    _ -> :error
+  catch
+    _, _ -> :error
+  end
+
+  defp extract(image) do
+    scale = min(1.0, @downsample / max(VixImage.width(image), VixImage.height(image)))
+
+    with {:ok, small} <- Operation.resize(image, scale),
+         {:ok, g8lazy} <- Operation.colourspace(small, :VIPS_INTERPRETATION_B_W),
+         # Pull the downsample+grayscale into RAM once so the convolutions and the
+         # histogram read the small buffer instead of re-evaluating the resize.
+         {:ok, g8} <- VixImage.copy_memory(g8lazy),
+         {:ok, gf} <- Operation.cast(g8, :VIPS_FORMAT_FLOAT),
+         {:ok, c0} <- conv(gf, @k0),
+         {:ok, c90} <- conv(gf, @k90),
+         {:ok, mag} <- gradient_magnitude(c0, c90),
+         {:ok, flat} <- frac(mag, :VIPS_OPERATION_RELATIONAL_LESS, @flat_thresh),
+         {:ok, hard} <- frac(mag, :VIPS_OPERATION_RELATIONAL_MORE, @hard_thresh),
+         {:ok, hist} <- Operation.hist_find(g8),
+         {:ok, ent} <- Operation.hist_entropy(hist) do
+      {:ok, %{palette_ent: ent / 8.0, nat_var: max(0.0, 1.0 - flat - hard)}}
+    end
+  end
+
+  defp conv(gf, kernel) do
+    with {:ok, mask} <- VixImage.new_from_list(kernel), do: Operation.conv(gf, mask)
+  end
+
+  defp gradient_magnitude(c0, c90) do
+    with {:ok, sq0} <- Operation.multiply(c0, c0),
+         {:ok, sq90} <- Operation.multiply(c90, c90),
+         {:ok, sumsq} <- Operation.add(sq0, sq90) do
+      Operation.math2_const(sumsq, :VIPS_OPERATION_MATH2_POW, [0.5])
+    end
+  end
+
+  # Fraction of pixels passing a relational test on the gradient magnitude. The
+  # boolean image is 255 where true, so avg / 255 is the fraction.
+  defp frac(mag, op, threshold) do
+    with {:ok, bool} <- Operation.relational_const(mag, op, [threshold]),
+         {:ok, avg} <- Operation.avg(bool) do
+      {:ok, avg / 255.0}
+    end
+  end
+end

--- a/lib/image_pipe/output/encode_search.ex
+++ b/lib/image_pipe/output/encode_search.ex
@@ -762,15 +762,32 @@ defmodule ImagePipe.Output.EncodeSearch do
   # per-tile reference failure surfaces through the score closure's throw.
   defp score_opts(image, %Resolved{quality_search: %RQS{objective: :ssim2} = rqs}, :crop, t) do
     tiles = CropScore.tile_count(Image.width(image), Image.height(image))
-    {class, _features} = ContentClassifier.classify(image)
-    # `Output.Policy.resolve_search/2` always stamps both :photo and :graphic keys
-    # for an :ssim2 search (the only objective that reaches the :crop path), so
-    # `fetch!` trusts the in-repo producer — a missing key is a resolver bug, not a
-    # runtime input. (The `RQS` default `%{}` only occurs for :size/:none, which
-    # never crop-score.)
-    offset = Map.fetch!(rqs.quality_search_offsets, class)
+    offset = classify_offset(image, rqs.quality_search_offsets, t)
     crop = fn bytes -> crop_estimate(image, bytes, tiles, offset, t) end
     {:ok, [score_fun: crop, scorer_tiles: tiles]}
+  end
+
+  # Classify the finalized image once and select its per-class offset, as a span
+  # (#380). Emitted from `run/3`'s setup, before `search/3` opens `[:encode,
+  # :search]`, so it is a sibling of the search under `[:encode]` — hence
+  # `[:encode, :classify]`, not `…:search:classify`. `fetch!` trusts the resolver,
+  # which always stamps both :photo and :graphic for an :ssim2 search (the only
+  # objective reaching this path). The classifier is total — never raises — so the
+  # span emits start/stop only.
+  defp classify_offset(image, offsets, telemetry_opts) do
+    Telemetry.span(telemetry_opts, [:encode, :classify], %{}, fn ->
+      {class, features} = ContentClassifier.classify(image)
+      offset = Map.fetch!(offsets, class)
+
+      {offset,
+       %{
+         result: :ok,
+         content_class: class,
+         applied_offset: offset,
+         palette_ent: features.palette_ent,
+         nat_var: features.nat_var
+       }}
+    end)
   end
 
   # The score_fun contract is float-returning, but Image.from_binary and

--- a/lib/image_pipe/output/encode_search.ex
+++ b/lib/image_pipe/output/encode_search.ex
@@ -29,6 +29,7 @@ defmodule ImagePipe.Output.EncodeSearch do
   replacing the search.
   """
 
+  alias ImagePipe.Output.ContentClassifier
   alias ImagePipe.Output.Encoder
   alias ImagePipe.Output.Resolved
   alias ImagePipe.Output.ResolvedQualitySearch, as: RQS
@@ -40,31 +41,6 @@ defmodule ImagePipe.Output.EncodeSearch do
   @default_max_bump_passes 2
   @max_bytes_alone_floor 10
   @max_bytes_alone_base 90
-
-  # Crop-scoring p10→full-frame correction (offset = tile_p10 − full_frame_score),
-  # subtracted from the tile p10 so the objective's walk-to-target band comparison
-  # reproduces the full-frame decision.
-  #
-  # Above the crossover the search ships the crop objective winner with NO
-  # full-frame confirm (#369), so this offset is the only correction lever left and
-  # must be conservative: set near the p90 of the systematic residual rather than
-  # the median, so it covers the over-prediction tail (concentrated in screen
-  # content) instead of leaving the tail to a confirm that no longer runs.
-  #
-  # 2.4 ≈ the p90 of the (even-K16 p10 − full-frame) residual measured on
-  # `mix autoquality.bench --part k` over a 46-case >6 MP cohort (median 0.12,
-  # p90 2.42, worst 5.84 in `qoi_web` screen content). Dropping the confirm cost
-  # 0 target-hit regressions vs the crop+confirm baseline at every swept offset
-  # 0→3; the residual median is ~0, so biasing to the p90 barely moves bytes —
-  # raising the offset 0→3 nudges on-target only ~35→39 % at ~0 % median byte cost,
-  # because the remaining misses are bracket-ceiling-bound, not offset-bound. See
-  # `docs/autoquality_benchmark.md` (Part K).
-  #
-  # The calibration is tied to `CropScore`'s `@subsample_k` (16 even tiles) and p10
-  # aggregation: changing the tile count or aggregator silently invalidates this
-  # offset — re-derive it with `mix autoquality.bench --part k` before shipping such
-  # a change.
-  @crop_confirm_skipped_offset 2.4
 
   @type outcome :: :hit | :best_effort | :skipped
 
@@ -776,16 +752,24 @@ defmodule ImagePipe.Output.EncodeSearch do
   end
 
   # Crop mode (above the crossover): crop score_fun (estimate) only — no full-frame
-  # confirm/bump (#369). The conservative `@crop_confirm_skipped_offset` baked into
-  # the estimate replaces the confirm as the crop→full correction; the objective
-  # walk's verdict ships as-is, bounding the large-image search to a flat ~4.2 MP
-  # metric sample. No whole-frame reference is built — `crop_estimate` references
-  # per-tile via `CropScore.p10/2`, so the O(pixels) full-frame reference (the very
-  # cost this path avoids) never runs; a per-tile reference failure surfaces through
-  # the score closure's throw.
-  defp score_opts(image, %Resolved{quality_search: %RQS{objective: :ssim2}}, :crop, t) do
+  # confirm/bump (#369). The per-`{format, content-class}` offset (resolved into
+  # `rqs.quality_search_offsets`, #380) baked into the estimate replaces the confirm
+  # as the crop→full correction; the content class is classified here once, lazily,
+  # from the finalized pixels. The objective walk's verdict ships as-is, bounding the
+  # large-image search to a flat ~4.2 MP metric sample. No whole-frame reference is
+  # built — `crop_estimate` references per-tile via `CropScore.p10/2`, so the
+  # O(pixels) full-frame reference (the very cost this path avoids) never runs; a
+  # per-tile reference failure surfaces through the score closure's throw.
+  defp score_opts(image, %Resolved{quality_search: %RQS{objective: :ssim2} = rqs}, :crop, t) do
     tiles = CropScore.tile_count(Image.width(image), Image.height(image))
-    crop = fn bytes -> crop_estimate(image, bytes, tiles, t) end
+    {class, _features} = ContentClassifier.classify(image)
+    # `Output.Policy.resolve_search/2` always stamps both :photo and :graphic keys
+    # for an :ssim2 search (the only objective that reaches the :crop path), so
+    # `fetch!` trusts the in-repo producer — a missing key is a resolver bug, not a
+    # runtime input. (The `RQS` default `%{}` only occurs for :size/:none, which
+    # never crop-score.)
+    offset = Map.fetch!(rqs.quality_search_offsets, class)
+    crop = fn bytes -> crop_estimate(image, bytes, tiles, offset, t) end
     {:ok, [score_fun: crop, scorer_tiles: tiles]}
   end
 
@@ -811,12 +795,12 @@ defmodule ImagePipe.Output.EncodeSearch do
   # Decode the candidate once; crop-score its tiles vs the base; subtract the
   # conservative confirm-skipped offset so the objective's walk-to-target band
   # comparison reproduces the full-frame decision without a full-frame confirm.
-  defp crop_estimate(base, bytes, tiles, telemetry_opts) do
+  defp crop_estimate(base, bytes, tiles, offset, telemetry_opts) do
     candidate = decode_leg(bytes, telemetry_opts)
 
     metric_leg(telemetry_opts, tiles, fn ->
       case CropScore.p10(base, candidate) do
-        {:ok, p10} -> p10 - @crop_confirm_skipped_offset
+        {:ok, p10} -> p10 - offset
         {:error, reason} -> throw({:image_pipe_score_error, reason})
       end
     end)

--- a/lib/image_pipe/output/policy.ex
+++ b/lib/image_pipe/output/policy.ex
@@ -22,7 +22,12 @@ defmodule ImagePipe.Output.Policy do
     :color_profile
   ]
   defstruct @enforce_keys ++
-              [flatten_background: Color.white(), quality_search: :none, max_bytes: nil]
+              [
+                flatten_background: Color.white(),
+                quality_search: :none,
+                max_bytes: nil,
+                quality_search_offsets: Output.default_quality_search_offsets()
+              ]
 
   @passthrough_source_formats [:jpeg, :png]
 
@@ -42,7 +47,8 @@ defmodule ImagePipe.Output.Policy do
           color_profile: Output.color_profile(),
           flatten_background: Color.t(),
           quality_search: :none | Output.QualitySearch.t(),
-          max_bytes: nil | pos_integer()
+          max_bytes: nil | pos_integer(),
+          quality_search_offsets: Output.quality_search_offsets()
         }
 
   @spec from_output_plan(Plug.Conn.t(), Output.t(), keyword()) :: t()
@@ -58,7 +64,8 @@ defmodule ImagePipe.Output.Policy do
       color_profile: output.color_profile,
       flatten_background: output.flatten_background,
       quality_search: output.quality_search,
-      max_bytes: output.max_bytes
+      max_bytes: output.max_bytes,
+      quality_search_offsets: output.quality_search_offsets
     }
   end
 
@@ -74,7 +81,8 @@ defmodule ImagePipe.Output.Policy do
       color_profile: output.color_profile,
       flatten_background: output.flatten_background,
       quality_search: output.quality_search,
-      max_bytes: output.max_bytes
+      max_bytes: output.max_bytes,
+      quality_search_offsets: output.quality_search_offsets
     }
   end
 
@@ -174,14 +182,21 @@ defmodule ImagePipe.Output.Policy do
 
   defp resolve_search(%__MODULE__{quality_search: :none}, _format), do: :none
 
-  defp resolve_search(%__MODULE__{quality_search: %Output.QualitySearch{} = search}, format) do
+  defp resolve_search(
+         %__MODULE__{quality_search: %Output.QualitySearch{} = search} = policy,
+         format
+       ) do
     %ResolvedQualitySearch{
       objective: search.objective,
       target: search.target,
       min_quality: Map.get(search.format_min, format, search.min_quality),
       max_quality: Map.get(search.format_max, format, search.max_quality),
       allowed_error: search.allowed_error,
-      max_resolution: search.max_resolution
+      max_resolution: search.max_resolution,
+      quality_search_offsets: %{
+        photo: Output.offset_for(policy.quality_search_offsets, format, :photo),
+        graphic: Output.offset_for(policy.quality_search_offsets, format, :graphic)
+      }
     }
   end
 

--- a/lib/image_pipe/output/resolved_quality_search.ex
+++ b/lib/image_pipe/output/resolved_quality_search.ex
@@ -4,10 +4,18 @@ defmodule ImagePipe.Output.ResolvedQualitySearch do
   the bracket is already per-format clamped, and the per-format maps have been
   consumed. `max_resolution` rides along for the encoder's skip check. Consumed by
   `ImagePipe.Output.EncodeSearch`.
+
+  `quality_search_offsets` is the per-content-class confirm-skipped crop offset for
+  the negotiated format (#380), collapsed from `Plan.Output.quality_search_offsets`.
+  The default `%{}` is the resolved shape only for `:size`/`:none` (which never
+  crop-score); the `:ssim2` resolver always populates both `:photo` and `:graphic`
+  keys, so the `:crop` path's `Map.fetch!` trusts a fully-populated map.
   """
 
+  @type content_class :: :photo | :graphic
+
   @enforce_keys [:objective, :target, :min_quality, :max_quality]
-  defstruct @enforce_keys ++ [allowed_error: 0, max_resolution: 0]
+  defstruct @enforce_keys ++ [allowed_error: 0, max_resolution: 0, quality_search_offsets: %{}]
 
   @type t :: %__MODULE__{
           objective: :size | :ssim2,
@@ -15,6 +23,7 @@ defmodule ImagePipe.Output.ResolvedQualitySearch do
           min_quality: 1..100,
           max_quality: 1..100,
           allowed_error: number(),
-          max_resolution: non_neg_integer()
+          max_resolution: non_neg_integer(),
+          quality_search_offsets: %{optional(content_class()) => number()}
         }
 end

--- a/lib/image_pipe/plan/output.ex
+++ b/lib/image_pipe/plan/output.ex
@@ -21,6 +21,15 @@ defmodule ImagePipe.Plan.Output do
 
   alias ImagePipe.Plan.Color
 
+  # The confirm-skipped crop-estimate correction per `{format, content-class}`
+  # (#380). Above the 6 MP crop crossover the `:ssim2` search ships the crop verdict
+  # minus this offset (the full-frame confirm #369 removed); a larger offset biases
+  # the estimate down so the search climbs to higher quality. AVIF × `:graphic`
+  # (dense graphic content) overshoots full-frame by ~6 and draws the big offset;
+  # every other cell stays at the lean 2.4 default. A defaulted seam (like
+  # `flatten_background`): no parser overrides it today.
+  @default_quality_search_offsets %{default: 2.4, overrides: %{{:avif, :graphic} => 6.0}}
+
   @enforce_keys [:mode]
   defstruct mode: :automatic,
             quality: :default,
@@ -31,12 +40,18 @@ defmodule ImagePipe.Plan.Output do
             hdr: :tone_map,
             flatten_background: Color.white(),
             quality_search: :none,
-            max_bytes: nil
+            max_bytes: nil,
+            quality_search_offsets: @default_quality_search_offsets
 
   @type format :: :avif | :webp | :jpeg | :png
   @type quality :: :default | {:quality, 1..100}
   @type color_profile :: :preserve_source | :strip | {:convert, term()}
   @type hdr :: :tone_map | :preserve
+  @type content_class :: :photo | :graphic
+  @type quality_search_offsets :: %{
+          default: number(),
+          overrides: %{optional({format(), content_class()}) => number()}
+        }
   @type t :: %__MODULE__{
           mode: :automatic | {:explicit, format()},
           quality: quality(),
@@ -47,6 +62,16 @@ defmodule ImagePipe.Plan.Output do
           hdr: hdr(),
           flatten_background: Color.t(),
           quality_search: :none | ImagePipe.Plan.Output.QualitySearch.t(),
-          max_bytes: nil | pos_integer()
+          max_bytes: nil | pos_integer(),
+          quality_search_offsets: quality_search_offsets()
         }
+
+  @doc "The built-in confirm-skipped crop-offset policy (bench Part M / #380)."
+  @spec default_quality_search_offsets() :: quality_search_offsets()
+  def default_quality_search_offsets, do: @default_quality_search_offsets
+
+  @doc "Resolve the offset for a `{format, content_class}` cell, defaulting per policy."
+  @spec offset_for(quality_search_offsets(), format(), content_class()) :: number()
+  def offset_for(%{overrides: overrides, default: default}, format, class),
+    do: Map.get(overrides, {format, class}, default)
 end

--- a/lib/image_pipe/telemetry/logger.ex
+++ b/lib/image_pipe/telemetry/logger.ex
@@ -16,6 +16,7 @@ defmodule ImagePipe.Telemetry.Logger do
       [:encode],
       [:encode, :search],
       [:encode, :search, :probe],
+      [:encode, :classify],
       [:deliver],
       [:render]
     ],
@@ -279,6 +280,11 @@ defmodule ImagePipe.Telemetry.Logger do
 
     "image_pipe encode search: #{outcome(meta)} (#{scorer}#{meta[:outcome]} " <>
       "q#{meta[:chosen_quality]} #{meta[:chosen_bytes]}b#{score})"
+  end
+
+  defp message([:encode, :classify | _], _m, meta) do
+    "image_pipe encode classify: #{outcome(meta)} " <>
+      "(#{meta[:content_class]} offset #{meta[:applied_offset]})"
   end
 
   defp message([:encode | _], _m, meta) do

--- a/lib/image_pipe/telemetry/trace/capture.ex
+++ b/lib/image_pipe/telemetry/trace/capture.ex
@@ -11,6 +11,9 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
     [:send],
     [:encode],
     [:encode, :search],
+    # Content classification for the per-class crop offset (#380). Emitted before
+    # the search span opens, so it is a sibling of [:encode, :search] under [:encode].
+    [:encode, :classify],
     [:encode, :search, :probe],
     # Per-probe cost legs (eager NIF/op calls → honest durations). The encode leg
     # is method-neutral (fires for every objective); the scoring legs carry the
@@ -108,6 +111,12 @@ defmodule ImagePipe.Telemetry.Trace.Capture do
     :iterations,
     :tiles_scored,
     :confirm_passes,
+    # content classification for the per-class crop offset (#380): all product-neutral
+    # (a class atom, a constant offset, two image statistics)
+    :content_class,
+    :applied_offset,
+    :palette_ent,
+    :nat_var,
     # per-probe span attributes: phase, the search-level limiting factor, and the
     # crop→full confirm residual (all product-neutral numbers/atoms)
     :phase,

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -89,6 +89,61 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
     end
   end
 
+  # A >6 MP white field overlaid with a fine black line grid: a dense line-art /
+  # text surrogate the content classifier reads as :graphic (two luminance values →
+  # low palette entropy; all-hard edges → low mid-band gradient). Above the crop
+  # crossover this is the cell whose crop estimate overshoots full-frame, so
+  # {avif, :graphic} draws the big offset (#380). 2480² ≈ 6.15 MP, just over the
+  # crossover (keeps AVIF encode cost down). Served JPEG to stay under the default
+  # 10 MB source max_body_bytes.
+  defmodule LargeGraphicOriginImage do
+    @moduledoc false
+
+    def call(conn, _opts) do
+      side = 2480
+      base = Image.new!(side, side, color: :white)
+
+      drawn =
+        Enum.reduce(0..(side - 1)//16, base, fn x, acc ->
+          acc
+          |> Image.Draw.rect!(x, 0, 1, side, color: :black)
+          |> Image.Draw.rect!(0, x, side, 1, color: :black)
+        end)
+
+      body = drawn |> Image.to_colorspace!(:srgb) |> Image.write!(:memory, suffix: ".jpg")
+
+      conn
+      |> Plug.Conn.put_resp_content_type("image/jpeg")
+      |> Plug.Conn.send_resp(200, body)
+    end
+  end
+
+  # A >6 MP continuous-tone field: a full-range luminance ramp (high palette
+  # entropy) plus softly-blurred noise (high mid-band gradient) → :photo. The
+  # no-inflation control: avif × :photo must keep the lean 2.4 offset (#380).
+  defmodule LargePhotoOriginImage do
+    @moduledoc false
+
+    def call(conn, _opts) do
+      side = 2480
+      {:ok, xyz} = Operation.xyz(side, side)
+      {:ok, x} = Operation.extract_band(xyz, 0)
+      {:ok, ramp} = Operation.linear(x, [255.0 / (side - 1)], [0.0])
+      {:ok, noise} = Operation.gaussnoise(side, side, sigma: 35, mean: 0)
+      {:ok, blurred} = Operation.gaussblur(noise, 1.2)
+      {:ok, sum} = Operation.add(ramp, blurred)
+      {:ok, uchar} = Operation.cast(sum, :VIPS_FORMAT_UCHAR)
+      {:ok, gray} = Operation.copy(uchar, interpretation: :VIPS_INTERPRETATION_B_W)
+      {:ok, rgb} = Operation.bandjoin([gray, gray, gray])
+      {:ok, srgb} = Operation.copy(rgb, interpretation: :VIPS_INTERPRETATION_sRGB)
+      body = Image.write!(srgb, :memory, suffix: ".jpg")
+
+      conn
+      |> Plug.Conn.put_resp_content_type("image/jpeg")
+      |> Plug.Conn.send_resp(200, body)
+    end
+  end
+
   # Deferred-orientation gate (#146) origins. Both serve the SAME displayed
   # pixels: `OrientedFrameOrigin` tags a stored image with an EXIF orientation
   # (so the pipeline must autorotate it), while `Orientation1TwinOrigin` decodes
@@ -716,6 +771,85 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
     assert meta.scorer == :crop
     assert meta.confirm_passes == 0
     assert meta.result == :ok
+  end
+
+  test "large graphic AVIF above the crossover selects the {avif, graphic} offset (#380)" do
+    # End-to-end contract: a large graphic AVIF render classifies :graphic and
+    # draws the big {avif, :graphic} offset on the crop path. NOT an "achieves
+    # target" assertion — on the crop path the search lands its offset-corrected
+    # estimate in-band by construction at any offset (that would be vacuous); the
+    # 6.0 magnitude's correctness is owned by `mix autoquality.bench --part m`.
+    telemetry_prefix = [:"ip_aq_graphic_#{System.unique_integer([:positive])}"]
+    test_pid = self()
+    handler_id = "aq-graphic-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach_many(
+      handler_id,
+      [
+        telemetry_prefix ++ [:encode, :classify, :stop],
+        telemetry_prefix ++ [:encode, :search, :stop]
+      ],
+      fn event, _measurements, meta, _config -> send(test_pid, {:stop, event, meta}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    opts = [
+      parser: ImagePipe.Parser.Imgproxy,
+      sources: [
+        path:
+          {RootHTTPAdapter,
+           root_url: "http://origin.test", req_options: [plug: LargeGraphicOriginImage]}
+      ],
+      imgproxy: [autoquality_method: :ssim2, autoquality_target: 70],
+      telemetry_prefix: telemetry_prefix
+    ]
+
+    # Explicit AVIF, no resize: the full >6 MP frame is finalized → crop scorer fires.
+    conn = call_imgproxy("/_/f:avif/plain/images/large.jpg", opts)
+
+    assert conn.status == 200
+    assert content_type(conn) == ["image/avif"]
+
+    classify_stop = telemetry_prefix ++ [:encode, :classify, :stop]
+    search_stop = telemetry_prefix ++ [:encode, :search, :stop]
+
+    assert_receive {:stop, ^classify_stop, %{content_class: :graphic, applied_offset: 6.0}}
+    assert_receive {:stop, ^search_stop, %{scorer: :crop}}
+  end
+
+  test "large photo AVIF above the crossover keeps the lean 2.4 offset (#380 no-inflation)" do
+    telemetry_prefix = [:"ip_aq_photo_#{System.unique_integer([:positive])}"]
+    test_pid = self()
+    handler_id = "aq-photo-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach(
+      handler_id,
+      telemetry_prefix ++ [:encode, :classify, :stop],
+      fn _event, _measurements, meta, _config -> send(test_pid, {:classify, meta}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    opts = [
+      parser: ImagePipe.Parser.Imgproxy,
+      sources: [
+        path:
+          {RootHTTPAdapter,
+           root_url: "http://origin.test", req_options: [plug: LargePhotoOriginImage]}
+      ],
+      imgproxy: [autoquality_method: :ssim2, autoquality_target: 70],
+      telemetry_prefix: telemetry_prefix
+    ]
+
+    conn = call_imgproxy("/_/f:avif/plain/images/large.jpg", opts)
+
+    assert conn.status == 200
+    assert content_type(conn) == ["image/avif"]
+    # avif × :photo keeps the prior global 2.4 → no byte inflation vs today.
+    assert_receive {:classify, %{content_class: :photo, applied_offset: 2.4}}
   end
 
   test "equivalent imgproxy option order shares filesystem cache through real Plug requests" do

--- a/test/image_pipe/imgproxy_wire_conformance_test.exs
+++ b/test/image_pipe/imgproxy_wire_conformance_test.exs
@@ -129,7 +129,7 @@ defmodule ImagePipe.ImgproxyWireConformanceTest do
       {:ok, xyz} = Operation.xyz(side, side)
       {:ok, x} = Operation.extract_band(xyz, 0)
       {:ok, ramp} = Operation.linear(x, [255.0 / (side - 1)], [0.0])
-      {:ok, noise} = Operation.gaussnoise(side, side, sigma: 35, mean: 0)
+      {:ok, noise} = Operation.gaussnoise(side, side, sigma: 35, mean: 0, seed: 1)
       {:ok, blurred} = Operation.gaussblur(noise, 1.2)
       {:ok, sum} = Operation.add(ramp, blurred)
       {:ok, uchar} = Operation.cast(sum, :VIPS_FORMAT_UCHAR)

--- a/test/image_pipe/output/content_classifier_test.exs
+++ b/test/image_pipe/output/content_classifier_test.exs
@@ -1,0 +1,57 @@
+defmodule ImagePipe.Output.ContentClassifierTest do
+  use ExUnit.Case, async: true
+
+  alias ImagePipe.Output.ContentClassifier
+  alias Vix.Vips.Operation
+
+  # A continuous-tone field: a full-range luminance ramp (high palette entropy)
+  # plus softly-blurred noise (abundant mid-band gradient, high nat_var) → :photo.
+  # Both features land near the photo extreme, well clear of any plausible
+  # threshold, so the verdict is robust to the exact pinned constants.
+  defp photo_image do
+    side = 512
+    {:ok, xyz} = Operation.xyz(side, side)
+    {:ok, x} = Operation.extract_band(xyz, 0)
+    {:ok, ramp} = Operation.linear(x, [255.0 / (side - 1)], [0.0])
+    {:ok, noise} = Operation.gaussnoise(side, side, sigma: 35, mean: 0)
+    {:ok, blurred} = Operation.gaussblur(noise, 1.2)
+    {:ok, sum} = Operation.add(ramp, blurred)
+    {:ok, uchar} = Operation.cast(sum, :VIPS_FORMAT_UCHAR)
+    {:ok, gray} = Operation.copy(uchar, interpretation: :VIPS_INTERPRETATION_B_W)
+    {:ok, rgb} = Operation.bandjoin([gray, gray, gray])
+    {:ok, srgb} = Operation.copy(rgb, interpretation: :VIPS_INTERPRETATION_sRGB)
+    srgb
+  end
+
+  # A hard-edged two-tone field (line-art surrogate): a white canvas overlaid with
+  # a fine black line grid → two luminance values (low palette entropy) + all-hard
+  # edges (near-zero mid-band) → :graphic. Built with Image.Draw, not Operation.grid.
+  defp graphic_image do
+    side = 512
+    base = Image.new!(side, side, color: :white)
+
+    drawn =
+      Enum.reduce(0..(side - 1)//8, base, fn x, acc ->
+        acc
+        |> Image.Draw.rect!(x, 0, 1, side, color: :black)
+        |> Image.Draw.rect!(0, x, side, 1, color: :black)
+      end)
+
+    Image.to_colorspace!(drawn, :srgb)
+  end
+
+  test "classifies a continuous-tone field as :photo" do
+    assert {:photo, %{palette_ent: pe, nat_var: nv}} = ContentClassifier.classify(photo_image())
+    assert is_float(pe) and is_float(nv)
+  end
+
+  test "classifies a hard-edged two-tone field as :graphic" do
+    assert {:graphic, _features} = ContentClassifier.classify(graphic_image())
+  end
+
+  test "falls back to :graphic on a degenerate 1x1 input (no raise)" do
+    {:ok, tiny} = Operation.black(1, 1)
+    {:ok, srgb} = Operation.copy(tiny, interpretation: :VIPS_INTERPRETATION_sRGB)
+    assert {:graphic, _features} = ContentClassifier.classify(srgb)
+  end
+end

--- a/test/image_pipe/output/content_classifier_test.exs
+++ b/test/image_pipe/output/content_classifier_test.exs
@@ -13,7 +13,7 @@ defmodule ImagePipe.Output.ContentClassifierTest do
     {:ok, xyz} = Operation.xyz(side, side)
     {:ok, x} = Operation.extract_band(xyz, 0)
     {:ok, ramp} = Operation.linear(x, [255.0 / (side - 1)], [0.0])
-    {:ok, noise} = Operation.gaussnoise(side, side, sigma: 35, mean: 0)
+    {:ok, noise} = Operation.gaussnoise(side, side, sigma: 35, mean: 0, seed: 1)
     {:ok, blurred} = Operation.gaussblur(noise, 1.2)
     {:ok, sum} = Operation.add(ramp, blurred)
     {:ok, uchar} = Operation.cast(sum, :VIPS_FORMAT_UCHAR)

--- a/test/image_pipe/output/encode_search_telemetry_test.exs
+++ b/test/image_pipe/output/encode_search_telemetry_test.exs
@@ -273,7 +273,7 @@ defmodule ImagePipe.Output.EncodeSearchTelemetryTest do
     {:ok, xyz} = Operation.xyz(side, side)
     {:ok, x} = Operation.extract_band(xyz, 0)
     {:ok, ramp} = Operation.linear(x, [255.0 / (side - 1)], [0.0])
-    {:ok, noise} = Operation.gaussnoise(side, side, sigma: 35, mean: 0)
+    {:ok, noise} = Operation.gaussnoise(side, side, sigma: 35, mean: 0, seed: 1)
     {:ok, blurred} = Operation.gaussblur(noise, 1.2)
     {:ok, sum} = Operation.add(ramp, blurred)
     {:ok, uchar} = Operation.cast(sum, :VIPS_FORMAT_UCHAR)

--- a/test/image_pipe/output/encode_search_telemetry_test.exs
+++ b/test/image_pipe/output/encode_search_telemetry_test.exs
@@ -307,7 +307,11 @@ defmodule ImagePipe.Output.EncodeSearchTelemetryTest do
     attach_classify()
     opts = Telemetry.telemetry_opts(telemetry_prefix: @prefix)
 
-    EncodeSearch.run(large_graphic_image(), crop_resolved(), scorer: :crop, telemetry_opts: opts)
+    assert {:ok, _bin, _meta} =
+             EncodeSearch.run(large_graphic_image(), crop_resolved(),
+               scorer: :crop,
+               telemetry_opts: opts
+             )
 
     assert_receive {:classify, meta}
     assert meta.content_class == :graphic
@@ -319,7 +323,11 @@ defmodule ImagePipe.Output.EncodeSearchTelemetryTest do
     attach_classify()
     opts = Telemetry.telemetry_opts(telemetry_prefix: @prefix)
 
-    EncodeSearch.run(large_photo_image(), crop_resolved(), scorer: :crop, telemetry_opts: opts)
+    assert {:ok, _bin, _meta} =
+             EncodeSearch.run(large_photo_image(), crop_resolved(),
+               scorer: :crop,
+               telemetry_opts: opts
+             )
 
     assert_receive {:classify, meta}
     assert meta.content_class == :photo

--- a/test/image_pipe/output/encode_search_telemetry_test.exs
+++ b/test/image_pipe/output/encode_search_telemetry_test.exs
@@ -2,8 +2,10 @@ defmodule ImagePipe.Output.EncodeSearchTelemetryTest do
   use ExUnit.Case, async: true
 
   alias ImagePipe.Output.EncodeSearch
+  alias ImagePipe.Output.Resolved
   alias ImagePipe.Output.ResolvedQualitySearch, as: RQS
   alias ImagePipe.Telemetry
+  alias Vix.Vips.Operation
 
   # Unique prefix so the global :telemetry handler can't catch another module's
   # default-prefixed emissions and leak them into this async test's mailbox.
@@ -268,21 +270,21 @@ defmodule ImagePipe.Output.EncodeSearchTelemetryTest do
   # plus softly-blurred noise (high mid-band gradient) → :photo.
   defp large_photo_image do
     side = 2480
-    {:ok, xyz} = Vix.Vips.Operation.xyz(side, side)
-    {:ok, x} = Vix.Vips.Operation.extract_band(xyz, 0)
-    {:ok, ramp} = Vix.Vips.Operation.linear(x, [255.0 / (side - 1)], [0.0])
-    {:ok, noise} = Vix.Vips.Operation.gaussnoise(side, side, sigma: 35, mean: 0)
-    {:ok, blurred} = Vix.Vips.Operation.gaussblur(noise, 1.2)
-    {:ok, sum} = Vix.Vips.Operation.add(ramp, blurred)
-    {:ok, uchar} = Vix.Vips.Operation.cast(sum, :VIPS_FORMAT_UCHAR)
-    {:ok, gray} = Vix.Vips.Operation.copy(uchar, interpretation: :VIPS_INTERPRETATION_B_W)
-    {:ok, rgb} = Vix.Vips.Operation.bandjoin([gray, gray, gray])
-    {:ok, srgb} = Vix.Vips.Operation.copy(rgb, interpretation: :VIPS_INTERPRETATION_sRGB)
+    {:ok, xyz} = Operation.xyz(side, side)
+    {:ok, x} = Operation.extract_band(xyz, 0)
+    {:ok, ramp} = Operation.linear(x, [255.0 / (side - 1)], [0.0])
+    {:ok, noise} = Operation.gaussnoise(side, side, sigma: 35, mean: 0)
+    {:ok, blurred} = Operation.gaussblur(noise, 1.2)
+    {:ok, sum} = Operation.add(ramp, blurred)
+    {:ok, uchar} = Operation.cast(sum, :VIPS_FORMAT_UCHAR)
+    {:ok, gray} = Operation.copy(uchar, interpretation: :VIPS_INTERPRETATION_B_W)
+    {:ok, rgb} = Operation.bandjoin([gray, gray, gray])
+    {:ok, srgb} = Operation.copy(rgb, interpretation: :VIPS_INTERPRETATION_sRGB)
     srgb
   end
 
   defp crop_resolved do
-    %ImagePipe.Output.Resolved{
+    %Resolved{
       format: :jpeg,
       quality: :default,
       response_headers: [],

--- a/test/image_pipe/output/encode_search_telemetry_test.exs
+++ b/test/image_pipe/output/encode_search_telemetry_test.exs
@@ -225,4 +225,102 @@ defmodule ImagePipe.Output.EncodeSearchTelemetryTest do
       0 -> {Enum.reverse(probes), Enum.reverse(durations)}
     end
   end
+
+  # --- classify span (#380): the per-content-class offset is selected on the crop
+  # path. Uses run/3 on a real >6 MP image (so the crop scorer fires) but encodes
+  # JPEG (cheap) — the classify span's offset lookup is format-agnostic, so the
+  # resolved offset map can carry the avif×graphic 6.0 regardless of encode format.
+
+  @classify @prefix ++ [:encode, :classify, :stop]
+
+  defp attach_classify do
+    handler_id = "encode-classify-#{System.unique_integer([:positive])}"
+    test_pid = self()
+
+    :telemetry.attach(
+      handler_id,
+      @classify,
+      fn _e, _m, meta, _config -> send(test_pid, {:classify, meta}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+
+  # >6 MP hard-edged two-tone field (dense line-art surrogate): a white canvas with
+  # a fine black line grid → two luminance values (low palette entropy) + all-hard
+  # edges (low mid-band) → :graphic. Built with Image.Draw, not Operation.grid.
+  defp large_graphic_image do
+    side = 2480
+    base = Image.new!(side, side, color: :white)
+
+    drawn =
+      Enum.reduce(0..(side - 1)//16, base, fn x, acc ->
+        acc
+        |> Image.Draw.rect!(x, 0, 1, side, color: :black)
+        |> Image.Draw.rect!(0, x, side, 1, color: :black)
+      end)
+
+    Image.to_colorspace!(drawn, :srgb)
+  end
+
+  # >6 MP continuous-tone field: a full-range luminance ramp (high palette entropy)
+  # plus softly-blurred noise (high mid-band gradient) → :photo.
+  defp large_photo_image do
+    side = 2480
+    {:ok, xyz} = Vix.Vips.Operation.xyz(side, side)
+    {:ok, x} = Vix.Vips.Operation.extract_band(xyz, 0)
+    {:ok, ramp} = Vix.Vips.Operation.linear(x, [255.0 / (side - 1)], [0.0])
+    {:ok, noise} = Vix.Vips.Operation.gaussnoise(side, side, sigma: 35, mean: 0)
+    {:ok, blurred} = Vix.Vips.Operation.gaussblur(noise, 1.2)
+    {:ok, sum} = Vix.Vips.Operation.add(ramp, blurred)
+    {:ok, uchar} = Vix.Vips.Operation.cast(sum, :VIPS_FORMAT_UCHAR)
+    {:ok, gray} = Vix.Vips.Operation.copy(uchar, interpretation: :VIPS_INTERPRETATION_B_W)
+    {:ok, rgb} = Vix.Vips.Operation.bandjoin([gray, gray, gray])
+    {:ok, srgb} = Vix.Vips.Operation.copy(rgb, interpretation: :VIPS_INTERPRETATION_sRGB)
+    srgb
+  end
+
+  defp crop_resolved do
+    %ImagePipe.Output.Resolved{
+      format: :jpeg,
+      quality: :default,
+      response_headers: [],
+      strip_metadata: true,
+      keep_copyright: false,
+      color_profile: :preserve_source,
+      quality_search: %RQS{
+        objective: :ssim2,
+        target: 80.0,
+        min_quality: 40,
+        max_quality: 95,
+        allowed_error: 1.0,
+        max_resolution: 0,
+        quality_search_offsets: %{photo: 2.4, graphic: 6.0}
+      }
+    }
+  end
+
+  test "classify span selects the graphic offset (6.0) for graphic content" do
+    attach_classify()
+    opts = Telemetry.telemetry_opts(telemetry_prefix: @prefix)
+
+    EncodeSearch.run(large_graphic_image(), crop_resolved(), scorer: :crop, telemetry_opts: opts)
+
+    assert_receive {:classify, meta}
+    assert meta.content_class == :graphic
+    assert meta.applied_offset == 6.0
+    assert is_float(meta.palette_ent) and is_float(meta.nat_var)
+  end
+
+  test "classify span keeps the lean offset (2.4) for photo content" do
+    attach_classify()
+    opts = Telemetry.telemetry_opts(telemetry_prefix: @prefix)
+
+    EncodeSearch.run(large_photo_image(), crop_resolved(), scorer: :crop, telemetry_opts: opts)
+
+    assert_receive {:classify, meta}
+    assert meta.content_class == :photo
+    assert meta.applied_offset == 2.4
+  end
 end

--- a/test/image_pipe/output/encoder_crop_scoring_test.exs
+++ b/test/image_pipe/output/encoder_crop_scoring_test.exs
@@ -52,7 +52,12 @@ defmodule ImagePipe.Output.EncoderCropScoringTest do
         min_quality: 40,
         max_quality: 95,
         allowed_error: 1.0,
-        max_resolution: 0
+        max_resolution: 0,
+        # Content-neutral: both classes subtract the prior global 2.4, so the
+        # full-vs-crop tolerance below is independent of how the zone plate
+        # classifies. The per-class offset behavior is proven in the telemetry/wire
+        # tests, not here.
+        quality_search_offsets: %{photo: 2.4, graphic: 2.4}
       }
     }
   end

--- a/test/image_pipe/output_policy_test.exs
+++ b/test/image_pipe/output_policy_test.exs
@@ -414,6 +414,37 @@ defmodule ImagePipe.Output.PolicyTest do
       assert rs.max_resolution == 16
     end
 
+    test "resolves quality_search_offsets to the per-class map for an avif negotiation" do
+      search = %QualitySearch{
+        objective: :ssim2,
+        target: 78.0,
+        min_quality: 70,
+        max_quality: 80,
+        allowed_error: 1.0
+      }
+
+      assert {:ok, %Resolved{quality_search: %ResolvedQualitySearch{} = rs}} =
+               Policy.resolve(policy_with(search, format: :avif), nil)
+
+      # avif × graphic draws the big offset; photo keeps the lean default.
+      assert rs.quality_search_offsets == %{photo: 2.4, graphic: 6.0}
+    end
+
+    test "a non-avif format keeps the lean default for both classes" do
+      search = %QualitySearch{
+        objective: :ssim2,
+        target: 78.0,
+        min_quality: 70,
+        max_quality: 80,
+        allowed_error: 1.0
+      }
+
+      assert {:ok, %Resolved{quality_search: %ResolvedQualitySearch{} = rs}} =
+               Policy.resolve(policy_with(search, format: :jpeg), nil)
+
+      assert rs.quality_search_offsets == %{photo: 2.4, graphic: 2.4}
+    end
+
     test "none stays none" do
       assert {:ok, %Resolved{quality_search: :none}} = Policy.resolve(policy_with(:none), nil)
     end

--- a/test/image_pipe/plan/output_test.exs
+++ b/test/image_pipe/plan/output_test.exs
@@ -7,4 +7,18 @@ defmodule ImagePipe.Plan.OutputTest do
     assert o.quality_search == :none
     assert o.max_bytes == nil
   end
+
+  test "default quality_search_offsets carries the 2.4 default and the avif×graphic override" do
+    %Output{quality_search_offsets: offsets} = %Output{mode: :automatic}
+    assert offsets.default == 2.4
+    assert Map.fetch!(offsets.overrides, {:avif, :graphic}) == 6.0
+  end
+
+  test "offset_for/3 falls back to the default for unlisted cells" do
+    offsets = Output.default_quality_search_offsets()
+    assert Output.offset_for(offsets, :avif, :graphic) == 6.0
+    assert Output.offset_for(offsets, :avif, :photo) == 2.4
+    assert Output.offset_for(offsets, :jpeg, :graphic) == 2.4
+    assert Output.offset_for(offsets, :webp, :photo) == 2.4
+  end
 end

--- a/test/image_pipe/telemetry/logger_test.exs
+++ b/test/image_pipe/telemetry/logger_test.exs
@@ -115,6 +115,28 @@ defmodule ImagePipe.Telemetry.LoggerTest do
     assert log =~ "encode search: ok (crop hit q72 12345b score 90.42)"
   end
 
+  test "renders the content-class classify span at base level" do
+    Telemetry.attach_default_logger(level: :info)
+
+    log =
+      capture_log(fn ->
+        :telemetry.execute(
+          [:image_pipe, :encode, :classify, :stop],
+          %{duration: System.convert_time_unit(12, :millisecond, :native)},
+          %{
+            result: :ok,
+            content_class: :graphic,
+            applied_offset: 6.0,
+            palette_ent: 0.34,
+            nat_var: 0.11
+          }
+        )
+      end)
+
+    refute log =~ "[warning]"
+    assert log =~ "encode classify: ok (graphic offset 6.0)"
+  end
+
   test "escalates a best-effort encode-search to warning" do
     Telemetry.attach_default_logger(level: :info)
 

--- a/test/image_pipe/telemetry/trace/capture_test.exs
+++ b/test/image_pipe/telemetry/trace/capture_test.exs
@@ -80,6 +80,31 @@ defmodule ImagePipe.Telemetry.Trace.CaptureTest do
     assert span.attributes[:target] == 90.0
   end
 
+  test "captures the content-class classify span with its allowlisted attributes" do
+    Telemetry.span(
+      [],
+      [:encode, :classify],
+      %{},
+      fn ->
+        {:ok,
+         %{
+           result: :ok,
+           content_class: :graphic,
+           applied_offset: 6.0,
+           palette_ent: 0.34,
+           nat_var: 0.11
+         }}
+      end
+    )
+
+    assert_receive {:span, %Span{name: "image_pipe.encode.classify"} = span}
+    assert span.status == :ok
+    assert span.attributes[:content_class] == :graphic
+    assert span.attributes[:applied_offset] == 6.0
+    assert span.attributes[:palette_ent] == 0.34
+    assert span.attributes[:nat_var] == 0.11
+  end
+
   test "captures the encode-search probe as a span nested under the search, with its phase/numbers" do
     Telemetry.span([], [:encode, :search], %{objective: :ssim2}, fn ->
       Telemetry.span(

--- a/test/support/mix/tasks/autoquality.bench.ex
+++ b/test/support/mix/tasks/autoquality.bench.ex
@@ -3838,7 +3838,9 @@ defmodule Mix.Tasks.Autoquality.Bench do
         "nat_var ≥ #{@prod_nat_threshold}) — the frozen ContentClassifier thresholds"
     )
 
-    IO.puts("    photo→photo #{recall}/#{length(photos)}   photo→screen #{length(photos) - recall}")
+    IO.puts(
+      "    photo→photo #{recall}/#{length(photos)}   photo→screen #{length(photos) - recall}"
+    )
 
     IO.puts(
       "    screen→screen #{length(screens) - leak}/#{length(screens)}   " <>

--- a/test/support/mix/tasks/autoquality.bench.ex
+++ b/test/support/mix/tasks/autoquality.bench.ex
@@ -3811,6 +3811,39 @@ defmodule Mix.Tasks.Autoquality.Bench do
         names = Enum.map_join(strong, ",", & &1.name)
         m_rule_report("strong-features AND-rule (sep≥#{@m_strong_sep}: #{names})", rows, strong)
     end
+
+    # The exact rule production ships (#380): :photo iff palette_ent ≥ θ AND nat_var ≥ θ
+    # at the FROZEN `ImagePipe.Output.ContentClassifier` thresholds (not the Youden θ
+    # above — those leak 1 screen→photo on this cohort). screen→photo must be 0.
+    m_production_rule_report(rows)
+  end
+
+  # ContentClassifier's frozen thresholds (#380). Kept in sync with that module by
+  # hand; this report's screen→photo count is the safety evidence for the pair.
+  @prod_palette_threshold 0.82
+  @prod_nat_threshold 0.27
+
+  defp m_production_rule_report(rows) do
+    photo_pred = fn r ->
+      r.palette_entropy >= @prod_palette_threshold and r.natural_variation >= @prod_nat_threshold
+    end
+
+    photos = Enum.filter(rows, &(&1.class == :photo))
+    screens = Enum.filter(rows, &(&1.class == :screen_or_other))
+    recall = Enum.count(photos, photo_pred)
+    leak = Enum.count(screens, photo_pred)
+
+    IO.puts(
+      "\n  PRODUCTION rule (palette_ent ≥ #{@prod_palette_threshold} ∧ " <>
+        "nat_var ≥ #{@prod_nat_threshold}) — the frozen ContentClassifier thresholds"
+    )
+
+    IO.puts("    photo→photo #{recall}/#{length(photos)}   photo→screen #{length(photos) - recall}")
+
+    IO.puts(
+      "    screen→screen #{length(screens) - leak}/#{length(screens)}   " <>
+        "screen→photo #{leak} (TEXT DAMAGE)" <> if(leak == 0, do: "  ✓ safe", else: "  ✗")
+    )
   end
 
   defp m_feature_stat({key, name, _hyp}, photos, screens) do

--- a/test/support/mix/tasks/autoquality.bench.ex
+++ b/test/support/mix/tasks/autoquality.bench.ex
@@ -315,6 +315,7 @@ defmodule Mix.Tasks.Autoquality.Bench do
   use Mix.Task
   use Boundary, top_level?: true, check: [out: false]
 
+  alias ImagePipe.Output.ContentClassifier
   alias ImagePipe.Output.Encoder
   alias ImagePipe.Output.EncodeSearch
   alias ImagePipe.Output.Resolved
@@ -3670,7 +3671,7 @@ defmodule Mix.Tasks.Autoquality.Bench do
     feat_rows = Enum.flat_map(sources, &m_source_rows(&1, downsample))
     resid_rows = m_residual_rows(sources)
 
-    m_report_separation(feat_rows)
+    m_report_separation(feat_rows, downsample)
     m_report_residual(feat_rows, resid_rows)
 
     %{feat: feat_rows, resid: resid_rows}
@@ -3775,9 +3776,10 @@ defmodule Mix.Tasks.Autoquality.Bench do
 
   # --- Part M (a): separation reporting --------------------------------------
 
-  defp m_report_separation([]), do: IO.puts("\nPart M (a): no labeled images in cohort.")
+  defp m_report_separation([], _downsample),
+    do: IO.puts("\nPart M (a): no labeled images in cohort.")
 
-  defp m_report_separation(rows) do
+  defp m_report_separation(rows, downsample) do
     photos = Enum.filter(rows, &(&1.class == :photo))
     screens = Enum.filter(rows, &(&1.class == :screen_or_other))
 
@@ -3813,29 +3815,30 @@ defmodule Mix.Tasks.Autoquality.Bench do
     end
 
     # The exact rule production ships (#380): :photo iff palette_ent ≥ θ AND nat_var ≥ θ
-    # at the FROZEN `ImagePipe.Output.ContentClassifier` thresholds (not the Youden θ
-    # above — those leak 1 screen→photo on this cohort). screen→photo must be 0.
-    m_production_rule_report(rows)
+    # at the FROZEN `ContentClassifier` thresholds (not the Youden θ above — those leak
+    # 1 screen→photo on this cohort). screen→photo must be 0.
+    m_production_rule_report(rows, downsample)
   end
 
-  # ContentClassifier's frozen thresholds (#380). Kept in sync with that module by
-  # hand; this report's screen→photo count is the safety evidence for the pair.
-  @prod_palette_threshold 0.82
-  @prod_nat_threshold 0.27
-
-  defp m_production_rule_report(rows) do
-    photo_pred = fn r ->
-      r.palette_entropy >= @prod_palette_threshold and r.natural_variation >= @prod_nat_threshold
-    end
+  # Evaluate the shipped rule at `ContentClassifier`'s own frozen thresholds (no
+  # hand-synced duplicate) over the labeled cohort; the screen→photo count is the
+  # safety evidence for the pair. The thresholds are calibrated for the 512 px
+  # downsample, so this line only certifies production when run `--downsample 512`.
+  defp m_production_rule_report(rows, downsample) do
+    {palette_t, nat_t} = ContentClassifier.photo_thresholds()
+    photo_pred = fn r -> r.palette_entropy >= palette_t and r.natural_variation >= nat_t end
 
     photos = Enum.filter(rows, &(&1.class == :photo))
     screens = Enum.filter(rows, &(&1.class == :screen_or_other))
     recall = Enum.count(photos, photo_pred)
     leak = Enum.count(screens, photo_pred)
 
+    caveat =
+      if downsample == 512, do: "", else: "  ⚠ calibrated for 512 — rerun --downsample 512"
+
     IO.puts(
-      "\n  PRODUCTION rule (palette_ent ≥ #{@prod_palette_threshold} ∧ " <>
-        "nat_var ≥ #{@prod_nat_threshold}) — the frozen ContentClassifier thresholds"
+      "\n  PRODUCTION rule (palette_ent ≥ #{palette_t} ∧ nat_var ≥ #{nat_t}) — " <>
+        "frozen ContentClassifier thresholds @ downsample #{downsample}#{caveat}"
     )
 
     IO.puts(

--- a/test/support/mix/tasks/autoquality.bench.ex
+++ b/test/support/mix/tasks/autoquality.bench.ex
@@ -3823,8 +3823,10 @@ defmodule Mix.Tasks.Autoquality.Bench do
   # Evaluate the shipped rule at `ContentClassifier`'s own frozen thresholds (no
   # hand-synced duplicate) over the labeled cohort; the screen→photo count is the
   # safety evidence for the pair. The thresholds are calibrated for the 512 px
-  # downsample, so this line only certifies production when run `--downsample 512`.
-  defp m_production_rule_report(rows, downsample) do
+  # downsample, so the safety verdict is only printed (and only valid) at 512 — a
+  # ≠512 run shows the rule but withholds the ✓/✗ so it can't be misread as
+  # certifying the wrong regime.
+  defp m_production_rule_report(rows, 512) do
     {palette_t, nat_t} = ContentClassifier.photo_thresholds()
     photo_pred = fn r -> r.palette_entropy >= palette_t and r.natural_variation >= nat_t end
 
@@ -3833,12 +3835,9 @@ defmodule Mix.Tasks.Autoquality.Bench do
     recall = Enum.count(photos, photo_pred)
     leak = Enum.count(screens, photo_pred)
 
-    caveat =
-      if downsample == 512, do: "", else: "  ⚠ calibrated for 512 — rerun --downsample 512"
-
     IO.puts(
       "\n  PRODUCTION rule (palette_ent ≥ #{palette_t} ∧ nat_var ≥ #{nat_t}) — " <>
-        "frozen ContentClassifier thresholds @ downsample #{downsample}#{caveat}"
+        "frozen ContentClassifier thresholds @ downsample 512 (certifying)"
     )
 
     IO.puts(
@@ -3848,6 +3847,16 @@ defmodule Mix.Tasks.Autoquality.Bench do
     IO.puts(
       "    screen→screen #{length(screens) - leak}/#{length(screens)}   " <>
         "screen→photo #{leak} (TEXT DAMAGE)" <> if(leak == 0, do: "  ✓ safe", else: "  ✗")
+    )
+  end
+
+  defp m_production_rule_report(_rows, downsample) do
+    {palette_t, nat_t} = ContentClassifier.photo_thresholds()
+
+    IO.puts(
+      "\n  PRODUCTION rule (palette_ent ≥ #{palette_t} ∧ nat_var ≥ #{nat_t}) @ downsample " <>
+        "#{downsample} — NOT certifying; the safety verdict only holds at 512, " <>
+        "rerun `--downsample 512`."
     )
   end
 


### PR DESCRIPTION
## Summary

Replaces the single global confirm-skipped crop offset (`@crop_confirm_skipped_offset = 2.4`) with a `{format, content-class} → offset` policy keyed on a cheap libvips content classifier. Above the 6 MP crop crossover (#369), large AVIF renders of **dense graphic/text content** were shipping ~3.7 ssim2 *below* target (silent under-quality) because the crop estimate overshoots full-frame by ~6 there, and the full-frame confirm that would have caught it is what #369 removed for cost. A flat raise to ~6 would over-inflate every AVIF photo; this keys the offset on content class instead.

Validated by the Part M benchmark (#379). The only cell whose behavior changes is **`avif × :graphic` → 6.0**; every other `{format, class}` keeps the lean 2.4 (no byte inflation vs today).

### What changed
- **`ImagePipe.Output.ContentClassifier`** (new) — classifies the finalized image `:photo` / `:graphic` on a 512 px downsample (`palette_ent` ∧ `nat_var` AND-rule, safe `:graphic` fallback). Runs **lazily, only on the `:ssim2` + >6 MP crop path** where the offset is consumed — no cost on other requests. Total: never raises (any libvips error → `:graphic`).
- **`Plan.Output.quality_search_offsets`** — the declarative `{default: 2.4, overrides: %{{:avif, :graphic} => 6.0}}` policy (a defaulted seam, like `flatten_background`; no parser overrides it today), resolved per negotiated format into `ResolvedQualitySearch`.
- **`EncodeSearch`** — the global constant is gone; the per-class offset is classified once and applied in `crop_estimate`. The pure `search/3` core is unchanged.
- **`[:encode, :classify]` telemetry span** on both the default Logger and the OTel exporter (`content_class`, `applied_offset`, `palette_ent`, `nat_var` — product-neutral), with `docs/telemetry.md` updated.

### Pinned constants (Part M bench, downsample 512, 133 photo / 56 screen)
- `palette_ent ≥ 0.82` ∧ `nat_var ≥ 0.27` → `:photo`. Set above the per-feature Youden split (0.70/0.27), which leaks 1 screen→photo (a photo-embedding `qoi_web` screenshot); the frozen pair gives **0 screen→photo** with a 0.048 margin and 71 % photo recall. The bench's `PRODUCTION rule` line (run `--downsample 512`) is the reproducible safety evidence and now consumes `ContentClassifier.photo_thresholds/0` (no hand-synced duplicate).
- `{avif, :graphic}` offset **6.0** — avif×screen residual p90 5.44 overall, `web_sc` (binding dense-text worst case) 6.07.

The architecture is the lazy-at-boundary variant of the issue's design (discussed in the spec): the class is still derived purely from runtime image inspection and the table still lives on `Plan.Output`, but it's classified at the encode boundary rather than carried on `Transform.State`, since it's consumed in exactly one place.

Spec + plan: `docs/superpowers/specs/2026-06-23-autoquality-content-class-offset-design.md`, `docs/superpowers/plans/2026-06-23-autoquality-content-class-offset.md`.

## Test Plan
- [x] `mix precommit` green — format, `compile --warnings-as-errors`, `credo --strict`, `mix test` (2582 tests, 81 properties, 1 doctest, 0 failures)
- [x] Classifier unit tests (`:photo`/`:graphic`/degenerate fallback)
- [x] Resolution test: `Plan.Output.quality_search_offsets` collapses per negotiated format
- [x] Request-boundary contract (`ImagePipe.call/2`): large graphic AVIF → `:graphic`/6.0 + `scorer: :crop`; large photo AVIF → `:photo`/2.4 (no inflation)
- [x] Telemetry: `[:encode, :classify]` span on Logger + OTel Capture surfaces
- [x] Part M bench re-run to pin and verify the constants (0 screen→photo at 512)
- [x] Architecture boundary test (classifier stays in `Output.*`)

The WebP `max_quality` ceiling-bound question (an orthogonal cap lever, not an offset lever) is tracked separately in #381 and intentionally **not** addressed here.

Fixes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic content classification system that distinguishes between photo and graphic images
  * Implemented dynamic crop offset adjustment based on detected content class and output format (e.g., different offsets for AVIF graphics vs photos)
  * Added classification telemetry with metadata tracking

* **Documentation**
  * Added telemetry documentation for new classification events
  * Added design specification and implementation plan

* **Tests**
  * Added classifier validation tests
  * Added wire conformance tests for format and content-class-specific offsets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->