### PR TITLE
fix(imgproxy): make debug headers a signed `debug:1` path option

### DIFF
--- a/docs/debug_headers.md
+++ b/docs/debug_headers.md
@@ -19,26 +19,32 @@ Two independent controls must both be satisfied for any header to be emitted:
      allow_debug_headers: true
    ```
 
-2. **Per-request `_debug=1` query parameter** — the trigger. Dialect-neutral
-   (works for imgproxy / IIIF / TwicPics / native), parsed at the request entry
-   boundary. Honored only when `allow_debug_headers: true`; otherwise ignored.
+2. **Per-request trigger** — opts a single request into debug headers. Honored
+   only when `allow_debug_headers: true`; otherwise ignored. The trigger is
+   **dialect-specific**:
+   - **imgproxy**: the `debug:1` processing option, e.g.
+     `/{signature}/rs:fit:400:300/debug:1/plain/images/cat.jpg`. It rides in the
+     signed processing-options path, so imgproxy's path signature covers it.
+   - Other dialects (IIIF / TwicPics) do not currently expose a URL trigger; a
+     caller constructing a plan directly sets `Plan.Response.debug?`.
 
-`_debug=1` does **not** change the produced image bytes: it is excluded from the
-cache key and the ETag, so a `_debug` request and a normal request resolve to the
-same cache entry. (Facts are collected and stored on every generation regardless
-of the flag, so enabling `allow_debug_headers: true` immediately surfaces headers
-for already-cached items, with no cache invalidation.)
+The `debug:1` option does **not** change the produced image bytes: it lives on
+`Plan.Response`, which is excluded from both the cache key and the ETag, so a
+debug request and a plain request resolve to the same cache entry. (Facts are
+collected and stored on every generation regardless of the flag, so enabling
+`allow_debug_headers: true` immediately surfaces headers for already-cached
+items, with no cache invalidation.)
 
 ## Security and disclosure
 
-> **Signed-URL caveat — read before enabling in production.**
-> `_debug=1` is a **query parameter**. imgproxy's built-in signature signs the
-> request **path only**, so it does **not** cover `_debug`. Enabling
-> `allow_debug_headers: true` is safe in production **only** if your URL signing
-> covers the full URL **including the query string** (e.g. CDN/edge signed URLs).
-> If you rely solely on imgproxy path signatures, an attacker can append
-> `?_debug=1` to any otherwise-valid URL and read the debug headers — so leave
-> `allow_debug_headers: false`, or front the deployment with whole-URL signing.
+> **Signing.** For imgproxy, `debug:1` is part of the signed processing-options
+> path, so a configured path signature (HMAC) protects it: an attacker cannot
+> append `debug:1` to an otherwise-valid signed URL without invalidating the
+> signature. (This closes the gap from the earlier `_debug=1` **query**-param
+> trigger, which imgproxy's path-only signature did not cover.) On `unsafe`/
+> unsigned mounts there is no such protection — anyone can add `debug:1` — so
+> enable `allow_debug_headers: true` there only if the disclosed facts below are
+> acceptable to expose.
 
 When triggered, a response discloses: internal source dimensions and
 format/color/ICC/bit-depth/alpha facts; the negotiated output and its
@@ -129,7 +135,8 @@ Server-Timing: decode;dur=8.123, transform;dur=21.0, encode;dur=140.5, cache;dur
 ## Demo (fiddle)
 
 The bundled demo (`fiddle/`) configures its three mounts with
-`allow_debug_headers: true` and adds `_debug=1` to its preview requests. Its
+`allow_debug_headers: true` and adds the `debug:1` processing option to its
+preview requests. Its
 service worker reads these headers off the fetched response and surfaces them in
 a **Debug headers** panel under the preview, including the derived output size and
 compression ratio.

--- a/docs/imgproxy_support_matrix.md
+++ b/docs/imgproxy_support_matrix.md
@@ -1012,6 +1012,7 @@ transforms or output encoding.
 | `expires` | `exp` | Supported | Rejects expired requests before source/cache side effects. |
 | `filename` | `fn` | Supported | Percent-decoded or URL-safe Base64 filename stem. |
 | `return_attachment` | `att` | Supported | Controls `Content-Disposition` disposition. |
+| ➕ `debug` | | Supported (ImagePipe extension) | **No imgproxy counterpart.** `debug:1` (also `debug:true`/`debug:0`/`debug:false`) opts a single request into `X-ImagePipe-*` debug response headers, honored only under the `allow_debug_headers: true` mount flag. Because it rides in the **signed** processing-options path, a configured path signature (HMAC) covers it — an attacker cannot append it to an otherwise-valid signed URL. This replaces the earlier `_debug=1` **query**-param trigger, which imgproxy's path-only signature did not protect (issue #398). Delivery-only: it sets `Plan.Response.debug?` and never affects produced bytes, the cache key, or the ETag (all three exclude `Plan.Response`), so a debug and a plain request share one cache entry. See [debug_headers.md](debug_headers.md). |
 | `preset` | `pr` | Supported | Normal processing URLs support configured named presets, more than one name in one segment, `default` automatic expansion, nested presets with recursive re-entry skipped, and documented chained-pipeline merge semantics. |
 | `hashsum` | `hs` | Missing | Pro source integrity check. |
 

--- a/fiddle/assets/App.svelte
+++ b/fiddle/assets/App.svelte
@@ -76,15 +76,15 @@
   let previewWorkerDisposed = false; // guards the register-promise-vs-unmount race
   let currentRequestId = 0;
   let lastPreviewAbsolute: string | null = null; // dedupe on resolved URL, not raw path
-  const updatePreviewPath = debounce((nextPath: string) => {
-    // Request the preview with `_debug=1` so the debug-enabled mounts emit the
-    // X-ImagePipe-* + Server-Timing headers the SW reads. `_debug` is a reserved
-    // query param (ignored by every dialect parser, excluded from the cache key /
-    // ETag), so it changes nothing about the produced image. It rides ONLY the
-    // preview <img> request — the copyable / "Open" URL (`path`) stays clean.
-    const debugUrl = new URL(nextPath, window.location.origin);
-    debugUrl.searchParams.set("_debug", "1");
-    const absolute = debugUrl.href;
+  const updatePreviewPath = debounce((nextPath: string, provider: string) => {
+    // Request the preview with the imgproxy `debug:1` processing option so the
+    // debug-enabled mount emits the X-ImagePipe-* + Server-Timing headers the SW
+    // reads. `debug:1` rides in the signed processing-options path (HMAC-covered),
+    // is excluded from the cache key / ETag, and changes nothing about the
+    // produced image. It rides ONLY the preview <img> request — the copyable /
+    // "Open" URL (`path`) stays clean. Only imgproxy exposes a debug trigger;
+    // the IIIF / TwicPics previews carry no debug option.
+    const absolute = previewRequestUrl(nextPath, provider);
     // Dedupe on the RESOLVED url (not the raw path): a no-op must never flip
     // previewLoading=true without a following <img> load event, or the spinner
     // would strand. This same absolute is the SW-message correlation key.
@@ -95,8 +95,18 @@
     previewLoading = true;
     previewError = null;
     processedMetadata = null;
-    previewImageUrl = absolute; // same-origin → <img> triggers the real, SW-intercepted request (with _debug=1)
+    previewImageUrl = absolute; // same-origin → <img> triggers the real, SW-intercepted request (with debug:1 for imgproxy)
   }, 150);
+  // Builds the absolute preview-request URL. For imgproxy it injects the
+  // `debug:1` processing option ahead of the `/plain/` source marker; other
+  // dialects are returned unchanged (no debug trigger).
+  function previewRequestUrl(nextPath: string, provider: string): string {
+    const url = new URL(nextPath, window.location.origin);
+    if (provider === "imgproxy") {
+      url.pathname = url.pathname.replace("/plain/", "/debug:1/plain/");
+    }
+    return url.href;
+  }
   const updateFiddleLocation = debounce((nextPath: string) => {
     if (
       typeof window === "undefined" ||
@@ -159,7 +169,7 @@
     }
   });
   $effect(() => {
-    updatePreviewPath(path);
+    updatePreviewPath(path, appState.provider);
   });
   $effect(() => {
     updateFiddleLocation(appPathForState(appState));

--- a/fiddle/lib/image_pipe_fiddle/application.ex
+++ b/fiddle/lib/image_pipe_fiddle/application.ex
@@ -61,7 +61,8 @@ defmodule ImagePipeFiddle.Application do
       # than erroring; the default Logger surfaces any detection fallback.
       detector_required: false,
       # Demo deployment: emit the opt-in X-ImagePipe-* / Server-Timing debug headers.
-      # The fiddle adds `_debug=1` to its preview requests so the panel always populates.
+      # The fiddle adds the `debug:1` processing option to its imgproxy preview
+      # requests so the panel populates (only imgproxy exposes a debug trigger).
       allow_debug_headers: true
     ]
     |> maybe_put_cache(Application.get_env(:image_pipe_fiddle, :cache))

--- a/lib/image_pipe/parser/imgproxy/option_grammar.ex
+++ b/lib/image_pipe/parser/imgproxy/option_grammar.ex
@@ -67,7 +67,8 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammar do
     "keep_copyright" => {:keep_copyright, [:keep_copyright]},
     "kcr" => {:keep_copyright, [:keep_copyright]},
     "preserve_hdr" => {:preserve_hdr, [:preserve_hdr]},
-    "ph" => {:preserve_hdr, [:preserve_hdr]}
+    "ph" => {:preserve_hdr, [:preserve_hdr]},
+    "debug" => {:debug, [:debug]}
   }
 
   # Declarative specs for regular fixed-arity pipeline options. Each entry maps
@@ -172,7 +173,7 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammar do
 
   defp scoped_assignments(:expires, assignments), do: {:policy, assignments}
 
-  defp scoped_assignments(kind, assignments) when kind in [:filename, :return_attachment],
+  defp scoped_assignments(kind, assignments) when kind in [:filename, :return_attachment, :debug],
     do: {:response, assignments}
 
   defp scoped_assignments(_kind, assignments), do: {:pipeline, assignments}
@@ -228,6 +229,17 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammar do
     case parse_boolean(value) do
       {:ok, true} -> {:ok, [disposition: :attachment]}
       {:ok, false} -> {:ok, [disposition: :inline]}
+      {:error, {:invalid_boolean, _value}} -> {:error, {:invalid_option_segment, segment}}
+    end
+  end
+
+  # `debug:1` opts the response into `X-ImagePipe-*` debug headers. It lives in
+  # the signed processing-options path (not a query param), so imgproxy's path
+  # HMAC covers it; it does not affect produced bytes, the cache key, or the ETag
+  # (it rides on `Plan.Response`, which all three exclude).
+  defp parse_known_option(:debug, [:debug], [value], segment) when value != "" do
+    case parse_boolean(value) do
+      {:ok, debug?} -> {:ok, [debug?: debug?]}
       {:error, {:invalid_boolean, _value}} -> {:error, {:invalid_option_segment, segment}}
     end
   end

--- a/lib/image_pipe/parser/imgproxy/parsed_request.ex
+++ b/lib/image_pipe/parser/imgproxy/parsed_request.ex
@@ -17,7 +17,7 @@ defmodule ImagePipe.Parser.Imgproxy.ParsedRequest do
   }
   @default_policy %{expires: 0}
   @default_cache %{cachebuster: nil}
-  @default_response %{filename: nil, disposition: :default}
+  @default_response %{filename: nil, disposition: :default, debug?: false}
 
   @enforce_keys [:signature, :source_kind, :source_path, :pipelines]
   defstruct @enforce_keys ++
@@ -48,7 +48,8 @@ defmodule ImagePipe.Parser.Imgproxy.ParsedRequest do
   @type cache_request() :: %{required(:cachebuster) => String.t() | nil}
   @type response_request() :: %{
           required(:filename) => String.t() | nil,
-          required(:disposition) => :default | :inline | :attachment
+          required(:disposition) => :default | :inline | :attachment,
+          required(:debug?) => boolean()
         }
 
   @type t() :: %__MODULE__{

--- a/lib/image_pipe/parser/imgproxy/plan_builder.ex
+++ b/lib/image_pipe/parser/imgproxy/plan_builder.ex
@@ -189,19 +189,19 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilder do
     do: {:ok, cachebuster}
 
   defp response_plan(
-         %{filename: nil, disposition: disposition},
+         %{filename: nil, disposition: disposition, debug?: debug?},
          source
        ) do
-    {:ok, %Response{filename: source_filename(source), disposition: disposition}}
+    {:ok, %Response{filename: source_filename(source), disposition: disposition, debug?: debug?}}
   end
 
   defp response_plan(
-         %{filename: filename, disposition: disposition},
+         %{filename: filename, disposition: disposition, debug?: debug?},
          _source
        )
        when is_binary(filename) do
     if Response.valid_filename?(filename) do
-      {:ok, %Response{filename: filename, disposition: disposition}}
+      {:ok, %Response{filename: filename, disposition: disposition, debug?: debug?}}
     else
       {:error, {:invalid_filename, filename}}
     end

--- a/lib/image_pipe/plan/response.ex
+++ b/lib/image_pipe/plan/response.ex
@@ -3,16 +3,22 @@ defmodule ImagePipe.Plan.Response do
   Delivery metadata attached to an `ImagePipe.Plan`.
 
   Parsers use this struct for response-specific request options such as
-  `Content-Disposition` and delivery filename selection.
+  `Content-Disposition`, delivery filename selection, and the per-request
+  `debug?` opt-in for `X-ImagePipe-*` debug headers.
+
+  `debug?` is delivery-only: it never affects the produced image bytes, the
+  cache key, or the ETag (none of which read `Plan.Response`), so a debug and a
+  plain request resolve to the same cached entry.
   """
 
   @delivery_content_types ["image/jxl", "image/jpeg", "image/png", "image/webp", "image/avif"]
 
-  defstruct disposition: :default, filename: nil
+  defstruct disposition: :default, filename: nil, debug?: false
 
   @type t :: %__MODULE__{
           disposition: :default | :inline | :attachment,
-          filename: String.t() | nil
+          filename: String.t() | nil,
+          debug?: boolean()
         }
 
   @doc """

--- a/lib/image_pipe/plug.ex
+++ b/lib/image_pipe/plug.ex
@@ -59,7 +59,6 @@ defmodule ImagePipe.Plug do
 
   defp do_call(%Plug.Conn{} = conn, opts) do
     parser = Keyword.fetch!(opts, :parser)
-    opts = put_debug_flag(conn, opts)
 
     case parse(conn, parser, opts) do
       {:redirect, status, location} ->
@@ -82,6 +81,7 @@ defmodule ImagePipe.Plug do
          {:ok, %Source.Resolved{} = resolved_source} <-
            Source.resolve(plan.source, opts, Options.source_runtime_opts(opts)) do
       opts = Runner.with_detector_identity(opts, plan)
+      opts = put_debug_flag(plan, opts)
       prepared_http_cache = HTTPCache.prepare(conn, plan, resolved_source, opts)
       send_conditional_response(conn, plan, resolved_source, prepared_http_cache, opts)
     else
@@ -249,24 +249,17 @@ defmodule ImagePipe.Plug do
     |> Parser.validate_options!(opts)
   end
 
-  # `_debug=1` is the per-request trigger, honored only when the mount opted in
-  # via `allow_debug_headers`. It is a reserved query param: it does not affect
-  # the parsed plan, cache key, or ETag (those derive from the plan + Accept), so
-  # it needs no stripping — only gating.
-  defp put_debug_flag(%Plug.Conn{} = conn, opts) do
-    Keyword.put(opts, :debug?, debug_requested?(conn, opts))
+  # Debug headers are gated by two independent controls: the mount-level
+  # `allow_debug_headers` opt-in and the per-request `debug?` flag the parser
+  # surfaces on `Plan.Response`. For imgproxy that flag is the `debug:1`
+  # processing option, which rides in the signed path (HMAC-covered). The flag
+  # never affects the cache key or ETag (both exclude `Plan.Response`), so a
+  # debug and a plain request resolve to the same cached entry.
+  defp put_debug_flag(%Plan{} = plan, opts) do
+    Keyword.put(opts, :debug?, debug_requested?(plan, opts))
   end
 
-  defp debug_requested?(%Plug.Conn{} = conn, opts) do
-    Keyword.get(opts, :allow_debug_headers, false) and debug_param_truthy?(conn)
-  end
-
-  defp debug_param_truthy?(%Plug.Conn{} = conn) do
-    conn = Plug.Conn.fetch_query_params(conn)
-
-    case conn.query_params do
-      %{"_debug" => value} -> value in ["1", "true", ""]
-      _ -> false
-    end
+  defp debug_requested?(%Plan{response: response}, opts) do
+    Keyword.get(opts, :allow_debug_headers, false) and response.debug?
   end
 end

--- a/test/image_pipe/debug_headers_wire_test.exs
+++ b/test/image_pipe/debug_headers_wire_test.exs
@@ -200,11 +200,31 @@ defmodule ImagePipe.DebugHeadersWireTest do
     conn |> get_resp_header(name) |> List.first()
   end
 
+  # Injects the `debug:1` processing option into an imgproxy path. The option
+  # rides in the signed processing-options segment (before `/plain/`), so it is
+  # covered by the path HMAC — unlike the old `?_debug=1` query param.
+  defp with_debug(path), do: String.replace(path, "/plain/", "/debug:1/plain/")
+
+  # Hex-encoded "test-key" / "test-salt", matching the signed mount config below.
+  @sig_keys ["746573742d6b6579"]
+  @sig_salts ["746573742d73616c74"]
+
+  defp signed_request_path(signed_path) do
+    key = Base.decode16!(hd(@sig_keys), case: :lower)
+    salt = Base.decode16!(hd(@sig_salts), case: :lower)
+
+    signature =
+      :crypto.mac(:hmac, :sha256, key, salt <> signed_path)
+      |> Base.url_encode64(padding: false)
+
+    "/" <> signature <> signed_path
+  end
+
   # ---------------------------------------------------------------------------
   # G1 — wire-level miss-path gate tests
   # ---------------------------------------------------------------------------
 
-  test "no debug headers without _debug param, even when allow_debug_headers: true" do
+  test "no debug headers without the debug option, even when allow_debug_headers: true" do
     conn = call(request_path(), base_opts(allow_debug_headers: true))
 
     assert conn.status == 200
@@ -213,16 +233,25 @@ defmodule ImagePipe.DebugHeadersWireTest do
     assert header(conn, "server-timing") == nil
   end
 
-  test "no debug headers with _debug=1 when allow_debug_headers: false (default)" do
-    conn = call(request_path() <> "?_debug=1", base_opts(allow_debug_headers: false))
+  test "the _debug=1 query param is no longer a trigger (replaced by debug:1)" do
+    conn = call(request_path() <> "?_debug=1", base_opts(allow_debug_headers: true))
+
+    assert conn.status == 200
+    assert header(conn, "x-imagepipe-output-format") == nil
+    assert header(conn, "x-imagepipe-cache") == nil
+    assert header(conn, "server-timing") == nil
+  end
+
+  test "no debug headers with debug:1 when allow_debug_headers: false (default)" do
+    conn = call(with_debug(request_path()), base_opts(allow_debug_headers: false))
 
     assert conn.status == 200
     assert header(conn, "x-imagepipe-output-format") == nil
     assert header(conn, "x-imagepipe-cache") == nil
   end
 
-  test "debug headers present with _debug=1 when allow_debug_headers: true (cache miss)" do
-    conn = call(request_path() <> "?_debug=1", base_opts(allow_debug_headers: true))
+  test "debug headers present with debug:1 when allow_debug_headers: true (cache miss)" do
+    conn = call(with_debug(request_path()), base_opts(allow_debug_headers: true))
 
     assert conn.status == 200
 
@@ -256,11 +285,11 @@ defmodule ImagePipe.DebugHeadersWireTest do
   # ---------------------------------------------------------------------------
 
   describe "cache identity invariance" do
-    test "_debug=1 does not change the generated ETag" do
+    test "debug:1 does not change the generated ETag" do
       opts = stable_opts(allow_debug_headers: true)
 
       plain = call(stable_request_path(), opts)
-      debug = call(stable_request_path() <> "?_debug=1", opts)
+      debug = call(with_debug(stable_request_path()), opts)
 
       plain_etag = header(plain, "etag")
       debug_etag = header(debug, "etag")
@@ -268,10 +297,10 @@ defmodule ImagePipe.DebugHeadersWireTest do
       assert is_binary(plain_etag), "expected plain request to carry an ETag"
 
       assert plain_etag == debug_etag,
-             "expected _debug=1 not to change ETag; got plain=#{inspect(plain_etag)} debug=#{inspect(debug_etag)}"
+             "expected debug:1 not to change ETag; got plain=#{inspect(plain_etag)} debug=#{inspect(debug_etag)}"
     end
 
-    test "conditional GET with _debug=1 still 304s against the plain ETag" do
+    test "conditional GET with debug:1 still 304s against the plain ETag" do
       opts = stable_opts(allow_debug_headers: true)
       plain = call(stable_request_path(), opts)
       etag = header(plain, "etag")
@@ -279,12 +308,44 @@ defmodule ImagePipe.DebugHeadersWireTest do
       assert is_binary(etag), "expected initial request to carry an ETag"
 
       conn =
-        conn(:get, stable_request_path() <> "?_debug=1")
+        conn(:get, with_debug(stable_request_path()))
         |> put_req_header("if-none-match", etag)
         |> ImagePipe.Plug.call(ImagePipe.Plug.init(opts))
 
       assert conn.status == 304,
-             "expected conditional GET with _debug=1 to 304; got #{conn.status}"
+             "expected conditional GET with debug:1 to 304; got #{conn.status}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Signature coverage (issue #398) — debug:1 rides in the signed path, so
+  # imgproxy's path HMAC protects it. An attacker cannot append it to an
+  # otherwise-valid signed URL.
+  # ---------------------------------------------------------------------------
+
+  describe "signature coverage" do
+    defp signed_opts(overrides) do
+      base_opts(overrides)
+      |> Keyword.put(:imgproxy, signature: [keys: @sig_keys, salts: @sig_salts])
+    end
+
+    test "a correctly signed URL carrying debug:1 renders debug headers" do
+      signed_path = "/rs:fit:400:300/f:jpeg/debug:1/plain/images/beach.jpg"
+      conn = call(signed_request_path(signed_path), signed_opts(allow_debug_headers: true))
+
+      assert conn.status == 200
+      assert header(conn, "x-imagepipe-cache") == "miss"
+      assert header(conn, "x-imagepipe-source-format") == "jpeg"
+    end
+
+    test "injecting debug:1 into an otherwise-valid signed URL invalidates the signature" do
+      # Sign a path WITHOUT debug:1, then inject it — the HMAC no longer matches.
+      signed_path = "/rs:fit:400:300/f:jpeg/plain/images/beach.jpg"
+      tampered = with_debug(signed_request_path(signed_path))
+
+      conn = call(tampered, signed_opts(allow_debug_headers: true))
+
+      assert conn.status == 403
     end
   end
 
@@ -292,14 +353,14 @@ defmodule ImagePipe.DebugHeadersWireTest do
   # G3 — autoquality AQ-* header coverage
   # ---------------------------------------------------------------------------
 
-  test "autoquality ssim2 request emits AQ-* headers with _debug=1" do
+  test "autoquality ssim2 request emits AQ-* headers with debug:1" do
     opts =
       large_ssim2_opts(
         allow_debug_headers: true,
         imgproxy: [autoquality_method: :ssimulacra2, autoquality_target: 85]
       )
 
-    conn = call(autoquality_path() <> "?_debug=1", opts)
+    conn = call(with_debug(autoquality_path()), opts)
 
     assert conn.status == 200
 
@@ -320,7 +381,7 @@ defmodule ImagePipe.DebugHeadersWireTest do
       {opts, cache_root} = cached_opts(allow_debug_headers: true)
 
       try do
-        miss = call(request_path() <> "?_debug=1", opts)
+        miss = call(with_debug(request_path()), opts)
         assert miss.status == 200
         assert header(miss, "x-imagepipe-cache") == "miss"
         assert_received :origin_fetch
@@ -328,7 +389,7 @@ defmodule ImagePipe.DebugHeadersWireTest do
         miss_output_width = header(miss, "x-imagepipe-output-width")
         assert is_binary(miss_source_format)
 
-        hit = call(request_path() <> "?_debug=1", opts)
+        hit = call(with_debug(request_path()), opts)
         assert hit.status == 200
         assert hit.resp_body == miss.resp_body
         refute_received :origin_fetch
@@ -354,7 +415,7 @@ defmodule ImagePipe.DebugHeadersWireTest do
       try do
         # Generated while debug output was OFF — no debug headers, but facts are
         # collected and stored unconditionally.
-        off = call(request_path() <> "?_debug=1", Keyword.put(base, :allow_debug_headers, false))
+        off = call(with_debug(request_path()), Keyword.put(base, :allow_debug_headers, false))
         assert off.status == 200
         assert header(off, "x-imagepipe-cache") == nil
         assert header(off, "x-imagepipe-source-format") == nil
@@ -362,7 +423,7 @@ defmodule ImagePipe.DebugHeadersWireTest do
 
         # Same path, now with the mount flag ON. Reuses the cached entry (flag is
         # not in the key) and replays the stored facts — no origin re-fetch.
-        on = call(request_path() <> "?_debug=1", Keyword.put(base, :allow_debug_headers, true))
+        on = call(with_debug(request_path()), Keyword.put(base, :allow_debug_headers, true))
         assert on.status == 200
         assert on.resp_body == off.resp_body
         refute_received :origin_fetch
@@ -376,15 +437,15 @@ defmodule ImagePipe.DebugHeadersWireTest do
       end
     end
 
-    test "_debug and a plain request share one cache entry; a plain hit emits no debug headers" do
+    test "debug:1 and a plain request share one cache entry; a plain hit emits no debug headers" do
       {opts, cache_root} = cached_opts(allow_debug_headers: true)
 
       try do
-        first = call(request_path() <> "?_debug=1", opts)
+        first = call(with_debug(request_path()), opts)
         assert first.status == 200
         assert_received :origin_fetch
 
-        # Plain request (no _debug): hits the same entry, identical bytes, and
+        # Plain request (no debug:1): hits the same entry, identical bytes, and
         # renders NO debug headers despite the stored facts. (A different cache
         # key would miss and re-fetch — so this also proves key invariance.)
         plain = call(request_path(), opts)

--- a/test/parser/imgproxy/option_grammar_test.exs
+++ b/test/parser/imgproxy/option_grammar_test.exs
@@ -631,6 +631,24 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammarTest do
     end
   end
 
+  describe "debug" do
+    test "debug:1 / debug:true parse a truthy response-scoped flag" do
+      assert OptionGrammar.parse("debug:1") == {:ok, {:response, [debug?: true]}}
+      assert OptionGrammar.parse("debug:true") == {:ok, {:response, [debug?: true]}}
+    end
+
+    test "debug:0 / debug:false parse an explicitly disabled flag" do
+      assert OptionGrammar.parse("debug:0") == {:ok, {:response, [debug?: false]}}
+      assert OptionGrammar.parse("debug:false") == {:ok, {:response, [debug?: false]}}
+    end
+
+    test "debug with a missing or malformed value is rejected" do
+      assert {:error, {:invalid_option_segment, "debug:"}} = OptionGrammar.parse("debug:")
+      assert {:error, {:invalid_option_segment, "debug:x"}} = OptionGrammar.parse("debug:x")
+      assert {:error, {:invalid_option_segment, "debug:1:2"}} = OptionGrammar.parse("debug:1:2")
+    end
+  end
+
   defp color!(red, green, blue) do
     assert {:ok, color} = Color.rgb(red, green, blue)
     color

--- a/test/parser/imgproxy/options_test.exs
+++ b/test/parser/imgproxy/options_test.exs
@@ -230,6 +230,14 @@ defmodule ImagePipe.Parser.Imgproxy.OptionsTest do
     assert request.response.disposition == :attachment
   end
 
+  test "debug option accumulates onto the response map and defaults off" do
+    assert {:ok, request} = Options.parse([], Presets.empty())
+    assert request.response.debug? == false
+
+    assert {:ok, request} = Options.parse(~w(debug:1), Presets.empty())
+    assert request.response.debug? == true
+  end
+
   test "max_bytes and autoquality accumulate onto the output map" do
     assert {:ok, request} =
              Options.parse(

--- a/test/parser/imgproxy/plan_builder_test.exs
+++ b/test/parser/imgproxy/plan_builder_test.exs
@@ -1268,6 +1268,21 @@ defmodule ImagePipe.Parser.Imgproxy.PlanBuilderTest do
             }} = PlanBuilder.to_plan(request, clock: fn -> ~U[2026-05-05 12:00:00Z] end)
   end
 
+  test "carries the response debug? flag onto the plan, defaulting off" do
+    base = %ParsedRequest{
+      signature: "_",
+      source_kind: :plain,
+      source_path: "images/cat.jpg",
+      pipelines: [%PipelineRequest{}],
+      output: output_request()
+    }
+
+    assert {:ok, %Plan{response: %Response{debug?: false}}} = PlanBuilder.to_plan(base, [])
+
+    debug = %{base | response: response_request(debug?: true)}
+    assert {:ok, %Plan{response: %Response{debug?: true}}} = PlanBuilder.to_plan(debug, [])
+  end
+
   test "derives response filename stem from source basename when omitted" do
     assert {:ok,
             %Plan{


### PR DESCRIPTION
## What

Closes the signed-URL gap from the debug-headers feature (#398). The debug-header trigger was the `_debug=1` **query** param, which sits outside imgproxy's path-only HMAC — an attacker could append `?_debug=1` to any otherwise-valid signed URL and read the debug headers. This replaces it with a `debug:1` imgproxy **processing option** that rides in the signed processing-options path, so imgproxy's existing path signature protects it.

## How

- **Grammar** (`OptionGrammar`): new `debug` option — `debug:1` / `debug:0` / `debug:true` / `debug:false`, scoped to `:response`.
- **Plan**: new `Plan.Response.debug?` field. It is already excluded from **both** the cache key (`Cache.Key` reads `output`/`pipelines`/`auto_rotate`/`render`/`cachebuster`) and the ETag (`etag_material` uses the same `Key.plan_material`), so the "debug and plain share one cache entry" / "ETag unchanged" invariants hold with **zero special-casing**.
- **Wiring**: `ParsedRequest.response_request` default + `Options.update_response` → `PlanBuilder.response_plan` → `Plan.Response.debug?`.
- **Gate** (`Plug`): now computes `debug? = allow_debug_headers AND plan.response.debug?` *after* parsing; the query read is deleted. `Response.Sender` is unchanged.

## Scope decision

The dialect-neutral `_debug=1` query trigger is **dropped entirely** (it was advertised but untested for non-imgproxy dialects). IIIF/TwicPics no longer expose a URL debug trigger; a caller constructing a plan directly sets `Plan.Response.debug?`. Consequence: the fiddle's debug panel now populates for the **imgproxy** mount only.

## Tests

- The debug-headers wire suite now drives debug via the signed `debug:1` path option (incl. ETag-stability, shared-cache-entry, and 304 cases).
- New guards: `?_debug=1` query is ignored; **injecting `debug:1` into an otherwise-valid signed URL returns `403`** (the core #398 proof).
- Grammar / options / plan-builder unit coverage for the new option.

## Docs + demo

- `docs/debug_headers.md`: signing caveat rewritten — the hole is closed under imgproxy path signing, still open on `unsafe`/unsigned mounts.
- `docs/imgproxy_support_matrix.md`: new `➕ debug` extension row (surface axis).
- Fiddle injects `debug:1` into imgproxy preview requests (preview-only; copy/Open URL stays clean).

## Verification

- `mise run precommit` green (2752 passed: format / compile --warnings-as-errors / credo --strict / test).
- Fiddle: `mix format`/`compile --warnings-as-errors`/`mix test` (16) green; JS `test` (286) / `check` / `format:check` / `lint` / `build` green. (The fresh-worktree `precommit:fiddle` ordering runs the fiddle `mix test` before the Vite build; verified green after building the manifest.)

Fixes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)