### PR TITLE
debug: tidy Debug.Headers helpers + emit default-quality sentinel

### DIFF
--- a/docs/superpowers/specs/2026-06-25-debug-response-headers-design.md
+++ b/docs/superpowers/specs/2026-06-25-debug-response-headers-design.md
@@ -149,7 +149,7 @@ Flat `X-ImagePipe-*` headers, one fact per header. Timings use `Server-Timing`.
 | `X-ImagePipe-Output-Accept` | `image/avif,...` | request `Accept` echoed (always on; revisit length cap later) |
 | `X-ImagePipe-Output-Width` | `1200` | `Image.width` on finalized image (pre-encode) |
 | `X-ImagePipe-Output-Height` | `900` | `Image.height` |
-| `X-ImagePipe-Output-Quality` | `72` | effective quality: `EncodeSearch.meta.quality` if search ran, else `resolved_output.quality` |
+| `X-ImagePipe-Output-Quality` | `72` | effective quality: `EncodeSearch.meta.quality` if search ran, else `resolved_output.quality`; renders the `default` sentinel when ImagePipe set no quality and the encoder's own default applied (resolves to a number once #389 lands) |
 | `X-ImagePipe-Output-Stripped` | `true` | `resolved_output.strip_metadata` |
 | `X-ImagePipe-Output-Color-Profile` | `srgb` | `resolved_output.color_profile` |
 | `X-ImagePipe-Output-Distance` | `1.0` | JXL native distance selected (JXL output only) |

--- a/lib/image_pipe/debug/headers.ex
+++ b/lib/image_pipe/debug/headers.ex
@@ -56,7 +56,7 @@ defmodule ImagePipe.Debug.Headers do
       kv("x-imagepipe-output-accept", accept),
       kv("x-imagepipe-output-width", info.output_width),
       kv("x-imagepipe-output-height", info.output_height),
-      kv("x-imagepipe-output-quality", quality_value(info.output_quality)),
+      kv("x-imagepipe-output-quality", info.output_quality),
       kv("x-imagepipe-output-stripped", info.output_stripped?),
       kv("x-imagepipe-output-color-profile", info.output_color_profile),
       kv("x-imagepipe-output-distance", info.output_distance)
@@ -112,11 +112,10 @@ defmodule ImagePipe.Debug.Headers do
   defp shrink_header(nil), do: nil
   defp shrink_header(%{w: w, h: h}), do: {"x-imagepipe-shrink", "w=#{w};h=#{h}"}
 
-  defp quality_value(:default), do: nil
-  defp quality_value(value), do: value
-
   # An absent value (nil) or an empty string omits the header. Only the echoed
-  # request Accept can be "" (every other fact is an atom/boolean/number).
+  # request Accept can be "" (every other fact is an atom/boolean/number). An
+  # `:default` output quality stringifies to "default" — the sentinel meaning
+  # ImagePipe set no quality and the encoder's own default applied.
   defp kv(_name, nil), do: nil
   defp kv(_name, ""), do: nil
   defp kv(name, value), do: {name, to_string(value)}

--- a/lib/image_pipe/debug/headers.ex
+++ b/lib/image_pipe/debug/headers.ex
@@ -53,7 +53,7 @@ defmodule ImagePipe.Debug.Headers do
     [
       kv("x-imagepipe-output-format", info.output_format),
       kv("x-imagepipe-output-negotiated", info.output_negotiated?),
-      accept_header(accept),
+      kv("x-imagepipe-output-accept", accept),
       kv("x-imagepipe-output-width", info.output_width),
       kv("x-imagepipe-output-height", info.output_height),
       kv("x-imagepipe-output-quality", quality_value(info.output_quality)),
@@ -112,14 +112,12 @@ defmodule ImagePipe.Debug.Headers do
   defp shrink_header(nil), do: nil
   defp shrink_header(%{w: w, h: h}), do: {"x-imagepipe-shrink", "w=#{w};h=#{h}"}
 
-  defp accept_header(accept) when is_binary(accept) and accept != "",
-    do: {"x-imagepipe-output-accept", accept}
-
-  defp accept_header(_accept), do: nil
-
   defp quality_value(:default), do: nil
   defp quality_value(value), do: value
 
+  # An absent value (nil) or an empty string omits the header. Only the echoed
+  # request Accept can be "" (every other fact is an atom/boolean/number).
   defp kv(_name, nil), do: nil
+  defp kv(_name, ""), do: nil
   defp kv(name, value), do: {name, to_string(value)}
 end

--- a/lib/image_pipe/debug/headers.ex
+++ b/lib/image_pipe/debug/headers.ex
@@ -121,9 +121,5 @@ defmodule ImagePipe.Debug.Headers do
   defp quality_value(value), do: value
 
   defp kv(_name, nil), do: nil
-  defp kv(name, value), do: {name, to_header_value(value)}
-
-  defp to_header_value(value) when is_binary(value), do: value
-  defp to_header_value(value) when is_atom(value), do: Atom.to_string(value)
-  defp to_header_value(value), do: to_string(value)
+  defp kv(name, value), do: {name, to_string(value)}
 end

--- a/test/image_pipe/debug/headers_test.exs
+++ b/test/image_pipe/debug/headers_test.exs
@@ -68,6 +68,15 @@ defmodule ImagePipe.Debug.HeadersTest do
     refute header(headers, "x-imagepipe-source-width")
     refute header(headers, "x-imagepipe-output-format")
     refute header(headers, "x-imagepipe-output-accept")
+    refute header(headers, "x-imagepipe-output-quality")
+  end
+
+  test "renders :default output quality as the \"default\" sentinel" do
+    info = %Info{output_format: :jpeg, output_quality: :default}
+    headers = Headers.render(info, accept: "", cache: :miss)
+
+    assert header(headers, "x-imagepipe-output-quality") ==
+             {"x-imagepipe-output-quality", "default"}
   end
 
   test "renders autoquality block including per-format quality bounds" do


### PR DESCRIPTION
## Summary
Follow-up cleanups to the debug-response-headers rendering helpers (#392), plus one small behavior change to the output-quality header.

### Refactors (no behavior change)
1. **Drop `to_header_value/2`** — it hand-rolled what `to_string/1` already does (every value has a `String.Chars` impl). Folded into `kv/2`.
2. **Omit empty header values in `kv/2`; drop `accept_header/1`** — `kv/2` now treats `""` like `nil` (omit), so the echoed `Accept` folds into a uniform `kv/2` call. `Accept` is the only fact that can be empty.

### Behavior change
3. **Emit a `default` sentinel for unset output quality.** Previously `X-ImagePipe-Output-Quality` was *omitted* when `resolved.quality` was `:default` (ImagePipe sets no quality → the encoder uses its own format default, and ImagePipe doesn't know the number). Now it renders `X-ImagePipe-Output-Quality: default`, so a missing header isn't ambiguous ("default, or collection failed?"). `to_string(:default)` yields `"default"`, which made `quality_value/1` redundant — removed. This resolves to a concrete number for lossy formats once host-config default quality (#389) lands.

`kv/2`'s nil/empty omission is what earns its keep — ~25 field lines drop absent facts via the single `Enum.reject(&is_nil/1)` in `render/2`. The header list shape (`[{name, value}]`) is unchanged. (The separate `accept_header/1` in `sender.ex` for content negotiation is untouched.)

## Test Plan
- [x] `mix test test/image_pipe/debug/headers_test.exs` — 5/5 pass (added: `:default` → `"default"`; `nil` quality still omitted)
- [x] `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict` — clean
- [x] spec catalogue note updated for the sentinel

🤖 Generated with [Claude Code](https://claude.com/claude-code)