### PR TITLE
feat(fiddle): debug headers in a popover next to the URL preview

### DIFF
--- a/fiddle/assets/App.svelte
+++ b/fiddle/assets/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { Collapsible, RadioGroup } from "bits-ui";
+  import { Collapsible, Popover, RadioGroup } from "bits-ui";
   import ImgproxyControls from "./ImgproxyControls.svelte";
   import IiifControls from "./IiifControls.svelte";
   import TwicPicsControls from "./TwicPicsControls.svelte";
@@ -583,7 +583,23 @@
       >
         ☰
       </button>
-      <code class="parameter-preview">{previewParameters}</code>
+      <div class="url-preview">
+        <code class="parameter-preview">{previewParameters}</code>
+        <Popover.Root>
+          <Popover.Trigger class="debug-trigger" aria-label="Debug headers" title="Debug headers">
+            <svg class="debug-trigger-icon" viewBox="0 0 24 24" aria-hidden="true">
+              <circle cx="12" cy="12" r="9"></circle>
+              <path d="M12 8h.01"></path>
+              <path d="M11 12h1v4h1"></path>
+            </svg>
+          </Popover.Trigger>
+          <Popover.Portal>
+            <Popover.Content class="debug-popover" align="start" sideOffset={8}>
+              <DebugInfoPanel groups={debugGroups} />
+            </Popover.Content>
+          </Popover.Portal>
+        </Popover.Root>
+      </div>
       <div class="preview-actions">
         <RadioGroup.Root
           class="theme-toggle"
@@ -646,7 +662,6 @@
           {/if}
         </figure>
       </div>
-      <DebugInfoPanel groups={debugGroups} />
       {#if previewError !== null}
         <div class="preview-error" role="status">{previewError}</div>
       {/if}
@@ -734,15 +749,69 @@
     background: var(--surface-bar);
   }
 
-  .parameter-preview {
+  .url-preview {
     min-width: 0;
     flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .parameter-preview {
+    min-width: 0;
+    flex: 0 1 auto;
     overflow: hidden;
     color: var(--text-muted);
     font-size: 13px;
     line-height: 18px;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  :global(.debug-trigger) {
+    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--border-strong);
+    border-radius: 8px;
+    background: var(--surface-button-quiet);
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+
+  :global(.debug-trigger:hover),
+  :global(.debug-trigger[data-state="open"]) {
+    color: var(--text-heading);
+  }
+
+  :global(.debug-trigger:focus-visible) {
+    outline: 2px solid var(--focus-ring);
+    outline-offset: 2px;
+  }
+
+  .debug-trigger-icon {
+    width: 18px;
+    height: 18px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  :global(.debug-popover) {
+    max-width: min(420px, calc(100vw - 24px));
+    max-height: var(--bits-popover-content-available-height);
+    overflow-y: auto;
+    padding: 14px;
+    border: 1px solid var(--border-strong);
+    border-radius: 10px;
+    background: var(--surface-sidebar);
+    box-shadow: var(--image-shadow);
+    z-index: 50;
   }
 
   .desktop-actions,

--- a/fiddle/assets/DebugInfoPanel.svelte
+++ b/fiddle/assets/DebugInfoPanel.svelte
@@ -1,36 +1,39 @@
 <script lang="ts">
-  import { Collapsible } from "bits-ui";
   import { type DebugGroup } from "./debug-headers";
 
   let { groups }: { groups: DebugGroup[] | null } = $props();
 </script>
 
 {#if groups !== null}
-  <Collapsible.Root class="debug-panel">
-    <Collapsible.Trigger class="debug-panel-trigger">Debug headers</Collapsible.Trigger>
-    <Collapsible.Content class="debug-panel-content">
-      {#each groups as group (group.title)}
-        <section class="debug-group">
-          <h4 class="debug-group-title">{group.title}</h4>
-          <dl class="debug-rows">
-            {#each group.rows as detail (detail.label)}
-              <div class="debug-row">
-                <dt>{detail.label}</dt>
-                <dd>{detail.value}</dd>
-              </div>
-            {/each}
-          </dl>
-        </section>
-      {/each}
-    </Collapsible.Content>
-  </Collapsible.Root>
+  <div class="debug-panel">
+    {#each groups as group (group.title)}
+      <section class="debug-group">
+        <h4 class="debug-group-title">{group.title}</h4>
+        <dl class="debug-rows">
+          {#each group.rows as detail (detail.label)}
+            <div class="debug-row">
+              <dt>{detail.label}</dt>
+              <dd>{detail.value}</dd>
+            </div>
+          {/each}
+        </dl>
+      </section>
+    {/each}
+  </div>
+{:else}
+  <p class="debug-empty">No debug headers available for this response.</p>
 {/if}
 
 <style>
+  .debug-empty {
+    margin: 0;
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+
   .debug-group-title {
     margin: 0 0 4px;
     font-size: 11px;
-    text-transform: uppercase;
     letter-spacing: 0.04em;
     color: var(--text-muted);
   }
@@ -39,6 +42,10 @@
     margin: 0 0 10px;
     display: grid;
     gap: 2px;
+  }
+
+  .debug-group:last-child .debug-rows {
+    margin-bottom: 0;
   }
 
   .debug-row {
@@ -55,6 +62,7 @@
   .debug-row dd {
     margin: 0;
     color: var(--text-primary);
+    font-family: var(--font-mono);
     font-variant-numeric: tabular-nums;
     overflow-wrap: anywhere;
   }


### PR DESCRIPTION
## What

The debug response headers (`X-ImagePipe-*` / `Server-Timing`) were rendered loose and unstyled inside the preview canvas, awkwardly overlapping the rendered image. This moves them into a **bits-ui Popover** triggered by an info icon that sits immediately next to the URL preview in the command bar.

## Changes

- **`App.svelte`** — wrap the URL `<code>` and a new `Popover.Trigger` (info-icon button) in a flex group so the icon hugs the URL: the code sizes to its content and ellipsizes when long. The popover content holds `DebugInfoPanel`; its height grows to the available viewport via `--bits-popover-content-available-height` and only then scrolls. Removed the loose `<DebugInfoPanel>` from `.preview-canvas`. bits-ui parts styled under `:global(...)` per the existing convention.
- **`DebugInfoPanel.svelte`** — dropped the inner `Collapsible` (the popover is the disclosure now) and render the groups directly. Added an empty state (*"No debug headers available for this response."*) shown when no debug headers are present; the trigger stays enabled regardless. Group headings are no longer uppercased; values use the mono font (`--font-mono`). Even top/bottom padding (zeroed the last group's trailing margin).

## Notes

The fiddle's preview request always carries the debug trigger, so real responses populate the panel; the empty message only shows before a response lands.

## Verification

Fiddle JS gate green: `check` (0 errors), `lint` (0 warnings), `format:check`, `test` (300 passed), `build`. Visual placement confirmed in-browser by the author. No Elixir/library code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)