### PR TITLE
test(content-classifier): replace dead is_float guard with threshold-margin assertion

### DIFF
--- a/test/image_pipe/output/content_classifier_test.exs
+++ b/test/image_pipe/output/content_classifier_test.exs
@@ -42,7 +42,15 @@ defmodule ImagePipe.Output.ContentClassifierTest do
 
   test "classifies a continuous-tone field as :photo" do
     assert {:photo, %{palette_ent: pe, nat_var: nv}} = ContentClassifier.classify(photo_image())
-    assert is_float(pe) and is_float(nv)
+
+    # The fixture is built to land well clear of the pinned photo-side thresholds,
+    # so the verdict is robust to the exact constants (and to libvips drift). A bare
+    # :photo verdict only proves the features cleared the thresholds; pin the margin
+    # the fixture's design promises instead of re-checking float types the compiler
+    # already knows.
+    {palette_threshold, nat_var_threshold} = ContentClassifier.photo_thresholds()
+    assert pe >= palette_threshold + 0.1
+    assert nv >= nat_var_threshold + 0.1
   end
 
   test "classifies a hard-edged two-tone field as :graphic" do


### PR DESCRIPTION
## Problem

`mise exec -- mix test` surfaced a compile-time type warning from `test/image_pipe/output/content_classifier_test.exs:45`:

```
warning: the following conditional expression will always succeed:
    is_float(pe)
because it evaluates to: dynamic(true)
```

`ImagePipe.Output.ContentClassifier.classify/1` is typed `@spec classify :: {class(), features()}` with `@type features :: %{palette_ent: float(), nat_var: float()}`. The compiler proves `pe`/`nv` are floats from the destructure on the preceding line, so `assert is_float(pe) and is_float(nv)` is statically dead — exactly the tautological-test smell AGENTS.md warns against. This is **not** producer drift; the return shape still matches the destructure.

## Fix

Replaced the dead type guard with the assertion the fixture's docstring already promises but never checked: the features land *well clear* of the pinned photo-side thresholds, so the verdict is robust to the exact constants (and to libvips drift). A bare `:photo` verdict only proves the features cleared the thresholds — it does **not** prove the margin. Thresholds are sourced from the existing `ContentClassifier.photo_thresholds/0` accessor rather than hardcoded.

Measured fixture values: `pe=0.996` (clears 0.82 by 0.18), `nv=0.81` (clears 0.27 by 0.54), so the `+0.1` margin is comfortable and won't flake, while still able to fail if the fixture degrades toward the boundary.

Scanned all other `assert is_*(...)` in `test/`; the rest sit at genuinely dynamic boundaries (telemetry metadata maps, behaviour returns, parsed JSON) where the compiler can't narrow the type, so none triggers this warning. This was the only dead-guard instance.

## Verification

- `mise exec -- mix test test/image_pipe/output/content_classifier_test.exs` → 3 passed
- Same file under `--warnings-as-errors` → clean, no "always succeed" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)