### PR TITLE
feat(debug): per-request debug-header triggers for IIIF and TwicPics

### DIFF
--- a/docs/debug_headers.md
+++ b/docs/debug_headers.md
@@ -25,10 +25,19 @@ Two independent controls must both be satisfied for any header to be emitted:
    - **imgproxy**: the `debug:1` processing option, e.g.
      `/{signature}/rs:fit:400:300/debug:1/plain/images/cat.jpg`. It rides in the
      signed processing-options path, so imgproxy's path signature covers it.
-   - Other dialects (IIIF / TwicPics) do not currently expose a URL trigger; a
-     caller constructing a plan directly sets `Plan.Response.debug?`.
+   - **TwicPics**: a `debug=1` segment in the `twic` manipulation chain, e.g.
+     `/images/cat.jpg?twic=v1/resize=400/debug=1`. Order-independent; emits no
+     transform.
+   - **IIIF**: a `?debug=1` query param, e.g.
+     `/iiif/cat/full/400,/0/default.jpg?debug=1`. The IIIF path grammar has no
+     free slot, so the trigger is an out-of-band query param (read leniently — a
+     malformed value is ignored, never a 400).
 
-The `debug:1` option does **not** change the produced image bytes: it lives on
+   All triggers accept the boolean spellings `1`/`true`. imgproxy and TwicPics
+   also accept `0`/`false` to explicitly opt out. The TwicPics and IIIF triggers
+   are **not signature-protected** — see below.
+
+A debug trigger does **not** change the produced image bytes: it lives on
 `Plan.Response`, which is excluded from both the cache key and the ETag, so a
 debug request and a plain request resolve to the same cache entry. (Facts are
 collected and stored on every generation regardless of the flag, so enabling
@@ -45,6 +54,12 @@ items, with no cache invalidation.)
 > unsigned mounts there is no such protection — anyone can add `debug:1` — so
 > enable `allow_debug_headers: true` there only if the disclosed facts below are
 > acceptable to expose.
+>
+> **TwicPics / IIIF** have no request signing at all, so their `debug=1` /
+> `?debug=1` triggers are **always unprotected** — anyone who can reach the mount
+> can add them. Enable `allow_debug_headers: true` on those mounts only if the
+> disclosed facts below are acceptable to expose. (If those dialects gain signing
+> later, the trigger should ride the signed material.)
 
 When triggered, a response discloses: internal source dimensions and
 format/color/ICC/bit-depth/alpha facts; the negotiated output and its
@@ -135,8 +150,8 @@ Server-Timing: decode;dur=8.123, transform;dur=21.0, encode;dur=140.5, cache;dur
 ## Demo (fiddle)
 
 The bundled demo (`fiddle/`) configures its three mounts with
-`allow_debug_headers: true` and adds the `debug:1` processing option to its
-preview requests. Its
+`allow_debug_headers: true` and injects each dialect's debug trigger into its
+preview requests (imgproxy `debug:1`, TwicPics `debug=1`, IIIF `?debug=1`). Its
 service worker reads these headers off the fetched response and surfaces them in
 a **Debug headers** panel under the preview, including the derived output size and
 compression ratio.

