### PR TITLE
feat(fiddle): s3proxy fake-S3 + local/S3/HTTP source-type selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,11 +173,29 @@ the library's OpenTelemetry exporter end to end (see
 [the cookbook](docs/cookbook/opentelemetry-jaeger.md)):
 
 ```sh
-mise run jaeger        # start Jaeger (OTLP + UI) via fiddle/docker-compose.yml
-mise run server:otel   # boots the dev server with tracing on (FIDDLE_OTEL=1)
+mise run sidecars jaeger   # start Jaeger (OTLP + UI) via fiddle/docker-compose.yml
+mise run server:otel       # boots the dev server with tracing on (FIDDLE_OTEL=1)
 ```
 
 Issue an `/img` request, then open the Jaeger UI at http://localhost:16686 and
 look for the `image_pipe.request` trace under the `image_pipe_fiddle` service.
 Plain `mise run server` leaves tracing off (no `FIDDLE_OTEL`), so it needs no
 Jaeger.
+
+### Source types (local / S3 / HTTP)
+
+The imgproxy provider can fetch the sample images through three source adapters,
+chosen with the fiddle's **Source type** control: the local filesystem, a fake S3,
+or HTTP. All three resolve to byte-identical bytes from `priv/static/images`, so
+switching source types is a clean adapter comparison.
+
+The **S3** source type needs the opt-in s3proxy sidecar — a fake S3 over the local
+filesystem that mirrors `priv/static/images` (`mise run sidecars` brings up both
+Jaeger and s3proxy; `mise run sidecars s3proxy` starts just the fake S3):
+
+```sh
+mise run sidecars s3proxy   # fake S3 at http://localhost:8081, bucket "sources"
+```
+
+The **HTTP** source type needs no sidecar — it fetches the fiddle's own
+`Plug.Static` at `http://localhost:4000/images/<file>`.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The interactive demo (ImagePipe Fiddle) is a standalone Phoenix app in `fiddle/`
 
 ```sh
 mise run setup       # installs library + fiddle deps
-mise run server      # boots Phoenix (:4000) + Vite (:5173)
+mise run fiddle      # boots Phoenix (:4000) + Vite (:5173)
 ```
 
 Open http://localhost:4000. The imgproxy-compatible processing endpoint is
@@ -173,13 +173,13 @@ the library's OpenTelemetry exporter end to end (see
 [the cookbook](docs/cookbook/opentelemetry-jaeger.md)):
 
 ```sh
-mise run sidecars jaeger   # start Jaeger (OTLP + UI) via fiddle/docker-compose.yml
-mise run server:otel       # boots the dev server with tracing on (FIDDLE_OTEL=1)
+mise run fiddle:sidecars jaeger   # start Jaeger (OTLP + UI) via fiddle/docker-compose.yml
+mise run fiddle otel              # boots the dev server with tracing on (FIDDLE_OTEL=1)
 ```
 
 Issue an `/img` request, then open the Jaeger UI at http://localhost:16686 and
 look for the `image_pipe.request` trace under the `image_pipe_fiddle` service.
-Plain `mise run server` leaves tracing off (no `FIDDLE_OTEL`), so it needs no
+Plain `mise run fiddle` leaves tracing off (no `FIDDLE_OTEL`), so it needs no
 Jaeger.
 
 ### Source types (local / S3 / HTTP)
@@ -190,11 +190,11 @@ or HTTP. All three resolve to byte-identical bytes from `priv/static/images`, so
 switching source types is a clean adapter comparison.
 
 The **S3** source type needs the opt-in s3proxy sidecar — a fake S3 over the local
-filesystem that mirrors `priv/static/images` (`mise run sidecars` brings up both
-Jaeger and s3proxy; `mise run sidecars s3proxy` starts just the fake S3):
+filesystem that mirrors `priv/static/images` (`mise run fiddle:sidecars` brings up
+both Jaeger and s3proxy; `mise run fiddle:sidecars s3proxy` starts just the fake S3):
 
 ```sh
-mise run sidecars s3proxy   # fake S3 at http://localhost:8081, bucket "sources"
+mise run fiddle:sidecars s3proxy   # fake S3 at http://localhost:8081, bucket "sources"
 ```
 
 The **HTTP** source type needs no sidecar — it fetches the fiddle's own

