### PR TITLE
fix(fiddle): sign the debug trigger into the request path

### DIFF
--- a/fiddle/assets/App.svelte
+++ b/fiddle/assets/App.svelte
@@ -15,8 +15,10 @@
   import { defaultIiifState, iiifFetchPath } from "./iiif-path";
   import { defaultTwicPicsState, twicFetchPath } from "./twicpics-path";
   import {
+    buildDebugPreviewPath,
     buildProcessingPath,
     debounce,
+    debugTriggerPath,
     processedSizeLabel,
     processingPathFromSignedPath,
     resetCropPixelsToSource,
@@ -57,6 +59,16 @@
         ? iiifFetchPath(initial.iiif)
         : twicFetchPath(initial.twicpics),
   );
+  // The preview <img> request carries each dialect's debug trigger, built into
+  // the path/query by the same builder that produces `path` (and signed, for
+  // imgproxy, over the debug-augmented path) — never injected after signing.
+  let previewBasePath = $state(
+    initial.provider === "imgproxy"
+      ? buildDebugPreviewPath(initial.imgproxy)
+      : initial.provider === "iiif"
+        ? iiifFetchPath(initial.iiif, { debug: true })
+        : twicFetchPath(initial.twicpics, { debug: true }),
+  );
   let previewImageUrl: string | null = $state(null);
   let previewLoading = $state(true);
   let previewError: string | null = $state(null);
@@ -76,41 +88,25 @@
   let previewWorkerDisposed = false; // guards the register-promise-vs-unmount race
   let currentRequestId = 0;
   let lastPreviewAbsolute: string | null = null; // dedupe on resolved URL, not raw path