--- a/docs/iiif_3_support_matrix.md
+++ b/docs/iiif_3_support_matrix.md
@@ -14,7 +14,7 @@ Each row tracks one of three axes (same discipline as `docs/imgproxy_support_mat
 | **Stage / order** | Do we run compatible processing stages in IIIF order? | "Processing order" + the shared native pipeline (`docs/imgproxy_support_matrix.md`) |
 | **Behavioral / pixel** | Does a matching request produce conformant output? | the wire tests (`test/parser/iiif_wire_test.exs`) + the official `image-validator` gate + the "Diverges" notes |
 
-Status legend: ✅ supported · ➖ deliberately deferred (an optional `extraFeature`) · ⚠️ supported with a documented divergence.
+Status legend: ✅ supported · ➖ deliberately deferred (an optional `extraFeature`) · ⚠️ supported with a documented divergence · ➕ ImagePipe extension (no IIIF counterpart).
 
 ## Compliance level
 
@@ -108,6 +108,7 @@ Emitted from the **display** dimensions (`SourceInfo.display_dimensions/1`, so E
 | `cors` | ✅ | `Access-Control-Allow-Origin: *` on every IIIF response (image, info.json, redirect, errors) + `OPTIONS` preflight → 200, applied by the mount-level `ImagePipe.Parser.IIIF.CORS` plug (the parser's `parse/2` returns a tuple, not a conn, so CORS *must* be mount-level). |
 | Percent-encoded path segments | ✅ | Every token (`{identifier}`/`{region}`/`{size}`/`{rotation}`/`{quality}`/`{format}`) is percent-decoded per RFC 3986, so e.g. `^` sent as `%5E` or `:` as `%3A` is treated identically to its literal form (`ImagePipe.Parser.IIIF.Path.classify/1`). |
 | `jsonldMediaType` | ✅ | See info.json negotiation. |
+| `?debug=1` query param | ➕ | **No IIIF counterpart.** Opts a single image request into `X-ImagePipe-*` debug response headers, honored only under the `allow_debug_headers: true` mount flag. The IIIF path grammar has no free slot, so the trigger is an out-of-band query param, read **leniently** — only `1`/`true` enable it; any other value (absent, `0`, `false`, garbage) is ignored, never a 400. Sets `Plan.Response.debug?` (excluded from the cache key and ETag), so it never affects produced bytes or cache identity. Applies to image requests only (not `info.json`). Deliberately **not** advertised as an `extraFeature` in `info.json` (§4.9 says extensions *should* be listed, but advertising an unsigned disclosure trigger publicly is undesirable). **Unprotected:** IIIF has no request signing, so anyone reaching the mount can add it — see [debug_headers.md](debug_headers.md). |
 | Canonical `Link` header (`rel="canonical"`) | ➖ | Optional (`may` per spec); not implemented. Computing the canonical-spelling URL and threading a per-request response header is deferred; the validator does not require it. |
 
 - **Tiled region extraction** — tiled `{x,y,w,h}/{w,h}` requests reuse the existing region-crop + resize path (`regionByPx` + `sizeByWh` → `:stretch`); there is no IIIF-specific tiling stage. Shrink-on-load **engages** for the crop+downscale tile shape (verified: a deep-scale-factor tile decodes the source at reduced resolution — `DecodePlanner` returns `shrink: 4` for a 4096-region→512 tile from a 6000×4000 source; see `test/image_pipe/transform/iiif_tile_decode_test.exs`). End-to-end memory high-water + info/derivative caching are tracked as a follow-up.

--- a/docs/imgproxy_support_matrix.md
+++ b/docs/imgproxy_support_matrix.md
@@ -722,8 +722,8 @@ has no built-in cloud cache adapters.
 ImagePipe supports URL `return_attachment`/`att` per request. It doesn't expose
 Imgproxy's global response-header, ETag/Last-Modified, TTL, canonical-link, or
 default attachment configuration knobs. ImagePipe provides its own opt-in
-`x-imagepipe-*` debug headers (`allow_debug_headers` mount option + `_debug=1`
-query param); it does not implement Imgproxy's `IMGPROXY_ENABLE_DEBUG_HEADERS`
+`x-imagepipe-*` debug headers (`allow_debug_headers` mount option + the signed
+`debug:1` processing option); it does not implement Imgproxy's `IMGPROXY_ENABLE_DEBUG_HEADERS`
 contract (`X-Origin-*`/`X-Result-*`). Host Plugs can add fixed response headers
 outside ImagePipe.
 

--- a/docs/twicpics_support_matrix.md
+++ b/docs/twicpics_support_matrix.md
@@ -44,6 +44,7 @@ Source index: <https://www.twicpics.com/llms.txt>
 | Status | Meaning |
 | --- | --- |
 | ✅ Supported | The parser translates this into `ImagePipe.Plan` or another request facet. |
+| ➕ Extension | An ImagePipe feature with no TwicPics counterpart, exposed through the dialect grammar. |
 | 📋 Planned (v1) | Scoped for the first iteration, not yet implemented. Flip to ✅ when it lands. |
 | ⚠️ Partial | Some TwicPics syntax or semantics supported, but not the whole option. |
 | 🔗 URL-only | Supported as a request option, but not a TwicPics dashboard / config default. |
@@ -137,6 +138,12 @@ Mapped against [API Parameters](https://www.twicpics.com/docs/reference/paramete
 | `output=h264\|h265\|vp9` | 🛑 Out of scope | Video output codecs. |
 | `quality=1..100` | ✅ Supported | `Plan.Output` quality. |
 | `quality-max` / `quality-min` | 🚫 Rejected | Conditional variants deferred. |
+
+## Debug headers (ImagePipe extension)
+
+| Chain segment | Status | Notes |
+| --- | --- | --- |
+| `debug=1` (also `true`/`0`/`false`) | ➕ Extension | **No TwicPics counterpart.** Opts a single request into `X-ImagePipe-*` debug response headers, honored only under the `allow_debug_headers: true` mount flag. Sets `Plan.Response.debug?` and emits no operation, so it is **order-independent** and never affects produced bytes, the cache key, or the ETag (all three exclude `Plan.Response`). An invalid value is rejected (`{:invalid_debug, value}`) before side effects, like any bad chain segment. **Unprotected:** TwicPics has no request signing, so anyone reaching the mount can add it — see [debug_headers.md](debug_headers.md). |
 
 ## Metadata and orientation
 

--- a/fiddle/assets/App.svelte
+++ b/fiddle/assets/App.svelte
@@ -77,13 +77,11 @@
   let currentRequestId = 0;
   let lastPreviewAbsolute: string | null = null; // dedupe on resolved URL, not raw path
   const updatePreviewPath = debounce((nextPath: string, provider: string) => {
-    // Request the preview with the imgproxy `debug:1` processing option so the
-    // debug-enabled mount emits the X-ImagePipe-* + Server-Timing headers the SW
-    // reads. `debug:1` rides in the signed processing-options path (HMAC-covered),
-    // is excluded from the cache key / ETag, and changes nothing about the
+    // Request the preview with each dialect's debug trigger so the debug-enabled
+    // mount emits the X-ImagePipe-* + Server-Timing headers the SW reads. The
+    // trigger is excluded from the cache key / ETag and changes nothing about the
     // produced image. It rides ONLY the preview <img> request — the copyable /
-    // "Open" URL (`path`) stays clean. Only imgproxy exposes a debug trigger;
-    // the IIIF / TwicPics previews carry no debug option.
+    // "Open" URL (`path`) stays clean.
     const absolute = previewRequestUrl(nextPath, provider);
     // Dedupe on the RESOLVED url (not the raw path): a no-op must never flip
     // previewLoading=true without a following <img> load event, or the spinner
@@ -95,15 +93,21 @@
     previewLoading = true;
     previewError = null;
     processedMetadata = null;
-    previewImageUrl = absolute; // same-origin → <img> triggers the real, SW-intercepted request (with debug:1 for imgproxy)
+    previewImageUrl = absolute; // same-origin → <img> triggers the real, SW-intercepted request (with the debug trigger)
   }, 150);
-  // Builds the absolute preview-request URL. For imgproxy it injects the
-  // `debug:1` processing option ahead of the `/plain/` source marker; other
-  // dialects are returned unchanged (no debug trigger).
+  // Builds the absolute preview-request URL, injecting each dialect's debug
+  // trigger: imgproxy's `debug:1` processing option ahead of the `/plain/`
+  // source marker, TwicPics' `debug=1` chain segment appended to the `twic`
+  // manipulation, and IIIF's `?debug=1` query param.
   function previewRequestUrl(nextPath: string, provider: string): string {
     const url = new URL(nextPath, window.location.origin);
     if (provider === "imgproxy") {
       url.pathname = url.pathname.replace("/plain/", "/debug:1/plain/");
+    } else if (provider === "iiif") {
+      url.searchParams.set("debug", "1");
+    } else if (provider === "twicpics") {
+      const twic = url.searchParams.get("twic");
+      if (twic) url.searchParams.set("twic", `${twic}/debug=1`);
     }
     return url.href;
   }

--- a/fiddle/lib/image_pipe_fiddle/application.ex
+++ b/fiddle/lib/image_pipe_fiddle/application.ex
@@ -61,8 +61,9 @@ defmodule ImagePipeFiddle.Application do
       # than erroring; the default Logger surfaces any detection fallback.
       detector_required: false,
       # Demo deployment: emit the opt-in X-ImagePipe-* / Server-Timing debug headers.
-      # The fiddle adds the `debug:1` processing option to its imgproxy preview
-      # requests so the panel populates (only imgproxy exposes a debug trigger).
+      # The fiddle injects each dialect's debug trigger into its preview requests
+      # (imgproxy `debug:1`, TwicPics `debug=1`, IIIF `?debug=1`) so the panel
+      # populates on every mount.
       allow_debug_headers: true
     ]
     |> maybe_put_cache(Application.get_env(:image_pipe_fiddle, :cache))

--- a/lib/image_pipe/parser.ex
+++ b/lib/image_pipe/parser.ex
@@ -72,4 +72,15 @@ defmodule ImagePipe.Parser do
   defp keyword_return_error(parser, returned) do
     "#{inspect(parser)}.validate_options!/1 must return a keyword list, got: #{inspect(returned)}"
   end
+
+  @doc """
+  Coerce a URL boolean flag value shared across dialect parsers.
+
+  Accepts the boolean spellings `1`/`t`/`true` and `0`/`f`/`false`; any other
+  value is `{:error, {:invalid_boolean, value}}`.
+  """
+  @spec parse_boolean(String.t()) :: {:ok, boolean()} | {:error, {:invalid_boolean, String.t()}}
+  def parse_boolean(value) when value in ["1", "t", "true"], do: {:ok, true}
+  def parse_boolean(value) when value in ["0", "f", "false"], do: {:ok, false}
+  def parse_boolean(value), do: {:error, {:invalid_boolean, value}}
 end

--- a/lib/image_pipe/parser/iiif.ex
+++ b/lib/image_pipe/parser/iiif.ex
@@ -71,7 +71,11 @@ defmodule ImagePipe.Parser.IIIF do
       {:image, id, tokens} ->
         with {:ok, source} <- resolve(id, iiif),
              {:ok, parsed} <- parse_tokens(tokens) do
-          PlanBuilder.image_plan(source, parsed, iiif)
+          PlanBuilder.image_plan(
+            source,
+            parsed,
+            Keyword.put(iiif, :debug?, debug_requested?(conn))
+          )
         end
 
       :not_found ->
@@ -85,6 +89,19 @@ defmodule ImagePipe.Parser.IIIF do
   def handle_error(%Plug.Conn{} = conn, {:error, reason}) do
     {status, body} = status_for(reason)
     send_resp(conn, status, body)
+  end
+
+  # `?debug=1` (also `?debug=true`) opts the response into `X-ImagePipe-*` debug
+  # headers, honored only under the `allow_debug_headers: true` mount flag. The
+  # IIIF Image API path grammar has no free slot, so the trigger is an
+  # out-of-band query param — an ImagePipe extension, not part of the IIIF spec.
+  # It is read leniently: any non-true value (absent, `0`, `false`, garbage)
+  # disables it, so a malformed flag never fails an otherwise-valid image
+  # request. IIIF has no request signing, so the trigger is unprotected; see
+  # docs/iiif_3_support_matrix.md.
+  defp debug_requested?(%Plug.Conn{} = conn) do
+    conn = Plug.Conn.fetch_query_params(conn)
+    Map.get(conn.query_params, "debug") in ["1", "true"]
   end
 
   defp resolve(id, iiif) do

--- a/lib/image_pipe/parser/iiif/plan_builder.ex
+++ b/lib/image_pipe/parser/iiif/plan_builder.ex
@@ -53,13 +53,16 @@ defmodule ImagePipe.Parser.IIIF.PlanBuilder do
   `source` is an `ImagePipe.Plan.Source.*` struct already resolved by the caller.
   `tokens` is a map with keys `:region`, `:size`, `:rotation`, `:quality`, `:format`
   carrying the typed grammar values produced by `ImagePipe.Parser.IIIF.Grammar`.
-  `opts` accepts `auto_rotate: boolean()` (default `false`) and the size-ceiling
-  bounds `max_width`/`max_height`/`max_area`.
+  `opts` accepts `auto_rotate: boolean()` (default `false`), the size-ceiling
+  bounds `max_width`/`max_height`/`max_area`, and `debug?: boolean()` (default
+  `false`) which opts the response into `X-ImagePipe-*` debug headers via
+  `Plan.Response.debug?`.
   """
   @spec image_plan(ImagePipe.Plan.Source.t(), map(), keyword()) ::
           {:ok, Plan.t()} | {:error, term()}
   def image_plan(source, tokens, opts \\ []) do
     auto_rotate = Keyword.get(opts, :auto_rotate, false)
+    debug? = Keyword.get(opts, :debug?, false)
     max_width = Keyword.get(opts, :max_width)
 
     # IIIF Image API 3.0 §5.1: when maxHeight is unset, clients infer
@@ -83,7 +86,7 @@ defmodule ImagePipe.Parser.IIIF.PlanBuilder do
          auto_rotate: auto_rotate,
          pipelines: [%Pipeline{operations: operations}],
          output: output,
-         response: %Response{}
+         response: %Response{debug?: debug?}
        }}
     end
   end

--- a/lib/image_pipe/parser/imgproxy/option_grammar.ex
+++ b/lib/image_pipe/parser/imgproxy/option_grammar.ex
@@ -550,9 +550,7 @@ defmodule ImagePipe.Parser.Imgproxy.OptionGrammar do
     end
   end
 
-  defp parse_boolean(value) when value in ["1", "t", "true"], do: {:ok, true}
-  defp parse_boolean(value) when value in ["0", "f", "false"], do: {:ok, false}
-  defp parse_boolean(value), do: {:error, {:invalid_boolean, value}}
+  defp parse_boolean(value), do: ImagePipe.Parser.parse_boolean(value)
 
   # Generic interpreter for @special_specs entries: each spec is a fixed list of
   # required, non-empty args. Arity/empty-arg failures yield the uniform

--- a/lib/image_pipe/parser/twic_pics/plan_builder.ex
+++ b/lib/image_pipe/parser/twic_pics/plan_builder.ex
@@ -6,9 +6,10 @@ defmodule ImagePipe.Parser.TwicPics.PlanBuilder do
   alias ImagePipe.Plan
   alias ImagePipe.Plan.Operation
   alias ImagePipe.Plan.Pipeline
+  alias ImagePipe.Plan.Response
   alias ImagePipe.Plan.Source
 
-  @initial %{ops: [], guide: :carried, format: :auto, quality: :default}
+  @initial %{ops: [], guide: :carried, format: :auto, quality: :default, debug?: false}
 
   @spec to_plan(Source.t(), [{String.t(), String.t()}]) :: {:ok, Plan.t()} | {:error, term()}
   def to_plan(source, chain) when is_list(chain) do
@@ -19,7 +20,8 @@ defmodule ImagePipe.Parser.TwicPics.PlanBuilder do
          source: source,
          pipelines: [%Pipeline{operations: Enum.reverse(acc.ops)}],
          output: output,
-         auto_rotate: true
+         auto_rotate: true,
+         response: %Response{debug?: acc.debug?}
        }}
     end
   end
@@ -41,7 +43,21 @@ defmodule ImagePipe.Parser.TwicPics.PlanBuilder do
   defp apply_segment("focus", args, acc), do: focus(args, acc)
   defp apply_segment("output", args, acc), do: output(args, acc)
   defp apply_segment("quality", args, acc), do: quality(args, acc)
+  defp apply_segment("debug", args, acc), do: debug(args, acc)
   defp apply_segment(name, _args, _acc), do: {:error, {:unsupported_transform, name}}
+
+  # `debug=1` opts the response into `X-ImagePipe-*` debug headers (honored only
+  # under the `allow_debug_headers: true` mount flag). It is an ImagePipe
+  # extension with no TwicPics counterpart, sets `Plan.Response.debug?`, and
+  # emits no operation — so it is order-independent and never affects produced
+  # bytes, the cache key, or the ETag. TwicPics has no request signing, so the
+  # trigger is unprotected; see docs/twicpics_support_matrix.md.
+  defp debug(args, acc) do
+    case ImagePipe.Parser.parse_boolean(args) do
+      {:ok, debug?} -> {:ok, %{acc | debug?: debug?}}
+      {:error, _} -> {:error, {:invalid_debug, args}}
+    end
+  end
 
   defp resize(args, acc) do
     if String.contains?(args, ":") do

--- a/test/image_pipe/twic_pics_wire_conformance_test.exs
+++ b/test/image_pipe/twic_pics_wire_conformance_test.exs
@@ -452,4 +452,73 @@ defmodule ImagePipe.TwicPicsWireConformanceTest do
     assert second.resp_body == first.resp_body
     refute_received :origin_fetch
   end
+
+  defp header(%Plug.Conn{} = conn, name) do
+    case Plug.Conn.get_resp_header(conn, name) do
+      [value | _] -> value
+      [] -> nil
+    end
+  end
+
+  defp debug_opts(extra), do: Keyword.merge(@opts, extra)
+
+  describe "debug headers trigger (debug chain segment)" do
+    test "the debug=1 segment emits x-imagepipe-* headers when allow_debug_headers: true" do
+      conn =
+        call(
+          "/images/beach.jpg?twic=v1/resize=200/debug=1/output=jpeg",
+          debug_opts(allow_debug_headers: true)
+        )
+
+      assert conn.status == 200
+      assert header(conn, "x-imagepipe-output-format") != nil
+      assert header(conn, "x-imagepipe-cache") == "miss"
+      assert header(conn, "x-imagepipe-source-format") != nil
+    end
+
+    test "no debug headers without the debug segment, even when allow_debug_headers: true" do
+      conn =
+        call(
+          "/images/beach.jpg?twic=v1/resize=200/output=jpeg",
+          debug_opts(allow_debug_headers: true)
+        )
+
+      assert conn.status == 200
+      assert header(conn, "x-imagepipe-output-format") == nil
+      assert header(conn, "x-imagepipe-cache") == nil
+    end
+
+    test "no debug headers with debug=1 when allow_debug_headers: false (default)" do
+      conn =
+        call(
+          "/images/beach.jpg?twic=v1/resize=200/debug=1/output=jpeg",
+          debug_opts(allow_debug_headers: false)
+        )
+
+      assert conn.status == 200
+      assert header(conn, "x-imagepipe-output-format") == nil
+      assert header(conn, "x-imagepipe-cache") == nil
+    end
+
+    test "debug=0 is an explicit opt-out (no headers even under allow_debug_headers: true)" do
+      conn =
+        call(
+          "/images/beach.jpg?twic=v1/resize=200/debug=0/output=jpeg",
+          debug_opts(allow_debug_headers: true)
+        )
+
+      assert conn.status == 200
+      assert header(conn, "x-imagepipe-output-format") == nil
+    end
+
+    test "an invalid debug value is a 400 (consistent with other bad chain segments)" do
+      conn =
+        call(
+          "/images/beach.jpg?twic=v1/resize=200/debug=maybe/output=jpeg",
+          debug_opts(allow_debug_headers: true)
+        )
+
+      assert conn.status == 400
+    end
+  end
 end

--- a/test/parser/iiif_wire_test.exs
+++ b/test/parser/iiif_wire_test.exs
@@ -625,4 +625,49 @@ defmodule ImagePipe.Parser.IIIFWireTest do
       refute Map.has_key?(body, "maxArea")
     end
   end
+
+  defp header(conn, name) do
+    case get_resp_header(conn, name) do
+      [value | _] -> value
+      [] -> nil
+    end
+  end
+
+  defp iiif_debug_opts(origin_plug) do
+    Keyword.put(iiif_opts(origin_plug), :allow_debug_headers, true)
+  end
+
+  describe "debug headers trigger (?debug=1 query param)" do
+    test "?debug=1 emits x-imagepipe-* headers when allow_debug_headers: true" do
+      conn = call_iiif("/img/full/max/0/default.png?debug=1", iiif_debug_opts(OriginImage))
+
+      assert conn.status == 200
+      assert header(conn, "x-imagepipe-output-format") != nil
+      assert header(conn, "x-imagepipe-cache") == "miss"
+      assert header(conn, "x-imagepipe-source-format") != nil
+    end
+
+    test "no debug headers without ?debug=1, even when allow_debug_headers: true" do
+      conn = call_iiif("/img/full/max/0/default.png", iiif_debug_opts(OriginImage))
+
+      assert conn.status == 200
+      assert header(conn, "x-imagepipe-output-format") == nil
+      assert header(conn, "x-imagepipe-cache") == nil
+    end
+
+    test "no debug headers with ?debug=1 when allow_debug_headers: false (default)" do
+      conn = call_iiif("/img/full/max/0/default.png?debug=1", iiif_opts(OriginImage))
+
+      assert conn.status == 200
+      assert header(conn, "x-imagepipe-output-format") == nil
+      assert header(conn, "x-imagepipe-cache") == nil
+    end
+
+    test "a garbage debug value is ignored (200, no headers) — not a 400" do
+      conn = call_iiif("/img/full/max/0/default.png?debug=maybe", iiif_debug_opts(OriginImage))
+
+      assert conn.status == 200
+      assert header(conn, "x-imagepipe-output-format") == nil
+    end
+  end
 end


### PR DESCRIPTION
## What & why

#398/#399 moved the debug-header trigger onto the signed imgproxy `debug:1` processing option and **dropped the dialect-neutral query trigger entirely**, so IIIF and TwicPics lost any per-request URL knob to opt a single request into the `X-ImagePipe-*` / `Server-Timing` debug headers (issue #400). This restores a trigger for each dialect, using a shape that fits its grammar.

`Plan.Response.debug?` stays the **single source of truth** — the post-parse Plug gate (`allow_debug_headers AND response.debug?`) and `Response.Sender` are unchanged. The flag is excluded from the cache key and ETag, so a debug and a plain request resolve to the same cache entry.

## Trigger shapes

- **TwicPics** — a native `debug` segment in the `?twic=v1/…` manipulation chain, e.g. `?twic=v1/resize=400/debug=1` (also `0`/`false` to opt out). Sets `Plan.Response.debug?`, emits no operation (so it's order-independent), and an invalid value is a `400` like any other bad chain segment.
- **IIIF** — an out-of-band `?debug=1` query param, e.g. `/iiif/cat/full/400,/0/default.jpg?debug=1` (the positional path grammar has no free slot; IIIF Image API 3.0 §4.9 explicitly endorses query-param extensions). Read **leniently** — only `1`/`true` enable it; any other value (absent/`0`/`false`/garbage) is ignored, never a `400`, so a malformed flag can't fail an otherwise-valid image request. Image requests only (not `info.json`).

Neither dialect signs requests today, so both triggers are **deliberately unsigned/unprotected** (documented). If those dialects gain signing later, the trigger should ride the signed material.

## Notable changes

- Shared `ImagePipe.Parser.parse_boolean/1` extracted so the imgproxy and TwicPics boolean coercion no longer duplicate (credo flagged it).
- Docs: `debug_headers.md` (all three triggers + signing caveat), the IIIF and TwicPics support matrices (new `➕` extension rows on the **surface** axis), and a drive-by fix of a stale `_debug=1`→`debug:1` reference in the imgproxy matrix left over from #399.
- Fiddle: `previewRequestUrl` now injects each dialect's trigger into preview requests, so the **Debug headers** panel populates on every mount.

## Tests / verification

- Wire-level gating tests for both dialects (trigger on + `allow_debug_headers: true` → headers present; trigger off → absent; `allow_debug_headers: false` → absent even with trigger; TwicPics invalid → `400`; IIIF garbage value → `200`, no headers).
- Full Elixir gate green: `mix format --check`, `compile --warnings-as-errors`, `credo --strict`, `mix test` (2767 tests).
- Fiddle JS green: format/lint/check, 286 tests, build.

A two-lens review cycle (compatibility + code-quality/boundary) returned no blockers — the compatibility reviewer verified the IIIF §4.9 extension mechanism and that TwicPics has no `debug` collision.

Fixes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)