--- a/docs/superpowers/plans/2026-06-26-fiddle-s3proxy-source-types.md
+++ b/docs/superpowers/plans/2026-06-26-fiddle-s3proxy-source-types.md
@@ -1,0 +1,601 @@
+# Fiddle s3proxy + multi-source-type selector — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the fiddle's imgproxy provider fetch the same sample images through three source adapters — local filesystem, a local s3proxy fake-S3, and HTTP against the fiddle's own static server — selectable from a new "Source type" UI control.
+
+**Architecture:** No `ImagePipe` library changes. Add an opt-in `s3proxy` Docker Compose service mirroring `priv/static/images`, mount the existing `Source.S3` and `Source.HTTP` adapters in the fiddle's imgproxy options (config-driven), and encode the chosen source type into the imgproxy processing path's source identifier scheme (`local:///…` / `s3://sources/…` / `http://localhost:4000/images/…`), which round-trips through the fiddle's URL state.
+
+**Tech Stack:** Elixir/Phoenix (fiddle backend + config), Docker Compose + mise tasks, Svelte 5 + TypeScript (fiddle UI), Vitest (JS tests).
+
+**Spec:** `docs/superpowers/specs/2026-06-26-fiddle-s3proxy-source-types-design.md`
+
+**Conventions for every task below:** run JS commands from `fiddle/assets` and Elixir/mix commands from `fiddle/` via `mise exec -- …`. Commit after each task.
+
+---
+
+## File Structure
+
+- `fiddle/docker-compose.yml` — add `s3proxy` service alongside `jaeger`; update header comment.
+- `mise.toml` — scope `[tasks.jaeger]` to `up jaeger`; add `[tasks.s3proxy]`.
+- `fiddle/config/config.exs` — add `:s3_source` config block (endpoint/region/credentials).
+- `fiddle/lib/image_pipe_fiddle/application.ex` — add `s3:`/`url:` mounts to the imgproxy `sources:` (imgproxy only); read s3 config.
+- `fiddle/test/image_pipe_fiddle/imgproxy_source_mounts_test.exs` — Elixir test that the mounts validate via `ImagePipe.Plug.init/1`.
+- `fiddle/assets/processing-path.ts` — `SourceType` type, `sourceIdentifierForRequest(source, sourceType)`, inverse `parseSourceIdentifier(identifier)`, `FiddleState.sourceType`, `defaultFiddleState.sourceType`, `signedPathForState`.
+- `fiddle/assets/fiddle-url-state.ts` — route `sourceFromIdentifier`/`parseFiddlePathParts`/`parseFiddlePath` through `parseSourceIdentifier`; carry `sourceType`.
+- `fiddle/assets/App.svelte` — "Source type" `<select>` in the imgproxy request section.
+- `fiddle/assets/processing-path.test.ts` — build/parse unit tests.
+- `fiddle/assets/fiddle-url-state.test.ts` — round-trip test.
+
+---
+
+## Task 1: s3proxy Compose service + mise tasks
+
+**Files:**
+- Modify: `fiddle/docker-compose.yml`
+- Modify: `mise.toml` (`[tasks.jaeger]` ~line 91, add `[tasks.s3proxy]`)
+
+This task is infra config (no unit test); verification is `docker compose config` parsing the file.
+
+- [ ] **Step 1: Add the s3proxy service to `fiddle/docker-compose.yml`**
+
+Replace the existing header comment + `services:` block so the file reads:
+
+```yaml
+# Local sidecar services for the fiddle demo (opt-in; not needed for `mise run server`).
+#
+# Jaeger — OpenTelemetry traces:
+#   mise run jaeger                 # docker compose ... up jaeger
+#   FIDDLE_OTEL=1 mise run server   # emit traces; UI at http://localhost:16686
+#
+# s3proxy — fake S3 over the local filesystem, mirrors priv/static/images so the
+# fiddle's "S3" source type can fetch the sample images as s3://sources/<file>:
+#   mise run s3proxy                # docker compose ... up s3proxy
+# Endpoint http://localhost:8081, bucket "sources" == ./priv/static/images (read-only).
+services:
+  jaeger:
+    image: cr.jaegertracing.io/jaegertracing/jaeger:2.19.0
+    container_name: jaeger
+    ports:
+      - "16686:16686" # Jaeger UI
+      - "4317:4317" # OTLP gRPC
+      - "4318:4318" # OTLP HTTP (the fiddle exports here)
+      - "5778:5778" # sampling/config
+      - "9411:9411" # Zipkin
+
+  s3proxy:
+    image: andrewgaul/s3proxy:sha-ba0b833
+    container_name: fiddle-s3proxy
+    ports:
+      - "8081:80" # s3proxy listens on container port 80
+    environment:
+      S3PROXY_AUTHORIZATION: aws-v2-or-v4
+      S3PROXY_IDENTITY: fiddle
+      S3PROXY_CREDENTIAL: fiddlesecret
+      JCLOUDS_PROVIDER: filesystem
+      JCLOUDS_FILESYSTEM_BASEDIR: /data
+    volumes:
+      # Mounted read-only: the demo only reads. Bucket name == the subdir under basedir.
+      - ./priv/static/images:/data/sources:ro
+```
+
+> Note: the `andrewgaul/s3proxy` image tag above pins a known-good digest-style tag. If it does not resolve at implementation time, substitute the current `andrewgaul/s3proxy:latest` digest and record it here.
+
+- [ ] **Step 2: Scope the jaeger mise task and add the s3proxy task in `mise.toml`**
+
+Replace the existing `[tasks.jaeger]` block (currently `run = "docker compose -f fiddle/docker-compose.yml up"`) with:
+
+```toml
+[tasks.jaeger]
+description = "Run a local Jaeger (OTLP + UI) for the fiddle's OpenTelemetry traces"
+run = "docker compose -f fiddle/docker-compose.yml up jaeger"
+
+[tasks.s3proxy]
+description = "Run a local s3proxy (fake S3 over priv/static/images) for the fiddle's S3 source type"
+run = "docker compose -f fiddle/docker-compose.yml up s3proxy"
+```
+
+- [ ] **Step 3: Verify Compose file parses**
+
+Run: `docker compose -f fiddle/docker-compose.yml config >/dev/null && echo OK`
+Expected: prints `OK` (both `jaeger` and `s3proxy` services resolve, no YAML/schema errors).
+
+If Docker is unavailable in the working environment, instead run `mise exec -- ... ` is not applicable; verify by eye that YAML indentation matches the block above and move on — the live check happens in manual verification.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add fiddle/docker-compose.yml mise.toml
+git commit -m "feat(fiddle): add opt-in s3proxy compose service + mise task"
+```
+
+---
+
+## Task 2: Fiddle `:s3_source` config block
+
+**Files:**
+- Modify: `fiddle/config/config.exs` (after the existing `:imgproxy` block, ~line 25)
+
+- [ ] **Step 1: Add the config block**
+
+Insert directly after the `config :image_pipe_fiddle, :imgproxy, …` block:
+
+```elixir
+# Connection coordinates for the fiddle's S3 source type, served by the opt-in
+# s3proxy compose service (see fiddle/docker-compose.yml). These mirror the
+# s3proxy env: bucket "sources" == priv/static/images. Dev-only fake credentials.
+config :image_pipe_fiddle, :s3_source,
+  region: "us-east-1",
+  endpoint: "http://localhost:8081",
+  access_key_id: "fiddle",
+  secret_access_key: "fiddlesecret"
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run (from `fiddle/`): `mise exec -- mix compile --warnings-as-errors`
+Expected: compiles with no warnings/errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add fiddle/config/config.exs
+git commit -m "feat(fiddle): add :s3_source config for s3proxy connection"
+```
+
+---
+
+## Task 3: Mount S3 + HTTP source adapters in the imgproxy options (TDD)
+
+**Files:**
+- Modify: `fiddle/lib/image_pipe_fiddle/application.ex` (`build_imgproxy_opts/0`, lines 50-69)
+- Test: `fiddle/test/image_pipe_fiddle/imgproxy_source_mounts_test.exs` (create)
+
+The test asserts the exact mount shapes the app builds are accepted by the library's host-config validation (`ImagePipe.Plug.init/1` raises on invalid source config). It reads the same `:s3_source` config the app uses, so there are no duplicated literals.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `fiddle/test/image_pipe_fiddle/imgproxy_source_mounts_test.exs`:
+
+```elixir
+defmodule ImagePipeFiddle.ImgproxySourceMountsTest do
+  use ExUnit.Case, async: true
+
+  # The fiddle mounts three source adapters for the imgproxy provider so the demo
+  # can fetch the same sample images via local / s3 / http. This pins that the s3
+  # and http mount shapes are accepted by ImagePipe's host-config validation
+  # (Plug.init raises on an invalid source config).
+  test "imgproxy_source_mounts/0 is accepted by ImagePipe.Plug.init/1" do
+    opts =
+      ImagePipe.Plug.init(
+        parser: ImagePipe.Parser.Imgproxy,
+        imgproxy: Application.fetch_env!(:image_pipe_fiddle, :imgproxy),
+        sources: ImagePipeFiddle.Application.imgproxy_source_mounts()
+      )
+
+    assert is_list(opts)
+    sources = Keyword.fetch!(opts, :sources)
+    # url: fans out to :http/:https inside ImagePipe; s3 stays under :s3.
+    assert Map.has_key?(sources, :s3)
+    assert Map.has_key?(sources, :http)
+  end
+end
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run (from `fiddle/`): `mise exec -- mix test test/image_pipe_fiddle/imgproxy_source_mounts_test.exs`
+Expected: FAIL — `ImagePipeFiddle.Application.imgproxy_source_mounts/0` is undefined.
+
+- [ ] **Step 3: Extract the source mounts into a public function and add the s3/url mounts**
+
+In `fiddle/lib/image_pipe_fiddle/application.ex`, change `build_imgproxy_opts/0` to use a new public `imgproxy_source_mounts/0`. Replace the `sources:` keyword inside `build_imgproxy_opts/0` (currently lines 56-58) with `sources: imgproxy_source_mounts(),` and add the new function:
+
+```elixir
+  @doc false
+  # Source adapters mounted for the imgproxy provider. The local File source is
+  # always available; s3 (via the opt-in s3proxy compose service) and http (the
+  # fiddle's own Plug.Static over loopback) let the demo compare source adapters
+  # on byte-identical sample images. Scoped to imgproxy — iiif/twicpics keep File.
+  def imgproxy_source_mounts do
+    static_root = Application.app_dir(:image_pipe_fiddle, "priv/static")
+    s3 = Application.fetch_env!(:image_pipe_fiddle, :s3_source)
+
+    [
+      path: {ImagePipe.Source.File, root: static_root, root_id: "static", stable: :trusted},
+      s3:
+        {ImagePipe.Source.S3,
+         default: [
+           region: Keyword.fetch!(s3, :region),
+           endpoint: Keyword.fetch!(s3, :endpoint),
+           credentials: [
+             access_key_id: Keyword.fetch!(s3, :access_key_id),
+             secret_access_key: Keyword.fetch!(s3, :secret_access_key)
+           ]
+         ],
+         buckets: %{"sources" => []}},
+      # DEV-ONLY SSRF relaxation: the http source type fetches the fiddle's own
+      # Plug.Static over loopback, so localhost must be explicitly allowed. This
+      # lives only in the fiddle demo — never in ImagePipe library defaults.
+      url:
+        {ImagePipe.Source.HTTP, allowed_hosts: ["localhost", "127.0.0.1"], allow_loopback: true}
+    ]
+  end
+```
+
+The `static_root` local previously declared at the top of `build_imgproxy_opts/0` is now only used inside `imgproxy_source_mounts/0`; remove the now-unused binding from `build_imgproxy_opts/0` so it doesn't warn.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run (from `fiddle/`): `mise exec -- mix test test/image_pipe_fiddle/imgproxy_source_mounts_test.exs`
+Expected: PASS.
+
+- [ ] **Step 5: Verify no compile warnings**
+
+Run (from `fiddle/`): `mise exec -- mix compile --warnings-as-errors`
+Expected: compiles clean (no "unused variable static_root" warning).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add fiddle/lib/image_pipe_fiddle/application.ex fiddle/test/image_pipe_fiddle/imgproxy_source_mounts_test.exs
+git commit -m "feat(fiddle): mount s3 + http source adapters for imgproxy provider"
+```
+
+---
+
+## Task 4: Source-type-aware path building (TDD)
+
+**Files:**
+- Modify: `fiddle/assets/processing-path.ts` (add `SourceType`, source-id constants, `sourceIdentifierForRequest`, `parseSourceIdentifier`, `FiddleState.sourceType`, `defaultFiddleState.sourceType`, `signedPathForState`)
+- Test: `fiddle/assets/processing-path.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+`processing-path.test.ts` already imports `{ afterEach, describe, expect, it, vi }` from `vitest` and a large block from `./processing-path`. **Add `sourceIdentifierForRequest` and `parseSourceIdentifier` to the existing `./processing-path` import block** (do not add a duplicate `vitest` import), then append these `describe` blocks:
+
+```ts
+describe("sourceIdentifierForRequest", () => {
+  it("builds a local:/// identifier", () => {
+    expect(sourceIdentifierForRequest("images/dog.jpg", "local")).toBe("local:///images/dog.jpg");
+  });
+
+  it("builds an s3://sources/<file> identifier from the basename", () => {
+    expect(sourceIdentifierForRequest("images/dog.jpg", "s3")).toBe("s3://sources/dog.jpg");
+  });
+
+  it("builds an http://localhost:4000 identifier", () => {
+    expect(sourceIdentifierForRequest("images/dog.jpg", "http")).toBe(
+      "http://localhost:4000/images/dog.jpg",
+    );
+  });
+});
+
+describe("parseSourceIdentifier", () => {
+  it("round-trips each source type", () => {
+    for (const sourceType of ["local", "s3", "http"] as const) {
+      const id = sourceIdentifierForRequest("images/dog.jpg", sourceType);
+      expect(parseSourceIdentifier(id)).toEqual({ source: "images/dog.jpg", sourceType });
+    }
+  });
+
+  it("returns null for an unknown scheme", () => {
+    expect(parseSourceIdentifier("ftp://nope/dog.jpg")).toBeNull();
+  });
+
+  it("returns null when the identifier does not map to a known sample image", () => {
+    expect(parseSourceIdentifier("s3://sources/not-a-real-image.jpg")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run (from `fiddle/assets`): `mise exec -- pnpm vitest run processing-path.test.ts`
+Expected: FAIL — `parseSourceIdentifier` not exported / `sourceIdentifierForRequest` takes one arg.
+
+- [ ] **Step 3: Implement the type, constants, builder, and parser**
+
+In `fiddle/assets/processing-path.ts`, add near the `SourceImage` type (after line 18):
+
+```ts
+export type SourceType = "local" | "s3" | "http";
+
+const localSourceScheme = "local:///";
+const s3SourceBucketPrefix = "s3://sources/";
+const httpSourcePrefix = "http://localhost:4000/";
+```
+
+Add `sourceType: SourceType;` to the `FiddleState` type (next to `source: SourceImage;`, line 113) and `sourceType: "local",` to `defaultFiddleState` (next to `source: "images/dog.jpg",`, line 349).
+
+Replace the existing `sourceIdentifierForRequest` (lines 942-944) with:
+
+```ts
+export function sourceIdentifierForRequest(source: SourceImage, sourceType: SourceType): string {
+  switch (sourceType) {
+    case "local":
+      return `${localSourceScheme}${source}`;
+    case "s3":
+      // Bucket "sources" is rooted at priv/static/images, so the key is the basename.
+      return `${s3SourceBucketPrefix}${source.slice(source.lastIndexOf("/") + 1)}`;
+    case "http":
+      // The fiddle's own Plug.Static serves priv/static/images at /images/<file>.
+      return `${httpSourcePrefix}${source}`;
+  }
+}
+
+// Inverse of sourceIdentifierForRequest: recovers (source, sourceType) from a
+// processing-path source identifier, or null if it is not a known sample image.
+export function parseSourceIdentifier(
+  identifier: string,
+): { source: SourceImage; sourceType: SourceType } | null {
+  const candidate = sourceTypeAndPath(identifier);
+
+  if (candidate === null) {
+    return null;
+  }
+
+  const { source, sourceType } = candidate;
+  const known = sampleImages.some((image) => image.path === source);
+  return known ? { source: source as SourceImage, sourceType } : null;
+}
+
+function sourceTypeAndPath(identifier: string): { source: string; sourceType: SourceType } | null {
+  if (identifier.startsWith(localSourceScheme)) {
+    return { source: identifier.slice(localSourceScheme.length), sourceType: "local" };
+  }
+
+  if (identifier.startsWith(httpSourcePrefix)) {
+    return { source: identifier.slice(httpSourcePrefix.length), sourceType: "http" };
+  }
+
+  if (identifier.startsWith(s3SourceBucketPrefix)) {
+    // Reconstruct the images/<file> source from the basename key.
+    return { source: `images/${identifier.slice(s3SourceBucketPrefix.length)}`, sourceType: "s3" };
+  }
+
+  return null;
+}
+```
+
+> Membership is checked against the imported `sampleImages` array (already in scope at the top of `processing-path.ts`). `sampleImages.some(...)` is fine for the ~11-image sample set.
+
+Update `signedPathForState` (line 947-950) to pass the source type:
+
+```ts
+export function signedPathForState(currentState: FiddleState): string {
+  const options = optionSegments(currentState).join("/");
+  const optionsPath = options === "" ? "" : `/${options}`;
+
+  return `${optionsPath}/plain/${sourceIdentifierForRequest(currentState.source, currentState.sourceType)}`;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run (from `fiddle/assets`): `mise exec -- pnpm vitest run processing-path.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run (from `fiddle/assets`): `mise exec -- pnpm check`
+Expected: no type errors (every `FiddleState` literal now has `sourceType`; `defaultFiddleState` supplies it for spreads). The `check` script runs `tsgo --noEmit` (×2 projects) + `svelte-check`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add fiddle/assets/processing-path.ts fiddle/assets/processing-path.test.ts
+git commit -m "feat(fiddle): source-type-aware processing-path identifiers"
+```
+
+---
+
+## Task 5: Round-trip source type through URL state (TDD)
+
+**Files:**
+- Modify: `fiddle/assets/fiddle-url-state.ts` (`sourceFromIdentifier` lines 158-165, `parseFiddlePathParts` lines 133-156, `parseFiddlePath` lines 74-100)
+- Test: `fiddle/assets/fiddle-url-state.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`fiddle-url-state.test.ts` already imports `{ describe, expect, it }` from `vitest`, `defaultFiddleState` from `./processing-path`, and a block from `./fiddle-url-state`. **Add `parseFiddlePath` and `fiddlePathForState` to the existing `./fiddle-url-state` import block** (don't duplicate the others), then append:
+
+```ts
+describe("source type round-trip", () => {
+  for (const sourceType of ["local", "s3", "http"] as const) {
+    it(`preserves sourceType=${sourceType} through path build + parse`, () => {
+      const state = { ...defaultFiddleState, source: "images/dog.jpg" as const, sourceType };
+      const path = fiddlePathForState(state);
+      const parsed = parseFiddlePath(path);
+      expect(parsed.source).toBe("images/dog.jpg");
+      expect(parsed.sourceType).toBe(sourceType);
+    });
+  }
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run (from `fiddle/assets`): `mise exec -- pnpm vitest run fiddle-url-state.test.ts`
+Expected: FAIL — `parsed.sourceType` is `undefined` (defaults to `"local"` via spread, so the s3/http cases fail).
+
+- [ ] **Step 3: Route parsing through `parseSourceIdentifier` and carry `sourceType`**
+
+In `fiddle/assets/fiddle-url-state.ts`:
+
+Add `parseSourceIdentifier` and `type SourceType` to the existing import from `./processing-path` (line 16 area). Remove the now-unused `localSourcePrefix` constant (line 47) and the `sourceImages` set if it becomes unused (line 48 — keep it only if other code references it; otherwise delete).
+
+Replace `sourceFromIdentifier` (lines 158-165) — change `parseFiddlePathParts` to return the parsed `{ source, sourceType }` pair. Update `parseFiddlePathParts` (lines 133-156):
+
+```ts
+function parseFiddlePathParts(
+  pathname: string,
+): { optionSegments: string[]; source: SourceImage; sourceType: SourceType } | null {
+  const path = pathname.endsWith("/") && pathname !== "/" ? pathname.slice(0, -1) : pathname;
+
+  const plainIndex = path.indexOf(plainSourceMarker);
+
+  if (plainIndex === -1) {
+    return null;
+  }
+
+  const optionSegments = path.slice(0, plainIndex).split("/").filter(Boolean);
+  const parsedSource = parseSourceIdentifier(path.slice(plainIndex + plainSourceMarker.length));
+
+  if (parsedSource === null) {
+    return null;
+  }
+
+  return {
+    optionSegments,
+    source: parsedSource.source,
+    sourceType: parsedSource.sourceType,
+  };
+}
+```
+
+Delete the standalone `sourceFromIdentifier` function (now replaced by `parseSourceIdentifier`).
+
+Update `parseFiddlePath` (lines 74-100) so the seed state carries the source type:
+
+```ts
+  let state = resetCropPixelsToSource({
+    ...defaultFiddleState,
+    source: parsed.source,
+    sourceType: parsed.sourceType,
+  });
+```
+
+Ensure `SourceImage` and `SourceType` are imported from `./processing-path` (add `type SourceType` to the import list).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run (from `fiddle/assets`): `mise exec -- pnpm vitest run fiddle-url-state.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full JS test + typecheck**
+
+Run (from `fiddle/assets`): `mise exec -- pnpm vitest run && mise exec -- pnpm check`
+Expected: all suites PASS, no type errors. (Confirms no other caller of the removed `sourceFromIdentifier`/`localSourcePrefix` broke.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add fiddle/assets/fiddle-url-state.ts fiddle/assets/fiddle-url-state.test.ts
+git commit -m "feat(fiddle): round-trip source type through imgproxy URL state"
+```
+
+---
+
+## Task 6: "Source type" UI control
+
+**Files:**
+- Modify: `fiddle/assets/App.svelte` (inside the `{#if appState.provider === "imgproxy"}` block in the Request section, after the "Source image" `<label>`, ~line 477)
+
+No unit test — behavior is covered by Tasks 4/5 (state) and manual verification. Svelte's `bind:value` writes the chosen type straight into `appState.imgproxy.sourceType`, which the path builder already consumes.
+
+- [ ] **Step 1: Add the control**
+
+Inside the imgproxy `{#if}` block, immediately after the closing `</label>` of the existing "Signature" field's sibling — placed as the first imgproxy-only field — add:
+
+```svelte
+              <label class="field">
+                <span>Source type</span>
+                <select bind:value={appState.imgproxy.sourceType}>
+                  <option value="local">Local (filesystem)</option>
+                  <option value="s3">S3 (s3proxy)</option>
+                  <option value="http">HTTP (Plug.Static)</option>
+                </select>
+              </label>
+```
+
+(Place it directly after the `{#if appState.provider === "imgproxy"}` line and before the existing "Signature" `<label>`, so source-related controls sit together.)
+
+- [ ] **Step 2: Typecheck / svelte-check**
+
+Run (from `fiddle/assets`): `mise exec -- pnpm check`
+Expected: no errors. (`appState.imgproxy.sourceType` is typed via `FiddleState`.)
+
+> If the project has no `check` script, run `mise exec -- pnpm tsc --noEmit` and `mise exec -- pnpm svelte-check` as available; confirm the exact lint/check command from `fiddle/assets/package.json` scripts before running.
+
+- [ ] **Step 3: Build the assets**
+
+Run (from `fiddle/assets`): `mise exec -- pnpm build`
+Expected: Vite build succeeds (produces the manifest the Elixir tests need).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add fiddle/assets/App.svelte fiddle/assets/dist 2>/dev/null || git add fiddle/assets/App.svelte
+git commit -m "feat(fiddle): add Source type selector to imgproxy request toolbox"
+```
+
+> Only stage built assets (`dist`) if the repo tracks them; check `git status` and match the existing convention.
+
+---
+
+## Task 7: Docs
+
+**Files:**
+- Modify: `fiddle/README.md` (or the doc where `mise run jaeger` is described — locate with `rg -l "mise run jaeger"`)
+
+- [ ] **Step 1: Document the s3proxy workflow**
+
+Add a short subsection next to the existing Jaeger instructions:
+
+```markdown
+### S3 source type (s3proxy)
+
+The imgproxy provider can fetch the sample images through three source adapters,
+chosen with the **Source type** control: local filesystem, a fake S3, or HTTP.
+
+For the **S3** source type, start the opt-in s3proxy sidecar (a fake S3 over the
+local filesystem that mirrors `priv/static/images`):
+
+    mise run s3proxy
+
+It serves at `http://localhost:8081` with bucket `sources` (== `priv/static/images`,
+read-only). The **HTTP** source type needs no sidecar — it fetches the fiddle's own
+`Plug.Static` at `http://localhost:4000/images/<file>`. All three resolve to
+byte-identical bytes, so switching source types is a clean adapter comparison.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add fiddle/README.md
+git commit -m "docs(fiddle): document s3proxy / source type workflow"
+```
+
+---
+
+## Task 8: Final gate
+
+- [ ] **Step 1: Run the fiddle gate**
+
+Run: `mise run precommit:fiddle`
+Expected: Elixir gate (format/compile/credo/test) + fiddle JS verify (test/check/lint/format/build) all green.
+
+- [ ] **Step 2: Manual verification (records the result; not a blocker for the gate)**
+
+1. `mise run s3proxy` in one terminal.
+2. `mise run server` in another.
+3. Open the fiddle, imgproxy provider. Toggle **Source type** between Local / S3 / HTTP on the same sample image.
+4. Confirm: all three render identically; the URL updates with `local:///…` / `s3://sources/…` / `http://localhost:4000/images/…`; reloading the page preserves the chosen source type.
+5. Stop s3proxy and confirm only the S3 source type fails (Local/HTTP still work), proving the opt-in wiring.
+
+- [ ] **Step 3: Final commit if the gate produced formatting changes**
+
+```bash
+git add -A
+git commit -m "chore(fiddle): gate fixups for s3proxy source types" || echo "nothing to commit"
+```
+
+---
+
+## Self-Review notes (for the executor)
+
+- **Library untouched:** no task edits anything under `lib/` — confirm before finishing.
+- **imgproxy-only scope:** `iiif`/`twicpics` opts in `application.ex` keep `path:` only; the `sourceType` field lives on `FiddleState` (imgproxy state) only.
+- **HTTP port coupling:** `http://localhost:4000` is hard-coded by decision; if Phoenix runs on a custom `PORT`, the HTTP source type breaks (documented, accepted).
+- **Naming consistency:** builder `sourceIdentifierForRequest(source, sourceType)` ↔ parser `parseSourceIdentifier(identifier)`; backend `imgproxy_source_mounts/0`; config key `:s3_source`; bucket `"sources"`.

--- a/docs/superpowers/plans/2026-06-26-fiddle-s3proxy-source-types.md
+++ b/docs/superpowers/plans/2026-06-26-fiddle-s3proxy-source-types.md
@@ -87,13 +87,15 @@ services:
 The existing `[tasks.jaeger]` already runs `docker compose -f fiddle/docker-compose.yml up`
 (no service filter), which once a second service exists starts **both**. Lean into that:
 replace `[tasks.jaeger]` with one `sidecars` task that defaults to bringing up both
-services, but accepts an optional service name to scope to one. mise renders the empty-default
-arg as no trailing service → `docker compose … up` (all services):
+services, but accepts an optional service name to scope to one. The arg is an **optional
+vararg** (`var=true, required=false`): when omitted it renders to nothing, so the command
+is `docker compose … up` (all services). (A `default=''` arg instead renders a literal
+`''`, which `docker compose` rejects as an empty service name.)
 
 ```toml
 [tasks.sidecars]
 description = "Run the fiddle's local sidecars (Jaeger + s3proxy). Defaults to both; pass a service to run just one, e.g. `mise run sidecars s3proxy`."
-run = "docker compose -f fiddle/docker-compose.yml up {{arg(name='service', default='')}}"
+run = "docker compose -f fiddle/docker-compose.yml up {{arg(name='service', var=true, required=false)}}"
 ```
 
 Then update the `[tasks."server:otel"]` description, which currently reads "start

--- a/docs/superpowers/plans/2026-06-26-fiddle-s3proxy-source-types.md
+++ b/docs/superpowers/plans/2026-06-26-fiddle-s3proxy-source-types.md
@@ -17,7 +17,7 @@
 ## File Structure
 
 - `fiddle/docker-compose.yml` — add `s3proxy` service alongside `jaeger`; update header comment.
-- `mise.toml` — scope `[tasks.jaeger]` to `up jaeger`; add `[tasks.s3proxy]`.
+- `mise.toml` — replace `[tasks.jaeger]` with a single `[tasks.sidecars]` (defaults to both services, optional service arg); fix the `server:otel` description.
 - `fiddle/config/config.exs` — add `:s3_source` config block (endpoint/region/credentials).
 - `fiddle/lib/image_pipe_fiddle/application.ex` — add `s3:`/`url:` mounts to the imgproxy `sources:` (imgproxy only); read s3 config.
 - `fiddle/test/image_pipe_fiddle/imgproxy_source_mounts_test.exs` — Elixir test that the mounts validate via `ImagePipe.Plug.init/1`.
@@ -33,7 +33,7 @@
 
 **Files:**
 - Modify: `fiddle/docker-compose.yml`
-- Modify: `mise.toml` (`[tasks.jaeger]` ~line 91, add `[tasks.s3proxy]`)
+- Modify: `mise.toml` (`[tasks.jaeger]` ~line 91 → `[tasks.sidecars]`; `server:otel` description)
 
 This task is infra config (no unit test); verification is `docker compose config` parsing the file.
 
@@ -44,13 +44,14 @@ Replace the existing header comment + `services:` block so the file reads:
 ```yaml
 # Local sidecar services for the fiddle demo (opt-in; not needed for `mise run server`).
 #
+#   mise run sidecars               # both services (docker compose ... up)
+#   mise run sidecars s3proxy       # just one, by service name
+#
 # Jaeger — OpenTelemetry traces:
-#   mise run jaeger                 # docker compose ... up jaeger
 #   FIDDLE_OTEL=1 mise run server   # emit traces; UI at http://localhost:16686
 #
 # s3proxy — fake S3 over the local filesystem, mirrors priv/static/images so the
-# fiddle's "S3" source type can fetch the sample images as s3://sources/<file>:
-#   mise run s3proxy                # docker compose ... up s3proxy
+# fiddle's "S3" source type can fetch the sample images as s3://sources/<file>.
 # Endpoint http://localhost:8081, bucket "sources" == ./priv/static/images (read-only).
 services:
   jaeger:
@@ -81,19 +82,22 @@ services:
 
 > Note: the `andrewgaul/s3proxy` image tag above pins a known-good digest-style tag. If it does not resolve at implementation time, substitute the current `andrewgaul/s3proxy:latest` digest and record it here.
 
-- [ ] **Step 2: Scope the jaeger mise task and add the s3proxy task in `mise.toml`**
+- [ ] **Step 2: Replace `[tasks.jaeger]` with a single `sidecars` task in `mise.toml`**
 
-Replace the existing `[tasks.jaeger]` block (currently `run = "docker compose -f fiddle/docker-compose.yml up"`) with:
+The existing `[tasks.jaeger]` already runs `docker compose -f fiddle/docker-compose.yml up`
+(no service filter), which once a second service exists starts **both**. Lean into that:
+replace `[tasks.jaeger]` with one `sidecars` task that defaults to bringing up both
+services, but accepts an optional service name to scope to one. mise renders the empty-default
+arg as no trailing service → `docker compose … up` (all services):
 
 ```toml
-[tasks.jaeger]
-description = "Run a local Jaeger (OTLP + UI) for the fiddle's OpenTelemetry traces"
-run = "docker compose -f fiddle/docker-compose.yml up jaeger"
-
-[tasks.s3proxy]
-description = "Run a local s3proxy (fake S3 over priv/static/images) for the fiddle's S3 source type"
-run = "docker compose -f fiddle/docker-compose.yml up s3proxy"
+[tasks.sidecars]
+description = "Run the fiddle's local sidecars (Jaeger + s3proxy). Defaults to both; pass a service to run just one, e.g. `mise run sidecars s3proxy`."
+run = "docker compose -f fiddle/docker-compose.yml up {{arg(name='service', default='')}}"
 ```
+
+Then update the `[tasks."server:otel"]` description, which currently reads "start
+`mise run jaeger` first", to "start `mise run sidecars jaeger` first".
 
 - [ ] **Step 3: Verify Compose file parses**
 
@@ -537,7 +541,7 @@ git commit -m "feat(fiddle): add Source type selector to imgproxy request toolbo
 ## Task 7: Docs
 
 **Files:**
-- Modify: `fiddle/README.md` (or the doc where `mise run jaeger` is described — locate with `rg -l "mise run jaeger"`)
+- Modify: `fiddle/README.md` (or the doc where the Jaeger/sidecar workflow is described — locate with `rg -l "jaeger" fiddle docs`)
 
 - [ ] **Step 1: Document the s3proxy workflow**
 
@@ -549,10 +553,11 @@ Add a short subsection next to the existing Jaeger instructions:
 The imgproxy provider can fetch the sample images through three source adapters,
 chosen with the **Source type** control: local filesystem, a fake S3, or HTTP.
 
-For the **S3** source type, start the opt-in s3proxy sidecar (a fake S3 over the
-local filesystem that mirrors `priv/static/images`):
+For the **S3** source type, start the opt-in sidecars (`mise run sidecars` brings up
+both Jaeger and s3proxy; `mise run sidecars s3proxy` starts just the fake S3, a fake S3
+over the local filesystem that mirrors `priv/static/images`):
 
-    mise run s3proxy
+    mise run sidecars s3proxy
 
 It serves at `http://localhost:8081` with bucket `sources` (== `priv/static/images`,
 read-only). The **HTTP** source type needs no sidecar — it fetches the fiddle's own
@@ -578,7 +583,7 @@ Expected: Elixir gate (format/compile/credo/test) + fiddle JS verify (test/check
 
 - [ ] **Step 2: Manual verification (records the result; not a blocker for the gate)**
 
-1. `mise run s3proxy` in one terminal.
+1. `mise run sidecars s3proxy` in one terminal.
 2. `mise run server` in another.
 3. Open the fiddle, imgproxy provider. Toggle **Source type** between Local / S3 / HTTP on the same sample image.
 4. Confirm: all three render identically; the URL updates with `local:///…` / `s3://sources/…` / `http://localhost:4000/images/…`; reloading the page preserves the chosen source type.

--- a/docs/superpowers/plans/2026-06-26-fiddle-s3proxy-source-types.md
+++ b/docs/superpowers/plans/2026-06-26-fiddle-s3proxy-source-types.md
@@ -212,20 +212,29 @@ In `fiddle/lib/image_pipe_fiddle/application.ex`, change `build_imgproxy_opts/0`
          default: [
            region: Keyword.fetch!(s3, :region),
            endpoint: Keyword.fetch!(s3, :endpoint),
-           credentials: [
-             access_key_id: Keyword.fetch!(s3, :access_key_id),
-             secret_access_key: Keyword.fetch!(s3, :secret_access_key)
-           ]
+           credentials:
+             {:static,
+              [
+                access_key_id: Keyword.fetch!(s3, :access_key_id),
+                secret_access_key: Keyword.fetch!(s3, :secret_access_key)
+              ]}
          ],
          buckets: %{"sources" => []}},
       # DEV-ONLY SSRF relaxation: the http source type fetches the fiddle's own
-      # Plug.Static over loopback, so localhost must be explicitly allowed. This
-      # lives only in the fiddle demo — never in ImagePipe library defaults.
+      # Plug.Static over loopback, so localhost must be explicitly allowed and the
+      # address policy must permit loopback IPs. This lives only in the fiddle demo
+      # — never in ImagePipe library defaults.
       url:
-        {ImagePipe.Source.HTTP, allowed_hosts: ["localhost", "127.0.0.1"], allow_loopback: true}
+        {ImagePipe.Source.HTTP,
+         allowed_hosts: ["localhost", "127.0.0.1"], address_policy: [allow_loopback: true]}
     ]
   end
 ```
+
+> Note on shapes (verified against the adapters): `Source.S3` credentials must be the
+> tagged `{:static, [access_key_id: …, secret_access_key: …]}` form (a bare keyword list
+> is rejected as `:invalid_credentials`). `Source.HTTP` has no top-level `allow_loopback`;
+> loopback is permitted via `address_policy: [allow_loopback: true]`.
 
 The `static_root` local previously declared at the top of `build_imgproxy_opts/0` is now only used inside `imgproxy_source_mounts/0`; remove the now-unused binding from `build_imgproxy_opts/0` so it doesn't warn.
 

--- a/docs/superpowers/specs/2026-06-26-fiddle-s3proxy-source-types-design.md
+++ b/docs/superpowers/specs/2026-06-26-fiddle-s3proxy-source-types-design.md
@@ -88,7 +88,8 @@ currently only has `path:`):
 sources: [
   path: {ImagePipe.Source.File, root: static_root, root_id: "static", stable: :trusted},
   s3:   {ImagePipe.Source.S3, s3_source_opts},
-  url:  {ImagePipe.Source.HTTP, allowed_hosts: ["localhost", "127.0.0.1"], allow_loopback: true}
+  url:  {ImagePipe.Source.HTTP,
+         allowed_hosts: ["localhost", "127.0.0.1"], address_policy: [allow_loopback: true]}
 ]
 ```
 
@@ -99,14 +100,19 @@ s3_source_opts = [
   default: [
     region: s3_cfg[:region],
     endpoint: s3_cfg[:endpoint],
-    credentials: [
+    credentials: {:static, [
       access_key_id: s3_cfg[:access_key_id],
       secret_access_key: s3_cfg[:secret_access_key]
-    ]
+    ]}
   ],
   buckets: %{"sources" => []}
 ]
 ```
+
+> Shapes verified against the adapters: `Source.S3` credentials use the tagged
+> `{:static, [...]}` form (a bare keyword list is rejected as `:invalid_credentials`);
+> `Source.HTTP` permits loopback via `address_policy: [allow_loopback: true]`, not a
+> top-level `allow_loopback`.
 
 Scoped to the **imgproxy** provider only. `build_iiif_opts/0` and `build_twicpics_opts/0`
 keep `path:` only.

--- a/docs/superpowers/specs/2026-06-26-fiddle-s3proxy-source-types-design.md
+++ b/docs/superpowers/specs/2026-06-26-fiddle-s3proxy-source-types-design.md
@@ -1,0 +1,185 @@
+# Fiddle: s3proxy fake-S3 + multi-source-type selector
+
+**Date:** 2026-06-26
+**Status:** Approved (brainstorming) — pending implementation plan
+**Scope:** `fiddle/` demo app only. No `ImagePipe` library changes.
+
+## Problem
+
+The fiddle exercises the imgproxy compatibility provider against sample images, but
+only through the **local filesystem** source adapter (`local:///images/<file>` →
+`ImagePipe.Source.File`). The S3 (`ImagePipe.Source.S3`) and HTTP
+(`ImagePipe.Source.HTTP`) source adapters already exist and are already understood by
+the imgproxy parser (`s3://bucket/key`, `http(s)://host/path`), but there is no way to
+drive them from the demo. We want to:
+
+1. Stand up a **fake S3** endpoint, backed by the local filesystem, that mirrors the
+   existing sample images — so the fiddle can exercise the S3 source path end-to-end
+   without a real cloud bucket.
+2. Extend the fiddle's imgproxy request toolbox with a **source-type selector** so a
+   demo user can pick whether a given sample image is fetched via local, S3, or HTTP.
+
+## Key insight
+
+All three source adapters can resolve to **byte-identical bytes** from the same
+`fiddle/priv/static/images/` set:
+
+| Source type | Request source identifier         | Adapter              | Backing bytes                         |
+|-------------|-----------------------------------|----------------------|---------------------------------------|
+| local       | `local:///images/dog.jpg`         | `Source.File`        | `priv/static/images/dog.jpg`          |
+| s3          | `s3://sources/dog.jpg`            | `Source.S3` → s3proxy| `priv/static/images/dog.jpg` (mounted)|
+| http        | `http://localhost:4000/images/dog.jpg` | `Source.HTTP`   | `priv/static/images/dog.jpg` (Plug.Static) |
+
+This makes the fiddle a true **side-by-side comparison of source adapters on identical
+inputs**. The library needs **zero changes** — all three adapters and the imgproxy
+scheme parsing already exist.
+
+Confirmed facts:
+- `ImagePipe.Source.S3` requires a `region`, an `endpoint` (http allowed, with a port),
+  and `credentials` (validated at `Plug.init`). All satisfiable by s3proxy.
+- The `sources:` keyword routes an `s3://` `Plan.Source.Object` (`adapter: :s3`) to the
+  adapter mounted under the `s3:` key, and `http(s)://` `Plan.Source.URL` to the adapter
+  mounted under `url:` (which `expand_url_source_config/1` fans out to `:http`/`:https`).
+- `ImagePipe.Source.HTTP` requires explicit `allowed_hosts` and denies loopback by
+  default; permitting `localhost`/`127.0.0.1` needs `allow_loopback: true`.
+- Phoenix serves `priv/static/images/` via `Plug.Static` (`static_paths/0` includes
+  `images`) on the endpoint's own HTTP listener, dev port **4000**
+  (`PORT` default in `runtime.exs`). `static_url: [port: 5173]` only affects generated
+  asset URLs, not where `Plug.Static` listens — so a server-side fetch of
+  `http://127.0.0.1:4000/images/<file>` is served by `Plug.Static`.
+
+## Design
+
+### 1. Compose service — `fiddle/docker-compose.yml`
+
+Add an `s3proxy` service alongside the existing `jaeger` service, using the
+`andrewgaul/s3proxy` image with the jclouds **filesystem** backend:
+
+- `JCLOUDS_PROVIDER=filesystem`, filesystem basedir `/data`.
+- Bind-mount `./priv/static/images` → `/data/sources:ro` (read-only). The top-level dir
+  under basedir becomes the bucket, so bucket `sources` == the images dir.
+- Fixed dev credentials via `S3PROXY_AUTHORIZATION=aws-v2-or-v4`,
+  `S3PROXY_IDENTITY`, `S3PROXY_CREDENTIAL`.
+- Host port **8081** (avoids 4000/5173 and Jaeger's ports).
+
+Because `andrewgaul/s3proxy` listens on container port 80 by default, map `8081:80`
+(or set `S3PROXY_ENDPOINT=http://0.0.0.0:80`).
+
+### 2. mise tasks — `mise.toml`
+
+The existing `[tasks.jaeger]` runs `docker compose -f fiddle/docker-compose.yml up`,
+which (once a second service exists) would start **both** services. Scope each task to
+its own service so they start independently:
+
+- `[tasks.jaeger]` → `... up jaeger`
+- `[tasks.s3proxy]` (new) → `... up s3proxy`, described as starting the local fake-S3
+  used by the fiddle's S3 source type.
+
+### 3. Fiddle backend — `fiddle/lib/image_pipe_fiddle/application.ex`
+
+In `build_imgproxy_opts/0`, add two mounts to the existing `sources:` keyword (which
+currently only has `path:`):
+
+```elixir
+sources: [
+  path: {ImagePipe.Source.File, root: static_root, root_id: "static", stable: :trusted},
+  s3:   {ImagePipe.Source.S3, s3_source_opts},
+  url:  {ImagePipe.Source.HTTP, allowed_hosts: ["localhost", "127.0.0.1"], allow_loopback: true}
+]
+```
+
+The S3 options are **config-driven**, read from a new application-env block (see §4):
+
+```elixir
+s3_source_opts = [
+  default: [
+    region: s3_cfg[:region],
+    endpoint: s3_cfg[:endpoint],
+    credentials: [
+      access_key_id: s3_cfg[:access_key_id],
+      secret_access_key: s3_cfg[:secret_access_key]
+    ]
+  ],
+  buckets: %{"sources" => []}
+]
+```
+
+Scoped to the **imgproxy** provider only. `build_iiif_opts/0` and `build_twicpics_opts/0`
+keep `path:` only.
+
+> **Safety note (documented inline):** `allow_loopback: true` plus loopback
+> `allowed_hosts` is a deliberate SSRF relaxation that exists **only in the fiddle demo**,
+> never in the `ImagePipe` library defaults. The comment must say why (the fiddle's HTTP
+> source type fetches the fiddle's own `Plug.Static` over loopback).
+
+### 4. Config — `fiddle/config/config.exs` (+ `dev.exs` if needed)
+
+New block with the s3proxy connection defaults:
+
+```elixir
+config :image_pipe_fiddle, :s3_source,
+  region: "us-east-1",
+  endpoint: "http://localhost:8081",
+  access_key_id: "fiddle",
+  secret_access_key: "fiddlesecret"
+```
+
+`build_imgproxy_opts/0` reads it via `Application.fetch_env!/2` (or `get_env` with a
+fallback). Keeping it in config keeps the s3proxy credential/endpoint coordinates in one
+place that matches the compose env values.
+
+### 5. Svelte UI
+
+**State — `fiddle/assets/fiddle-url-state.ts`:**
+Add `sourceType: "local" | "s3" | "http"` to the **imgproxy** slice, default `"local"`,
+serialized/round-tripped through the URL state exactly like the other imgproxy controls.
+(iiif/twicpics slices unchanged.)
+
+**Path building — `fiddle/assets/processing-path.ts`:**
+`sourceIdentifierForRequest(source, sourceType)` branches on `sourceType`. `source`
+is the sample path (e.g. `images/dog.jpg`); `<file>` is its basename:
+
+- `local` → `local:///images/<file>`  (unchanged behavior)
+- `s3`    → `s3://sources/<file>`
+- `http`  → `http://localhost:4000/images/<file>`
+
+The HTTP port `4000` is hard-coded (accepted coupling — breaks only if Phoenix is run on
+a custom `PORT`, which the demo doesn't do).
+
+**Control — `fiddle/assets/App.svelte`:**
+A new **"Source type"** `<select>` (Local | S3 | HTTP) in the imgproxy request section,
+adjacent to the existing "Source image" picker, bound to the imgproxy `sourceType` state.
+
+### 6. Testing
+
+- **JS (vitest):** unit-test `sourceIdentifierForRequest` for all three source types
+  (correct scheme/host/key per type), and round-trip `sourceType` through the URL-state
+  encode/decode.
+- **Elixir:** a fiddle test asserting `build_imgproxy_opts/0` (i.e. `ImagePipe.Plug.init`)
+  accepts the new `s3:` and `url:` mounts — config validation happens at boot, so this
+  pins that the mounts are well-formed. No live s3proxy fetch in CI (the service is
+  opt-in, the same way Jaeger isn't required for the default gate).
+- **Manual:** run `mise run s3proxy`, toggle source types in the UI against the same
+  sample image, confirm identical output across local/s3/http.
+
+## Out of scope (YAGNI)
+
+- Bucket browsing / object listing in the UI.
+- Free-text bucket/key inputs (we mirror the fixed sample set).
+- MinIO / LocalStack (s3proxy's filesystem backend mirrors the dir directly, which is
+  exactly the "mirror the local sources" requirement).
+- Always-on dev stack (s3proxy stays opt-in like Jaeger).
+- HTTP/S3 source types for the iiif/twicpics providers.
+- Threading the Phoenix `PORT` into the frontend (4000 hard-coded by decision).
+
+## Files touched
+
+- `fiddle/docker-compose.yml` — add `s3proxy` service.
+- `mise.toml` — scope `jaeger` task, add `s3proxy` task.
+- `fiddle/config/config.exs` — add `:s3_source` config block.
+- `fiddle/lib/image_pipe_fiddle/application.ex` — add `s3:`/`url:` mounts (imgproxy only).
+- `fiddle/assets/fiddle-url-state.ts` — `sourceType` state + serialization.
+- `fiddle/assets/processing-path.ts` — `sourceIdentifierForRequest` branching.
+- `fiddle/assets/App.svelte` — "Source type" select control.
+- JS + Elixir tests per §6.
+- A short README/usage note (where `mise run jaeger` is documented) for `mise run s3proxy`.

--- a/docs/superpowers/specs/2026-06-26-fiddle-s3proxy-source-types-design.md
+++ b/docs/superpowers/specs/2026-06-26-fiddle-s3proxy-source-types-design.md
@@ -67,13 +67,17 @@ Because `andrewgaul/s3proxy` listens on container port 80 by default, map `8081:
 
 ### 2. mise tasks — `mise.toml`
 
-The existing `[tasks.jaeger]` runs `docker compose -f fiddle/docker-compose.yml up`,
-which (once a second service exists) would start **both** services. Scope each task to
-its own service so they start independently:
+The existing `[tasks.jaeger]` runs `docker compose -f fiddle/docker-compose.yml up`
+(no service filter), which once a second service exists already starts **both**. Replace
+it with a single `[tasks.sidecars]` that **defaults to bringing up both** services and
+accepts an optional service name to scope to one:
 
-- `[tasks.jaeger]` → `... up jaeger`
-- `[tasks.s3proxy]` (new) → `... up s3proxy`, described as starting the local fake-S3
-  used by the fiddle's S3 source type.
+- `mise run sidecars` → `... up` (both Jaeger + s3proxy)
+- `mise run sidecars s3proxy` → `... up s3proxy` (just one), via an optional positional
+  arg (`{{arg(name='service', default='')}}`).
+
+Update the `server:otel` task description to reference `mise run sidecars` instead of the
+removed `mise run jaeger`.
 
 ### 3. Fiddle backend — `fiddle/lib/image_pipe_fiddle/application.ex`
 

--- a/docs/superpowers/specs/2026-06-26-fiddle-s3proxy-source-types-design.md
+++ b/docs/superpowers/specs/2026-06-26-fiddle-s3proxy-source-types-design.md
@@ -74,7 +74,8 @@ accepts an optional service name to scope to one:
 
 - `mise run sidecars` → `... up` (both Jaeger + s3proxy)
 - `mise run sidecars s3proxy` → `... up s3proxy` (just one), via an optional positional
-  arg (`{{arg(name='service', default='')}}`).
+  optional vararg (`{{arg(name='service', var=true, required=false)}}` — a `default=''`
+  arg instead renders a literal `''` that `docker compose` rejects).
 
 Update the `server:otel` task description to reference `mise run sidecars` instead of the
 removed `mise run jaeger`.

--- a/docs/superpowers/specs/2026-06-26-fiddle-s3proxy-source-types-design.md
+++ b/docs/superpowers/specs/2026-06-26-fiddle-s3proxy-source-types-design.md
@@ -67,18 +67,17 @@ Because `andrewgaul/s3proxy` listens on container port 80 by default, map `8081:
 
 ### 2. mise tasks — `mise.toml`
 
-The existing `[tasks.jaeger]` runs `docker compose -f fiddle/docker-compose.yml up`
-(no service filter), which once a second service exists already starts **both**. Replace
-it with a single `[tasks.sidecars]` that **defaults to bringing up both** services and
-accepts an optional service name to scope to one:
+Consolidate the fiddle dev tasks under a `fiddle` namespace (replacing the standalone
+`server`, `server:otel`, and `jaeger` tasks):
 
-- `mise run sidecars` → `... up` (both Jaeger + s3proxy)
-- `mise run sidecars s3proxy` → `... up s3proxy` (just one), via an optional positional
-  optional vararg (`{{arg(name='service', var=true, required=false)}}` — a `default=''`
-  arg instead renders a literal `''` that `docker compose` rejects).
-
-Update the `server:otel` task description to reference `mise run sidecars` instead of the
-removed `mise run jaeger`.
+- `mise run fiddle` → boots Phoenix + Vite (`mix phx.server`).
+- `mise run fiddle otel` → same, with OpenTelemetry tracing on. The `otel` token is an
+  optional vararg the run script checks to `export FIDDLE_OTEL=1` (mise's static `env`
+  table can't be set conditionally from an arg, so the toggle lives in the shell script).
+- `mise run fiddle:sidecars` → `docker compose … up` (both Jaeger + s3proxy).
+- `mise run fiddle:sidecars s3proxy` → `… up s3proxy` (just one), via an optional vararg
+  (`{{arg(name='service', var=true, required=false)}}` — a `default=''` arg instead
+  renders a literal `''` that `docker compose` rejects as an empty service name).
 
 ### 3. Fiddle backend — `fiddle/lib/image_pipe_fiddle/application.ex`
 

--- a/fiddle/assets/App.svelte
+++ b/fiddle/assets/App.svelte
@@ -488,6 +488,15 @@
 
             {#if appState.provider === "imgproxy"}
               <label class="field">
+                <span>Source type</span>
+                <select bind:value={appState.imgproxy.sourceType}>
+                  <option value="local">Local (filesystem)</option>
+                  <option value="s3">S3 (s3proxy)</option>
+                  <option value="http">HTTP (Plug.Static)</option>
+                </select>
+              </label>
+
+              <label class="field">
                 <span>Signature</span>
                 <select bind:value={appState.imgproxy.signatureMode}>
                   <option value="unsigned">unsigned</option>

--- a/fiddle/assets/fiddle-url-state.test.ts
+++ b/fiddle/assets/fiddle-url-state.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from "vitest";
 import { defaultFiddleState } from "./processing-path";
 import { defaultIiifState } from "./iiif-path";
 import { defaultTwicPicsState } from "./twicpics-path";
-import { appPathForState, parseAppPath, type AppState } from "./fiddle-url-state";
+import {
+  appPathForState,
+  fiddlePathForState,
+  parseAppPath,
+  parseFiddlePath,
+  type AppState,
+} from "./fiddle-url-state";
 
 function baseAppState(): AppState {
   return {
@@ -99,4 +105,16 @@ describe("twicpics provider dispatch", () => {
     expect(parsed.provider).toBe("twicpics");
     expect(parsed.twicpics).toEqual(defaultTwicPicsState);
   });
+});
+
+describe("source type round-trip", () => {
+  for (const sourceType of ["local", "s3", "http"] as const) {
+    it(`preserves sourceType=${sourceType} through path build + parse`, () => {
+      const state = { ...defaultFiddleState, source: "images/dog.jpg" as const, sourceType };
+      const path = fiddlePathForState(state);
+      const parsed = parseFiddlePath(path);
+      expect(parsed.source).toBe("images/dog.jpg");
+      expect(parsed.sourceType).toBe(sourceType);
+    });
+  }
 });

--- a/fiddle/assets/fiddle-url-state.ts
+++ b/fiddle/assets/fiddle-url-state.ts
@@ -1,7 +1,7 @@
 import {
   defaultFiddleState,
+  parseSourceIdentifier,
   resetCropPixelsToSource,
-  sampleImages,
   signedPathForState,
   type ColorProfile,
   type CropDimensionUnit,
@@ -14,6 +14,7 @@ import {
   type ResizeMode,
   type Rotate,
   type SourceImage,
+  type SourceType,
   type ObjSubMode,
   type TrimBackgroundMode,
 } from "./processing-path";
@@ -44,8 +45,6 @@ type ParsedDimension<Unit> = {
 };
 
 const plainSourceMarker = "/plain/";
-const localSourcePrefix = "local:///";
-const sourceImages = new Set<string>(sampleImages.map((image) => image.path));
 const resizeModes = new Set<string>(["fit", "fill", "fill-down", "force", "auto"]);
 const gravityValues = new Set<string>([
   "ce",
@@ -82,6 +81,7 @@ export function parseFiddlePath(pathname: string): FiddleState {
   let state = resetCropPixelsToSource({
     ...defaultFiddleState,
     source: parsed.source,
+    sourceType: parsed.sourceType,
   });
 
   for (const segment of parsed.optionSegments) {
@@ -133,7 +133,7 @@ export function expandedToolboxesForState(currentState: FiddleState): ExpandedTo
 
 function parseFiddlePathParts(
   pathname: string,
-): { optionSegments: string[]; source: SourceImage } | null {
+): { optionSegments: string[]; source: SourceImage; sourceType: SourceType } | null {
   const path = pathname.endsWith("/") && pathname !== "/" ? pathname.slice(0, -1) : pathname;
 
   const plainIndex = path.indexOf(plainSourceMarker);
@@ -143,25 +143,17 @@ function parseFiddlePathParts(
   }
 
   const optionSegments = path.slice(0, plainIndex).split("/").filter(Boolean);
-  const source = sourceFromIdentifier(path.slice(plainIndex + plainSourceMarker.length));
+  const parsedSource = parseSourceIdentifier(path.slice(plainIndex + plainSourceMarker.length));
 
-  if (source === null) {
+  if (parsedSource === null) {
     return null;
   }
 
   return {
     optionSegments,
-    source,
+    source: parsedSource.source,
+    sourceType: parsedSource.sourceType,
   };
-}
-
-function sourceFromIdentifier(identifier: string): SourceImage | null {
-  if (!identifier.startsWith(localSourcePrefix)) {
-    return null;
-  }
-
-  const source = identifier.slice(localSourcePrefix.length);
-  return sourceImages.has(source) ? (source as SourceImage) : null;
 }
 
 function applyOptionSegment(currentState: FiddleState, segment: string): FiddleState | null {

--- a/fiddle/assets/processing-path.test.ts
+++ b/fiddle/assets/processing-path.test.ts
@@ -23,6 +23,8 @@ import {
   resolvedOutputLabel,
   signProcessingPath,
   signedPathForState,
+  sourceIdentifierForRequest,
+  parseSourceIdentifier,
   trimOptionSegment,
 } from "./processing-path";
 import {
@@ -2020,5 +2022,38 @@ describe("object-gravity + focal-point segment building", () => {
       objWeights: { dog: 2, person: 1 },
     };
     expect(objGravitySegmentFromState(state)).toBe("g:objw:dog:2:person:1");
+  });
+});
+
+describe("sourceIdentifierForRequest", () => {
+  it("builds a local:/// identifier", () => {
+    expect(sourceIdentifierForRequest("images/dog.jpg", "local")).toBe("local:///images/dog.jpg");
+  });
+
+  it("builds an s3://sources/<file> identifier from the basename", () => {
+    expect(sourceIdentifierForRequest("images/dog.jpg", "s3")).toBe("s3://sources/dog.jpg");
+  });
+
+  it("builds an http://localhost:4000 identifier", () => {
+    expect(sourceIdentifierForRequest("images/dog.jpg", "http")).toBe(
+      "http://localhost:4000/images/dog.jpg",
+    );
+  });
+});
+
+describe("parseSourceIdentifier", () => {
+  it("round-trips each source type", () => {
+    for (const sourceType of ["local", "s3", "http"] as const) {
+      const id = sourceIdentifierForRequest("images/dog.jpg", sourceType);
+      expect(parseSourceIdentifier(id)).toEqual({ source: "images/dog.jpg", sourceType });
+    }
+  });
+
+  it("returns null for an unknown scheme", () => {
+    expect(parseSourceIdentifier("ftp://nope/dog.jpg")).toBeNull();
+  });
+
+  it("returns null when the identifier does not map to a known sample image", () => {
+    expect(parseSourceIdentifier("s3://sources/not-a-real-image.jpg")).toBeNull();
   });
 });

--- a/fiddle/assets/processing-path.ts
+++ b/fiddle/assets/processing-path.ts
@@ -17,6 +17,15 @@ export type Rotate = 0 | 90 | 180 | 270;
 export type SignatureMode = "unsigned" | "signed";
 export type SourceImage = (typeof sampleImages)[number]["path"];
 
+// How a sample image is delivered to the imgproxy provider. All three resolve to
+// byte-identical bytes from priv/static/images: local filesystem, the opt-in
+// s3proxy fake S3, and HTTP against the fiddle's own Plug.Static.
+export type SourceType = "local" | "s3" | "http";
+
+const localSourceScheme = "local:///";
+const s3SourceBucketPrefix = "s3://sources/";
+const httpSourcePrefix = "http://localhost:4000/";
+
 // COCO-80 object classes in underscore spelling, matching the hardcoded list in
 // ImagePipe.Transform.Detector.ImageVision.Objects (@coco_classes).
 export const cocoClasses = [
@@ -111,6 +120,7 @@ export type FiddleState = {
   signatureKey: string;
   signatureSalt: string;
   source: SourceImage;
+  sourceType: SourceType;
   autoRotateEnabled: boolean;
   flip: Flip;
   rotate: Rotate;
@@ -347,6 +357,7 @@ export const defaultFiddleState: FiddleState = {
   signatureKey: "736563726574",
   signatureSalt: "68656c6c6f",
   source: "images/dog.jpg",
+  sourceType: "local",
   autoRotateEnabled: false,
   flip: "none",
   rotate: 0,
@@ -939,15 +950,57 @@ export function imageRequestBytesFromPerformance(
   return null;
 }
 
-export function sourceIdentifierForRequest(source: SourceImage): string {
-  return `local:///${source}`;
+export function sourceIdentifierForRequest(source: SourceImage, sourceType: SourceType): string {
+  switch (sourceType) {
+    case "local":
+      return `${localSourceScheme}${source}`;
+    case "s3":
+      // Bucket "sources" is rooted at priv/static/images, so the key is the basename.
+      return `${s3SourceBucketPrefix}${source.slice(source.lastIndexOf("/") + 1)}`;
+    case "http":
+      // The fiddle's own Plug.Static serves priv/static/images at /images/<file>.
+      return `${httpSourcePrefix}${source}`;
+  }
+}
+
+// Inverse of sourceIdentifierForRequest: recovers (source, sourceType) from a
+// processing-path source identifier, or null if it is not a known sample image.
+export function parseSourceIdentifier(
+  identifier: string,
+): { source: SourceImage; sourceType: SourceType } | null {
+  const candidate = sourceTypeAndPath(identifier);
+
+  if (candidate === null) {
+    return null;
+  }
+
+  const { source, sourceType } = candidate;
+  const known = sampleImages.some((image) => image.path === source);
+  return known ? { source: source as SourceImage, sourceType } : null;
+}
+
+function sourceTypeAndPath(identifier: string): { source: string; sourceType: SourceType } | null {
+  if (identifier.startsWith(localSourceScheme)) {
+    return { source: identifier.slice(localSourceScheme.length), sourceType: "local" };
+  }
+
+  if (identifier.startsWith(httpSourcePrefix)) {
+    return { source: identifier.slice(httpSourcePrefix.length), sourceType: "http" };
+  }
+
+  if (identifier.startsWith(s3SourceBucketPrefix)) {
+    // Reconstruct the images/<file> source from the basename key.
+    return { source: `images/${identifier.slice(s3SourceBucketPrefix.length)}`, sourceType: "s3" };
+  }
+
+  return null;
 }
 
 export function signedPathForState(currentState: FiddleState): string {
   const options = optionSegments(currentState).join("/");
   const optionsPath = options === "" ? "" : `/${options}`;
 
-  return `${optionsPath}/plain/${sourceIdentifierForRequest(currentState.source)}`;
+  return `${optionsPath}/plain/${sourceIdentifierForRequest(currentState.source, currentState.sourceType)}`;
 }
 
 const processingPrefix = "/img";

--- a/fiddle/config/config.exs
+++ b/fiddle/config/config.exs
@@ -55,7 +55,7 @@ config :phoenix, :json_library, Jason
 # OpenTelemetry → local Jaeger (see docker-compose.yml). Traces are only emitted
 # when the tracer is attached at startup (FIDDLE_OTEL=1; see
 # ImagePipeFiddle.Application) — with no spans the SDK never contacts the collector,
-# so this is inert for a plain `mise run server` with no Jaeger running.
+# so this is inert for a plain `mise run fiddle` with no Jaeger running.
 config :opentelemetry,
   span_processor: :batch,
   traces_exporter: :otlp,

--- a/fiddle/config/config.exs
+++ b/fiddle/config/config.exs
@@ -24,6 +24,15 @@ config :image_pipe_fiddle, :imgproxy,
   ],
   smart_crop_face_detection: true
 
+# Connection coordinates for the fiddle's S3 source type, served by the opt-in
+# s3proxy compose service (see fiddle/docker-compose.yml). These mirror the
+# s3proxy env: bucket "sources" == priv/static/images. Dev-only fake credentials.
+config :image_pipe_fiddle, :s3_source,
+  region: "us-east-1",
+  endpoint: "http://localhost:8081",
+  access_key_id: "fiddle",
+  secret_access_key: "fiddlesecret"
+
 # Configure the endpoint
 config :image_pipe_fiddle, ImagePipeFiddleWeb.Endpoint,
   url: [host: "localhost"],

--- a/fiddle/docker-compose.yml
+++ b/fiddle/docker-compose.yml
@@ -1,10 +1,10 @@
-# Local sidecar services for the fiddle demo (opt-in; not needed for `mise run server`).
+# Local sidecar services for the fiddle demo (opt-in; not needed for `mise run fiddle`).
 #
-#   mise run sidecars               # both services (docker compose ... up)
-#   mise run sidecars s3proxy       # just one, by service name
+#   mise run fiddle:sidecars            # both services (docker compose ... up)
+#   mise run fiddle:sidecars s3proxy    # just one, by service name
 #
 # Jaeger (all-in-one v2) — OpenTelemetry traces:
-#   FIDDLE_OTEL=1 mise run server   # emit traces; UI at http://localhost:16686
+#   mise run fiddle otel                # emit traces; UI at http://localhost:16686
 # Then look for the `image_pipe.request` trace after issuing an /img request.
 #
 # s3proxy — fake S3 over the local filesystem, mirrors priv/static/images so the

--- a/fiddle/docker-compose.yml
+++ b/fiddle/docker-compose.yml
@@ -1,10 +1,15 @@
-# Local Jaeger (all-in-one v2) for the fiddle's OpenTelemetry traces.
+# Local sidecar services for the fiddle demo (opt-in; not needed for `mise run server`).
 #
-#   docker compose -f fiddle/docker-compose.yml up   # or: mise run jaeger
-#   FIDDLE_OTEL=1 mise run server                     # emit traces
+#   mise run sidecars               # both services (docker compose ... up)
+#   mise run sidecars s3proxy       # just one, by service name
 #
-# Then open the Jaeger UI at http://localhost:16686 and look for the
-# `image_pipe.request` trace after issuing an /img request.
+# Jaeger (all-in-one v2) — OpenTelemetry traces:
+#   FIDDLE_OTEL=1 mise run server   # emit traces; UI at http://localhost:16686
+# Then look for the `image_pipe.request` trace after issuing an /img request.
+#
+# s3proxy — fake S3 over the local filesystem, mirrors priv/static/images so the
+# fiddle's "S3" source type can fetch the sample images as s3://sources/<file>.
+# Endpoint http://localhost:8081, bucket "sources" == ./priv/static/images (read-only).
 services:
   jaeger:
     image: cr.jaegertracing.io/jaegertracing/jaeger:2.19.0
@@ -15,3 +20,18 @@ services:
       - "4318:4318" # OTLP HTTP (the fiddle exports here)
       - "5778:5778" # sampling/config
       - "9411:9411" # Zipkin
+
+  s3proxy:
+    image: andrewgaul/s3proxy:sha-7894241
+    container_name: fiddle-s3proxy
+    ports:
+      - "8081:80" # s3proxy listens on container port 80
+    environment:
+      S3PROXY_AUTHORIZATION: aws-v2-or-v4
+      S3PROXY_IDENTITY: fiddle
+      S3PROXY_CREDENTIAL: fiddlesecret
+      JCLOUDS_PROVIDER: filesystem
+      JCLOUDS_FILESYSTEM_BASEDIR: /data
+    volumes:
+      # Mounted read-only: the demo only reads. Bucket name == the subdir under basedir.
+      - ./priv/static/images:/data/sources:ro

--- a/fiddle/lib/image_pipe_fiddle/application.ex
+++ b/fiddle/lib/image_pipe_fiddle/application.ex
@@ -37,7 +37,7 @@ defmodule ImagePipeFiddle.Application do
 
   # Opt-in OpenTelemetry tracing: with FIDDLE_OTEL=1 (and Jaeger running — see
   # docker-compose.yml), replay ImagePipe's spans into the OTel SDK, which exports
-  # them over OTLP to Jaeger. Off by default so `mise run server` needs no Jaeger.
+  # them over OTLP to Jaeger. Off by default so `mise run fiddle` needs no Jaeger.
   defp maybe_attach_tracer do
     if System.get_env("FIDDLE_OTEL") in ~w(1 true) do
       ImagePipe.Telemetry.attach_tracer(

--- a/fiddle/lib/image_pipe_fiddle/application.ex
+++ b/fiddle/lib/image_pipe_fiddle/application.ex
@@ -47,15 +47,46 @@ defmodule ImagePipeFiddle.Application do
     end
   end
 
+  @doc false
+  # Source adapters mounted for the imgproxy provider. The local File source is
+  # always available; s3 (via the opt-in s3proxy compose service) and http (the
+  # fiddle's own Plug.Static over loopback) let the demo compare source adapters
+  # on byte-identical sample images. Scoped to imgproxy — iiif/twicpics keep File.
+  def imgproxy_source_mounts do
+    static_root = Application.app_dir(:image_pipe_fiddle, "priv/static")
+    s3 = Application.fetch_env!(:image_pipe_fiddle, :s3_source)
+
+    [
+      path: {ImagePipe.Source.File, root: static_root, root_id: "static", stable: :trusted},
+      s3:
+        {ImagePipe.Source.S3,
+         default: [
+           region: Keyword.fetch!(s3, :region),
+           endpoint: Keyword.fetch!(s3, :endpoint),
+           credentials:
+             {:static,
+              [
+                access_key_id: Keyword.fetch!(s3, :access_key_id),
+                secret_access_key: Keyword.fetch!(s3, :secret_access_key)
+              ]}
+         ],
+         buckets: %{"sources" => []}},
+      # DEV-ONLY SSRF relaxation: the http source type fetches the fiddle's own
+      # Plug.Static over loopback, so localhost must be explicitly allowed and the
+      # address policy must permit loopback IPs. This lives only in the fiddle demo
+      # — never in ImagePipe library defaults.
+      url:
+        {ImagePipe.Source.HTTP,
+         allowed_hosts: ["localhost", "127.0.0.1"], address_policy: [allow_loopback: true]}
+    ]
+  end
+
   defp build_imgproxy_opts do
     imgproxy = Application.fetch_env!(:image_pipe_fiddle, :imgproxy)
-    static_root = Application.app_dir(:image_pipe_fiddle, "priv/static")
 
     [
       parser: ImagePipe.Parser.Imgproxy,
-      sources: [
-        path: {ImagePipe.Source.File, root: static_root, root_id: "static", stable: :trusted}
-      ],
+      sources: imgproxy_source_mounts(),
       imgproxy: imgproxy,
       # Graceful fallback: detection failures degrade to attention crop (200) rather
       # than erroring; the default Logger surfaces any detection fallback.

--- a/fiddle/test/image_pipe_fiddle/imgproxy_source_mounts_test.exs
+++ b/fiddle/test/image_pipe_fiddle/imgproxy_source_mounts_test.exs
@@ -1,0 +1,22 @@
+defmodule ImagePipeFiddle.ImgproxySourceMountsTest do
+  use ExUnit.Case, async: true
+
+  # The fiddle mounts three source adapters for the imgproxy provider so the demo
+  # can fetch the same sample images via local / s3 / http. This pins that the s3
+  # and http mount shapes are accepted by ImagePipe's host-config validation
+  # (Plug.init raises on an invalid source config).
+  test "imgproxy_source_mounts/0 is accepted by ImagePipe.Plug.init/1" do
+    opts =
+      ImagePipe.Plug.init(
+        parser: ImagePipe.Parser.Imgproxy,
+        imgproxy: Application.fetch_env!(:image_pipe_fiddle, :imgproxy),
+        sources: ImagePipeFiddle.Application.imgproxy_source_mounts()
+      )
+
+    assert is_list(opts)
+    sources = Keyword.fetch!(opts, :sources)
+    # url: fans out to :http/:https inside ImagePipe; s3 stays under :s3.
+    assert Map.has_key?(sources, :s3)
+    assert Map.has_key?(sources, :http)
+  end
+end

--- a/mise.toml
+++ b/mise.toml
@@ -77,19 +77,18 @@ run = [
 description = "Remove regenerable dirs (deps, _build, fiddle deps/_build/node_modules, .dexter, .expert) from every worktree (→ mix worktrees.clean)"
 run = "mix worktrees.clean"
 
-[tasks.server]
-description = "Run the ImagePipe Fiddle dev server (Phoenix + Vite)"
+[tasks.fiddle]
+description = "Run the ImagePipe Fiddle dev server (Phoenix + Vite). Pass `otel` to enable OpenTelemetry tracing (start `mise run fiddle:sidecars jaeger` first)."
 dir = "fiddle"
-run = "mix phx.server"
+run = """
+if [ "{{arg(name='mode', var=true, required=false)}}" = "otel" ]; then
+  export FIDDLE_OTEL=1
+fi
+exec mix phx.server
+"""
 
-[tasks."server:otel"]
-description = "Run the fiddle dev server with OpenTelemetry tracing on (start `mise run sidecars jaeger` first)"
-dir = "fiddle"
-env = { FIDDLE_OTEL = "1" }
-run = "mix phx.server"
-
-[tasks.sidecars]
-description = "Run the fiddle's local sidecars (Jaeger + s3proxy). Defaults to both; pass a service to run just one, e.g. `mise run sidecars s3proxy`."
+[tasks."fiddle:sidecars"]
+description = "Run the fiddle's local sidecars (Jaeger + s3proxy). Defaults to both; pass a service to run just one, e.g. `mise run fiddle:sidecars s3proxy`."
 run = "docker compose -f fiddle/docker-compose.yml up {{arg(name='service', var=true, required=false)}}"
 
 # IIIF image-validator gate (requires Docker).

--- a/mise.toml
+++ b/mise.toml
@@ -90,7 +90,7 @@ run = "mix phx.server"
 
 [tasks.sidecars]
 description = "Run the fiddle's local sidecars (Jaeger + s3proxy). Defaults to both; pass a service to run just one, e.g. `mise run sidecars s3proxy`."
-run = "docker compose -f fiddle/docker-compose.yml up {{arg(name='service', default='')}}"
+run = "docker compose -f fiddle/docker-compose.yml up {{arg(name='service', var=true, required=false)}}"
 
 # IIIF image-validator gate (requires Docker).
 # Builds the iiif-validator Docker image, starts a local IIIF server on port

--- a/mise.toml
+++ b/mise.toml
@@ -83,14 +83,14 @@ dir = "fiddle"
 run = "mix phx.server"
 
 [tasks."server:otel"]
-description = "Run the fiddle dev server with OpenTelemetry tracing on (start `mise run jaeger` first)"
+description = "Run the fiddle dev server with OpenTelemetry tracing on (start `mise run sidecars jaeger` first)"
 dir = "fiddle"
 env = { FIDDLE_OTEL = "1" }
 run = "mix phx.server"
 
-[tasks.jaeger]
-description = "Run a local Jaeger (OTLP + UI) for the fiddle's OpenTelemetry traces"
-run = "docker compose -f fiddle/docker-compose.yml up"
+[tasks.sidecars]
+description = "Run the fiddle's local sidecars (Jaeger + s3proxy). Defaults to both; pass a service to run just one, e.g. `mise run sidecars s3proxy`."
+run = "docker compose -f fiddle/docker-compose.yml up {{arg(name='service', default='')}}"
 
 # IIIF image-validator gate (requires Docker).
 # Builds the iiif-validator Docker image, starts a local IIIF server on port


### PR DESCRIPTION
## Summary

Lets the fiddle's imgproxy provider fetch the sample images through three source
adapters — local filesystem, a local **s3proxy** fake-S3, and HTTP against the
fiddle's own `Plug.Static` — selectable from a new **Source type** control. All
three resolve to byte-identical bytes from `priv/static/images`, so switching
source types is a clean adapter comparison.

No `ImagePipe` library changes — the S3 and HTTP source adapters and the imgproxy
`s3://` / `http://` scheme parsing already exist; this only wires them up in the
fiddle.

### What changed
- **Compose + mise:** opt-in `s3proxy` service in `fiddle/docker-compose.yml`
  (filesystem backend, bind-mounts `priv/static/images` read-only as bucket
  `sources`, endpoint `http://localhost:8081`). The old `jaeger` task becomes a
  single `sidecars` task that defaults to both services and accepts an optional
  service name (`mise run sidecars s3proxy`).
- **Backend:** `ImagePipeFiddle.Application.imgproxy_source_mounts/0` mounts `s3:`
  (`Source.S3`, config-driven via `:s3_source`) and `url:` (`Source.HTTP`, with a
  dev-only loopback allowance documented inline) alongside the existing `path:`
  mount. Scoped to the imgproxy provider only.
- **Frontend:** `sourceType` (`local` | `s3` | `http`) on the imgproxy state,
  encoded into the processing-path source identifier scheme and round-tripped
  through the URL state; a **Source type** `<select>` in the imgproxy request
  toolbox.
- **Docs:** README "Source types" section + the renamed `sidecars` task.

## Test Plan
- [x] `mise run precommit:fiddle` green (Elixir format/compile/credo/test + JS test/check/lint/format/build)
- [x] New Elixir test: the s3/http mounts validate via `ImagePipe.Plug.init/1`
- [x] New JS tests: `sourceIdentifierForRequest` / `parseSourceIdentifier` per source type, and `sourceType` URL-state round-trip
- [x] In-process verification through the full Phoenix endpoint: local/s3/http all return 200 with byte-identical output (s3 fetched live from s3proxy via sigv4)
- [ ] Manual: `mise run sidecars s3proxy` + restart the fiddle, toggle **Source type** in the browser and confirm identical output; stop s3proxy and confirm only the S3 type fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)