-  const updatePreviewPath = debounce((nextPath: string, provider: string) => {
-    // Request the preview with each dialect's debug trigger so the debug-enabled
-    // mount emits the X-ImagePipe-* + Server-Timing headers the SW reads. The
-    // trigger is excluded from the cache key / ETag and changes nothing about the
-    // produced image. It rides ONLY the preview <img> request — the copyable /
-    // "Open" URL (`path`) stays clean.
-    const absolute = previewRequestUrl(nextPath, provider);
+  const updatePreviewPath = debounce((previewRequestPath: string) => {
+    // `previewRequestPath` already carries each dialect's debug trigger, built in
+    // by the provider's path builder (and signed, for imgproxy, over the
+    // debug-augmented path). The trigger is excluded from the cache key / ETag
+    // and changes nothing about the produced image — it rides ONLY the preview
+    // <img> request, while the copyable / "Open" URL (`path`) stays clean.
+    const absolute = new URL(previewRequestPath, window.location.origin).href;
     // Dedupe on the RESOLVED url (not the raw path): a no-op must never flip
     // previewLoading=true without a following <img> load event, or the spinner
     // would strand. This same absolute is the SW-message correlation key.
     if (absolute === lastPreviewAbsolute) return;
     lastPreviewAbsolute = absolute;
-    previewPath = nextPath;
+    previewPath = previewRequestPath;
     currentRequestId = previewMetadata.begin(absolute);
     previewLoading = true;
     previewError = null;
     processedMetadata = null;
     previewImageUrl = absolute; // same-origin → <img> triggers the real, SW-intercepted request (with the debug trigger)
   }, 150);
-  // Builds the absolute preview-request URL, injecting each dialect's debug
-  // trigger: imgproxy's `debug:1` processing option ahead of the `/plain/`
-  // source marker, TwicPics' `debug=1` chain segment appended to the `twic`
-  // manipulation, and IIIF's `?debug=1` query param.
-  function previewRequestUrl(nextPath: string, provider: string): string {
-    const url = new URL(nextPath, window.location.origin);
-    if (provider === "imgproxy") {
-      url.pathname = url.pathname.replace("/plain/", "/debug:1/plain/");
-    } else if (provider === "iiif") {
-      url.searchParams.set("debug", "1");
-    } else if (provider === "twicpics") {
-      const twic = url.searchParams.get("twic");
-      if (twic) url.searchParams.set("twic", `${twic}/debug=1`);
-    }
-    return url.href;
-  }
   const updateFiddleLocation = debounce((nextPath: string) => {
     if (
       typeof window === "undefined" ||
@@ -167,13 +163,15 @@
     } else if (appState.provider === "iiif") {
       pathRequestId += 1; // invalidate any in-flight imgproxy signing so it can't clobber `path`
       path = iiifFetchPath(appState.iiif);
+      previewBasePath = iiifFetchPath(appState.iiif, { debug: true });
     } else {
       pathRequestId += 1; // invalidate any in-flight imgproxy signing so it can't clobber `path`
       path = twicFetchPath(appState.twicpics);
+      previewBasePath = twicFetchPath(appState.twicpics, { debug: true });
     }
   });
   $effect(() => {
-    updatePreviewPath(path, appState.provider);
+    updatePreviewPath(previewBasePath);
   });
   $effect(() => {
     updateFiddleLocation(appPathForState(appState));
@@ -271,24 +269,34 @@
   function updateProcessingPath(currentState: FiddleState): void {
     const requestId = ++pathRequestId;
     const signedPath = signedPathForState(currentState);
+    const debugPath = debugTriggerPath(signedPath);
 
     if (currentState.signatureMode !== "signed") {
       signingError = null;
       path = buildProcessingPath(currentState);
+      previewBasePath = buildDebugPreviewPath(currentState);
       return;
     }
 
-    signProcessingPath(signedPath, currentState.signatureKey, currentState.signatureSalt)
-      .then((signature) => {
+    // Sign the clean and debug-augmented paths independently: `debug:1` lives
+    // inside the signed region, so the preview <img> needs its own signature
+    // over the debug-inclusive path — the clean signature would not validate it.
+    Promise.all([
+      signProcessingPath(signedPath, currentState.signatureKey, currentState.signatureSalt),
+      signProcessingPath(debugPath, currentState.signatureKey, currentState.signatureSalt),
+    ])
+      .then(([signature, debugSignature]) => {
         if (requestId === pathRequestId) {
           signingError = null;
           path = processingPathFromSignedPath(signature, signedPath);
+          previewBasePath = buildDebugPreviewPath(currentState, debugSignature);
         }
       })
       .catch((error: unknown) => {
         if (requestId === pathRequestId) {
           signingError = error instanceof Error ? error.message : "Unable to sign request";
           path = processingPathFromSignedPath("invalid-signature", signedPath);
+          previewBasePath = buildDebugPreviewPath(currentState, "invalid-signature");
         }
       });
   }

--- a/fiddle/assets/iiif-path.test.ts
+++ b/fiddle/assets/iiif-path.test.ts
@@ -85,6 +85,12 @@ describe("iiif segment building", () => {
     expect(iiifBrowserPath(defaultIiifState)).toBe("/iiif/dog/full/max/0/default.jpg");
     expect(iiifFetchPath(defaultIiifState)).toBe("/iiif-image/dog/full/max/0/default.jpg");
   });
+
+  it("appends the debug trigger inside the built path so future signing covers it", () => {
+    expect(iiifFetchPath(defaultIiifState, { debug: true })).toBe(
+      "/iiif-image/dog/full/max/0/default.jpg?debug=1",
+    );
+  });
 });
 
 describe("iiif tail parsing round-trips", () => {

--- a/fiddle/assets/iiif-path.ts
+++ b/fiddle/assets/iiif-path.ts
@@ -108,8 +108,12 @@ export function iiifBrowserPath(state: IiifState): string {
   return `/iiif/${iiifPathTail(state)}`;
 }
 
-export function iiifFetchPath(state: IiifState): string {
-  return `/iiif-image/${iiifPathTail(state)}`;
+// The `debug` trigger is built into the path (as imgproxy's `debug:1` is built
+// into the signed path) rather than injected into the finalized URL, so that
+// when IIIF request signing is introduced it signs the debug-inclusive request.
+export function iiifFetchPath(state: IiifState, options: { debug?: boolean } = {}): string {
+  const tail = iiifPathTail(state);
+  return options.debug ? `/iiif-image/${tail}?debug=1` : `/iiif-image/${tail}`;
 }
 
 // --- parsing (mirror lib/image_pipe/parser/iiif/grammar.ex) ---

--- a/fiddle/assets/processing-path.test.ts
+++ b/fiddle/assets/processing-path.test.ts
@@ -1,12 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  buildDebugPreviewPath,
   buildProcessingPath,
   cocoClasses,
   controlLimits,
   cropDimensionSegment,
   cropOptionSegment,
   cropPixelLimit,
+  debugTriggerPath,
   type FiddleState,
   defaultFiddleState,
   debounce,
@@ -118,6 +120,40 @@ describe("processing path generation", () => {
     expect(processingPathFromSignedPath("local-signature", signedPathForState(state))).toBe(
       "/img/local-signature/rs:fill:640:360:0/plain/local:///images/dog.jpg",
     );
+  });
+
+  it("inserts the debug:1 trigger ahead of the plain source marker in the signed path", () => {
+    expect(debugTriggerPath("/rs:fill:640:360:0/plain/local:///images/dog.jpg")).toBe(
+      "/rs:fill:640:360:0/debug:1/plain/local:///images/dog.jpg",
+    );
+  });
+
+  it("builds the unsigned debug preview path with the unsafe signature segment", () => {
+    const state = { ...defaultFiddleState, resizeEnabled: true };
+
+    expect(buildDebugPreviewPath(state)).toBe(
+      "/img/_/rs:fill:640:360:0/debug:1/plain/local:///images/dog.jpg",
+    );
+  });
+
+  it("signs the debug-augmented path so the trigger is covered by the signature", async () => {
+    const state = { ...defaultFiddleState, signatureMode: "signed" as const, resizeEnabled: true };
+    const debugPath = debugTriggerPath(signedPathForState(state));
+    const signature = await signProcessingPath(debugPath, state.signatureKey, state.signatureSalt);
+
+    // The debug preview path carries debug:1 inside the signed region.
+    expect(buildDebugPreviewPath(state, signature)).toBe(
+      processingPathFromSignedPath(signature, debugPath),
+    );
+
+    // The clean path's signature must differ: signing without debug:1 would not
+    // validate the debug-augmented request the preview <img> actually sends.
+    const cleanSignature = await signProcessingPath(
+      signedPathForState(state),
+      state.signatureKey,
+      state.signatureSalt,
+    );
+    expect(cleanSignature).not.toBe(signature);
   });
 
   it("generates imgproxy-compatible HMAC signatures", async () => {

--- a/fiddle/assets/processing-path.ts
+++ b/fiddle/assets/processing-path.ts
@@ -1019,6 +1019,28 @@ export function buildProcessingPath(currentState: FiddleState, signature?: strin
   return processingPathFromSignedPath(signatureSegment(), signedPath);
 }
 
+// imgproxy's debug-header trigger (`debug:1`) is a processing option that lives
+// inside the signed path region. It must be inserted ahead of the `/plain/`
+// source marker and signed along with the rest of the path — never appended
+// after signing, which would invalidate the HMAC.
+export function debugTriggerPath(signedPath: string): string {
+  return signedPath.replace("/plain/", "/debug:1/plain/");
+}
+
+// Full imgproxy preview-request path carrying the `debug:1` trigger. Mirrors
+// buildProcessingPath but over the debug-augmented signed path, so the trigger
+// is covered by the signature when one is supplied (and rides the unsafe
+// segment otherwise).
+export function buildDebugPreviewPath(currentState: FiddleState, signature?: string): string {
+  const debugPath = debugTriggerPath(signedPathForState(currentState));
+
+  if (signature !== undefined) {
+    return processingPathFromSignedPath(signature, debugPath);
+  }
+
+  return processingPathFromSignedPath(signatureSegment(), debugPath);
+}
+
 export async function signProcessingPath(
   signedPath: string,
   keyHex: string,

--- a/fiddle/assets/twicpics-path.test.ts
+++ b/fiddle/assets/twicpics-path.test.ts
@@ -252,6 +252,18 @@ describe("twicpics fetch and browser paths", () => {
       "/twicpics/images/dog.jpg?twic=v1/resize=340/output=auto/quality=80",
     );
   });
+
+  it("appends the debug trigger inside the twic chain so future signing covers it", () => {
+    const state: TwicPicsState = {
+      ...defaultTwicPicsState,
+      chain: [
+        { type: "resize", id: "1", w: { unit: "px", value: 340 }, h: { unit: "auto", value: 0 } },
+      ],
+    };
+    expect(twicFetchPath(state, { debug: true })).toBe(
+      "/twic/images/dog.jpg?twic=v1/resize=340/output=auto/quality=80/debug=1",
+    );
+  });
 });
 
 describe("defaultStep factory", () => {

--- a/fiddle/assets/twicpics-path.ts
+++ b/fiddle/assets/twicpics-path.ts
@@ -219,8 +219,12 @@ export function twicParam(state: TwicPicsState): string {
   return `v1/${segments.join("/")}`;
 }
 
-export function twicFetchPath(state: TwicPicsState): string {
-  return `/twic/${state.source}?twic=${twicParam(state)}`;
+// The `debug` trigger is appended to the twic manipulation chain (the signed
+// payload, once TwicPics request signing is introduced) rather than injected
+// into the finalized URL, so signing will cover the debug-inclusive request.
+export function twicFetchPath(state: TwicPicsState, options: { debug?: boolean } = {}): string {
+  const param = options.debug ? `${twicParam(state)}/debug=1` : twicParam(state);
+  return `/twic/${state.source}?twic=${param}`;
 }
 
 export function twicBrowserPath(state: TwicPicsState): string {


### PR DESCRIPTION
## Problem

Signed imgproxy URLs in the fiddle broke. The preview `<img>` requests each dialect's debug-header trigger so the debug-enabled mount emits the `X-ImagePipe-*` / `Server-Timing` headers the service worker reads. That trigger was injected into the **already-finalized** URL:

- imgproxy: `debug:1` spliced ahead of `/plain/`
- IIIF: `?debug=1`
- TwicPics: `/debug=1` appended to the `twic` chain

For imgproxy, `debug:1` is a **signed path option** — the server's HMAC covers everything after the signature segment (`lib/image_pipe/parser/imgproxy/path.ex`). Splicing `debug:1` in *after* signing meant the preview request's signature no longer matched its path → `:invalid_signature`. Unsigned mode skips verification, which is why only signed URLs failed and the bug was masked.

## Fix

Build the debug trigger into each provider's request **before** signing, never after:

- **imgproxy** (`processing-path.ts`): new `debugTriggerPath` / `buildDebugPreviewPath`. `updateProcessingPath` signs the clean and debug-augmented paths independently, so the preview carries its own signature over the debug-inclusive path. The clean copyable / "Open" URL stays untouched.
- **IIIF / TwicPics** (`iiif-path.ts`, `twicpics-path.ts`): `iiifFetchPath` / `twicFetchPath` gain a `{ debug }` option that bakes the trigger into the path / twic chain. They're unsigned today, but when signing is layered onto those builders it will wrap the debug-inclusive request automatically — no post-hoc injection left to break. (Requested in review: make it compatible with signing those providers later.)
- **App.svelte**: drops `previewRequestUrl` for a `previewBasePath` reactive the builders populate.

## Tests

- New unit tests assert the preview is signed over the debug-augmented path and that this signature differs from the clean one (so it actually validates the request being sent), plus `{ debug }` builder coverage for IIIF and TwicPics.
- Fiddle JS gate green: 300 tests pass, typecheck / svelte-check 0 errors, lint 0, format clean, build succeeds.

JS-only change under `fiddle/assets/`. The main-library / fiddle Elixir test suites OOM-killed locally (environmental; they don't exercise this change) — CI is the authoritative run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)